### PR TITLE
Fix version stamping. Add stamping to nextjs docs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -34,7 +34,6 @@ build:ci --build_metadata=ROLE=CI --workspace_status_command=./scripts/workspace
 build:ci --local_cpu_resources=8
 build:ci --local_ram_resources=15000
 build:ci --config="release"
-build:ci --action_env=NEXT_PUBLIC_GA_MEASUREMENT_ID=$NEXT_PUBLIC_GA_MEASUREMENT_ID
 
 build:release --stamp --workspace_status_command=./scripts/workspace-status.sh
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,9 +11,9 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 http_archive(
     name = "rules_player",
-    strip_prefix = "rules_player-0.2.1",
-    urls = ["https://github.com/player-ui/rules_player/archive/refs/tags/v0.2.1.tar.gz"],
-    sha256 = "b7f5cab8992e1c80d21eeace18736024a2ae249bfe9f3d7f2d464742548e3490"
+    strip_prefix = "rules_player-0.3.0",
+    urls = ["https://github.com/player-ui/rules_player/archive/refs/tags/v0.3.0.tar.gz"],
+    sha256 = "d92136eb30489f8f337d0c93e93ea45cf865965605f1a16d8fa4d4528a64356e"
 )
 
 load("@rules_player//:workspace.bzl", "deps")

--- a/core/player/src/player.ts
+++ b/core/player/src/player.ts
@@ -27,8 +27,8 @@ import type {
 import { NOT_STARTED_STATE } from './types';
 
 // Variables injected at build time
-const PLAYER_VERSION = '!!STABLE_VERSION!!';
-const COMMIT = '!!STABLE_GIT_COMMIT!!';
+const PLAYER_VERSION = '__VERSION__';
+const COMMIT = '__GIT_COMMIT__';
 
 export interface PlayerPlugin {
   /**

--- a/docs/site/BUILD
+++ b/docs/site/BUILD
@@ -47,8 +47,12 @@ next_export(
   name = "site",
   data = data,
   srcs = srcs,
+  substitutions ={
+    "NEXT_PUBLIC_GA_MEASUREMENT_ID": "STABLE_GA_MEASUREMENT_ID"
+  },
   env = {
-    "DOCS_BASE_PATH": "/next"
+    "DOCS_BASE_PATH": "/next",
+    "NEXT_PUBLIC_GA_MEASUREMENT_ID": "NEXT_PUBLIC_GA_MEASUREMENT_ID",
   },
 )
 

--- a/react/player/src/player.tsx
+++ b/react/player/src/player.tsx
@@ -19,8 +19,8 @@ import type { WebPlayerProps } from './app';
 import PlayerComp from './app';
 import OnUpdatePlugin from './plugins/onupdate-plugin';
 
-const WEB_PLAYER_VERSION = '!!STABLE_VERSION!!';
-const COMMIT = '!!STABLE_GIT_COMMIT!!';
+const WEB_PLAYER_VERSION = '__VERSION__';
+const COMMIT = '__GIT_COMMIT__';
 
 export interface DevtoolsGlobals {
   /** A global for a plugin to load to Player for devtools */

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -24,4 +24,4 @@ for pkg in $PKG_NPM_LABELS ; do
 done
 
 # Running this here because it will still have the pre-release version in the VERSION file before auto cleans it up
-bazel run //docs:deploy_docs
+bazel run --config=release //docs:deploy_docs

--- a/scripts/workspace-status.sh
+++ b/scripts/workspace-status.sh
@@ -13,3 +13,5 @@ echo "GIT_BRANCH $git_branch"
 
 git_tree_status=$(git diff-index --quiet HEAD -- && echo 'Clean' || echo 'Modified')
 echo "GIT_TREE_STATUS $git_tree_status"
+
+echo "STABLE_GA_MEASUREMENT_ID $NEXT_PUBLIC_GA_MEASUREMENT_ID"


### PR DESCRIPTION


## Release Notes

- Fixes the stamping for version and sha in `core` and `web` modules
- Stamps the nextjs docs for analytics id