### PR TITLE
Migrate from tapable to tapable-ts

### DIFF
--- a/core/binding/BUILD
+++ b/core/binding/BUILD
@@ -4,8 +4,7 @@ javascript_pipeline(
     name = "@player-ui/binding",
     dependencies = [
         "//core/binding-grammar:@player-ui/binding-grammar",
-        "@npm//tapable",
-        "@npm//@types/tapable",
+        "@npm//tapable-ts",
         "@npm//nested-error-stacks",
         "@npm//@types/nested-error-stacks"
     ],

--- a/core/binding/src/index.ts
+++ b/core/binding/src/index.ts
@@ -1,4 +1,4 @@
-import { SyncBailHook, SyncWaterfallHook } from 'tapable';
+import { SyncBailHook, SyncWaterfallHook } from 'tapable-ts';
 import NestedError from 'nested-error-stacks';
 import type { ParserResult, AnyNode } from '@player-ui/binding-grammar';
 import {
@@ -35,11 +35,10 @@ export class BindingParser {
   private parserOptions: BindingParserOptions;
 
   public hooks = {
-    skipOptimization: new SyncBailHook<string, void, void, boolean>(['path']),
+    skipOptimization: new SyncBailHook<[string], boolean>(),
     beforeResolveNode: new SyncWaterfallHook<
-      AnyNode,
-      Required<NormalizedResult> & ResolveBindingASTOptions
-    >(['node', 'context']),
+      [AnyNode, Required<NormalizedResult> & ResolveBindingASTOptions]
+    >(),
   };
 
   constructor(options?: Partial<BindingParserOptions>) {

--- a/core/binding/src/resolver.ts
+++ b/core/binding/src/resolver.ts
@@ -1,6 +1,6 @@
 import type { PathNode, AnyNode } from '@player-ui/binding-grammar';
 import NestedError from 'nested-error-stacks';
-import type { SyncWaterfallHook } from 'tapable';
+import type { SyncWaterfallHook } from 'tapable-ts';
 import { maybeConvertToNum } from '.';
 import { findInArray } from './utils';
 
@@ -26,8 +26,7 @@ export interface ResolveBindingASTOptions {
 export interface ResolveBindingASTHooks {
   /** A hook for transforming a node before fully resolving it */
   beforeResolveNode: SyncWaterfallHook<
-    AnyNode,
-    Required<NormalizedResult> & ResolveBindingASTOptions
+    [AnyNode, Required<NormalizedResult> & ResolveBindingASTOptions]
   >;
 }
 

--- a/core/data/BUILD
+++ b/core/data/BUILD
@@ -6,8 +6,7 @@ javascript_pipeline(
         "//core/binding:@player-ui/binding",
         "@npm//@types/dlv",
         "@npm//dlv",
-        "@npm//@types/tapable",
-        "@npm//tapable",
+        "@npm//tapable-ts",
         "@npm//timm",
     ],
 )

--- a/core/data/src/model.ts
+++ b/core/data/src/model.ts
@@ -1,4 +1,4 @@
-import { SyncHook } from 'tapable';
+import { SyncHook } from 'tapable-ts';
 import type { BindingLike, BindingFactory } from '@player-ui/binding';
 import { BindingInstance, isBinding } from '@player-ui/binding';
 import { NOOP_MODEL } from './noop-model';
@@ -170,7 +170,7 @@ export class PipelinedDataModel implements DataModelImpl {
   private effectiveDataModel: DataModelImpl;
 
   public readonly hooks = {
-    onSet: new SyncHook<BatchSetTransaction>(['transaction']),
+    onSet: new SyncHook<[BatchSetTransaction]>(),
   };
 
   constructor(pipeline: DataPipeline = []) {

--- a/core/expressions/BUILD
+++ b/core/expressions/BUILD
@@ -8,6 +8,6 @@ javascript_pipeline(
         "//core/string-resolver:@player-ui/string-resolver",
         "//core/types:@player-ui/types",
         "//core/logger:@player-ui/logger",
-        "@npm//tapable",
+        "@npm//tapable-ts",
     ],
 )

--- a/core/expressions/src/evaluator.ts
+++ b/core/expressions/src/evaluator.ts
@@ -1,4 +1,4 @@
-import { SyncWaterfallHook, SyncBailHook } from 'tapable';
+import { SyncWaterfallHook, SyncBailHook } from 'tapable-ts';
 import parse from './parser';
 import * as DEFAULT_EXPRESSION_HANDLERS from './evaluator-functions';
 import type {
@@ -90,17 +90,13 @@ export class ExpressionEvaluator {
   private readonly vars: Record<string, any> = {};
   public readonly hooks = {
     /** Resolve an AST node for an expression to a value */
-    resolve: new SyncWaterfallHook<any, ExpressionNode, HookOptions>([
-      'value',
-      'node',
-      'options',
-    ]),
+    resolve: new SyncWaterfallHook<[any, ExpressionNode, HookOptions]>(),
 
     /**
      * An optional means of handling an error in the expression execution
      * Return true if handled, to stop propagation of the error
      */
-    onError: new SyncBailHook<Error, never, never, true>(['error']),
+    onError: new SyncBailHook<[Error], true>(),
   };
 
   private readonly expressionsCache: Map<string, ExpressionNode> = new Map();

--- a/core/flow/BUILD
+++ b/core/flow/BUILD
@@ -5,7 +5,7 @@ javascript_pipeline(
     dependencies = [
         "//core/logger:@player-ui/logger",
         "//core/types:@player-ui/types",
-        "@npm//tapable",
+        "@npm//tapable-ts",
         "@npm//p-defer",
     ],
 )

--- a/core/flow/src/controller.ts
+++ b/core/flow/src/controller.ts
@@ -1,5 +1,5 @@
 import type { Logger } from '@player-ui/logger';
-import { SyncHook } from 'tapable';
+import { SyncHook } from 'tapable-ts';
 import type { Navigation, NavigationFlowEndState } from '@player-ui/types';
 import type { NamedState, TransitionOptions } from './flow';
 import { FlowInstance } from './flow';
@@ -7,7 +7,7 @@ import { FlowInstance } from './flow';
 /** A manager for the navigation section of a Content blob */
 export class FlowController {
   public readonly hooks = {
-    flow: new SyncHook<FlowInstance>(['flow']),
+    flow: new SyncHook<[FlowInstance]>(),
   };
 
   private readonly log?: Logger;

--- a/core/flow/src/flow.ts
+++ b/core/flow/src/flow.ts
@@ -1,4 +1,4 @@
-import { SyncBailHook, SyncHook, SyncWaterfallHook } from 'tapable';
+import { SyncBailHook, SyncHook, SyncWaterfallHook } from 'tapable-ts';
 import type { Logger } from '@player-ui/logger';
 import type { DeferredPromise } from 'p-defer';
 import defer from 'p-defer';
@@ -34,37 +34,30 @@ export class FlowInstance {
   public readonly id: string;
   public currentState?: NamedState;
   public readonly hooks = {
-    beforeStart: new SyncBailHook<NavigationFlow, NavigationFlow>(['flow']),
+    beforeStart: new SyncBailHook<[NavigationFlow], NavigationFlow>(),
 
     /** A callback when the onStart node was present */
-    onStart: new SyncHook<any>(['onStart']),
+    onStart: new SyncHook<[any]>(),
 
     /** A callback when the onEnd node was present */
-    onEnd: new SyncHook<any>(['onEnd']),
+    onEnd: new SyncHook<[any]>(),
 
     /** A hook to intercept and block a transition */
     skipTransition: new SyncBailHook<
-      NamedState | undefined,
-      string,
+      [NamedState | undefined, string],
       boolean | undefined
-    >(['oldState', 'transitionName']),
+    >(),
 
     /** A chance to manipulate the flow-node used to calculate the given transition used  */
     beforeTransition: new SyncWaterfallHook<
-      Exclude<NavigationFlowState, NavigationFlowEndState>,
-      string
-    >(['currentState', 'transitionName']),
+      [Exclude<NavigationFlowState, NavigationFlowEndState>, string]
+    >(),
 
     /** A chance to manipulate the flow-node calculated after a transition */
-    resolveTransitionNode: new SyncWaterfallHook<NavigationFlowState>([
-      'newState',
-    ]),
+    resolveTransitionNode: new SyncWaterfallHook<[NavigationFlowState]>(),
 
     /** A callback when a transition from 1 state to another was made */
-    transition: new SyncHook<NamedState | undefined, NamedState>([
-      'oldState',
-      'newState',
-    ]),
+    transition: new SyncHook<[NamedState | undefined, NamedState]>(),
   };
 
   constructor(

--- a/core/logger/BUILD
+++ b/core/logger/BUILD
@@ -3,7 +3,6 @@ load("//:index.bzl", "javascript_pipeline")
 javascript_pipeline(
     name = "@player-ui/logger",
     dependencies = [
-        "@npm//@types/tapable",
-        "@npm//tapable",
+        "@npm//tapable-ts",
     ],
 )

--- a/core/logger/src/tapableLogger.ts
+++ b/core/logger/src/tapableLogger.ts
@@ -1,15 +1,15 @@
-import { SyncHook } from 'tapable';
+import { SyncHook } from 'tapable-ts';
 import type { Logger, Severity } from './types';
 
 /** A logger that has a tapable subscriptions to callbacks */
 export default class TapableLogger implements Logger {
   public readonly hooks = {
-    trace: new SyncHook<Array<any>>(['args']),
-    debug: new SyncHook<Array<any>>(['args']),
-    info: new SyncHook<Array<any>>(['args']),
-    warn: new SyncHook<Array<any>>(['args']),
-    error: new SyncHook<Array<any>>(['args']),
-    log: new SyncHook<Severity, Array<any>>(['severity', 'args']),
+    trace: new SyncHook<[Array<any>]>(),
+    debug: new SyncHook<[Array<any>]>(),
+    info: new SyncHook<[Array<any>]>(),
+    warn: new SyncHook<[Array<any>]>(),
+    error: new SyncHook<[Array<any>]>(),
+    log: new SyncHook<[Severity, Array<any>]>(),
   };
 
   private logHandlers: Set<Logger> = new Set();

--- a/core/player/BUILD
+++ b/core/player/BUILD
@@ -20,7 +20,7 @@ javascript_pipeline(
         "@npm//dequal",
         "@npm//p-defer",
         "@npm//queue-microtask",
-        "@npm//tapable",
+        "@npm//tapable-ts",
         "@npm//timm",
     ],
     test_data = [

--- a/core/player/src/data.ts
+++ b/core/player/src/data.ts
@@ -1,4 +1,4 @@
-import { SyncHook, SyncWaterfallHook, SyncBailHook } from 'tapable';
+import { SyncHook, SyncWaterfallHook, SyncBailHook } from 'tapable-ts';
 import type { Logger } from '@player-ui/logger';
 import { omit, removeAt } from 'timm';
 import { dequal } from 'dequal';
@@ -18,21 +18,21 @@ import type { RawSetTransaction } from './types';
 /** The orchestrator for player data */
 export class DataController implements DataModelWithParser<DataModelOptions> {
   public hooks = {
-    resolve: new SyncWaterfallHook(['binding']),
-    resolveDataStages: new SyncWaterfallHook<DataPipeline>(['pipeline']),
+    resolve: new SyncWaterfallHook(),
+    resolveDataStages: new SyncWaterfallHook<[DataPipeline]>(),
 
     // On any set or get of an undefined value, redirect the value to be the default
-    resolveDefaultValue: new SyncBailHook<BindingInstance, any>(['binding']),
+    resolveDefaultValue: new SyncBailHook<[BindingInstance], any>(),
 
-    onDelete: new SyncHook<any, void>(['binding']),
-    onSet: new SyncHook<BatchSetTransaction, void>(['transaction']),
-    onGet: new SyncHook<any, any, void>(['binding', 'result']),
-    onUpdate: new SyncHook<Updates>(['updates']),
+    onDelete: new SyncHook<[any]>(),
+    onSet: new SyncHook<[BatchSetTransaction]>(),
+    onGet: new SyncHook<[any, any]>(),
+    onUpdate: new SyncHook<[Updates]>(),
 
-    format: new SyncWaterfallHook<any, BindingInstance>(['value', 'binding']),
-    deformat: new SyncWaterfallHook<any, BindingInstance>(['value', 'binding']),
+    format: new SyncWaterfallHook<[any, BindingInstance]>(),
+    deformat: new SyncWaterfallHook<[any, BindingInstance]>(),
 
-    serialize: new SyncWaterfallHook<any>(['data']),
+    serialize: new SyncWaterfallHook<[any]>(),
   };
 
   private model?: PipelinedDataModel;

--- a/core/player/src/player.ts
+++ b/core/player/src/player.ts
@@ -1,4 +1,4 @@
-import { SyncHook, SyncWaterfallHook } from 'tapable';
+import { SyncHook, SyncWaterfallHook } from 'tapable-ts';
 import type { FlowInstance } from '@player-ui/flow';
 import { FlowController } from '@player-ui/flow';
 import type { Logger } from '@player-ui/logger';
@@ -78,43 +78,39 @@ export class Player {
 
   public readonly hooks = {
     /** The hook that fires every time we create a new flowController (a new Content blob is passed in) */
-    flowController: new SyncHook<FlowController>(['flowController']),
+    flowController: new SyncHook<[FlowController]>(),
 
     /** The hook that updates/handles views */
-    viewController: new SyncHook<ViewController>(['viewController']),
+    viewController: new SyncHook<[ViewController]>(),
 
     /** A hook called every-time there's a new view. This is equivalent to the view hook on the view-controller */
-    view: new SyncHook<ViewInstance>(['view']),
+    view: new SyncHook<[ViewInstance]>(),
 
     /** Called when an expression evaluator was created */
-    expressionEvaluator: new SyncHook<ExpressionEvaluator>([
-      'expressionEvaluator',
-    ]),
+    expressionEvaluator: new SyncHook<[ExpressionEvaluator]>(),
 
     /** The hook that creates and manages data */
-    dataController: new SyncHook<DataController>(['dataController']),
+    dataController: new SyncHook<[DataController]>(),
 
     /** Called after the schema is created for a flow */
-    schema: new SyncHook<SchemaController>(['schema']),
+    schema: new SyncHook<[SchemaController]>(),
 
     /** Manages validations (schema and x-field ) */
-    validationController: new SyncHook<ValidationController>([
-      'validationController',
-    ]),
+    validationController: new SyncHook<[ValidationController]>(),
 
     /** Manages parsing binding */
-    bindingParser: new SyncHook<BindingParser>(['bindingParser']),
+    bindingParser: new SyncHook<[BindingParser]>(),
 
     /** A that's called for state changes in the flow execution */
-    state: new SyncHook<PlayerFlowState>(['state']),
+    state: new SyncHook<[PlayerFlowState]>(),
 
     /** A hook to access the current flow */
-    onStart: new SyncHook<FlowType>(['flow']),
+    onStart: new SyncHook<[FlowType]>(),
 
     /** A hook for when the flow ends either in success or failure */
-    onEnd: new SyncHook(),
+    onEnd: new SyncHook<[]>(),
     /** Mutate the Content flow before starting */
-    resolveFlowContent: new SyncWaterfallHook<FlowType>(['content']),
+    resolveFlowContent: new SyncWaterfallHook<[FlowType]>(),
   };
 
   constructor(config?: PlayerConfigOptions) {

--- a/core/player/src/plugins/flow-exp-plugin.ts
+++ b/core/player/src/plugins/flow-exp-plugin.ts
@@ -1,4 +1,8 @@
-import type { Expression, ExpressionObject } from '@player-ui/types';
+import type {
+  Expression,
+  ExpressionObject,
+  NavigationFlowState,
+} from '@player-ui/types';
 import type { ExpressionEvaluator } from '@player-ui/expressions';
 import type { FlowInstance } from '@player-ui/flow';
 import type { Player, PlayerPlugin } from '../player';
@@ -42,7 +46,7 @@ export class FlowExpPlugin implements PlayerPlugin {
         flow.hooks.onEnd.tap(this.name, (exp) => handleEval(exp));
         // Eval state nodes
         flow.hooks.resolveTransitionNode.intercept({
-          call: (nextState) => {
+          call: (nextState: NavigationFlowState) => {
             /** Get the current state of Player */
             const currentState = () => player.getState() as InProgressState;
 

--- a/core/player/src/validation/controller.ts
+++ b/core/player/src/validation/controller.ts
@@ -22,7 +22,7 @@ import type {
   ExpressionEvaluatorOptions,
   ExpressionType,
 } from '@player-ui/expressions';
-import { SyncHook, SyncWaterfallHook } from 'tapable';
+import { SyncHook, SyncWaterfallHook } from 'tapable-ts';
 import type { BindingTracker } from './binding-tracker';
 import { ValidationBindingTrackerViewPlugin } from './binding-tracker';
 
@@ -279,18 +279,17 @@ class ValidatedBinding {
 export class ValidationController implements BindingTracker {
   public readonly hooks = {
     /** A hook called to tap into the validator registry for adding more validators */
-    createValidatorRegistry: new SyncHook<ValidatorRegistry>(['registry']),
+    createValidatorRegistry: new SyncHook<[ValidatorRegistry]>(),
 
     /** A callback/event when a new validation is added to the view */
-    onAddValidation: new SyncWaterfallHook<ValidationResponse, BindingInstance>(
-      ['validation', 'binding']
-    ),
+    onAddValidation: new SyncWaterfallHook<
+      [ValidationResponse, BindingInstance]
+    >(),
 
     /** The inverse of onAddValidation, this is called when a validation is removed from the list */
     onRemoveValidation: new SyncWaterfallHook<
-      ValidationResponse,
-      BindingInstance
-    >(['validation', 'binding']),
+      [ValidationResponse, BindingInstance]
+    >(),
   };
 
   private tracker: BindingTracker | undefined;

--- a/core/player/src/view/controller.ts
+++ b/core/player/src/view/controller.ts
@@ -1,4 +1,4 @@
-import { SyncHook, SyncWaterfallHook } from 'tapable';
+import { SyncHook, SyncWaterfallHook } from 'tapable-ts';
 import type { Resolve } from '@player-ui/view';
 import { ViewInstance } from '@player-ui/view';
 import type { Logger } from '@player-ui/logger';
@@ -27,14 +27,12 @@ export interface ViewControllerOptions {
 export class ViewController {
   public readonly hooks = {
     /** Do any processing before the `View` instance is created */
-    resolveView: new SyncWaterfallHook<View, string, NavigationFlowViewState>([
-      'view',
-      'viewRef',
-      'viewState',
-    ]),
+    resolveView: new SyncWaterfallHook<
+      [View | undefined, string, NavigationFlowViewState]
+    >(),
 
     // The hook right before the View starts resolving. Attach anything custom here
-    view: new SyncHook<ViewInstance>(['view']),
+    view: new SyncHook<[ViewInstance]>(),
   };
 
   private readonly viewMap: Record<string, View>;

--- a/core/schema/BUILD
+++ b/core/schema/BUILD
@@ -7,7 +7,7 @@ javascript_pipeline(
         "//core/data:@player-ui/data",
         "//core/types:@player-ui/types",
         "//core/validator:@player-ui/validator",
-        "@npm//tapable",
+        "@npm//tapable-ts",
     ],
     test_data = [
         "//core/expressions:@player-ui/expressions",

--- a/core/schema/src/schema.ts
+++ b/core/schema/src/schema.ts
@@ -1,4 +1,4 @@
-import { SyncWaterfallHook } from 'tapable';
+import { SyncWaterfallHook } from 'tapable-ts';
 import type { BindingInstance } from '@player-ui/binding';
 import type { Schema as SchemaType, Formatting } from '@player-ui/types';
 import type {
@@ -94,9 +94,8 @@ export class SchemaController implements ValidationProvider {
 
   public readonly hooks = {
     resolveTypeForBinding: new SyncWaterfallHook<
-      SchemaType.DataType | undefined,
-      BindingInstance
-    >(['dataType', 'binding']),
+      [SchemaType.DataType | undefined, BindingInstance]
+    >(),
   };
 
   constructor(schema?: SchemaType.Schema) {

--- a/core/validator/BUILD
+++ b/core/validator/BUILD
@@ -9,7 +9,7 @@ javascript_pipeline(
         "//core/expressions:@player-ui/expressions",
         "//core/logger:@player-ui/logger",
         "//core/types:@player-ui/types",
-        "@npm//tapable",
+        "@npm//tapable-ts",
         "@npm//timm",
     ],
     test_data = [

--- a/core/view/BUILD
+++ b/core/view/BUILD
@@ -13,7 +13,7 @@ javascript_pipeline(
         "//core/logger:@player-ui/logger",
         "//core/string-resolver:@player-ui/string-resolver",
         "//core/validator:@player-ui/validator",
-        "@npm//tapable",
+        "@npm//tapable-ts",
         "@npm//timm",
         "@npm//dlv",
         "@npm//dequal",

--- a/core/view/src/parser/index.ts
+++ b/core/view/src/parser/index.ts
@@ -1,5 +1,5 @@
 import { omit, setIn } from 'timm';
-import { SyncWaterfallHook } from 'tapable';
+import { SyncWaterfallHook } from 'tapable-ts';
 import type { Template, AssetSwitch } from '@player-ui/types';
 import type { Node, AnyAssetType } from './types';
 import { NodeType } from './types';
@@ -30,10 +30,7 @@ export class Parser {
      *  If undefined, the original value is used.
      *  If null, we stop parsing this node.
      */
-    onParseObject: new SyncWaterfallHook<object, NodeType>([
-      'value',
-      'nodeType',
-    ]),
+    onParseObject: new SyncWaterfallHook<[object, NodeType]>(),
 
     /**
      * A callback to interact with an AST _after_ we parse it into the AST
@@ -45,9 +42,8 @@ export class Parser {
      *   If null, we ignore this node all together
      */
     onCreateASTNode: new SyncWaterfallHook<
-      Node.Node | undefined | null,
-      object
-    >(['node', 'value']),
+      [Node.Node | undefined | null, object]
+    >(),
   };
 
   public parseView(value: AnyAssetType): Node.View {

--- a/core/view/src/plugins/plugin.ts
+++ b/core/view/src/plugins/plugin.ts
@@ -1,4 +1,4 @@
-import type { SyncHook } from 'tapable';
+import type { SyncHook } from 'tapable-ts';
 import type { Resolver } from '../resolver';
 import type { Parser } from '../parser';
 
@@ -7,10 +7,10 @@ export interface View {
   /** The hooks for a view */
   hooks: {
     /** A hook when a parser is created for this view */
-    parser: SyncHook<Parser>;
+    parser: SyncHook<[Parser]>;
 
     /** A hook when a resolver is created for this view */
-    resolver: SyncHook<Resolver>;
+    resolver: SyncHook<[Resolver]>;
   };
 }
 

--- a/core/view/src/plugins/template-plugin.ts
+++ b/core/view/src/plugins/template-plugin.ts
@@ -1,4 +1,4 @@
-import { SyncWaterfallHook } from 'tapable';
+import { SyncWaterfallHook } from 'tapable-ts';
 import type { Parser, Node } from '../parser';
 import { NodeType } from '../parser';
 import type { ViewPlugin } from '.';
@@ -32,9 +32,8 @@ export default class TemplatePlugin implements ViewPlugin {
 
   hooks = {
     resolveTemplateSubstitutions: new SyncWaterfallHook<
-      TemplateSubstitution[],
-      TemplateItemInfo
-    >(['currentSubstitutions', 'templateItemInfo']),
+      [TemplateSubstitution[], TemplateItemInfo]
+    >(),
   };
 
   constructor(options: Options) {

--- a/core/view/src/resolver/index.ts
+++ b/core/view/src/resolver/index.ts
@@ -1,4 +1,4 @@
-import { SyncWaterfallHook, SyncHook } from 'tapable';
+import { SyncWaterfallHook, SyncHook } from 'tapable-ts';
 import { setIn, addLast } from 'timm';
 import dlv from 'dlv';
 import { dequal } from 'dequal';
@@ -53,53 +53,45 @@ export class Resolver {
   public readonly hooks = {
     /** A hook to allow skipping of the resolution tree for a specific node */
     skipResolve: new SyncWaterfallHook<
-      boolean,
-      Node.Node,
-      Resolve.NodeResolveOptions
-    >(['skipResolve', 'node', 'options']),
+      [boolean, Node.Node, Resolve.NodeResolveOptions]
+    >(),
 
     /** An event emitted before calculating the next update */
-    beforeUpdate: new SyncHook<Set<BindingInstance> | undefined>(['changes']),
+    beforeUpdate: new SyncHook<[Set<BindingInstance> | undefined]>(),
 
     /** An event emitted after calculating the next update */
-    afterUpdate: new SyncHook<any>(['update']),
+    afterUpdate: new SyncHook<[any]>(),
 
     /** The options passed to a node to resolve it to an object */
     resolveOptions: new SyncWaterfallHook<
-      Resolve.NodeResolveOptions,
-      Node.Node
-    >(['options', 'node']),
+      [Resolve.NodeResolveOptions, Node.Node]
+    >(),
 
     /** A hook to transform the AST node into a new AST node before resolving it */
     beforeResolve: new SyncWaterfallHook<
-      Node.Node | null,
-      Resolve.NodeResolveOptions
-    >(['node', 'options']),
+      [Node.Node | null, Resolve.NodeResolveOptions]
+    >(),
 
     /**
      * A hook to transform an AST node into it's resolved value.
      * This runs _before_ any children are resolved
      */
-    resolve: new SyncWaterfallHook<any, Node.Node, Resolve.NodeResolveOptions>([
-      'resolved',
-      'node',
-      'options',
-    ]),
+    resolve: new SyncWaterfallHook<
+      [any, Node.Node, Resolve.NodeResolveOptions]
+    >(),
 
     /**
      * A hook to transform the resolved value of an AST node.
      * This runs _after_ all children nodes are resolved
      */
     afterResolve: new SyncWaterfallHook<
-      any,
-      Node.Node,
-      Resolve.NodeResolveOptions
-    >(['resolved', 'node', 'options']),
+      [any, Node.Node, Resolve.NodeResolveOptions]
+    >(),
 
     /** Called at the very end of a node's tree being updated */
-    afterNodeUpdate: new SyncHook<Node.Node, Node.Node | undefined, NodeUpdate>(
-      ['originalNode', 'parent', 'nodeUpdate']
-    ),
+    afterNodeUpdate: new SyncHook<
+      [Node.Node, Node.Node | undefined, NodeUpdate]
+    >(),
   };
 
   /**

--- a/core/view/src/view.ts
+++ b/core/view/src/view.ts
@@ -5,7 +5,7 @@ import type {
   ValidationObject,
 } from '@player-ui/validator';
 import type { Logger } from '@player-ui/logger';
-import { SyncHook } from 'tapable';
+import { SyncHook } from 'tapable-ts';
 import type { Resolve } from './resolver';
 import { Resolver, toNodeResolveOptions } from './resolver';
 import type { Node } from './parser';
@@ -83,10 +83,10 @@ class CrossfieldProvider implements ValidationProvider {
 /** A stateful view instance from an content */
 export class ViewInstance implements ValidationProvider {
   public hooks = {
-    onUpdate: new SyncHook<ViewType>(['view']),
-    parser: new SyncHook<Parser>(['parser']),
-    resolver: new SyncHook<Resolver>(['resolver']),
-    templatePlugin: new SyncHook<TemplatePlugin>(['templatePlugin']),
+    onUpdate: new SyncHook<[ViewType]>(),
+    parser: new SyncHook<[Parser]>(),
+    resolver: new SyncHook<[Resolver]>(),
+    templatePlugin: new SyncHook<[TemplatePlugin]>(),
   };
 
   private resolver?: Resolver;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "private": true,
   "scripts": {
+    "test": "bazel test -- $(bazel query \"kind(nodejs_test, //...)\" --output label 2>/dev/null | tr '\\n' ' ')",
     "lint": "eslint --cache --ext .js,.jsx,.ts,.tsx $(scripts/pkg-roots.sh)",
     "prepare": "is-ci || husky install",
     "postinstall": "patch-package && node ./scripts/yarn-link-setup.js"
@@ -67,7 +68,6 @@
     "@types/react-redux": "^7.1.22",
     "@types/signale": "^1.4.2",
     "@types/std-mocks": "^1.0.1",
-    "@types/tapable": "^1.0.5",
     "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.1.0",
     "@typescript-eslint/parser": "^5.1.0",
@@ -172,8 +172,7 @@
     "std-mocks": "^1.0.1",
     "storybook": "^6.4.15",
     "storybook-dark-mode": "^1.0.8",
-    "tapable": "1.1.3",
-    "tapable-ts": "^0.0.2",
+    "tapable-ts": "^0.1.0",
     "terser-webpack-plugin": "^4.1.0",
     "time-fix-plugin": "^2.0.7",
     "timm": "^1.6.2",

--- a/plugins/beacon/core/BUILD
+++ b/plugins/beacon/core/BUILD
@@ -3,9 +3,8 @@ load("//:index.bzl", "javascript_pipeline")
 javascript_pipeline(
     name = "@player-ui/beacon-plugin",
     dependencies = [
-        "@npm//tapable",
+        "@npm//tapable-ts",
         "@npm//timm",
-        "@npm//@types/tapable",
     ],
     peer_dependencies = [
         "//core/player:@player-ui/player",

--- a/plugins/beacon/core/src/beacon.ts
+++ b/plugins/beacon/core/src/beacon.ts
@@ -1,4 +1,4 @@
-import { SyncBailHook, AsyncSeriesWaterfallHook, SyncHook } from 'tapable';
+import { SyncBailHook, AsyncSeriesWaterfallHook, SyncHook } from 'tapable-ts';
 import type {
   Player,
   PlayerPlugin,
@@ -85,12 +85,9 @@ export class BeaconPlugin implements PlayerPlugin {
   private expressionEvaluator?: ExpressionEvaluator;
 
   public hooks = {
-    buildBeacon: new AsyncSeriesWaterfallHook<unknown, HookArgs>([
-      'beacon',
-      'beaconArguments',
-    ]),
-    cancelBeacon: new SyncBailHook<HookArgs, boolean>(['args']),
-    publishBeacon: new SyncHook(['beacon']),
+    buildBeacon: new AsyncSeriesWaterfallHook<[unknown, HookArgs]>(),
+    cancelBeacon: new SyncBailHook<[HookArgs], boolean>(),
+    publishBeacon: new SyncHook<[any]>(),
   };
 
   constructor(options?: BeaconPluginOptions) {
@@ -102,7 +99,9 @@ export class BeaconPlugin implements PlayerPlugin {
 
     if (options?.callback) {
       this.hooks.publishBeacon.tap('BeaconCallback', (beacon: any) => {
-        if (options.callback) options.callback(beacon);
+        if (options.callback) {
+          options.callback(beacon);
+        }
       });
     }
   }
@@ -204,7 +203,7 @@ export class BeaconPlugin implements PlayerPlugin {
         logger: this.logger as Logger,
       };
       const beacon =
-        (await this.hooks.buildBeacon.promise(defaultBeacon, hookArgs)) ||
+        (await this.hooks.buildBeacon.call(defaultBeacon, hookArgs)) ||
         defaultBeacon;
       const shouldCancel = this.hooks.cancelBeacon.call(hookArgs) || false;
 

--- a/plugins/check-path/core/BUILD
+++ b/plugins/check-path/core/BUILD
@@ -5,8 +5,7 @@ javascript_pipeline(
     dependencies = [
         "//core/partial-match-registry:@player-ui/partial-match-registry",
         "@npm//dlv",
-        "@npm//tapable",
-        "@npm//@types/tapable",
+        "@npm//tapable-ts",
     ],
     test_data = [
         "//core/make-flow:@player-ui/make-flow",

--- a/plugins/computed-properties/core/BUILD
+++ b/plugins/computed-properties/core/BUILD
@@ -3,8 +3,7 @@ load("//:index.bzl", "javascript_pipeline")
 javascript_pipeline(
     name = "@player-ui/computed-properties-plugin",
     dependencies = [
-        "@npm//tapable",
-        "@npm//@types/tapable",
+        "@npm//tapable-ts",
     ],
     peer_dependencies = [
         "//core/player:@player-ui/player",

--- a/plugins/data-change-listener/core/src/index.ts
+++ b/plugins/data-change-listener/core/src/index.ts
@@ -10,6 +10,7 @@ import type {
   ExpressionEvaluator,
 } from '@player-ui/expressions';
 import type { BindingInstance, BindingParser } from '@player-ui/binding';
+import { Interceptor } from 'tapable-ts';
 
 const LISTENER_TYPES = {
   dataChange: 'dataChange.',
@@ -242,11 +243,10 @@ export class DataChangeListenerPlugin implements PlayerPlugin {
      * 3) view -> resolve ->  : all resolve hooks are called every update - the listeners should not change between data updates.
      */
     const resolveViewInterceptor = {
-      context: false,
-      call: (view: View) => {
+      call: (view: View | undefined) => {
         const playerState = player.getState();
 
-        if (playerState.status !== 'in-progress') {
+        if (playerState.status !== 'in-progress' || !view) {
           return;
         }
 

--- a/plugins/expression/core/BUILD
+++ b/plugins/expression/core/BUILD
@@ -3,8 +3,7 @@ load("//:index.bzl", "javascript_pipeline")
 javascript_pipeline(
     name = "@player-ui/expression-plugin",
     dependencies = [
-        "@npm//tapable",
-        "@npm//@types/tapable",
+        "@npm//tapable-ts",
     ],
     peer_dependencies = [
         "//core/player:@player-ui/player",

--- a/plugins/metrics/core/BUILD
+++ b/plugins/metrics/core/BUILD
@@ -4,8 +4,7 @@ javascript_pipeline(
     name = "@player-ui/metrics-plugin",
     dependencies = [
         "//plugins/beacon/core:@player-ui/beacon-plugin",
-        "@npm//tapable",
-        "@npm//@types/tapable",
+        "@npm//tapable-ts",
     ],
     peer_dependencies = [
         "//core/player:@player-ui/player",

--- a/plugins/metrics/core/src/index.test.ts
+++ b/plugins/metrics/core/src/index.test.ts
@@ -4,7 +4,6 @@ import { BeaconPlugin } from '@player-ui/beacon-plugin';
 import type { InProgressState } from '@player-ui/player';
 import { Player } from '@player-ui/player';
 import type { Flow } from '@player-ui/types';
-import type { Tap } from 'tapable';
 import type { NodeRenderMetrics } from '.';
 import {
   MetricsCorePlugin,
@@ -173,9 +172,9 @@ test('handles double updates', async () => {
 
 class MyBeaconPluginPlugin implements BeaconPluginPlugin {
   apply(beaconPlugin: BeaconPlugin) {
-    beaconPlugin.hooks.buildBeacon.tapPromise(
-      { name: 'my-beacon-plugin', context: true } as Tap,
-      async (context, beacon) => {
+    beaconPlugin.hooks.buildBeacon.tap(
+      { name: 'my-beacon-plugin', context: true },
+      async (context, beacon: any) => {
         const { renderTime } =
           (await (context as any)[MetricsViewBeaconPlugin.Symbol]) || {};
 

--- a/plugins/metrics/core/src/metrics.ts
+++ b/plugins/metrics/core/src/metrics.ts
@@ -1,5 +1,5 @@
 import type { Player, PlayerPlugin } from '@player-ui/player';
-import { SyncHook, SyncBailHook } from 'tapable';
+import { SyncHook, SyncBailHook } from 'tapable-ts';
 import type { BeaconPluginPlugin, BeaconArgs } from '@player-ui/beacon-plugin';
 import { BeaconPlugin } from '@player-ui/beacon-plugin';
 import {
@@ -112,7 +112,7 @@ export class MetricsViewBeaconPlugin implements BeaconPluginPlugin {
   apply(beaconPlugin: BeaconPlugin) {
     beaconPlugin.hooks.buildBeacon.intercept({
       context: true,
-      call: (context, beacon) => {
+      call: (context: any, beacon) => {
         if (context && (beacon as BeaconArgs).action === 'viewed') {
           context[this.symbol] = this.buildContext();
         }
@@ -251,48 +251,27 @@ export class MetricsCorePlugin implements PlayerPlugin {
   protected getTime: () => number;
 
   public readonly hooks = {
-    resolveRequestTime: new SyncBailHook<number>(['requestTime']),
+    resolveRequestTime: new SyncBailHook<[], number>(),
 
-    onFlowBegin: new SyncHook<PlayerFlowMetrics>(['update']),
-    onFlowEnd: new SyncHook<PlayerFlowMetrics>(['update']),
+    onFlowBegin: new SyncHook<[PlayerFlowMetrics]>(),
+    onFlowEnd: new SyncHook<[PlayerFlowMetrics]>(),
 
-    onInteractive: new SyncHook<Timing, PlayerFlowMetrics>([
-      'timing',
-      'update',
-    ]),
+    onInteractive: new SyncHook<[Timing, PlayerFlowMetrics]>(),
 
-    onNodeStart: new SyncHook<NodeMetrics | NodeRenderMetrics>([
-      'nodeMetrics',
-      'update',
-    ]),
-    onNodeEnd: new SyncHook<NodeMetrics | NodeRenderMetrics>([
-      'nodeMetrics',
-      'update',
-    ]),
+    onNodeStart: new SyncHook<[NodeMetrics | NodeRenderMetrics]>(),
+    onNodeEnd: new SyncHook<[NodeMetrics | NodeRenderMetrics]>(),
 
-    onRenderStart: new SyncHook<Timing, NodeRenderMetrics, PlayerFlowMetrics>([
-      'timing',
-      'nodeMetrics',
-      'update',
-    ]),
-    onRenderEnd: new SyncHook<Timing, NodeRenderMetrics, PlayerFlowMetrics>([
-      'timing',
-      'nodeMetrics',
-      'update',
-    ]),
+    onRenderStart: new SyncHook<
+      [Timing, NodeRenderMetrics, PlayerFlowMetrics]
+    >(),
+    onRenderEnd: new SyncHook<[Timing, NodeRenderMetrics, PlayerFlowMetrics]>(),
 
-    onUpdateStart: new SyncHook<Timing, NodeRenderMetrics, PlayerFlowMetrics>([
-      'timing',
-      'nodeMetrics',
-      'update',
-    ]),
-    onUpdateEnd: new SyncHook<Timing, NodeRenderMetrics, PlayerFlowMetrics>([
-      'timing',
-      'nodeMetrics',
-      'update',
-    ]),
+    onUpdateStart: new SyncHook<
+      [Timing, NodeRenderMetrics, PlayerFlowMetrics]
+    >(),
+    onUpdateEnd: new SyncHook<[Timing, NodeRenderMetrics, PlayerFlowMetrics]>(),
 
-    onUpdate: new SyncHook<PlayerFlowMetrics>(['update']),
+    onUpdate: new SyncHook<[PlayerFlowMetrics]>(),
   };
 
   private metrics: PlayerFlowMetrics = {};
@@ -321,7 +300,7 @@ export class MetricsCorePlugin implements PlayerPlugin {
 
     callbacks.forEach((hookName) => {
       if (options?.[hookName] !== undefined) {
-        this.hooks[hookName].tap('options', options?.[hookName] as any);
+        (this.hooks[hookName] as any).tap('options', options?.[hookName]);
       }
     });
   }
@@ -472,7 +451,7 @@ export class MetricsCorePlugin implements PlayerPlugin {
       this.metrics = {
         flow: {
           id: flow.id,
-          requestTime,
+          requestTime: requestTime ?? undefined,
           timeline: [],
           startTime,
           completed: false,

--- a/plugins/partial-match-fingerprint/core/BUILD
+++ b/plugins/partial-match-fingerprint/core/BUILD
@@ -3,8 +3,7 @@ load("//:index.bzl", "javascript_pipeline")
 javascript_pipeline(
     name = "@player-ui/partial-match-fingerprint-plugin",
     dependencies = [
-        "@npm//tapable",
-        "@npm//@types/tapable",
+        "@npm//tapable-ts",
     ],
     peer_dependencies = [
         "//core/player:@player-ui/player",

--- a/plugins/pubsub/core/BUILD
+++ b/plugins/pubsub/core/BUILD
@@ -3,8 +3,7 @@ load("//:index.bzl", "javascript_pipeline")
 javascript_pipeline(
     name = "@player-ui/pubsub-plugin",
     dependencies = [
-        "@npm//tapable",
-        "@npm//@types/tapable",
+        "@npm//tapable-ts",
         "@npm//pubsub-js",
         "@npm//@types/pubsub-js",
     ],

--- a/plugins/shared-constants/core/BUILD
+++ b/plugins/shared-constants/core/BUILD
@@ -3,8 +3,7 @@ load("//:index.bzl", "javascript_pipeline")
 javascript_pipeline(
     name = "@player-ui/shared-constants-plugin",
     dependencies = [
-        "@npm//tapable",
-        "@npm//@types/tapable",
+        "@npm//tapable-ts",
         "@npm//dlv",
     ],
     test_data = [

--- a/plugins/types-provider/core/BUILD
+++ b/plugins/types-provider/core/BUILD
@@ -3,8 +3,7 @@ load("//:index.bzl", "javascript_pipeline")
 javascript_pipeline(
     name = "@player-ui/types-provider-plugin",
     dependencies = [
-        "@npm//tapable",
-        "@npm//@types/tapable",
+        "@npm//tapable-ts",
     ],
     test_data = [
         "//core/make-flow:@player-ui/make-flow",

--- a/react/player/BUILD
+++ b/react/player/BUILD
@@ -11,8 +11,7 @@ javascript_pipeline(
         "//react/subscribe:@player-ui/react-subscribe",
         "//react/utils:@player-ui/react-utils",
         "@npm//react-error-boundary",
-        "@npm//tapable",
-        "@npm//@types/tapable",
+        "@npm//tapable-ts"
     ],
     test_data = [
         "//core/make-flow:@player-ui/make-flow",

--- a/react/player/src/player.tsx
+++ b/react/player/src/player.tsx
@@ -11,7 +11,7 @@ import type { AssetRegistryType } from '@player-ui/react-asset';
 import { AssetContext } from '@player-ui/react-asset';
 import { ErrorBoundary } from 'react-error-boundary';
 import { PlayerContext } from '@player-ui/react-utils';
-import { SyncWaterfallHook, AsyncParallelHook } from 'tapable';
+import { SyncWaterfallHook, AsyncParallelHook } from 'tapable-ts';
 import { Subscribe, useSubscribedState } from '@player-ui/react-subscribe';
 import { Registry } from '@player-ui/partial-match-registry';
 
@@ -84,20 +84,21 @@ export class WebPlayer {
     /**
      * A hook to create a React Component to be used for Player, regardless of the current flow state
      */
-    webComponent: new SyncWaterfallHook<React.ComponentType>(['webComponent']),
+    webComponent: new SyncWaterfallHook<[React.ComponentType]>(),
 
     /**
      * A hook to create a React Component that's used to render a specific view.
      * It will be called for each view update from the core player.
      * Typically this will just be `Asset`
      */
-    playerComponent: new SyncWaterfallHook<React.ComponentType<WebPlayerProps>>(
-      ['playerComponent']
-    ),
+    playerComponent: new SyncWaterfallHook<
+      [React.ComponentType<WebPlayerProps>]
+    >(),
+
     /**
      * A hook to execute async tasks before the view resets to undefined
      */
-    onBeforeViewReset: new AsyncParallelHook(),
+    onBeforeViewReset: new AsyncParallelHook<[]>(),
   };
 
   private viewUpdateSubscription = new Subscribe<View>();
@@ -229,7 +230,7 @@ export class WebPlayer {
       this.options.suspend && this.hooks.onBeforeViewReset.isUsed();
 
     return this.viewUpdateSubscription.reset(
-      shouldCallResetHook ? this.hooks.onBeforeViewReset.promise() : undefined
+      shouldCallResetHook ? this.hooks.onBeforeViewReset.call() : undefined
     );
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -190,7 +190,7 @@
     eslint-visitor-keys "^2.1.0"
     semver "^6.3.0"
 
-"@babel/generator@^7.12.11", "@babel/generator@^7.12.5", "@babel/generator@^7.16.7", "@babel/generator@^7.16.8", "@babel/generator@^7.7.2":
+"@babel/generator@^7.12.11", "@babel/generator@^7.12.5", "@babel/generator@^7.16.8", "@babel/generator@^7.7.2":
   version "7.16.8"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.16.8.tgz#359d44d966b8cd059d543250ce79596f792f2ebe"
   integrity sha512-1ojZwE9+lOXzcWdWmO6TbUzDfqLD39CmEhN8+2cX9XkDo5yW1OpgfejfliysR2AWLpMamTiOiAp/mtroaymhpw==
@@ -3028,11 +3028,6 @@
     "@octokit/request" "^5.6.0"
     "@octokit/types" "^6.0.3"
     universal-user-agent "^6.0.0"
-
-"@octokit/openapi-types@^11.2.0":
-  version "11.2.0"
-  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-11.2.0.tgz#b38d7fc3736d52a1e96b230c1ccd4a58a2f400a6"
-  integrity sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA==
 
 "@octokit/openapi-types@^12.7.0":
   version "12.8.0"
@@ -10767,7 +10762,7 @@ ignore@^4.0.3, ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.1, ignore@^5.1.4, ignore@^5.1.8, ignore@^5.2.0:
+ignore@^5.1.1, ignore@^5.1.8, ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
@@ -14795,7 +14790,7 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
-pirates@^4.0.0, pirates@^4.0.1, pirates@^4.0.4, pirates@^4.0.5:
+pirates@^4.0.1, pirates@^4.0.4, pirates@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.5.tgz#feec352ea5c3268fb23a37c702ab1699f35a5f3b"
   integrity sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==
@@ -17915,12 +17910,12 @@ taketalk@^1.0.0:
     get-stdin "^4.0.1"
     minimist "^1.1.0"
 
-tapable-ts@^0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/tapable-ts/-/tapable-ts-0.0.2.tgz#b34b20e886c245c08f16afb01b9109cf69b1e005"
-  integrity sha512-B8dDqg2etehxsdgzZCM94/dadDSroNF1ZxD6zkU7NWuL7WLpP879K00pEmIhnXAGUkFMygNC2TuKo3YbTRByZQ==
+tapable-ts@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/tapable-ts/-/tapable-ts-0.1.0.tgz#9ea393d3f5ed9c998ac1d5cff81a2293569ac47e"
+  integrity sha512-pLNOGWrzcm+cc4UnyqEFK+k+thwJtJiuugKnsTrj7WPah4oZTnwDxKVNx9jhP6+RVfDOghaDIc14B5aXfV8wfQ==
 
-tapable@1.1.3, tapable@^1.0.0, tapable@^1.1.3:
+tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==


### PR DESCRIPTION
Moving from `tapable` to `tapable-ts`. 

This will help us out later on when we introduce a plugin-manager and better cross-platform consistency 