### PR TITLE
dont persist everything, just the ios-build-number

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - .
+            - .ios-build-number
 
       - store_artifacts:
           path: bazel-bin/PlayerUI_Pod.zip


### PR DESCRIPTION
only really need to persist the `.ios-build-number`, not sure if this is why the release stage cant attach the workspace, but maybe