### PR TITLE
revert the multiline command and source bashrc per needed command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,11 +258,8 @@ jobs:
 
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
       - run: echo -e $GPG_KEY | gpg --import --batch
-      - run: |
-            source ~/.bashrc
-            bundle install
-            export CIRCLE_BUILD_NUMBER=$(cat .ios-build-number)
-            npx auto shipit --only-graduate-with-release-label -vv
+      - run: source ~/.bashrc && bundle install
+      - run: source ~/.bashrc && CIRCLE_BUILD_NUMBER=$(cat .ios-build-number) npx auto shipit --only-graduate-with-release-label -vv
 
 workflows:
   build_and_test_pr:


### PR DESCRIPTION
`bundle` wasn't found in the image when using multiline with one bash sourcing