### PR TITLE
remove version prefix

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -2,6 +2,7 @@
   "author": "intuit-svc <opensource-svc@intuit.com>",
   "baseBranch": "main",
   "versionBranches": true,
+  "noVersionPrefix": true,
   "plugins": [
     [
       "upload-assets",


### PR DESCRIPTION
CocoaPods doesn't allow it

Maven also shouldn't have it

NPM seems to strip it internally