### PR TITLE
persist iOS zip from iOS part of build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,6 +156,7 @@ jobs:
           root: .
           paths:
             - .ios-build-number
+            - bazel-bin/PlayerUI_Pod.zip
 
       - store_artifacts:
           path: bazel-bin/PlayerUI_Pod.zip


### PR DESCRIPTION
the `upload-assets` plugin for auto apparently does not care if the file does not exist