### PR TITLE
add delay before screenshotting for animations to finish

### DIFF
--- a/ios/packages/reference-assets/UITests/ActionAssetUITests.swift
+++ b/ios/packages/reference-assets/UITests/ActionAssetUITests.swift
@@ -3,29 +3,29 @@ import EyesXCUI
 
 class ActionAssetUITests: BaseTestCase {
     func testActionCounter() {
-        withEyes("action counter") { eyes in
+        withEyes("action counter") { check in
             waitFor(app.buttons["action"])
-            eyes?.checkApp(withTag: "Page Load")
+            check("Page Load")
 
             tap(app.buttons["action"])
             waitFor(app.buttons["action"])
 
             let buttonText = app.buttons["action"].label
 
-            eyes?.checkApp(withTag: "After Click")
+            check("After Click")
             XCTAssertEqual(buttonText, "Clicked 1 times")
         }
     }
 
     func testActionTransitionSuccess() {
-        withEyes("action transition to end", testName: "action transition to end - success") { eyes in
+        withEyes("action transition to end", testName: "action transition to end - success") { check in
             waitFor(app.buttons["action-good"])
-            eyes?.checkApp(withTag: "Page Load")
+            check("Page Load")
 
             tap(app.buttons["action-good"])
 
             waitFor(app.alerts["FlowFinished"])
-            eyes?.checkApp(withTag: "After Click")
+            check("After Click")
             XCTAssertTrue(app.alerts["FlowFinished"].exists)
 
             XCTAssertEqual(app.alerts["FlowFinished"].staticTexts.element(boundBy: 1).label, "done")
@@ -33,14 +33,14 @@ class ActionAssetUITests: BaseTestCase {
     }
 
     func testActionTransitionError() {
-        withEyes("action transition to end", testName: "action transition to end - error") { eyes in
+        withEyes("action transition to end", testName: "action transition to end - error") { check in
             waitFor(app.buttons["action-bad"])
-            eyes?.checkApp(withTag: "Page Load")
+            check("Page Load")
 
             tap(app.buttons["action-bad"])
 
             waitFor(app.alerts["FlowFinished"])
-            eyes?.checkApp(withTag: "After Click")
+            check("After Click")
             XCTAssertTrue(app.alerts["FlowFinished"].exists)
 
             XCTAssertTrue(app.alerts["FlowFinished"].staticTexts.element(boundBy: 1).label.contains("Unclosed brace"))

--- a/ios/packages/reference-assets/UITests/BaseTestCase.swift
+++ b/ios/packages/reference-assets/UITests/BaseTestCase.swift
@@ -68,17 +68,22 @@ class BaseTestCase: AssetUITestCase {
         }
     }
 
-    func withEyes(_ mockName: String, testName: String? = nil, body: (Eyes?) -> Void) {
+    func withEyes(_ mockName: String, testName: String? = nil, body: (ApplitoolsCheck) -> Void) {
         openFlow(mockName)
-        guard key != nil else { return body(nil) }
+        guard key != nil else { return body({ _ in }) }
         eyes.open(withApplicationName: "iOS Reference Assets", testName: "\(testName ?? mockName)")
-        body(eyes)
+        body({ tag in
+            XCTWaiter.delay()
+            eyes.checkApp(withTag: tag)
+        })
     }
 
     func withOutEyes(_ mockName: String, body: () -> Void) {
         openFlow(mockName)
         body()
     }
+
+    public typealias ApplitoolsCheck = (String) -> Void
 }
 
 extension Eyes {
@@ -88,5 +93,12 @@ extension Eyes {
         } else {
             self.checkWindow(withTag: tag)
         }
+    }
+}
+
+extension XCTWaiter {
+    @discardableResult
+    static func delay(ms duration: TimeInterval = 0.5) -> XCTWaiter.Result {
+        wait(for: [XCTestExpectation(description: "Fixed Delay")], timeout: duration)
     }
 }

--- a/ios/packages/reference-assets/UITests/CollectionAssetUITests.swift
+++ b/ios/packages/reference-assets/UITests/CollectionAssetUITests.swift
@@ -2,9 +2,9 @@ import XCTest
 
 class CollectionAssetUITests: BaseTestCase {
     func testBasicCollection() {
-        withEyes("collection basic") { eyes in
+        withEyes("collection basic") { check in
             waitFor(app.otherElements["view-1"])
-            eyes?.checkApp(withTag: "Page Load")
+            check("Page Load")
             let value1 = app.staticTexts["text-1"].label
             let value2 = app.staticTexts["text-2"].label
 

--- a/ios/packages/reference-assets/UITests/InfoAssetUITests.swift
+++ b/ios/packages/reference-assets/UITests/InfoAssetUITests.swift
@@ -3,14 +3,14 @@ import XCTest
 
 class InfoAssetUITests: BaseTestCase {
     func testInfoBasic() {
-        withEyes("info basic") { eyes in
+        withEyes("info basic") { check in
             waitFor(app.buttons["next-action"])
 
-            eyes?.checkApp(withTag: "Page Load")
+            check("Page Load")
 
             tap(app.buttons["next-action"])
 
-            eyes?.checkApp(withTag: "Flow End")
+            check("Flow End")
         }
     }
 }

--- a/ios/packages/reference-assets/UITests/InputAssetUITests.swift
+++ b/ios/packages/reference-assets/UITests/InputAssetUITests.swift
@@ -2,18 +2,18 @@ import XCTest
 
 class InputAssetUITests: BaseTestCase {
     func testBasicInput() {
-        withEyes("input basic") { eyes in
+        withEyes("input basic") { check in
             let enteredValue = "Hello World"
 
             waitFor(app.textFields["input"])
-            eyes?.checkApp(withTag: "Page Load")
+            check("Page Load")
             app.textFields["input"].firstMatch.tap()
             app.textFields["input"].firstMatch.typeText(enteredValue)
             app.textFields["input"].firstMatch.typeText("\n")
 
             waitFor(app.textFields["input"])
 
-            eyes?.checkApp(withTag: "Text Entered")
+            check("Text Entered")
 
             let labelValue = app.textFields["input"].firstMatch.value as? String
 
@@ -22,12 +22,12 @@ class InputAssetUITests: BaseTestCase {
     }
 
     func testInputValidation() {
-        withEyes("input validation") { eyes in
+        withEyes("input validation") { check in
             let enteredValue = "Hello World"
 
             waitFor(app.textFields["input-1"])
 
-            eyes?.checkApp(withTag: "Page Load")
+            check("Page Load")
 
             app.textFields["input-1"].firstMatch.tap()
             app.textFields["input-1"].firstMatch.typeText(enteredValue)
@@ -36,7 +36,7 @@ class InputAssetUITests: BaseTestCase {
             waitFor(app.textFields["input-1"])
             XCTAssertTrue(app.staticTexts["input-1-validation"].firstMatch.exists)
 
-            eyes?.checkApp(withTag: "input 1 validation active")
+            check("input 1 validation active")
 
             app.textFields["input-1"].firstMatch.tap()
             app.textFields["input-1"].firstMatch.typeText("55")
@@ -44,7 +44,7 @@ class InputAssetUITests: BaseTestCase {
 
             waitFor(app.textFields["input-1"])
             XCTAssertFalse(app.staticTexts["input-1-validation"].firstMatch.exists)
-            eyes?.checkApp(withTag: "input 1 validation inactive")
+            check("input 1 validation inactive")
         }
     }
 }

--- a/ios/packages/reference-assets/UITests/TextAssetUITests.swift
+++ b/ios/packages/reference-assets/UITests/TextAssetUITests.swift
@@ -2,9 +2,9 @@ import XCTest
 
 class TextAssetUITests: BaseTestCase {
     func testBasicText() {
-        withEyes("text basic") { eyes in
+        withEyes("text basic") { check in
             waitFor(app.staticTexts["text-1"])
-            eyes?.checkApp(withTag: "Page Load")
+            check("Page Load")
             let text = app.staticTexts["text-1"].label
             XCTAssertEqual(text, "This is some text.")
 


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

<!-- 
    Does the change need more description than just he PR title? 
    Uncomment the line below and write some release notes 
-->

tweak how applitools screenshots are done so they all have an implicit wait time to allow for the UI to complete animations

<!-- ## Release Notes -->
<!-- <release notes here> -->