### PR TITLE
[iOS] add registerPlugin(_:) to HeadlessPlayer API

### DIFF
--- a/ios/packages/core/Sources/Player/HeadlessPlayer.swift
+++ b/ios/packages/core/Sources/Player/HeadlessPlayer.swift
@@ -202,6 +202,15 @@ public extension HeadlessPlayer {
             ]])
     }
 
+    /// Registers a plugin with player after instantiation
+    /// Primarily for plugins to be able to add other plugins to player
+    /// - Parameter plugin: The plugin to register
+    func registerPlugin<P: JSBasePlugin>(_ plugin: P) {
+        assert(jsPlayerReference != nil, "Cannot register plugins before setuPlayer(context:plugins:) is called")
+        plugin.context = jsPlayerReference?.context
+        jsPlayerReference?.invokeMethod("registerPlugin", withArguments: [plugin.pluginRef as Any])
+    }
+
     /**
      Starts Player for the given flow
      - parameters:

--- a/ios/packages/core/Tests/HeadlessPlayerTests.swift
+++ b/ios/packages/core/Tests/HeadlessPlayerTests.swift
@@ -155,6 +155,25 @@ class HeadlessPlayerTests: XCTestCase {
         XCTAssertNotNil(state.controllers)
     }
 
+    func testRegisterPlugin() {
+        class RegisterMePlugin: JSBasePlugin {
+            convenience init() {
+                self.init(fileName: "", pluginName: "")
+            }
+
+            override func setup(context: JSContext) {}
+        }
+        let player = HeadlessPlayerImpl(plugins: [])
+
+        player.start(flow: FlowData.COUNTER) { _ in  }
+
+        let plugin = RegisterMePlugin()
+
+        player.registerPlugin(plugin)
+
+        XCTAssertNotNil(plugin.context)
+    }
+
     func testEmptyFlowObject() {
         let player = HeadlessPlayerImpl(plugins: [])
         player.start(flow: "{}") { (result) in


### PR DESCRIPTION
Primarily to enable plugins to register other plugins that have a JS resource 