### PR TITLE
[iOS] make some additional properties public

### DIFF
--- a/ios/packages/core/Sources/Types/Assets/BaseAssetRegistry.swift
+++ b/ios/packages/core/Sources/Types/Assets/BaseAssetRegistry.swift
@@ -174,10 +174,10 @@ open class BaseAssetRegistry<WrapperType>: PlayerRegistry where
     }
 }
 
-struct RegistryDecodeShim<Asset>: Decodable {
+public struct RegistryDecodeShim<Asset>: Decodable {
     let asset: Asset
 
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let decodeFunction: DecodeAssetFunction<Asset> = try decoder.getDecodeAssetFunction()
         asset = try decodeFunction(decoder)
     }
@@ -213,7 +213,7 @@ typealias DecodeAssetFunction<Asset> = ((Decoder) throws -> Asset)
 
 extension Decoder {
     /// A logger that can be used to track useful decoding details
-    var logger: TapableLogger? { userInfo[.logger] as? TapableLogger }
+    public var logger: TapableLogger? { userInfo[.logger] as? TapableLogger }
 
     /**
      Retrieves a `DecodeAssetFunction<Asset>` if the decoder has one
@@ -228,7 +228,7 @@ extension Decoder {
 
     /// Returns the JSValue found at the current coding path, or throws an error if decoding was not started
     /// with `JSONDecoder.decoder(_:from:)` provided a `JSValue` value.
-    func getJSValue() throws -> JSValue {
+    public func getJSValue() throws -> JSValue {
         guard let rootJS = userInfo[.rootJS] as? JSValue else {
             throw DecodingError.decoderNotAnAssetDecoder
         }

--- a/ios/packages/core/Sources/Types/Beacon.swift
+++ b/ios/packages/core/Sources/Types/Beacon.swift
@@ -22,6 +22,25 @@ public struct AssetBeacon: Codable {
 
     /// Any additional data to add to the beacon payload
     public var data: AnyType?
+
+
+    /// Constructs an AssetBeacon
+    /// - Parameters:
+    ///   - action: The action taken for the beacon
+    ///   - element: The kind of element that fired the beacon
+    ///   - asset: A minimal representation of the asset that fired the beacon
+    ///   - data: Arbitrary additional data to add to the beacon payload
+    public init(
+        action: String,
+        element: String,
+        asset: BeaconableAsset,
+        data: AnyType?
+    ) {
+        self.action = action
+        self.element = element
+        self.asset = asset
+        self.data = data
+    }
 }
 
 /// Container Object for matching the data type for the JS Beacon Plugin
@@ -34,6 +53,22 @@ public struct BeaconableAsset: Codable {
 
     /// The metaData of the asset that fired the beacon
     public var metaData: MetaData?
+
+
+    /// Constructs a BeaconableAsset
+    /// - Parameters:
+    ///   - id: The ID of the asset that fired the beacon
+    ///   - type: The type of the asset that fired the beacon
+    ///   - metaData: Beacon applicable metaData from the asset that fired the beacon
+    public init(
+        id: String,
+        type: String?,
+        metaData: MetaData?
+    ) {
+        self.id = id
+        self.type = type
+        self.metaData = metaData
+    }
 }
 
 /**

--- a/ios/packages/core/Sources/Types/Beacon.swift
+++ b/ios/packages/core/Sources/Types/Beacon.swift
@@ -23,7 +23,6 @@ public struct AssetBeacon: Codable {
     /// Any additional data to add to the beacon payload
     public var data: AnyType?
 
-
     /// Constructs an AssetBeacon
     /// - Parameters:
     ///   - action: The action taken for the beacon
@@ -53,7 +52,6 @@ public struct BeaconableAsset: Codable {
 
     /// The metaData of the asset that fired the beacon
     public var metaData: MetaData?
-
 
     /// Constructs a BeaconableAsset
     /// - Parameters:

--- a/ios/packages/core/Sources/Types/Beacon.swift
+++ b/ios/packages/core/Sources/Types/Beacon.swift
@@ -33,7 +33,7 @@ public struct AssetBeacon: Codable {
         action: String,
         element: String,
         asset: BeaconableAsset,
-        data: AnyType?
+        data: AnyType? = nil
     ) {
         self.action = action
         self.element = element
@@ -60,8 +60,8 @@ public struct BeaconableAsset: Codable {
     ///   - metaData: Beacon applicable metaData from the asset that fired the beacon
     public init(
         id: String,
-        type: String?,
-        metaData: MetaData?
+        type: String? = nil,
+        metaData: MetaData? = nil
     ) {
         self.id = id
         self.type = type

--- a/ios/plugins/BaseBeaconPlugin/Sources/BaseBeaconPlugin.swift
+++ b/ios/plugins/BaseBeaconPlugin/Sources/BaseBeaconPlugin.swift
@@ -34,9 +34,10 @@ public struct DefaultBeacon: Decodable {
  */
 open class BaseBeaconPlugin<BeaconStruct: Decodable>: JSBasePlugin {
     /// The callback to call when a beacon is fired from the plugin
-    var callback: ((BeaconStruct) -> Void)?
+    public var callback: ((BeaconStruct) -> Void)?
 
-    var plugins: [JSBasePlugin] = []
+    /// BeaconPluginPlugin's to use for this BeaconPlugin
+    public var plugins: [JSBasePlugin] = []
 
     /**
      Constructs a BeaconPlugin

--- a/ios/plugins/ExternalActionPlugin/Tests/ExternalActionPluginTests.swift
+++ b/ios/plugins/ExternalActionPlugin/Tests/ExternalActionPluginTests.swift
@@ -114,9 +114,8 @@ class ExternalActionPluginTests: XCTestCase {
         let player = HeadlessPlayerImpl(plugins: [plugin])
 
         player.start(flow: json) { (result) in
-            guard result != nil else { return }
             switch result {
-            case .success(let state):
+            case .success:
                 XCTFail("flow should have failed")
             case .failure:
                 completionExpectation.fulfill()


### PR DESCRIPTION
- Adds public initializer to Beacon related structs that is necessary for some custom beacon usage
- Make properties on BaseBeaconPlugin public for implementing BeaconPlugin for non-SwiftUI usage
- Makes some registry types/members public for custom registry implementations, such as for a headless test player