### PR TITLE
[iOS] relax requirements for sending beacon metadata

### DIFF
--- a/ios/packages/core/Sources/Types/Beacon.swift
+++ b/ios/packages/core/Sources/Types/Beacon.swift
@@ -42,6 +42,12 @@ public struct AssetBeacon: Codable {
     }
 }
 
+/// MetaData requirements for `BaseBeaconPlugin` and its extensions
+public protocol BeaconableMetaData {
+    /// Additional data to include when beaconing this asset
+    var beacon: AnyType? { get set }
+}
+
 /// Container Object for matching the data type for the JS Beacon Plugin
 public struct BeaconableAsset: Codable {
     /// The ID of the asset that fired the beacon
@@ -58,16 +64,31 @@ public struct BeaconableAsset: Codable {
     ///   - id: The ID of the asset that fired the beacon
     ///   - type: The type of the asset that fired the beacon
     ///   - metaData: Beacon applicable metaData from the asset that fired the beacon
-    public init(
+    public init<MetaDataType: BeaconableMetaData>(
         id: String,
         type: String? = nil,
-        metaData: MetaData? = nil
+        metaData: MetaDataType? = nil
     ) {
         self.id = id
         self.type = type
-        self.metaData = metaData
+        self.metaData = MetaData(beacon: metaData?.beacon)
+    }
+
+    /// Constructs a BeaconableAsset
+    /// - Parameters:
+    ///   - id: The ID of the asset that fired the beacon
+    ///   - type: The type of the asset that fired the beacon
+    public init(
+        id: String,
+        type: String? = nil
+    ) {
+        self.id = id
+        self.type = type
+        self.metaData = nil
     }
 }
+
+extension MetaData: BeaconableMetaData {}
 
 /**
  All potential Beacon Element types

--- a/ios/packages/reference-assets/Sources/SwiftUI/ActionAsset.swift
+++ b/ios/packages/reference-assets/Sources/SwiftUI/ActionAsset.swift
@@ -13,6 +13,9 @@ struct ActionData: AssetData {
     var label: WrappedAsset?
     /// A function to run in the core when this action is invoked
     var run: WrappedFunction<Void>?
+
+    /// Additional metaData for beaconing
+    var metaData: MetaData?
 }
 
 /**
@@ -40,7 +43,7 @@ struct ActionAssetView: View {
     var body: some View {
         Button(
             action: {
-                beaconContext?.beacon(action: "clicked", element: "button", id: model.data.id)
+                beaconContext?.beacon(action: "clicked", element: "button", id: model.data.id, metaData: model.data.metaData)
                 self.model.data.run?()
             },
             label: {

--- a/ios/plugins/BeaconPlugin/Sources/SwiftUIBeaconPlugin.swift
+++ b/ios/plugins/BeaconPlugin/Sources/SwiftUIBeaconPlugin.swift
@@ -54,14 +54,47 @@ public class BeaconContext: ObservableObject {
         - action: The type of action that occurred
         - element: The type of element in the asset that triggered the beacon
         - id: The ID of the asset that triggered the beacon
+        - metaData: `BeaconableMetaData` to include as extra data to the core BeaconPlugin
         - data: Additional arbitrary data to include in the beacon
      */
-    public func beacon(action: String, element: String, id: String, type: String? = nil, metaData: MetaData? = nil, data: AnyType? = nil) {
+    public func beacon<MetaDataType: BeaconableMetaData>(
+        action: String,
+        element: String,
+        id: String,
+        type: String? = nil,
+        metaData: MetaDataType? = nil,
+        data: AnyType? = nil
+    ) {
         self.beaconFn(
             AssetBeacon(
                 action: action,
                 element: element,
-                asset: BeaconableAsset(id: id, type: type, metaData: metaData),
+                asset: BeaconableAsset(id: id, type: type, metaData: metaData.map { MetaData(beacon: $0.beacon) }),
+                data: data
+            )
+        )
+    }
+
+    /**
+     Sends a beacon through the JavaScript beacon plugin
+     - parameters:
+        - action: The type of action that occurred
+        - element: The type of element in the asset that triggered the beacon
+        - id: The ID of the asset that triggered the beacon
+        - data: Additional arbitrary data to include in the beacon
+     */
+    public func beacon(
+        action: String,
+        element: String,
+        id: String,
+        type: String? = nil,
+        data: AnyType? = nil
+    ) {
+        self.beaconFn(
+            AssetBeacon(
+                action: action,
+                element: element,
+                asset: BeaconableAsset(id: id, type: type),
                 data: data
             )
         )


### PR DESCRIPTION
Sending `metaData.beacon` required decoding a specific type before, but the requirement is relaxed now to fit a protocol, and is mapped internally to a encodable structure that matches what the beacon plugin expects