### PR TITLE
[iOS] SwiftUIRegistry perf fix

### DIFF
--- a/ios/packages/core/Sources/Types/Assets/BaseAssetRegistry.swift
+++ b/ios/packages/core/Sources/Types/Assets/BaseAssetRegistry.swift
@@ -36,9 +36,6 @@ open class BaseAssetRegistry<WrapperType>: PlayerRegistry where
     WrapperType: AssetContainer,
     WrapperType.AssetType: Decodable {
 
-    /// A key for storing information in the decoder userInfo
-//    public static let decodeFunctionKey = CodingUserInfoKey(rawValue: "decodeFunction")!
-
     /// A type representing an entry in the registry
     public typealias RegistryEntry = (assetType: AssetType.Type, match: [String: Any])
 
@@ -107,8 +104,12 @@ open class BaseAssetRegistry<WrapperType>: PlayerRegistry where
         if let index = registry.firstIndex(where: { matched in
             return NSDictionary(dictionary: match).isEqual(to: matched.match)
         }) {
-            logger?.w("Overriding registration for match: \(String(describing: match))")
-            registry[index] = (assetType: asset, match: match)
+            if asset == registry[index].assetType {
+                self.logger?.t("Duplicate Registration skipped for \(String(describing: match)) asset: \(String(describing: asset))")
+            } else {
+                self.logger?.w("Overriding registration for match: \(String(describing: match))")
+                registry[index] = (assetType: asset, match: match)
+            }
         } else {
             registry.append((assetType: asset, match: match))
         }

--- a/ios/packages/swiftui/Sources/SwiftUIPlayer.swift
+++ b/ios/packages/swiftui/Sources/SwiftUIPlayer.swift
@@ -193,9 +193,9 @@ public struct SwiftUIPlayer: View, HeadlessPlayer {
         bodyContent
             .environment(\.inProgressState, (state as? InProgressState))
             // forward results from our Context along to our result binding
-            .onReceive(context.$result, perform: { result in
-                self.result = result
-            })
+            .onReceive(context.$result.debounce(for: 0.1, scheduler: RunLoop.main)) {
+                self.result = $0
+            }
             .onReceive(inspection.notice) { self.inspection.visit(self, $0) }
             .onDisappear {
                 guard unloadOnDisappear else { return }


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

When holding SwiftUIPlayer context outside of `ManagedPlayer`, it also holds the asset registry. Upon each invocation of `apply` the plugins would reregister all their assets, burning cycles in JSCore. This adds an equality check to no-op that exact duplicate registrations, rather than just checking for overriding

<!-- 
    Does the change need more description than just he PR title? 
    Uncomment the line below and write some release notes 
-->

<!-- ## Release Notes -->
<!-- <release notes here> -->