### PR TITLE
compare against tag name instead of release name

### DIFF
--- a/scripts/after-shipit-pod-push.js
+++ b/scripts/after-shipit-pod-push.js
@@ -16,7 +16,7 @@ class AfterShipItPodPush {
 
         while (!found && attempt < 10) {
           const { data } = await auto.git.github.repos.listReleases({owner: auto.config.owner, repo: auto.config.repo})
-          const release = data.find(element => element.name === newVersion)
+          const release = data.find(element => element.tag_name === newVersion)
           const { data: releaseData } = await auto.git.github.repos.getRelease({owner: auto.config.owner, repo: auto.config.repo, release_id: release.id})
           const zip = releaseData.assets.find(element => element.name === 'PlayerUI_Pod.zip' && element.state === 'uploaded')
 


### PR DESCRIPTION
Should address failure in https://app.circleci.com/pipelines/github/player-ui/player/860/workflows/37561963-1699-4d1e-a3aa-673f595cabfe/jobs/3732

For regular/prereleases the release name is the same as the tag, but not for canary, so we should compare against the tag name