### PR TITLE
add bundle property to package for targets that produce webpack bundles

### DIFF
--- a/index.bzl
+++ b/index.bzl
@@ -103,6 +103,10 @@ def javascript_pipeline(
 
     resolved_entry = entry if entry else _find_entry(root_dir, srcs)
 
+    # If library_name is defined, the package is being bundled and we should
+    # generate an entry in the package.json to point to the bundle file
+    additional_properties = ("{\"bundle\": \"./dist/%s.prod.js\"}" % name.split('/')[1]) if library_name else None
+
     js_library_pipeline(
         name = name,
         srcs = srcs,
@@ -119,6 +123,7 @@ def javascript_pipeline(
         out_dir = out_dir,
         create_package_json_opts = {
             "base_package_json": "//tools:pkg_json_template",
+            "additional_properties": additional_properties
         }
     )
 


### PR DESCRIPTION
Restores the `bundle` property in `package.json` for packages that have webpack bundles, so they can be copied easily into resource bundles for iOS