### PR TITLE
add webpack bundles to js_library_data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ jobs:
       - run: bazel sync
 
       - run: |
-          BUNDLE_TARGETS=$(bazel query "attr(name, '_Bundles', //...)" --output label 2>/dev/null | tr '\n' ' ')
+          BUNDLE_TARGETS=$(bazel query "attr(name, '^.*_Bundles$', //...)" --output label 2>/dev/null | tr '\n' ' ')
           bazel build --config=ci $BUNDLE_TARGETS
 
       - run: bazel shutdown

--- a/index.bzl
+++ b/index.bzl
@@ -120,6 +120,7 @@ def javascript_pipeline(
         test_data = include_if_unique(TEST_DATA + test_data, DATA + data),
         build_data = include_if_unique(BUILD_DATA + build_data, DATA + data),
         lint_data = include_if_unique(LINT_DATA + lint_data, DATA + data + TEST_DATA + test_data),
+        js_library_data = ["%s_Bundles" % library_name] if library_name else [],
         out_dir = out_dir,
         create_package_json_opts = {
             "base_package_json": "//tools:pkg_json_template",

--- a/xcode/Podfile
+++ b/xcode/Podfile
@@ -39,7 +39,7 @@ target 'PlayerUI_Example' do
 end
 
 plugin 'cocoapods-resource-bundle-copier', {
-  'bazelCommand' => 'bazel',
+  'bazelCommand' => 'bazel shutdown && bazel',
   'resource_map' => {
     # Core
     "PlayerUI/PlayerUI" => {


### PR DESCRIPTION
Adds the built bundles into `js_library_data` so bundles will be included in the published `dist`