### PR TITLE
Expose utils for expression LSP

### DIFF
--- a/core/player/src/expressions/__tests__/parser.test.ts
+++ b/core/player/src/expressions/__tests__/parser.test.ts
@@ -1,20 +1,22 @@
-import parse from '../parser';
+import { parseExpression } from '../parser';
 import { ExpNodeOpaqueIdentifier } from '../types';
 
 test('the happy stuff', () => {
-  expect(parse('foo')).toMatchSnapshot();
-  expect(parse('foo === bar')).toMatchSnapshot();
-  expect(parse('foo || bar')).toMatchSnapshot();
-  expect(parse('foo(bar)')).toMatchSnapshot();
-  expect(parse('{{foo}} = "bar"')).toMatchSnapshot();
-  expect(parse('{{foo}} ? "bar" : "baz"')).toMatchSnapshot();
-  expect(parse('foo[bar]')).toMatchSnapshot();
-  expect(parse('{{foo}} == "string\nwith\tbreaks"')).toMatchSnapshot();
-  expect(parse('foo = [1, 2, 3]')).toMatchSnapshot();
+  expect(parseExpression('foo')).toMatchSnapshot();
+  expect(parseExpression('foo === bar')).toMatchSnapshot();
+  expect(parseExpression('foo || bar')).toMatchSnapshot();
+  expect(parseExpression('foo(bar)')).toMatchSnapshot();
+  expect(parseExpression('{{foo}} = "bar"')).toMatchSnapshot();
+  expect(parseExpression('{{foo}} ? "bar" : "baz"')).toMatchSnapshot();
+  expect(parseExpression('foo[bar]')).toMatchSnapshot();
+  expect(
+    parseExpression('{{foo}} == "string\nwith\tbreaks"')
+  ).toMatchSnapshot();
+  expect(parseExpression('foo = [1, 2, 3]')).toMatchSnapshot();
 });
 
 test('nested binary op location', () => {
-  expect(parse('foo === bar === baz')).toStrictEqual({
+  expect(parseExpression('foo === bar === baz')).toStrictEqual({
     __id: ExpNodeOpaqueIdentifier,
     type: 'BinaryExpression',
     operator: '===',
@@ -62,32 +64,36 @@ test('nested binary op location', () => {
 });
 
 test('the bad stuff', () => {
-  expect(() => parse('{{foo')).toThrowError();
-  expect(() => parse('{{foo}')).toThrowError();
-  expect(() => parse('foo["bar"')).toThrowError();
-  expect(() => parse('foo["bar')).toThrowError();
-  expect(() => parse('foo]')).toThrowError();
-  expect(() => parse('foo = (bar')).toThrowError();
+  expect(() => parseExpression('{{foo')).toThrowError();
+  expect(() => parseExpression('{{foo}')).toThrowError();
+  expect(() => parseExpression('foo["bar"')).toThrowError();
+  expect(() => parseExpression('foo["bar')).toThrowError();
+  expect(() => parseExpression('foo]')).toThrowError();
+  expect(() => parseExpression('foo = (bar')).toThrowError();
 });
 describe('expression parser', () => {
   test('objects- in parser', () => {
-    expect(parse('{"foo": "value"}')).toMatchSnapshot();
-    expect(parse('{"foo": {{some.binding}}}')).toMatchSnapshot();
-    expect(parse('{"foo": 1 + 2}')).toMatchSnapshot();
-    expect(parse('{"foo": "value", "bar": "baz"}')).toMatchSnapshot();
+    expect(parseExpression('{"foo": "value"}')).toMatchSnapshot();
+    expect(parseExpression('{"foo": {{some.binding}}}')).toMatchSnapshot();
+    expect(parseExpression('{"foo": 1 + 2}')).toMatchSnapshot();
+    expect(parseExpression('{"foo": "value", "bar": "baz"}')).toMatchSnapshot();
     expect(
-      parse('{"foo": "value", "bar": { "baz":  "foo" }}')
+      parseExpression('{"foo": "value", "bar": { "baz":  "foo" }}')
     ).toMatchSnapshot();
-    expect(parse('publish("test", {"key": "value"})')).toMatchSnapshot();
+    expect(
+      parseExpression('publish("test", {"key": "value"})')
+    ).toMatchSnapshot();
     // no closing brace
-    expect(() => parse('{"foo": "value"')).toThrowError();
+    expect(() => parseExpression('{"foo": "value"')).toThrowError();
     // no key
-    expect(() => parse('{: "value"}')).toThrowError();
+    expect(() => parseExpression('{: "value"}')).toThrowError();
     // no value
-    expect(() => parse('{"key": }')).toThrowError();
+    expect(() => parseExpression('{"key": }')).toThrowError();
     // no colon
-    expect(() => parse('{"key" "value" }')).toThrowError();
+    expect(() => parseExpression('{"key" "value" }')).toThrowError();
     // no comma
-    expect(() => parse('{"key": "value" "key2": "value" }')).toThrowError();
+    expect(() =>
+      parseExpression('{"key": "value" "key2": "value" }')
+    ).toThrowError();
   });
 });

--- a/core/player/src/expressions/__tests__/parser.test.ts
+++ b/core/player/src/expressions/__tests__/parser.test.ts
@@ -70,6 +70,7 @@ test('the bad stuff', () => {
   expect(() => parseExpression('foo["bar')).toThrowError();
   expect(() => parseExpression('foo]')).toThrowError();
   expect(() => parseExpression('foo = (bar')).toThrowError();
+  expect(() => parseExpression('foo(')).toThrowError();
 });
 describe('expression parser', () => {
   test('objects- in parser', () => {

--- a/core/player/src/expressions/__tests__/parser.test.ts
+++ b/core/player/src/expressions/__tests__/parser.test.ts
@@ -97,3 +97,17 @@ describe('expression parser', () => {
     ).toThrowError();
   });
 });
+
+describe('graceful parsing', () => {
+  it('returns and sets the error for invalid expression', () => {
+    const parsed = parseExpression('{{foo}} = {{bar}', {
+      strict: false,
+    });
+
+    expect(parsed).toBeTruthy();
+    expect(parsed.error).toBeTruthy();
+    expect(parsed.error?.message).toBe(
+      'Unclosed brace after "bar}" at character 16'
+    );
+  });
+});

--- a/core/player/src/expressions/__tests__/utils.test.ts
+++ b/core/player/src/expressions/__tests__/utils.test.ts
@@ -1,10 +1,10 @@
-import parse from '../parser';
+import { parseExpression } from '../parser';
 import { findClosestNodeAtPosition } from '../utils';
 
 describe('findClosestNodeAtPosition', () => {
   it('finds the right nodes', () => {
     const expression = '{{foo}} = test("bar", 12, ["baz", "qux"]) + !true';
-    const parsed = parse(expression);
+    const parsed = parseExpression(expression);
 
     expect(findClosestNodeAtPosition(parsed, { character: 1 })).toStrictEqual(
       expect.objectContaining({

--- a/core/player/src/expressions/evaluator.ts
+++ b/core/player/src/expressions/evaluator.ts
@@ -1,5 +1,5 @@
 import { SyncWaterfallHook, SyncBailHook } from 'tapable-ts';
-import parse from './parser';
+import { parseExpression } from './parser';
 import * as DEFAULT_EXPRESSION_HANDLERS from './evaluator-functions';
 import { isExpressionNode } from './types';
 import type {
@@ -212,7 +212,7 @@ export class ExpressionEvaluator {
         return this._execAST(storedAST, options);
       }
 
-      const expAST = parse(matchedExp);
+      const expAST = parseExpression(matchedExp);
       this.expressionsCache.set(matchedExp, expAST);
 
       return this._execAST(expAST, options);

--- a/core/player/src/expressions/index.ts
+++ b/core/player/src/expressions/index.ts
@@ -1,3 +1,4 @@
 export * from './evaluator';
 export * from './types';
 export * from './utils';
+export * from './parser';

--- a/core/player/src/expressions/parser.ts
+++ b/core/player/src/expressions/parser.ts
@@ -797,6 +797,10 @@ export function parseExpression(
       args.push(node);
     }
 
+    if (charIndex !== termination) {
+      throwError(`Expected ${String.fromCharCode(termination)}`, index);
+    }
+
     return args;
   }
 

--- a/core/player/src/expressions/parser.ts
+++ b/core/player/src/expressions/parser.ts
@@ -195,7 +195,7 @@ function isModelRefStart(ch0: number, ch1: number) {
 }
 
 /** Parse out an expression from the string */
-export default function parseExpression(expr: string): ExpressionNode {
+export function parseExpression(expr: string): ExpressionNode {
   // `index` stores the character number we are currently at while `length` is a constant
   // All of the gobbles below will modify `index` as we move along
   const charAtFunc = expr.charAt;

--- a/core/player/src/expressions/types.ts
+++ b/core/player/src/expressions/types.ts
@@ -81,6 +81,12 @@ export interface BaseNode<T> {
 
   /** The location of the node in the source expression string */
   location?: NodeLocation;
+
+  /**
+   * The error that occurred while parsing this node
+   * This is only set if the parsing mode is set to non-strict
+   */
+  error?: Error;
 }
 
 /** A helper interface for nodes that container left and right children */


### PR DESCRIPTION
## Release Notes
- Expose `parseExpression` from the expression parser
- Adds a `strict` flag to `parseExpression` that will (when disabled) attach any parsing errors to the top-level node instead of throwing