### PR TITLE
Maven publish fix

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -43,4 +43,20 @@ if [ "$RELEASE_TYPE" == "release" ]; then
   STABLE_DOCS_BASE_PATH=$SEMVER_MAJOR bazel run --config=release //docs:deploy_docs -- --dest_dir "v$SEMVER_MAJOR"
 fi
 
-bazel run @rules_player//distribution:staged-maven-deploy -- "$RELEASE_TYPE" --package-group=com.intuit.player --legacy
+if [ "$RELEASE_TYPE" == "snapshot" ]; then
+  # Need to add snapshot identifier for snapshot releases
+  cp VERSION VERSION.bak
+  echo -n -SNAPSHOT >> VERSION
+fi
+
+readonly DEPLOY_LABELS=`bazel query --output=label "kind('deploy_maven rule', //...)"`
+# publish one package at a time to make it easier to spot any errors or warnings
+for pkg in $DEPLOY_LABELS ; do
+  bazel run $pkg -- "$RELEASE_TYPE"
+done
+
+# Cleanup
+if [ -f VERSION.bak ]; then
+  rm VERSION
+  mv VERSION.bak VERSION
+fi


### PR DESCRIPTION
This is essentially the same pr as the plugins repo fix for maven publishing, maybe player rules update is needed if this works, but it takes mostly from the player rules script
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.3.1--canary.118.4194</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.3.1--canary.118.4194
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
