### PR TITLE
dont try to push pod if its a canary release

### DIFF
--- a/scripts/after-shipit-pod-push.js
+++ b/scripts/after-shipit-pod-push.js
@@ -6,10 +6,17 @@ const { execSync } = require('child_process');
 class AfterShipItPodPush {
   name = 'after-shipit-pod-push';
 
+  wasCanary = false;
+
   apply(auto) {
+    auto.hooks.canary.tap(this.name, () => {
+      this.wasCanary = true
+    })
     auto.hooks.afterShipIt.tapPromise(this.name, async ({ dryRun, newVersion }) => {
       if (dryRun) {
-        auto.logger.log.info(`Dry run: would have pushed pod to trunk`);
+        auto.logger.log.info('Dry run: would have pushed pod to trunk');
+      } else if (this.wasCanary) {
+        auto.logger.log.info('[AfterShipItPodPush]: Canary not yet supported, skipping pod push.')
       } else {
         let found = false
         let attempt = 0


### PR DESCRIPTION
Added a flag to track if the canary hook is called, rather than spend time polling when we know there will be no tag/release
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.3.1--canary.123.4401</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.3.1--canary.123.4401
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
