### PR TITLE
Publish to Maven Central before the docs

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -29,6 +29,9 @@ bazel build --config=release //:PlayerUI_Podspec //:PlayerUI_Pod
 # VScode extension publishing
 bazel run --config=release //language/vscode-player-syntax:vscode-plugin.publish
 
+# Maven Central publishing
+bazel run @rules_player//distribution:staged-maven-deploy -- "$RELEASE_TYPE" --package-group=com.intuit.player --legacy
+
 # Running this here because it will still have the pre-release version in the VERSION file before auto cleans it up
 # Make sure to re-stamp the outputs with the BASE_PATH so nextjs knows what to do with links
 if [ "$RELEASE_TYPE" == "snapshot" ] && [ "$CURRENT_BRANCH" == "main" ]; then
@@ -42,5 +45,3 @@ if [ "$RELEASE_TYPE" == "release" ]; then
   SEMVER_MAJOR=$(cat VERSION | cut -d. -f1)
   STABLE_DOCS_BASE_PATH=$SEMVER_MAJOR bazel run --config=release //docs:deploy_docs -- --dest_dir "v$SEMVER_MAJOR"
 fi
-
-bazel run @rules_player//distribution:staged-maven-deploy -- "$RELEASE_TYPE" --package-group=com.intuit.player --legacy


### PR DESCRIPTION
Rationale: Even if docs fail to upload, the artifacts are more important since we can more easily fix docs upload manually.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.4.0--canary.129.4506</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.4.0--canary.129.4506
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
