### PR TITLE
Parse and Forward Symbols in the View Parser

### DIFF
--- a/core/player/src/view/parser/__tests__/parser.test.ts
+++ b/core/player/src/view/parser/__tests__/parser.test.ts
@@ -43,6 +43,16 @@ describe('generates the correct AST', () => {
     });
   });
 
+  test('works with objects that have symbols', () => {
+    const testSymbol = Symbol('foo');
+    expect(parser.parseObject({ [testSymbol]: 'bar' })).toStrictEqual({
+      type: NodeType.Value,
+      value: {
+        [testSymbol]: 'bar',
+      },
+    });
+  });
+
   test('works with applicability things', () => {
     expect(
       parser.parseObject({ foo: 'bar', applicability: '{{baz}}' })

--- a/core/player/src/view/parser/index.ts
+++ b/core/player/src/view/parser/index.ts
@@ -120,7 +120,13 @@ export class Parser {
 
       const objEntries = Array.isArray(localObj)
         ? localObj.map((v, i) => [i, v])
-        : Object.entries(localObj);
+        : [
+            ...Object.entries(localObj),
+            ...Object.getOwnPropertySymbols(localObj).map((s) => [
+              s,
+              (localObj as any)[s],
+            ]),
+          ];
 
       const defaultValue: NestedObj = {
         children: [],


### PR DESCRIPTION
If an Asset has a property that is keyed by a Symbol, that property is not retained in the final view output. While this can't really happen with content loaded from a JSON file, for content that is dynamically generated there may be symbols present. 