### PR TITLE
Increase Maven Central timeouts to 10 min

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -30,7 +30,7 @@ bazel build --config=release //:PlayerUI_Podspec //:PlayerUI_Pod
 bazel run --config=release //language/vscode-player-syntax:vscode-plugin.publish
 
 # Maven Central publishing
-bazel run @rules_player//distribution:staged-maven-deploy -- "$RELEASE_TYPE" --package-group=com.intuit.player --legacy
+bazel run @rules_player//distribution:staged-maven-deploy -- "$RELEASE_TYPE" --package-group=com.intuit.player --legacy --client-timeout=600 --connect-timeout=600
 
 # Running this here because it will still have the pre-release version in the VERSION file before auto cleans it up
 # Make sure to re-stamp the outputs with the BASE_PATH so nextjs knows what to do with links


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

<!-- 
    Does the change need more description than just he PR title? 
    Uncomment the line below and write some release notes 
-->

<!-- ## Release Notes -->
<!-- <release notes here> -->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.3.1--canary.134.4642</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.3.1--canary.134.4642
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
