### PR TITLE
extend AnyType cases for other primitives

### DIFF
--- a/ios/packages/core/Sources/Types/Generic/AnyType.swift
+++ b/ios/packages/core/Sources/Types/Generic/AnyType.swift
@@ -14,11 +14,29 @@ public enum AnyType: Hashable {
     /// The underlying data was a string
     case string(data: String)
 
-    /// The underlying data was a dictionary
+    /// The underlying data was a boolean
+    case bool(data: Bool)
+
+    /// The underlying data was a number
+    case number(data: Double)
+
+    /// The underlying data was a dictionary of strings
     case dictionary(data: [String: String])
+
+    /// The underlying data was a dictionary of numbers
+    case numberDictionary(data: [String: Double])
+
+    /// The underlying data was a dictionary of booleans
+    case booleanDictionary(data: [String: Bool])
 
     /// The underlying data was an array of strings
     case array(data: [String])
+
+    /// The underlying data was an array of numbers
+    case numberArray(data: [Double])
+
+    /// The underlying data was an array of booleans
+    case booleanArray(data: [Bool])
 
     /// The underlying data was not in a known format
     case unknownData
@@ -37,11 +55,29 @@ extension AnyType: Decodable {
         if let dictionary = try? decoder.singleValueContainer().decode([String: String].self) {
             self = .dictionary(data: dictionary)
             return
+        } else if let dictionary = try? decoder.singleValueContainer().decode([String: Double].self) {
+            self = .numberDictionary(data: dictionary)
+            return
+        } else if let dictionary = try? decoder.singleValueContainer().decode([String: Bool].self) {
+            self = .booleanDictionary(data: dictionary)
+            return
         } else if let stringArray = try? decoder.singleValueContainer().decode([String].self) {
             self = .array(data: stringArray)
             return
+        } else if let numberArray = try? decoder.singleValueContainer().decode([Double].self) {
+            self = .numberArray(data: numberArray)
+            return
+        } else if let boolArray = try? decoder.singleValueContainer().decode([Bool].self) {
+            self = .booleanArray(data: boolArray)
+            return
         } else if let string = try? decoder.singleValueContainer().decode(String.self) {
             self = .string(data: string)
+            return
+        } else if let bool = try? decoder.singleValueContainer().decode(Bool.self) {
+            self = .bool(data: bool)
+            return
+        } else if let number = try? decoder.singleValueContainer().decode(Double.self) {
+            self = .number(data: number)
             return
         }
         self = .unknownData
@@ -63,9 +99,21 @@ extension AnyType: Encodable {
         switch self {
         case .string(let string):
             try container.encode(string)
+        case .bool(let boolean):
+            try container.encode(boolean)
+        case .number(let number):
+            try container.encode(number)
         case .array(let stringArray):
             try container.encode(stringArray)
+        case .numberArray(let numberArray):
+            try container.encode(numberArray)
+        case .booleanArray(let booleanArray):
+            try container.encode(booleanArray)
         case .dictionary(let dictionary):
+            try container.encode(dictionary)
+        case .numberDictionary(let dictionary):
+            try container.encode(dictionary)
+        case .booleanDictionary(let dictionary):
             try container.encode(dictionary)
         default:
             try container.encodeNil()

--- a/ios/packages/core/Tests/Types/Generic/AnyTypeTests.swift
+++ b/ios/packages/core/Tests/Types/Generic/AnyTypeTests.swift
@@ -25,6 +25,48 @@ class AnyTypeTests: XCTestCase {
         }
     }
 
+    func testBoolData() {
+        let string = "true"
+        guard
+            let data = string.data(using: .utf8),
+            let anyType = try? JSONDecoder().decode(AnyType.self, from: data)
+        else { return XCTFail("could not decode") }
+        switch anyType {
+        case .bool(let result):
+            XCTAssertEqual(true, result)
+        default:
+            XCTFail("data was not string")
+        }
+    }
+
+    func testNumberDataNoDecimal() {
+        let string = "1"
+        guard
+            let data = string.data(using: .utf8),
+            let anyType = try? JSONDecoder().decode(AnyType.self, from: data)
+        else { return XCTFail("could not decode") }
+        switch anyType {
+        case .number(let result):
+            XCTAssertEqual(1, result)
+        default:
+            XCTFail("data was not string")
+        }
+    }
+
+    func testNumberDataDecimal() {
+        let string = "1.5"
+        guard
+            let data = string.data(using: .utf8),
+            let anyType = try? JSONDecoder().decode(AnyType.self, from: data)
+        else { return XCTFail("could not decode") }
+        switch anyType {
+        case .number(let result):
+            XCTAssertEqual(1.5, result)
+        default:
+            XCTFail("data was not string")
+        }
+    }
+
     func testArrayData() {
         let string = "[\"test\", \"data\"]"
         guard
@@ -34,6 +76,34 @@ class AnyTypeTests: XCTestCase {
         switch anyType {
         case .array(let result):
             XCTAssertEqual(["test", "data"], result)
+        default:
+            XCTFail("data was not array")
+        }
+    }
+
+    func testNumberArrayData() {
+        let string = "[1, 2]"
+        guard
+            let data = string.data(using: .utf8),
+            let anyType = try? JSONDecoder().decode(AnyType.self, from: data)
+        else { return XCTFail("could not decode") }
+        switch anyType {
+        case .numberArray(let result):
+            XCTAssertEqual([1, 2], result)
+        default:
+            XCTFail("data was not array")
+        }
+    }
+
+    func testBoolArrayData() {
+        let string = "[false, true]"
+        guard
+            let data = string.data(using: .utf8),
+            let anyType = try? JSONDecoder().decode(AnyType.self, from: data)
+        else { return XCTFail("could not decode") }
+        switch anyType {
+        case .booleanArray(let result):
+            XCTAssertEqual([false, true], result)
         default:
             XCTFail("data was not array")
         }
@@ -53,8 +123,36 @@ class AnyTypeTests: XCTestCase {
         }
     }
 
+    func testNumberDictionaryData() {
+        let string = "{\"key\":1}"
+        guard
+            let data = string.data(using: .utf8),
+            let anyType = try? JSONDecoder().decode(AnyType.self, from: data)
+        else { return XCTFail("could not decode") }
+        switch anyType {
+        case .numberDictionary(let result):
+            XCTAssertEqual(1, result["key"])
+        default:
+            XCTFail("data was not dictionary")
+        }
+    }
+
+    func testBoolDictionaryData() {
+        let string = "{\"key\":false}"
+        guard
+            let data = string.data(using: .utf8),
+            let anyType = try? JSONDecoder().decode(AnyType.self, from: data)
+        else { return XCTFail("could not decode") }
+        switch anyType {
+        case .booleanDictionary(let result):
+            XCTAssertEqual(false, result["key"])
+        default:
+            XCTFail("data was not dictionary")
+        }
+    }
+
     func testUnknownData() {
-        let string = "1"
+        let string = "{\"key\":\"value\", \"key2\": 2}"
         guard
             let data = string.data(using: .utf8),
             let anyType = try? JSONDecoder().decode(AnyType.self, from: data)
@@ -75,5 +173,25 @@ class AnyTypeTests: XCTestCase {
         else { return XCTFail("could not encode") }
 
         XCTAssertNotNil(data)
+    }
+
+    func testEncode() {
+        XCTAssertEqual("\"test\"", doEncode(AnyType.string(data: "test")))
+        XCTAssertEqual("1", doEncode(AnyType.number(data: 1)))
+        XCTAssertEqual("1.5", doEncode(AnyType.number(data: 1.5)))
+        XCTAssertEqual("false", doEncode(AnyType.bool(data: false)))
+        XCTAssertEqual("{\"key\":\"value\"}", doEncode(AnyType.dictionary(data: ["key": "value"])))
+        XCTAssertEqual("{\"key\":1}", doEncode(AnyType.numberDictionary(data: ["key": 1])))
+        XCTAssertEqual("{\"key\":1.5}", doEncode(AnyType.numberDictionary(data: ["key": 1.5])))
+        XCTAssertEqual("{\"key\":false}", doEncode(AnyType.booleanDictionary(data: ["key": false])))
+        XCTAssertEqual("[\"test\",\"data\"]", doEncode(AnyType.array(data: ["test", "data"])))
+        XCTAssertEqual("[1,2]", doEncode(AnyType.numberArray(data: [1, 2])))
+        XCTAssertEqual("[false,true]", doEncode(AnyType.booleanArray(data: [false, true])))
+    }
+
+    func doEncode(_ data: AnyType) -> String? {
+        let data = try? JSONEncoder().encode(data)
+        guard let data = data else { return nil }
+        return String(data: data, encoding: .utf8)
     }
 }


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

Extends `AnyType` for additional primitive data structures, numbers and booleans and arrays + dictionaries of numbers/bools

<!-- 
    Does the change need more description than just he PR title? 
    Uncomment the line below and write some release notes 
-->

<!-- ## Release Notes -->
<!-- <release notes here> -->