### PR TITLE
make ScrollPlugin public to be used outside ManagedPlayer

### DIFF
--- a/ios/packages/swiftui/Sources/ManagedPlayer/ManagedPlayer.swift
+++ b/ios/packages/swiftui/Sources/ManagedPlayer/ManagedPlayer.swift
@@ -187,11 +187,19 @@ internal struct ManagedPlayer14<Loading: View, Fallback: View>: View {
     func makePlayerView(flow: String) -> some View {
         SwiftUIPlayer(
             flow: flow,
-            plugins: plugins + [viewModel] + (handleScroll ? [ScrollPlugin()] : []),
+            plugins: plugins + [viewModel] + scrollPlugin,
             result: $viewModel.result,
             context: context,
             unloadOnDisappear: false
         )
+    }
+
+    var scrollPlugin: [NativePlugin] {
+        guard
+            plugins.filter({ $0 as? ScrollPlugin != nil }).count == 0,
+            handleScroll
+        else { return [] }
+        return [ScrollPlugin()]
     }
 }
 
@@ -289,11 +297,19 @@ internal struct ManagedPlayer13<Loading: View, Fallback: View>: View {
     func makePlayerView(flow: String) -> some View {
         SwiftUIPlayer(
             flow: flow,
-            plugins: plugins + [viewModel] + (handleScroll ? [ScrollPlugin()] : []),
+            plugins: plugins + [viewModel] + scrollPlugin,
             result: $viewModel.result,
             context: context,
             unloadOnDisappear: false
         )
+    }
+
+    var scrollPlugin: [NativePlugin] {
+        guard
+            plugins.filter({ $0 as? ScrollPlugin != nil }).count == 0,
+            handleScroll
+        else { return [] }
+        return [ScrollPlugin()]
     }
 }
 
@@ -331,21 +347,3 @@ internal final class Inspection<V> where V: View {
     }
 }
 
-class ScrollPlugin: NativePlugin {
-    var pluginName: String = "ScrollPlugin"
-
-    func apply<P>(player: P) where P: HeadlessPlayer {
-        guard let player = player as? SwiftUIPlayer else { return }
-        player.hooks?.view.tap(name: pluginName) { view in
-            if #available(iOS 14, *) {
-                return AnyView(ScrollView {
-                    ScrollViewReader { proxy in
-                        view.scrollToProxy(proxy)
-                    }
-                })
-            } else {
-                return AnyView(ScrollView { view })
-            }
-        }
-    }
-}

--- a/ios/packages/swiftui/Sources/ManagedPlayer/ScrollPlugin.swift
+++ b/ios/packages/swiftui/Sources/ManagedPlayer/ScrollPlugin.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+/// A plugin to wrap player content in a scrollview
+/// and provide `EnvironmentValues` for
+/// `\.scrollToProxy` for scrolling to elements
+/// `\.playerScrollPluginSize` for the size of the contained content
+public class ScrollPlugin: NativePlugin {
+    public var pluginName: String = "ScrollPlugin"
+
+    private let ignoredEdges: Edge.Set
+
+    /// Wraps SwiftUIPlayer content in `ScrollView`
+    /// - Parameter edgesIgnoringSafeArea: Edges to ignore for the safe area
+    public init(edgesIgnoringSafeArea: Edge.Set = []) {
+        self.ignoredEdges = edgesIgnoringSafeArea
+    }
+
+    public func apply<P>(player: P) where P: HeadlessPlayer {
+        guard let player = player as? SwiftUIPlayer else { return }
+        let ignoredEdges = self.ignoredEdges
+        player.hooks?.view.tap(name: pluginName) { view in
+            if #available(iOS 14, *) {
+                return AnyView(
+                    ScrollViewReader { proxy in
+                        ScrollView {
+                            view.scrollToProxy(proxy)
+                        }
+                    }
+                    .edgesIgnoringSafeArea(ignoredEdges)
+                    .modifier(MeasureToEnvironment(path: \.playerScrollPluginSize))
+                )
+            } else {
+                return AnyView(
+                    ScrollView { view }
+                        .edgesIgnoringSafeArea(ignoredEdges)
+                )
+            }
+        }
+    }
+}
+
+@available(iOS 14, *)
+struct MeasureToEnvironment: ViewModifier {
+    let path: WritableKeyPath<EnvironmentValues, CGSize>
+    @State var size: CGSize = .zero
+    func body(content: Content) -> some View {
+        content
+            .background(
+                GeometryReader { proxy in
+                    Color.clear
+                        .onAppear { size = proxy.size }
+                        .onChange(of: proxy.size, perform: { size = $0 })
+
+                }
+            )
+            .environment(path, size)
+    }
+}
+
+struct ScrollPluginSizeKey: EnvironmentKey {
+    static var defaultValue: CGSize = .zero
+}
+
+public extension EnvironmentValues {
+    /// The size of the ScrollView from SwiftUIPlayer ``ScrollViewPlugin``
+    var playerScrollPluginSize: CGSize {
+        get { self[ScrollPluginSizeKey.self] }
+        set { self[ScrollPluginSizeKey.self] = newValue }
+    }
+}

--- a/ios/packages/swiftui/ViewInspector/ManagedPlayer/ManagedPlayerTests.swift
+++ b/ios/packages/swiftui/ViewInspector/ManagedPlayer/ManagedPlayerTests.swift
@@ -78,6 +78,43 @@ class ManagedPlayer14Tests: ViewInspectorTestCase {
                 .vStack()
                 .first?
                 .anyView()
+                .scrollViewReader()
+                .scrollView()
+            XCTAssertNotNil(view)
+        }
+
+        wait(for: [exp2], timeout: 10)
+
+        ViewHosting.expel()
+    }
+
+    func testFlowLoadsWithSuppliedScrollPlugin() throws {
+        let player = ManagedPlayer(
+            plugins: [ReferenceAssetsPlugin(), ScrollPlugin()],
+            flowManager: AlwaysLoaded(),
+            context: .init(),
+            handleScroll: false, // Passed in ScrollPlugin should ignore this
+            onComplete: {_ in},
+            fallback: {(_) in},
+            loading: {
+                Text("Loading")
+            }
+        )
+
+        try player.inspect().anyView().view(ManagedPlayer14<Text, EmptyView>.self).vStack().group(0).color(0).callOnAppear()
+
+        ViewHosting.host(view: player)
+
+        let exp2 = player.inspection.inspect(after: 3) { view in
+            let view = try view.anyView()
+                .view(ManagedPlayer14<Text, EmptyView>.self)
+                .vStack()
+                .group(0)
+                .view(SwiftUIPlayer.self, 0)
+                .vStack()
+                .first?
+                .anyView()
+                .scrollViewReader()
                 .scrollView()
             XCTAssertNotNil(view)
         }
@@ -125,6 +162,7 @@ class ManagedPlayer14Tests: ViewInspectorTestCase {
 
 extension ManagedPlayer13: Inspectable {}
 
+@available(iOS 14, *)
 class ManagedPlayer13Tests: XCTestCase {
     func testLoadingView() throws {
         let viewModel = ManagedPlayerViewModel(
@@ -207,6 +245,43 @@ class ManagedPlayer13Tests: XCTestCase {
                 .vStack()
                 .first?
                 .anyView()
+                .scrollViewReader()
+                .scrollView()
+            XCTAssertNotNil(view)
+        }
+
+        wait(for: [exp2], timeout: 10)
+
+        ViewHosting.expel()
+    }
+
+    func testFlowLoadsWithSuppliedScrollPlugin() throws {
+        let player = ManagedPlayer13(
+            viewModel: ManagedPlayerViewModel(
+                manager: AlwaysLoaded(),
+                onComplete: {_ in}
+            ),
+            plugins: [ReferenceAssetsPlugin(), ScrollPlugin()],
+            context: .init(),
+            handleScroll: false, // ScrollPlugin passed in should ignore this
+            fallback: {(_) in},
+            loading: {
+                Text("Loading")
+            }
+        )
+
+        try player.inspect().vStack().group(0).color(0).callOnAppear()
+
+        ViewHosting.host(view: player)
+
+        let exp2 = player.inspection.inspect(after: 3) { view in
+            let view = try view.vStack()
+                .group(0)
+                .view(SwiftUIPlayer.self, 0)
+                .vStack()
+                .first?
+                .anyView()
+                .scrollViewReader()
                 .scrollView()
             XCTAssertNotNil(view)
         }
@@ -262,6 +337,7 @@ class NeverLoad: FlowManager {
 class ErrorLoaded: FlowManager {
     init() {}
     func next(_ result: CompletedState?) async throws -> NextState {
+        try await Task.sleep(nanoseconds: 500_000_000)
         throw PlayerError.jsConversionFailure
     }
 }


### PR DESCRIPTION
makes `ScrollPlugin` public to expose `\.scrollToProxy` and `\.playerScrollPluginSize` for consistent usage in and out of ManagedPlayer for scrolling