### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,8 @@ If the changes are larger (API design, architecture, etc), [opening an issue](ht
 * [yarn >= 1.22.19](https://yarnpkg.com/)
 
 * [Swift >= 5.2](https://www.swift.org/download/)
+
+_Do not upgrade macOS to Sonoma , the minimum xcode version for Sonoma is 15. Stay on Ventura to keep xcode 14.3_
 * [Xcode 14.3](https://developer.apple.com/download/all/) 
 * [Ruby >= 2.6 && <= 3.0](https://github.com/rbenv/rbenv)
 


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->
Added note to keep macOS to Ventura as the minimum version for xcode in Sonoma is xcode v15

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->