### PR TITLE
Added note to input asset

### DIFF
--- a/ios/packages/demo/Sources/MockFlows.swift
+++ b/ios/packages/demo/Sources/MockFlows.swift
@@ -774,6 +774,13 @@ static let inputBasic: String = """
           "type": "text",
           "value": "This is an input"
         }
+      },
+      "note": {
+        "asset": {
+          "id": "input-1-note",
+          "type": "text",
+          "value": "This is a note"
+        }
       }
     }
   ],

--- a/ios/packages/demo/Sources/MockFlows.swift
+++ b/ios/packages/demo/Sources/MockFlows.swift
@@ -777,7 +777,7 @@ static let inputBasic: String = """
       },
       "note": {
         "asset": {
-          "id": "input-1-note",
+          "id": "input-note",
           "type": "text",
           "value": "This is a note"
         }

--- a/ios/packages/reference-assets/Sources/SwiftUI/InfoAsset.swift
+++ b/ios/packages/reference-assets/Sources/SwiftUI/InfoAsset.swift
@@ -36,8 +36,8 @@ struct InfoAssetView: View {
     @ViewBuilder
     var body: some View {
         VStack {
-            model.data.title?.asset?.view.font(.title)
-            model.data.subTitle?.asset?.view.font(.subheadline)
+            model.data.title?.asset?.view.font(.title).padding(.bottom, 40)
+            model.data.subTitle?.asset?.view.font(.subheadline).padding(.bottom, 40)
             model.data.primaryInfo?.asset?.view
             if let actions = model.data.actions?.compactMap { $0.asset } {
                 ForEach(actions) { action in

--- a/ios/packages/reference-assets/Sources/SwiftUI/InputAsset.swift
+++ b/ios/packages/reference-assets/Sources/SwiftUI/InputAsset.swift
@@ -32,6 +32,8 @@ public struct InputData: AssetData, Equatable {
     var dataType: DataType?
     /// A validation if present on the input
     var validation: ValidationData?
+    /// An asset to use as a note for this asset
+    var note: WrappedAsset?
 }
 
 /**
@@ -87,7 +89,7 @@ struct InputAssetView: View {
     @ViewBuilder
     var body: some View {
         VStack(alignment: .leading) {
-            model.data.label?.asset?.view.foregroundColor(Color(red: 0.729, green: 0.745, blue: 0.773)).padding(.bottom, 0)
+            model.data.label?.asset?.view.foregroundColor(Color(red: 0.102, green: 0.125, blue: 0.173)).padding(.bottom, 8).font(.headline)
             TextField(
                 model.data.placeholder ?? "",
                 text: $model.text,
@@ -109,6 +111,7 @@ struct InputAssetView: View {
                 ValidationView(message: data.message, severity: data.severity, dismiss: dismissFunction)
                     .accessibility(identifier: "\(model.data.id)-validation")
             }
+            model.data.note?.asset?.view.foregroundColor(Color(red: 0.729, green: 0.745, blue: 0.773)).padding(.top, 8).font(.subheadline)
         }
     }
 }

--- a/plugins/reference-assets/mocks/input/input-basic.json
+++ b/plugins/reference-assets/mocks/input/input-basic.json
@@ -8,5 +8,12 @@
       "type": "text",
       "value": "This is an input"
     }
+  },
+  "note": {
+    "asset": {
+      "id": "input-note",
+      "type": "text",
+      "value": "This is a note"
+    }
   }
 }


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

Fixes #167 
Added a note to the iOS input asset to match web.
Changed the styling of the label on the iOS input asset to more closely match web.
Added padding underneath the info asset to match web (was affecting input transition mock flow)

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->