### PR TITLE
[Issue 162] iOS: Add footer to info reference asset

### DIFF
--- a/ios/packages/demo/Sources/MockFlows.swift
+++ b/ios/packages/demo/Sources/MockFlows.swift
@@ -307,6 +307,65 @@ static let collectionBasic: String = """
   }
 }
 """
+static let infoFooter: String = """
+{
+  "id": "generated-flow",
+  "views": [
+    {
+      "id": "info-view",
+      "type": "info",
+      "title": {
+        "asset": {
+          "id": "info-title",
+          "type": "text",
+          "value": "View Title"
+        }
+      },
+      "actions": [
+        {
+          "asset": {
+            "id": "next-action",
+            "value": "Next",
+            "type": "action",
+            "label": {
+              "asset": {
+                "id": "next-action-label",
+                "type": "text",
+                "value": "Continue"
+              }
+            }
+          }
+        }
+      ],
+      "footer": {
+        "asset": {
+          "id": "info-footer",
+          "type": "text",
+          "value": "Footer text"
+        }
+      }
+    }
+  ],
+  "data": {},
+  "navigation": {
+    "BEGIN": "FLOW_1",
+    "FLOW_1": {
+      "startState": "VIEW_1",
+      "VIEW_1": {
+        "state_type": "VIEW",
+        "ref": "info-view",
+        "transitions": {
+          "*": "END_Done"
+        }
+      },
+      "END_Done": {
+        "state_type": "END",
+        "outcome": "done"
+      }
+    }
+  }
+}
+"""
 static let infoDynamicFlow: String = """
 {
   "id": "modal-flow",
@@ -961,6 +1020,7 @@ static let textWithLink: String = """
             (name: "basic", flow: MockFlows.collectionBasic)
         ]),
         (title: "info", flows: [
+            (name: "footer", flow: MockFlows.infoFooter),
             (name: "dynamic flow", flow: MockFlows.infoDynamicFlow),
             (name: "basic", flow: MockFlows.infoBasic),
             (name: "modal flow", flow: MockFlows.infoModalFlow)

--- a/ios/packages/reference-assets/Sources/SwiftUI/InfoAsset.swift
+++ b/ios/packages/reference-assets/Sources/SwiftUI/InfoAsset.swift
@@ -16,6 +16,8 @@ struct InfoData: AssetData {
     var primaryInfo: WrappedAsset?
     /// Assets to use as actions in this asset
     var actions: [WrappedAsset]?
+    /// An asset to use as a footer for this asset
+    var footer: WrappedAsset?
 }
 
 /**
@@ -44,6 +46,7 @@ struct InfoAssetView: View {
                     action.view
                 }
             }
+            model.data.footer?.asset?.view.font(.subheadline).padding(.top, 12)
         }
         .accessibilityElement(children: .contain)
         .accessibility(identifier: model.data.id)

--- a/ios/packages/reference-assets/ViewInspector/SwiftUI/InfoAssetTests.swift
+++ b/ios/packages/reference-assets/ViewInspector/SwiftUI/InfoAssetTests.swift
@@ -79,7 +79,7 @@ class InfoAssetTests: SwiftUIAssetUnitTestCase {
 
         let stack = try view.inspect().vStack()
 
-        XCTAssertEqual(stack.count, 4)
+        XCTAssertEqual(stack.count, 5)
 
         let forEach = try stack.forEach(3)
 

--- a/plugins/reference-assets/mocks/info/info-footer.json
+++ b/plugins/reference-assets/mocks/info/info-footer.json
@@ -1,0 +1,34 @@
+{
+  "id": "info-view",
+  "type": "info",
+  "title": {
+    "asset": {
+      "id": "info-title",
+      "type": "text",
+      "value": "View Title"
+    }
+  },
+  "actions": [
+    {
+      "asset": {
+        "id": "next-action",
+        "value": "Next",
+        "type": "action",
+        "label": {
+          "asset": {
+            "id": "next-action-label",
+            "type": "text",
+            "value": "Continue"
+          }
+        }
+      }
+    }
+  ],
+  "footer": {
+    "asset": {
+      "id": "info-footer",
+      "type": "text",
+      "value": "Footer text"
+    }
+  }
+}


### PR DESCRIPTION
resolves #162 

Added optional footer asset to bottom of info reference asset, for the SwiftUI reference asset

Demo mock:

<img width="440" alt="Screenshot 2023-10-19 at 8 24 58 AM" src="https://github.com/player-ui/player/assets/75465289/4f861b20-53f9-4d69-ad96-3e29979f8aec">


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->