### PR TITLE
apply swift 6 warning fix to flaky iOS tests

### DIFF
--- a/ios/packages/swiftui/Tests/ManagedPlayer/ManagedPlayerViewModelTests.swift
+++ b/ios/packages/swiftui/Tests/ManagedPlayer/ManagedPlayerViewModelTests.swift
@@ -45,7 +45,7 @@ class ManagedPlayerViewModelTests: XCTestCase {
 
         viewModel.result = .success(state)
         try await Task.sleep(nanoseconds: 1_000_000_000)
-        wait(for: [completed], timeout: 2)
+        await fulfillment(of: [completed], timeout: 2)
     }
 
     func testViewModelSuccessMultiFlow() async throws {
@@ -223,7 +223,7 @@ class ManagedPlayerViewModelTests: XCTestCase {
 
         viewModel.result = .failure(.jsConversionFailure)
 
-        wait(for: [completed], timeout: 2)
+        await fulfillment(of: [completed], timeout: 2)
 
         cancellable.cancel()
     }


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

To hopefully address #12, Xcode15 was warning that `wait` for expecations in async context will be an error in swift 6 (not out yet), hoping that just means pre swift-6 they didnt document that it wasnt supported, and swapping will fix the flakiness

after several back to back runs, no random failures

resolves #12 

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->