### PR TITLE
iOS: remove strong self references in plugins

### DIFF
--- a/ios/plugins/BaseBeaconPlugin/Sources/BaseBeaconPlugin.swift
+++ b/ios/plugins/BaseBeaconPlugin/Sources/BaseBeaconPlugin.swift
@@ -84,7 +84,7 @@ open class BaseBeaconPlugin<BeaconStruct: Decodable>: JSBasePlugin {
         for plugin in plugins {
             plugin.context = self.context
         }
-        let callback: @convention(block) (JSValue?) -> Void = { rawBeacon in
+        let callback: @convention(block) (JSValue?) -> Void = { [weak self] rawBeacon in
             guard
                 let object = rawBeacon?.toObject(),
                 let data = try? JSONSerialization.data(withJSONObject: object),
@@ -92,7 +92,7 @@ open class BaseBeaconPlugin<BeaconStruct: Decodable>: JSBasePlugin {
                     .inject(to: JSONDecoder())
                     .decode(BeaconStruct.self, from: data)
             else { return }
-            self.callback?(beacon)
+            self?.callback?(beacon)
         }
         let jsCallback = JSValue(object: callback, in: context) as Any
         return [["callback": jsCallback, "plugins": plugins.map { $0.pluginRef }]]

--- a/ios/plugins/BeaconPlugin/Sources/SwiftUIBeaconPlugin.swift
+++ b/ios/plugins/BeaconPlugin/Sources/SwiftUIBeaconPlugin.swift
@@ -27,8 +27,9 @@ public class BeaconPlugin<BeaconStruct: Decodable>: BaseBeaconPlugin<BeaconStruc
 
     public func apply<P>(player: P) where P: HeadlessPlayer {
         guard let player = player as? SwiftUIPlayer else { return }
+        let beacon = self.beacon(assetBeacon:)
         player.hooks?.view.tap(name: "BeaconPlugin") { view in
-            AnyView(view.environment(\.beaconContext, BeaconContext(self.beacon(assetBeacon:))))
+            AnyView(view.environment(\.beaconContext, BeaconContext(beacon)))
         }
     }
 }

--- a/ios/plugins/ExpressionPlugin/Sources/ExpressionPlugin.swift
+++ b/ios/plugins/ExpressionPlugin/Sources/ExpressionPlugin.swift
@@ -31,12 +31,13 @@ public class ExpressionPlugin: JSBasePlugin, NativePlugin {
     override public func getArguments() -> [Any] {
         guard
             let map = context?.evaluateScript("Map")?.construct(withArguments: []),
-            let restWrapper = context?.evaluateScript("(fn) => (context, ...args) => fn(context, args)")
+            let restWrapper = context?.evaluateScript("(fn) => (context, ...args) => fn(context, args)"),
+            let context = self.context
         else { return [] }
         for (key, value) in expressions {
-            let callback: @convention(block) (JSValue?, JSValue?) -> JSValue? = { (context, params) in
+            let callback: @convention(block) (JSValue?, JSValue?) -> JSValue? = { (_, params) in
                 let args = params?.toObject() as? [Any] ?? []
-                return JSValue(object: value(args), in: self.context)
+                return JSValue(object: value(args), in: context)
             }
             let jsCallback = JSValue(object: callback, in: context)
             map.invokeMethod("set", withArguments: [key, restWrapper.call(withArguments: [jsCallback as Any]) as Any])

--- a/ios/plugins/ExternalActionPlugin/Sources/ExternalActionPlugin.swift
+++ b/ios/plugins/ExternalActionPlugin/Sources/ExternalActionPlugin.swift
@@ -42,13 +42,13 @@ public class ExternalActionPlugin: JSBasePlugin, NativePlugin {
      - returns: An array of arguments to construct the plugin
      */
     override public func getArguments() -> [Any] {
-            let callback: @convention(block) (JSValue, JSValue) -> JSValue? = { (state, options) in
+            let callback: @convention(block) (JSValue, JSValue) -> JSValue? = { [weak self] (state, options) in
                 guard
-                    let context = self.context,
+                    let context = self?.context,
                     let controllers = PlayerControllers(from: options),
                     let promise = JSUtilities.createPromise(context: context, handler: { (resolve, reject) in
                         do {
-                            try self.handler?(NavigationFlowExternalState(state), controllers) { transition in
+                            try self?.handler?(NavigationFlowExternalState(state), controllers) { transition in
                                 resolve(transition)
                             }
                         } catch {

--- a/ios/plugins/ExternalActionViewModifierPlugin/Sources/ExternalActionViewModifierPlugin.swift
+++ b/ios/plugins/ExternalActionViewModifierPlugin/Sources/ExternalActionViewModifierPlugin.swift
@@ -63,22 +63,22 @@ open class ExternalActionViewModifierPlugin<ModifierType: ExternalStateViewModif
      - returns: An array of arguments to construct the plugin
      */
     override open func getArguments() -> [Any] {
-        let callback: @convention(block) (JSValue, JSValue) -> JSValue? = { (state, options) in
+        let callback: @convention(block) (JSValue, JSValue) -> JSValue? = { [weak self] (state, options) in
             guard
-                let context = self.context,
+                let context = self?.context,
                 let controllers = PlayerControllers(from: options),
                 let promise = JSUtilities.createPromise(context: context, handler: { (resolve, reject) in
-                    self.isExternalState = true
+                    self?.isExternalState = true
                     let state = NavigationFlowExternalState(state)
-                    self.state = state
+                    self?.state = state
                     do {
-                        self.content = try self.handler?(state, controllers) { transition in
+                        self?.content = try self?.handler?(state, controllers) { transition in
                             resolve(transition)
                             withAnimation {
-                                self.isExternalState = false
-                                self.state = nil
+                                self?.isExternalState = false
+                                self?.state = nil
                             }
-                            self.content = nil
+                            self?.content = nil
                         }
                     } catch {
                         reject(JSValue(newErrorFromMessage: error.playerDescription, in: context) as Any)

--- a/ios/plugins/MetricsPlugin/Sources/MetricsPlugin.swift
+++ b/ios/plugins/MetricsPlugin/Sources/MetricsPlugin.swift
@@ -22,8 +22,8 @@ public class RequestTimePlugin: NativePlugin {
 
     public func apply<P>(player: P) where P: HeadlessPlayer {
         requestTimeWebPlugin.context = player.jsPlayerReference?.context
-        player.applyTo(MetricsPlugin.self) { plugin in
-            self.requestTimeWebPlugin.pluginRef?.invokeMethod("apply", withArguments: [plugin])
+        player.applyTo(MetricsPlugin.self) { [weak self] plugin in
+            self?.requestTimeWebPlugin.pluginRef?.invokeMethod("apply", withArguments: [plugin])
         }
     }
 }
@@ -74,9 +74,10 @@ public class MetricsPlugin: JSBasePlugin, NativePlugin, WithSymbol {
 
     public func apply<P>(player: P) where P: HeadlessPlayer {
         guard trackRenderTime, let player = player as? SwiftUIPlayer else { return }
+        let renderEnd = self.renderEnd
         player.hooks?.view.tap(name: pluginName, { (view) -> AnyView in
             AnyView(view.onAppear {
-                self.renderEnd()
+                renderEnd()
             })
         })
     }

--- a/ios/plugins/SwiftUICheckPathPlugin/Sources/SwiftUICheckPathPlugin.swift
+++ b/ios/plugins/SwiftUICheckPathPlugin/Sources/SwiftUICheckPathPlugin.swift
@@ -12,7 +12,7 @@ public class SwiftUICheckPathPlugin: BaseCheckPathPlugin, NativePlugin {
 
     public func apply<P>(player: P) where P: HeadlessPlayer {
         guard let player = player as? SwiftUIPlayer else { return }
-        player.hooks?.view.tap(name: self.pluginName) { view in
+        player.hooks?.view.tap(name: self.pluginName) { [weak self] view in
             AnyView(view.environment(\.checkPath, self))
         }
     }

--- a/scripts/after-shipit-pod-push.js
+++ b/scripts/after-shipit-pod-push.js
@@ -43,7 +43,7 @@ class AfterShipItPodPush {
           auto.logger.log.info('Pushing Pod to trunk')
           let process
           try {
-            process = execSync('bundle exec pod trunk push --skip-tests ./bazel-bin/PlayerUI.podspec')
+            process = execSync('bundle exec pod trunk push --verbose --skip-tests ./bazel-bin/PlayerUI.podspec')
           } catch(e) {
             auto.logger.log.error('Pod push failed: ', process && process.stderr.toString(), e)
             throw e


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->
Remove strong references to `self` in plugin closures

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.3.1--canary.209.6539</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.3.1--canary.209.6539
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
