### PR TITLE
feat/decouple back button

### DIFF
--- a/plugins/reference-assets/core/src/assets/action/__tests__/transform.test.ts
+++ b/plugins/reference-assets/core/src/assets/action/__tests__/transform.test.ts
@@ -105,7 +105,7 @@ describe('action transform', () => {
         },
       },
     });
-    expect(ref?.current?.metaData?.role).toBe(true);
+    expect(ref?.current?.metaData?.role).toBe('back');
     expect(ref.current?.id).toBe('view-1');
     ref.current?.run();
     expect(ref.current?.id).toBe('view-2');

--- a/plugins/reference-assets/core/src/assets/action/__tests__/transform.test.ts
+++ b/plugins/reference-assets/core/src/assets/action/__tests__/transform.test.ts
@@ -64,4 +64,54 @@ describe('action transform', () => {
     await (ref.player.getState() as InProgressState).flowResult;
     expect(ref.player.getState().status).toBe('completed');
   });
+
+  it('prev button transitions', async () => {
+    const ref = runTransform('action', actionTransform, {
+      id: 'test-flow',
+      views: [
+        {
+          type: 'action',
+          id: 'view-1',
+          value: 'Prev',
+        },
+        {
+          type: 'action',
+          id: 'view-2',
+          value: 'Prev',
+        },
+      ],
+      navigation: {
+        BEGIN: 'FLOW_1',
+        FLOW_1: {
+          startState: 'view_1',
+          view_1: {
+            state_type: 'VIEW',
+            ref: 'view-1',
+            transitions: {
+              '*': 'view_2',
+            },
+          },
+          view_2: {
+            state_type: 'VIEW',
+            ref: 'view-2',
+            transitions: {
+              '*': 'end',
+            },
+          },
+          end: {
+            state_type: 'END',
+            outcome: 'done',
+          },
+        },
+      },
+    });
+    expect(ref?.current?.metaData?.role).toBe(true);
+    expect(ref.current?.id).toBe('view-1');
+    ref.current?.run();
+    expect(ref.current?.id).toBe('view-2');
+    ref.current?.run();
+
+    await (ref.player.getState() as InProgressState).flowResult;
+    expect(ref.player.getState().status).toBe('completed');
+  });
 });

--- a/plugins/reference-assets/core/src/assets/action/transform.ts
+++ b/plugins/reference-assets/core/src/assets/action/transform.ts
@@ -6,6 +6,9 @@ import type {
 import { compose, composeBefore } from '@player-ui/asset-transform-plugin';
 import type { ActionAsset, TransformedAction } from './types';
 
+/**
+ *
+ */
 export function isBackAction(action: ActionAsset): boolean {
   return action.value === 'Prev';
 }
@@ -30,6 +33,28 @@ const transform: TransformFunction<ActionAsset, TransformedAction> = (
       }
     },
   };
+};
+
+/**
+ * De couples back button from the back icon
+ */
+const backIconTransform: TransformFunction<ActionAsset, ActionAsset> = (
+  action
+) => {
+  /** For previous versions of player, the back button would already have the back icon.
+   *  This ensures that the old functionality does not break and back button is still visible when they update the player.
+   */
+  if (isBackAction(action) && action?.metaData?.role === undefined) {
+    return {
+      ...action,
+      metaData: {
+        ...action?.metaData,
+        role: true,
+      },
+    };
+  }
+
+  return action;
 };
 
 /**
@@ -61,5 +86,6 @@ export const expPropTransform: BeforeTransformFunction<Asset> = (asset) => {
 
 export const actionTransform = compose(
   transform,
+  backIconTransform,
   composeBefore(expPropTransform)
 );

--- a/plugins/reference-assets/core/src/assets/action/transform.ts
+++ b/plugins/reference-assets/core/src/assets/action/transform.ts
@@ -7,7 +7,7 @@ import { compose, composeBefore } from '@player-ui/asset-transform-plugin';
 import type { ActionAsset, TransformedAction } from './types';
 
 /**
- *
+ * Function to find prev button
  */
 export function isBackAction(action: ActionAsset): boolean {
   return action.value === 'Prev';

--- a/plugins/reference-assets/core/src/assets/action/transform.ts
+++ b/plugins/reference-assets/core/src/assets/action/transform.ts
@@ -49,7 +49,7 @@ const backIconTransform: TransformFunction<ActionAsset, ActionAsset> = (
       ...action,
       metaData: {
         ...action?.metaData,
-        role: true,
+        role: 'back',
       },
     };
   }

--- a/plugins/reference-assets/core/src/assets/action/types.ts
+++ b/plugins/reference-assets/core/src/assets/action/types.ts
@@ -29,7 +29,7 @@ export interface ActionAsset<AnyTextAsset extends Asset = Asset>
     skipValidation?: boolean;
 
     /** boolean value to decide for the left anchor sign */
-    role?: boolean;
+    role?: string;
   };
 }
 

--- a/plugins/reference-assets/core/src/assets/action/types.ts
+++ b/plugins/reference-assets/core/src/assets/action/types.ts
@@ -27,6 +27,9 @@ export interface ActionAsset<AnyTextAsset extends Asset = Asset>
 
     /** Force transition to the next view without checking for validation */
     skipValidation?: boolean;
+
+    /** boolean value to decide for the left anchor sign */
+    role?: boolean;
   };
 }
 

--- a/plugins/reference-assets/core/src/assets/action/types.ts
+++ b/plugins/reference-assets/core/src/assets/action/types.ts
@@ -28,7 +28,7 @@ export interface ActionAsset<AnyTextAsset extends Asset = Asset>
     /** Force transition to the next view without checking for validation */
     skipValidation?: boolean;
 
-    /** boolean value to decide for the left anchor sign */
+    /** string value to decide for the left anchor sign */
     role?: string;
   };
 }

--- a/plugins/reference-assets/mocks/action/action-navigation.json
+++ b/plugins/reference-assets/mocks/action/action-navigation.json
@@ -28,6 +28,23 @@
         },
         {
           "asset": {
+            "id": "action-prev-without-icon",
+            "type": "action",
+            "value": "Prev",
+            "label": {
+              "asset": {
+                "id": "action-prev-id-without-icon",
+                "type": "text",
+                "value": "Go Back Without Icon"
+              }
+            },
+              "metaData": {
+                "role": false
+            }
+          }
+        },
+        {
+          "asset": {
             "id": "action-next",
             "type": "action",
             "value": "Next",

--- a/plugins/reference-assets/mocks/action/action-navigation.json
+++ b/plugins/reference-assets/mocks/action/action-navigation.json
@@ -21,9 +21,12 @@
               "asset": {
                 "id": "action-prev-id",
                 "type": "text",
-                "value": "Go Back"
+                "value": "Go Back Without Icon"
               }
-            }
+            },
+            "metaData": {
+              "role": ""
+          }
           }
         },
         {
@@ -35,11 +38,11 @@
               "asset": {
                 "id": "action-prev-id-without-icon",
                 "type": "text",
-                "value": "Go Back Without Icon"
+                "value": "Go Back With Role"
               }
             },
               "metaData": {
-                "role": false
+                "role": "back"
             }
           }
         },

--- a/plugins/reference-assets/react/src/assets/action/Action.tsx
+++ b/plugins/reference-assets/react/src/assets/action/Action.tsx
@@ -19,7 +19,7 @@ export const Action = (props: TransformedAction) => {
         variant={isBackAction(props) ? 'ghost' : 'solid'}
         {...buttonProps}
       >
-        {isBackAction(props) && <ChevronLeftIcon />}
+        {props?.metaData?.role && <ChevronLeftIcon />}
         {label && (
           <Text>
             <ReactAsset {...label} />

--- a/plugins/reference-assets/react/src/assets/action/Action.tsx
+++ b/plugins/reference-assets/react/src/assets/action/Action.tsx
@@ -19,7 +19,7 @@ export const Action = (props: TransformedAction) => {
         variant={isBackAction(props) ? 'ghost' : 'solid'}
         {...buttonProps}
       >
-        {props?.metaData?.role && <ChevronLeftIcon />}
+        {props?.metaData?.role === 'back' && <ChevronLeftIcon />}
         {label && (
           <Text>
             <ReactAsset {...label} />


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->
<img width="1703" alt="Screenshot 2023-11-05 at 11 58 40 AM" src="https://github.com/player-ui/player/assets/10923341/72c824bb-7360-4bdd-a558-58721c67acff">

https://github.com/player-ui/player/issues/169
### Change Type (required)
Indicate the type of change your pull request is:
Adds a role property inside the metaData on the action asset. This property is used to decouple the back Icon from the back button.
<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [X] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->