### PR TITLE
Return a Read Only Instance of the DataController on Player End State

### DIFF
--- a/core/player/src/__tests__/data.test.ts
+++ b/core/player/src/__tests__/data.test.ts
@@ -3,7 +3,7 @@ import { LocalModel } from '../data';
 import { ValidationMiddleware } from '../validator';
 import type { Logger } from '..';
 import { DataController } from '..';
-import { ReadOnlyDataController } from '../controllers/data/utils';
+import type { ReadOnlyDataController } from '../controllers/data/utils';
 
 test('works with basic data', () => {
   const model = {

--- a/core/player/src/controllers/data/controller.ts
+++ b/core/player/src/controllers/data/controller.ts
@@ -1,9 +1,8 @@
 import { SyncHook, SyncWaterfallHook, SyncBailHook } from 'tapable-ts';
-import { omit, removeAt } from 'timm';
 import { dequal } from 'dequal';
-import type { Logger } from '../logger';
-import type { BindingParser, BindingLike } from '../binding';
-import { BindingInstance } from '../binding';
+import type { Logger } from '../../logger';
+import type { BindingParser, BindingLike } from '../../binding';
+import { BindingInstance } from '../../binding';
 import type {
   BatchSetTransaction,
   Updates,
@@ -11,9 +10,10 @@ import type {
   DataModelWithParser,
   DataPipeline,
   DataModelMiddleware,
-} from '../data';
-import { PipelinedDataModel, LocalModel } from '../data';
-import type { RawSetTransaction } from '../types';
+} from '../../data';
+import { PipelinedDataModel, LocalModel } from '../../data';
+import type { RawSetTransaction } from '../../types';
+import { ReadOnlyDataController } from './utils';
 
 /** The orchestrator for player data */
 export class DataController implements DataModelWithParser<DataModelOptions> {
@@ -240,5 +240,9 @@ export class DataController implements DataModelWithParser<DataModelOptions> {
 
   public serialize(): object {
     return this.hooks.serialize.call(this.get(''));
+  }
+
+  public makeReadOnly(): ReadOnlyDataController {
+    return new ReadOnlyDataController(this, this.logger);
   }
 }

--- a/core/player/src/controllers/data/index.ts
+++ b/core/player/src/controllers/data/index.ts
@@ -1,0 +1,1 @@
+export * from './controller';

--- a/core/player/src/controllers/data/utils.ts
+++ b/core/player/src/controllers/data/utils.ts
@@ -1,0 +1,42 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import type { DataController } from '.';
+import type { Logger } from '../../logger';
+import type { BindingLike } from '../../binding';
+import type {
+  DataModelWithParser,
+  DataModelOptions,
+  Updates,
+} from '../../data';
+
+/** Wrapper for the Data Controller Class that prevents writes */
+export class ReadOnlyDataController
+  implements DataModelWithParser<DataModelOptions>
+{
+  private controller: DataController;
+  private logger?: Logger;
+
+  constructor(controller: DataController, logger?: Logger) {
+    this.controller = controller;
+    this.logger = logger;
+  }
+
+  get(binding: BindingLike, options?: DataModelOptions | undefined) {
+    return this.controller.get(binding, options);
+  }
+
+  set(
+    transaction: [BindingLike, any][],
+    options?: DataModelOptions | undefined
+  ): Updates {
+    this.logger?.error(
+      'Error: Tried to set in a read only instance of the DataController'
+    );
+    return [];
+  }
+
+  delete(binding: BindingLike, options?: DataModelOptions | undefined): void {
+    this.logger?.error(
+      'Error: Tried to delete in a read only instance of the DataController'
+    );
+  }
+}

--- a/core/player/src/controllers/index.ts
+++ b/core/player/src/controllers/index.ts
@@ -1,5 +1,5 @@
 export * from './flow';
 export * from './validation';
 export * from './view';
-export * from './data';
+export * from './data/controller';
 export * from './constants';

--- a/core/player/src/controllers/view/controller.ts
+++ b/core/player/src/controllers/view/controller.ts
@@ -8,7 +8,7 @@ import type { Resolve } from '../../view';
 import { ViewInstance } from '../../view';
 import type { Logger } from '../../logger';
 import type { FlowInstance, FlowController } from '../flow';
-import type { DataController } from '../data';
+import type { DataController } from '../data/controller';
 import { AssetTransformCorePlugin } from './asset-transform';
 import type { TransformRegistry } from './types';
 import type { BindingInstance } from '../../binding';

--- a/core/player/src/player.ts
+++ b/core/player/src/player.ts
@@ -501,6 +501,9 @@ export class Player {
         ref,
         status: 'completed',
         flow: state.flow,
+        controllers: {
+          data: state.controllers.data.makeReadOnly(),
+        },
       } as const;
 
       return maybeUpdateState({

--- a/core/player/src/types.ts
+++ b/core/player/src/types.ts
@@ -1,5 +1,4 @@
 import type { Flow, FlowResult } from '@player-ui/types';
-import type { DataModelWithParser } from './data';
 import type { BindingParser, BindingLike } from './binding';
 import type { SchemaController } from './schema';
 import type { ExpressionEvaluator } from './expressions';
@@ -10,6 +9,7 @@ import type {
   ValidationController,
   FlowController,
 } from './controllers';
+import type { ReadOnlyDataController } from './controllers/data/utils';
 
 /** The status for a flow's execution state */
 export type PlayerFlowStatus =
@@ -85,7 +85,13 @@ export type InProgressState = BaseFlowState<'in-progress'> &
 /** The flow completed properly */
 export type CompletedState = BaseFlowState<'completed'> &
   PlayerFlowExecutionData &
-  FlowResult;
+  FlowResult & {
+    /** Readonly Player controllers to provide Player functionality after the flow has ended */
+    controllers: {
+      /** A read only instance of the Data Controller */
+      data: ReadOnlyDataController;
+    };
+  };
 
 /** The flow finished but not successfully */
 export type ErrorState = BaseFlowState<'error'> & {


### PR DESCRIPTION
Currently, after Player reaches an end state it returns a serialized version of the final data model. One potential issue that may arise is if a binding needs to be evaluated to retrieve a value in the data model. One potential use case for this would be easily using a stored value to access another stored value. 

This solution uses a class that also extends `DataModelWithParser` but wraps a `DataController` instance. This allows a similar API while preventing any `set` or `delete` calls from being executed against the model while still allowing retrievals though the `get` method.  To make this easy to use, a new method `makeReadOnly()` has been added to the `DataController` which allows it to return itself wrapped in the read only class. 

### Change Type

- [x] `patch`
- [ ] `minor`
- [ ] `major`

# Release Notes
Return a read only instance of the Controller on Player's end state