### PR TITLE
fix iOS release, and fix script to show output properly

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -65,6 +65,7 @@ assemble_pod(
         "//plugins/external-action/core:ExternalActionPlugin_Bundles_bundle_prod": "ios/plugins/ExternalActionPlugin/Resources/",
         "//plugins/metrics/core:MetricsPlugin_Bundles_bundle_prod": "ios/plugins/MetricsPlugin/Resources/",
         "//plugins/pubsub/core:PubSubPlugin_Bundles_bundle_prod": "ios/plugins/PubSubPlugin/Resources/",
+        "//plugins/stage-revert-data/core:StageRevertDataPlugin_Bundles_bundle_prod": "ios/plugins/StageRevertDataPlugin/Resources/",
         "//plugins/types-provider/core:TypesProviderPlugin_Bundles_bundle_prod": "ios/plugins/TypesProviderPlugin/Resources/",
     },
     podspec = ":PlayerUI_Podspec",

--- a/scripts/after-shipit-pod-push.js
+++ b/scripts/after-shipit-pod-push.js
@@ -43,7 +43,7 @@ class AfterShipItPodPush {
           auto.logger.log.info('Pushing Pod to trunk')
           let process
           try {
-            process = execSync('bundle exec pod trunk push --verbose --skip-tests ./bazel-bin/PlayerUI.podspec')
+            process = execSync('bundle exec pod trunk push --verbose --skip-tests ./bazel-bin/PlayerUI.podspec', {stdio: 'inherit'})
           } catch(e) {
             auto.logger.log.error('Pod push failed: ', process && process.stderr.toString(), e)
             throw e


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->
- Fixed missing resource bundle for `StageDataRevertPlugin` in the pod zip
- fixed stdout for `after-shipit-pod-push` when using `execSync` so the pod errors will show in the build log

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->