### PR TITLE
feat: adds react player subscriber

### DIFF
--- a/react/player/src/index.tsx
+++ b/react/player/src/index.tsx
@@ -3,6 +3,8 @@ export * from './player';
 export * from './hooks';
 export * from './manager/managed-player';
 export * from './manager/request-time';
+export * from './subscriber/subscriber-player';
+export * from './subscriber/types';
 export * from './manager/types';
 export * from './asset';
 export * from './utils';

--- a/react/player/src/subscriber/__tests__/subscriber-player.test.tsx
+++ b/react/player/src/subscriber/__tests__/subscriber-player.test.tsx
@@ -1,0 +1,140 @@
+import { makeFlow } from '@player-ui/make-flow';
+import type { Flow } from '@player-ui/types';
+import { act, configure, getNodeText, render } from '@testing-library/react';
+import React from 'react';
+import { SimpleAssetPlugin } from '../../__tests__/helpers/simple-asset-plugin';
+import { PlayerSubscriber } from '../subscriber-player';
+import type { PlayerPublisher, SupportedEvents } from '../types';
+
+configure({ testIdAttribute: 'id' });
+
+const mockInitialFlow = makeFlow({
+  id: 'loading-page',
+  type: 'simple',
+  value: 'Loading...',
+});
+
+/**
+ * Mock Publisher
+ */
+class MockPublisher implements PlayerPublisher {
+  subscribers: Set<(event: SupportedEvents) => void> = new Set();
+
+  subscribe = (callback: (event: SupportedEvents) => void) => {
+    this.subscribers.add(callback);
+    return () => {
+      this.subscribers.delete(callback);
+    };
+  };
+
+  publish = (event: SupportedEvents) => {
+    this.subscribers.forEach((callback) => callback(event));
+  };
+}
+
+const mockPlayerConfig = { plugins: [new SimpleAssetPlugin()] };
+
+describe('PlayerSubscriber', () => {
+  test('renders the initial flow', async () => {
+    const Publisher = new MockPublisher();
+    const component = render(
+      <PlayerSubscriber
+        {...{
+          initialFlow: mockInitialFlow,
+          subscribe: Publisher.subscribe,
+          playerConfig: mockPlayerConfig,
+        }}
+      />
+    );
+
+    const viewNode = await component.findByTestId('loading-page');
+    expect(getNodeText(viewNode)).toBe('Loading...');
+  });
+
+  test('renders the flow from the FLOW_CHANGE event', async () => {
+    const Publisher = new MockPublisher();
+    const component = render(
+      <PlayerSubscriber
+        {...{
+          initialFlow: mockInitialFlow,
+          subscribe: Publisher.subscribe,
+          playerConfig: mockPlayerConfig,
+        }}
+      />
+    );
+
+    act(() => {
+      Publisher.publish({
+        type: 'FLOW_CHANGE',
+        payload: makeFlow({
+          id: 'new-flow',
+          type: 'simple',
+          value: 'New Flow',
+        }),
+      });
+    });
+
+    const viewNode = await component.findByTestId('new-flow');
+    expect(getNodeText(viewNode)).toBe('New Flow');
+  });
+
+  test('updates the data on DATA_CHANGE event', async () => {
+    const Publisher = new MockPublisher();
+    const initialFlow = {
+      id: 'flow_1',
+      views: [
+        {
+          id: 'first_view',
+          type: 'simple',
+          value: '{{foo.bar}}',
+        },
+      ],
+      data: {
+        foo: {
+          bar: 'Initial Value',
+        },
+      },
+      navigation: {
+        BEGIN: 'flow_1',
+        flow_1: {
+          startState: 'view_1',
+          view_1: {
+            state_type: 'VIEW',
+            ref: 'first_view',
+            transitions: {
+              '*': 'end_1',
+            },
+          },
+          end_1: {
+            state_type: 'END',
+            outcome: 'end',
+          },
+        },
+      },
+    } as Flow;
+
+    const component = render(
+      <PlayerSubscriber
+        {...{
+          initialFlow,
+          subscribe: Publisher.subscribe,
+          playerConfig: mockPlayerConfig,
+        }}
+      />
+    );
+
+    act(() => {
+      Publisher.publish({
+        type: 'DATA_CHANGE',
+        payload: {
+          foo: {
+            bar: 'New Value',
+          },
+        },
+      });
+    });
+
+    const viewNode = await component.findByTestId('first_view');
+    expect(getNodeText(viewNode)).toBe('New Value');
+  });
+});

--- a/react/player/src/subscriber/subscriber-player.tsx
+++ b/react/player/src/subscriber/subscriber-player.tsx
@@ -1,0 +1,54 @@
+import type { Flow } from '@player-ui/types';
+import React, { useCallback, useEffect, useState } from 'react';
+import { useReactPlayer } from '../hooks';
+import type { PlayerSubscriberProps, SupportedEvents } from './types';
+
+/**
+ * Player Subscriber
+ *
+ * This component wraps the ReactPlayer and subscribes to events.
+ */
+export const PlayerSubscriber = ({
+  playerConfig,
+  initialFlow,
+  subscribe,
+}: PlayerSubscriberProps) => {
+  const [state, setState] = useState<Flow>(initialFlow);
+  const { reactPlayer } = useReactPlayer(playerConfig);
+
+  const setData = useCallback(
+    (data: Flow['data']) => {
+      const playerState = reactPlayer.player.getState();
+      if (data && playerState.status === 'in-progress') {
+        playerState.controllers.data.set(data);
+      }
+    },
+    [reactPlayer.player]
+  );
+
+  const eventHandler = useCallback(
+    (event: SupportedEvents) => {
+      switch (event.type) {
+        case 'FLOW_CHANGE':
+          setState((currState) => ({ ...currState, ...event.payload }));
+          break;
+        case 'DATA_CHANGE':
+          setData(event.payload);
+          break;
+        default:
+          break;
+      }
+    },
+    [setData]
+  );
+
+  useEffect(() => {
+    return subscribe(eventHandler);
+  }, [eventHandler, subscribe]);
+
+  useEffect(() => {
+    reactPlayer.start(state);
+  }, [reactPlayer, state]);
+
+  return <reactPlayer.Component />;
+};

--- a/react/player/src/subscriber/types.ts
+++ b/react/player/src/subscriber/types.ts
@@ -1,0 +1,34 @@
+import type { Flow } from '@player-ui/types';
+import type { ReactPlayerOptions } from '../player';
+
+export type SupportedEvents =
+  | {
+      /** Event type. */
+      type: 'FLOW_CHANGE';
+      /** Flow change event payload. */
+      payload: Partial<Flow>;
+    }
+  | {
+      /** Event type. */
+      type: 'DATA_CHANGE';
+      /** Data change event payload. */
+      payload: Flow['data'];
+    };
+
+export interface PlayerSubscriberProps {
+  /** ReactPlayer config. */
+  playerConfig: ReactPlayerOptions;
+  /** Initial Flow. */
+  initialFlow: Flow;
+  /** Subscribe to events. */
+  subscribe: (callback: (event: SupportedEvents) => void) => () => void;
+}
+
+export interface PlayerPublisher {
+  /** Set of subscribers. */
+  subscribers: Set<(event: SupportedEvents) => void>;
+  /** Subscribe to events and returns a function to unsubscribe. */
+  subscribe: (callback: (event: SupportedEvents) => void) => () => void;
+  /** Publish an event to all subscribers. */
+  publish: (event: SupportedEvents) => void;
+}


### PR DESCRIPTION
Issue #221 

## Description

Adds `PlayerSubscriber` to the `ReactPlayer` as part of the effort to add support to content being pushed to the Player.

### Change Type

- [ ] `patch`
- [x] `minor`
- [ ] `major`

# Release Notes

Adds support to pushing content to the Player. So we can handle pulling content, leveraging the `ManagedPlayer`, and reacting to content being pushed to the Player using the `PlayerSubscriber`.

  ```typescript
class MyPublisher implements PlayerPublisher {
  subscribers: Set<(event: SupportedEvents) => void> = new Set();

  subscribe = (callback: (event: SupportedEvents) => void) => {
    this.subscribers.add(callback);
    return () => {
      this.subscribers.delete(callback);
    };
  };

  publish = (event: SupportedEvents) => {
    this.subscribers.forEach((callback) => callback(event));
  };
}

// ...
const Publisher = new MyPublisher();
// ...

<PlayerSubscriber {...{ initialFlow, playerConfig, subscribe: Publisher.subscribe }} />
  ```
