### PR TITLE
iOS: Add swift wrapper for ComputedPropertiesPlugin

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -61,6 +61,7 @@ assemble_pod(
         "//plugins/check-path/core:CheckPathPlugin_Bundles_bundle_prod": "ios/plugins/CheckPathPlugin/Resources/",
         "//plugins/common-types/core:CommonTypesPlugin_Bundles_bundle_prod": "ios/plugins/CommonTypesPlugin/Resources/",
         "//plugins/common-expressions/core:CommonExpressionsPlugin_Bundles_bundle_prod": "ios/plugins/CommonExpressionsPlugin/Resources/",
+        "//plugins/computed-properties/core:ComputedPropertiesPlugin_Bundles_bundle_prod": "ios/plugins/ComputedPropertiesPlugin/Resources/",
         "//plugins/expression/core:ExpressionPlugin_Bundles_bundle_prod": "ios/plugins/ExpressionPlugin/Resources/",
         "//plugins/external-action/core:ExternalActionPlugin_Bundles_bundle_prod": "ios/plugins/ExternalActionPlugin/Resources/",
         "//plugins/metrics/core:MetricsPlugin_Bundles_bundle_prod": "ios/plugins/MetricsPlugin/Resources/",

--- a/PlayerUI.podspec
+++ b/PlayerUI.podspec
@@ -271,6 +271,14 @@ and display it as a SwiftUI view comprised of registered assets.
     }
   end
 
+  s.subspec 'ComputedPropertiesPlugin' do |plugin|
+    plugin.dependency 'PlayerUI/Core'
+    plugin.source_files = 'ios/plugins/ComputedPropertiesPlugin/Sources/**/*'
+    plugin.resource_bundles = {
+      'ComputedPropertiesPlugin' => ['ios/plugins/ComputedPropertiesPlugin/Resources/**/*.js']
+    }
+  end
+
   s.subspec 'CommonExpressionsPlugin' do |plugin|
     plugin.dependency 'PlayerUI/Core'
     plugin.source_files = 'ios/plugins/CommonExpressionsPlugin/Sources/**/*'

--- a/generated.bzl
+++ b/generated.bzl
@@ -59,6 +59,14 @@ def PlayerUI(
             "ios/plugins/CommonTypesPlugin/Sources/**/*.c",
             "ios/plugins/CommonTypesPlugin/Sources/**/*.cc",
             "ios/plugins/CommonTypesPlugin/Sources/**/*.cpp",
+            "ios/plugins/ComputedPropertiesPlugin/Sources/**/*.h",
+            "ios/plugins/ComputedPropertiesPlugin/Sources/**/*.hh",
+            "ios/plugins/ComputedPropertiesPlugin/Sources/**/*.m",
+            "ios/plugins/ComputedPropertiesPlugin/Sources/**/*.mm",
+            "ios/plugins/ComputedPropertiesPlugin/Sources/**/*.swift",
+            "ios/plugins/ComputedPropertiesPlugin/Sources/**/*.c",
+            "ios/plugins/ComputedPropertiesPlugin/Sources/**/*.cc",
+            "ios/plugins/ComputedPropertiesPlugin/Sources/**/*.cpp",
             "ios/packages/core/Sources/**/*.h",
             "ios/packages/core/Sources/**/*.hh",
             "ios/packages/core/Sources/**/*.m",
@@ -213,6 +221,12 @@ def PlayerUI(
             ),
             "CommonTypesPlugin": glob(
                 ["ios/plugins/CommonTypesPlugin/Resources/**/*.js"],
+                exclude_directories = 0,
+            ),
+            "ComputedPropertiesPlugin": glob(
+                [
+                    "ios/plugins/ComputedPropertiesPlugin/Resources/**/*.js",
+                ],
                 exclude_directories = 0,
             ),
             "PlayerUI": glob(

--- a/ios/plugins/ComputedPropertiesPlugin/Sources/ComputedPropertiesPlugin.swift
+++ b/ios/plugins/ComputedPropertiesPlugin/Sources/ComputedPropertiesPlugin.swift
@@ -1,0 +1,20 @@
+/**
+ Wrapper to instantiate @player/computed-properties-plugin
+ */
+public class ComputedPropertiesPlugin: JSBasePlugin, NativePlugin {
+    /**
+     Constructs a PartialMatchRegistry JS object
+     */
+    public convenience init() {
+        self.init(fileName: "computed-properties-plugin.prod", pluginName: "ComputedPropertiesPlugin.ComputedPropertiesPlugin")
+    }
+
+    override open func getUrlForFile(fileName: String) -> URL? {
+        ResourceUtilities.urlForFile(
+            name: fileName,
+            ext: "js",
+            bundle: Bundle(for: ComputedPropertiesPlugin.self),
+            pathComponent: "ComputedPropertiesPlugin.bundle"
+        )
+    }
+}

--- a/ios/plugins/ComputedPropertiesPlugin/Tests/ComputedPropertiesPluginTests.swift
+++ b/ios/plugins/ComputedPropertiesPlugin/Tests/ComputedPropertiesPluginTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import XCTest
+import JavaScriptCore
+@testable import PlayerUI
+
+class ComputedPropertiesPluginTests: XCTestCase {
+    func testPluginConstructs() {
+        let context = JSContext()
+
+        let plugin = ComputedPropertiesPlugin()
+        plugin.context = context
+
+        XCTAssertNotNil(plugin.pluginRef)
+    }
+
+    func testPluginSimple() {
+        let player = HeadlessPlayerImpl(plugins: [ComputedPropertiesPlugin()])
+
+        let flow = """
+        {
+          "id": "generated-flow",
+          "views": [],
+          "schema": {
+            "ROOT": {
+              "foo": {
+                "type": "FooType"
+              }
+            },
+            "FooType": {
+              "computedValue": {
+                "type": "Expression",
+                "exp": "1 + 2 + 3"
+              }
+            }
+          },
+          "navigation": {
+            "BEGIN": "FLOW_1",
+            "FLOW_1": {
+              "startState": "VIEW_1",
+              "VIEW_1": {
+                "state_type": "ACTION",
+                "exp": "true",
+                "transitions": {
+                  "*": "END_Done"
+                }
+              },
+              "END_Done": {
+                "state_type": "END",
+                "outcome": "{{foo.computedValue}}"
+              }
+            }
+          }
+        }
+
+        """
+
+        let expectation = XCTestExpectation(description: "Computed Property Calculated")
+
+        player.start(flow: flow) { result in
+            guard
+                case .success(let success) = result
+            else {
+                return XCTFail("Flow Failed")
+            }
+
+            XCTAssertEqual("6", success.endState?.outcome)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1)
+
+    }
+}

--- a/plugins/computed-properties/core/BUILD
+++ b/plugins/computed-properties/core/BUILD
@@ -15,5 +15,6 @@ javascript_pipeline(
         "//plugins/asset-transform/core:@player-ui/asset-transform-plugin",
         "//core/make-flow:@player-ui/make-flow",
         "//core/partial-match-registry:@player-ui/partial-match-registry"
-    ]
+    ],
+    library_name = 'ComputedPropertiesPlugin',
 )

--- a/xcode/Podfile
+++ b/xcode/Podfile
@@ -21,6 +21,7 @@ target 'PlayerUI_Example' do
   pod 'PlayerUI/CheckPathPlugin', :path => '../'
   pod 'PlayerUI/CommonTypesPlugin', :path => '../'
   pod 'PlayerUI/CommonExpressionsPlugin', :path => '../'
+  pod 'PlayerUI/ComputedPropertiesPlugin', :path => '../'
   pod 'PlayerUI/ExpressionPlugin', :path => '../'
   pod 'PlayerUI/ExternalActionPlugin', :path => '../'
   pod 'PlayerUI/ExternalActionViewModifierPlugin', :path => '../'
@@ -68,6 +69,7 @@ plugin 'cocoapods-resource-bundle-copier', {
     "PlayerUI/CommonTypesPlugin" => {'target' => "//plugins/common-types/core:CommonTypesPlugin_Bundles_bundle_prod", 'files' => ['common-types-plugin.prod.js']},
     "PlayerUI/CheckPathPlugin" => {'target' => "//plugins/check-path/core:CheckPathPlugin_Bundles_bundle_prod", 'files' => ['check-path-plugin.prod.js']},
     "PlayerUI/CommonExpressionsPlugin" => {'target' => "//plugins/common-expressions/core:CommonExpressionsPlugin_Bundles_bundle_prod", 'files' => ['common-expressions-plugin.prod.js']},
+    "PlayerUI/ComputedPropertiesPlugin" => {'target' => "//plugins/computed-properties/core:ComputedPropertiesPlugin_Bundles_bundle_prod", 'files' => ['computed-properties-plugin.prod.js']},
     "PlayerUI/ExpressionPlugin" => {'target' => "//plugins/expression/core:ExpressionPlugin_Bundles_bundle_prod", 'files' => ['expression-plugin.prod.js']},
     "PlayerUI/ExternalActionPlugin" => {'target' => "//plugins/external-action/core:ExternalActionPlugin_Bundles_bundle_prod", 'files' => ['external-action-plugin.prod.js']},
     "PlayerUI/MetricsPlugin" => {'target' => "//plugins/metrics/core:MetricsPlugin_Bundles_bundle_prod", 'files' => ['metrics-plugin.prod.js']},

--- a/xcode/Podfile.lock
+++ b/xcode/Podfile.lock
@@ -14,6 +14,8 @@ PODS:
     - PlayerUI/Core
   - PlayerUI/CommonTypesPlugin (0.0.1-placeholder):
     - PlayerUI/Core
+  - PlayerUI/ComputedPropertiesPlugin (0.0.1-placeholder):
+    - PlayerUI/Core
   - PlayerUI/Core (0.0.1-placeholder):
     - PlayerUI/Logger
     - SwiftHooks (>= 0.1.0, ~> 0)
@@ -91,6 +93,7 @@ DEPENDENCIES:
   - PlayerUI/CheckPathPlugin (from `../`)
   - PlayerUI/CommonExpressionsPlugin (from `../`)
   - PlayerUI/CommonTypesPlugin (from `../`)
+  - PlayerUI/ComputedPropertiesPlugin (from `../`)
   - PlayerUI/Core (from `../`)
   - PlayerUI/Demo (from `../`)
   - PlayerUI/ExpressionPlugin (from `../`)
@@ -126,11 +129,11 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   EyesXCUI: bbb10a48b8bd1a15d541f2bc1f4d18f4db654ef1
-  PlayerUI: 4151c9a81d752e04d8c7ef269c3205dc3551325d
+  PlayerUI: 49f4b664b10f3488c7d3caab950b7b1ec8bf3923
   SwiftHooks: 3ecc67c23da335d44914a8a74bd1dd23c7c149e6
   SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
   ViewInspector: 53313c757eddc5c4842bc7943a66821a68d02d3e
 
-PODFILE CHECKSUM: 4dced11617263934702383efbea39a6c14419c2d
+PODFILE CHECKSUM: c49c2abae4f08be69e1ede1d83a369338a9b401f
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

- Wrap `ComputedPropertiesPlugin` for iOS

marked as `minor` since there was a wonky release 

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->