### PR TITLE
Pin @moncao-editor/react to non `.mjs` Only Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@emotion/styled": "^11",
     "@kendallgassner/eslint-plugin-package-json": "^0.2.1",
     "@mdx-js/loader": "^1.6.22",
-    "@monaco-editor/react": "^4.6.0",
+    "@monaco-editor/react": "4.3.1",
     "@player-tools/cli": "0.4.0-next.3",
     "@player-tools/dsl": "0.4.0-next.3",
     "@reduxjs/toolkit": "^1.9.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2692,19 +2692,20 @@
   resolved "https://registry.yarnpkg.com/@mdx-js/util/-/util-1.6.22.tgz#219dfd89ae5b97a8801f015323ffa4b62f45718b"
   integrity sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==
 
-"@monaco-editor/loader@^1.4.0":
+"@monaco-editor/loader@^1.2.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@monaco-editor/loader/-/loader-1.4.0.tgz#f08227057331ec890fa1e903912a5b711a2ad558"
   integrity sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==
   dependencies:
     state-local "^1.0.6"
 
-"@monaco-editor/react@^4.6.0":
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/@monaco-editor/react/-/react-4.6.0.tgz#bcc68671e358a21c3814566b865a54b191e24119"
-  integrity sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==
+"@monaco-editor/react@4.3.1":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@monaco-editor/react/-/react-4.3.1.tgz#d65bcbf174c39b6d4e7fec43d0cddda82b70a12a"
+  integrity sha512-f+0BK1PP/W5I50hHHmwf11+Ea92E5H1VZXs+wvKplWUWOfyMa1VVwqkJrXjRvbcqHL+XdIGYWhWNdi4McEvnZg==
   dependencies:
-    "@monaco-editor/loader" "^1.4.0"
+    "@monaco-editor/loader" "^1.2.0"
+    prop-types "^15.7.2"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"


### PR DESCRIPTION
Use slightly older version of the monaco editor in the storybook integration to make it easier to integrate the storybook plugin in plugins still using webpack4. 

### Change Type (required)
- [x] `patch`
- [ ] `minor`
- [ ] `major`

# Release Notes
Pin `@moncao-editor/react` to `4.3.1`