### PR TITLE
build: comment out major doc deploy for now

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -40,8 +40,10 @@ elif [ "$RELEASE_TYPE" == "release" ] && [ "$CURRENT_BRANCH" == "main" ]; then
   STABLE_DOCS_BASE_PATH=latest bazel run --verbose_failures --config=release //docs:deploy_docs -- --dest_dir latest
 fi
 
+# Commented out for now due to failures to deploy
+# causes lots of "java.io.IOException: io.grpc.StatusRuntimeException: CANCELLED: Failed to read message." messages in the build
 # Also deploy to the versioned folder for main releases
-if [ "$RELEASE_TYPE" == "release" ]; then
-  SEMVER_MAJOR=$(cat VERSION | cut -d. -f1)
-  STABLE_DOCS_BASE_PATH=$SEMVER_MAJOR bazel run --verbose_failures --config=release //docs:deploy_docs -- --dest_dir "$SEMVER_MAJOR"
-fi
+# if [ "$RELEASE_TYPE" == "release" ]; then
+#   SEMVER_MAJOR=$(cat VERSION | cut -d. -f1)
+#   STABLE_DOCS_BASE_PATH=$SEMVER_MAJOR bazel run --verbose_failures --config=release //docs:deploy_docs -- --dest_dir "$SEMVER_MAJOR"
+# fi


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

This doc deploy is blowing up with bazel errors and `--verbose_failures` did not provide additional insight. We just need to fix this prior to 1.0 but shouldnt block ourselves from moving forward right now just for having copies of major docs.

`latest` docs works fine

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->