### PR TITLE
Fix PR Titles Created During Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           
       - name: create-pr
         id: open-pr
-        uses: repo-sync/pull-request@v2
+        uses: repo-sync/pull-request@v2.9
         with:
           source_branch: ${{ env.SOURCE_RELEASE_BRANCH }}
           destination_branch: "main"


### PR DESCRIPTION
Pins the `repo-sync/pull-request` action used during release to version 