### PR TITLE
Add Automation ID to Error Element in Storybook

### DIFF
--- a/tools/storybook/src/player/PlayerFlowSummary.tsx
+++ b/tools/storybook/src/player/PlayerFlowSummary.tsx
@@ -64,7 +64,7 @@ export const PlayerFlowSummary = (props: PlayerFlowSummaryProps) => {
 
       {props.error && (
         <Code colorScheme="red">
-          <pre>{props.error?.message}</pre>
+          <pre data-automation-id="Error-Content">{props.error?.message}</pre>
         </Code>
       )}
 


### PR DESCRIPTION
### Change Type (required)

- [x] `patch`
- [ ] `minor`
- [ ] `major`

## Release Notes
Storybook error element has a `data-automation-id` property which allows it to be programmably found in tests