### PR TITLE
iOS: make AssetBeacon equatable and add public init for metadata

### DIFF
--- a/ios/packages/core/Sources/Types/Assets/Wrappers.swift
+++ b/ios/packages/core/Sources/Types/Assets/Wrappers.swift
@@ -90,4 +90,9 @@ public struct MetaData: Codable, Hashable {
 
     /// The role of this asset
     public var role: String?
+
+    public init(beacon: AnyType?, role: String? = nil) {
+        self.beacon = beacon
+        self.role = role
+    }
 }

--- a/ios/packages/core/Sources/Types/Beacon.swift
+++ b/ios/packages/core/Sources/Types/Beacon.swift
@@ -10,7 +10,7 @@ import Foundation
 /**
  An object representing a beacon fired from an `Asset`
  */
-public struct AssetBeacon: Codable {
+public struct AssetBeacon: Codable, Equatable {
     /// The action that caused the beacon
     public var action: String
 
@@ -49,7 +49,7 @@ public protocol BeaconableMetaData {
 }
 
 /// Container Object for matching the data type for the JS Beacon Plugin
-public struct BeaconableAsset: Codable {
+public struct BeaconableAsset: Codable, Equatable {
     /// The ID of the asset that fired the beacon
     public var id: String
 


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

Minor things missed when porting

- `Equatable` AssetBeacon
- public init for `MetaData`

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->