### PR TITLE
iOS: add SwiftUIPendingTransactionPlugin to reference asset dependencies

### DIFF
--- a/PlayerUI.podspec
+++ b/PlayerUI.podspec
@@ -207,6 +207,7 @@ and display it as a SwiftUI view comprised of registered assets.
     assets.dependency 'PlayerUI/Core'
     assets.dependency 'PlayerUI/SwiftUI'
     assets.dependency 'PlayerUI/BeaconPlugin'
+    assets.dependency 'PlayerUI/SwiftUIPendingTransactionPlugin'
 
     assets.source_files = 'ios/packages/reference-assets/Sources/**/*'
     assets.resource_bundles = {


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

Fixed dependencies for iOS Reference Assets subspec, should have had as a dep, instead of relying on it as a peer dep

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->