### PR TITLE
iOS - allow navigationFlowViewState attributes to take Any instead of string

### DIFF
--- a/ios/packages/core/Sources/Types/Core/NavigationStates.swift
+++ b/ios/packages/core/Sources/Types/Core/NavigationStates.swift
@@ -43,8 +43,8 @@ public class NavigationFlowViewState: NavigationFlowTransitionableState {
     public var ref: String { rawValue.objectForKeyedSubscript("ref").toString() }
 
     /// View meta-properties
-    public var attributes: [String: String]? {
-        rawValue.objectForKeyedSubscript("attributes").toObject() as? [String: String]
+    public var attributes: [String: Any]? {
+        rawValue.objectForKeyedSubscript("attributes").toObject() as? [String: Any]
     }
 
     public subscript<T>(dynamicMember member: String) -> T? {

--- a/ios/packages/core/Tests/FlowStateTests.swift
+++ b/ios/packages/core/Tests/FlowStateTests.swift
@@ -21,7 +21,7 @@ class FlowStateTests: XCTestCase {
         XCTAssertNotNil(inProgress.controllers?.flow.current?.currentState?.value as? NavigationFlowViewState)
         let view = inProgress.controllers?.flow.current?.currentState?.value as? NavigationFlowViewState
 
-        XCTAssertEqual(view?.attributes?["test"], "value")
+        XCTAssertEqual(view?.attributes?["test"] as? String, "value")
     }
 
     func testExternalFlowState() {


### PR DESCRIPTION
The stacked attribute used in existing content is defined as Bool https://github.intuit.com/player-plugins/intuit/blob/next/plugins/view-attributes/react/src/index.tsx#L8

Change the objects value to take Any to support Bools as well

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->