### PR TITLE
update iOS StageRevertDataPluginTests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
           paths:
             - ~/android-tools
 
-      - run: gem install bundler
+      - run: gem install bundler -v 2.4.22
 
       - restore_cache:
           keys:

--- a/ios/plugins/StageRevertDataPlugin/Tests/StageRevertDataPluginTests.swift
+++ b/ios/plugins/StageRevertDataPlugin/Tests/StageRevertDataPluginTests.swift
@@ -67,12 +67,13 @@ class StageRevertDataPluginTests: XCTestCase {
 
         player.hooks?.viewController.tap { viewController in
             viewController.hooks.view.tap { view in
-                guard view.id == "view-3" else {
-                    (player.state as? InProgressState)?.controllers?.data.set(transaction: ["name": "Test"])
-                    (player.state as? InProgressState)?.controllers?.flow.transition(with: "clear")
-                    return
-                }
                 view.hooks.onUpdate.tap { value in
+                    guard view.id == "view-3" else {
+                        (player.state as? InProgressState)?.controllers?.data.set(transaction: ["name": "Test"])
+                        (player.state as? InProgressState)?.controllers?.flow.transition(with: "clear")
+                        return
+                    }
+
                     let labelValue = value.objectForKeyedSubscript("value").toString()
 
                     XCTAssertEqual(labelValue, "default")
@@ -91,12 +92,13 @@ class StageRevertDataPluginTests: XCTestCase {
 
         player.hooks?.viewController.tap { viewController in
             viewController.hooks.view.tap { view in
-                guard view.id == "view-2" else {
-                    (player.state as? InProgressState)?.controllers?.data.set(transaction: ["name": "Test"])
-                    (player.state as? InProgressState)?.controllers?.flow.transition(with: "commit")
-                    return
-                }
                 view.hooks.onUpdate.tap { value in
+                    guard view.id == "view-2" else {
+                        (player.state as? InProgressState)?.controllers?.data.set(transaction: ["name": "Test"])
+                        (player.state as? InProgressState)?.controllers?.flow.transition(with: "commit")
+                        return
+                    }
+
                     let labelValue = value.objectForKeyedSubscript("value").toString()
 
                     XCTAssertEqual(labelValue, "Test")


### PR DESCRIPTION
<!-- 

Need to update StageRevertDataPluginTests after Change in core for not allowing another transition during an active transition
Call the transition in the test during the onUpdate tap instead of during the view hook where the transition is still active to pass the test

-->


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->