### PR TITLE
Fix SwiftUIPendingTransactionPlugin Docs Page

### DIFF
--- a/docs/site/pages/plugins/swiftui-pending-transaction.mdx
+++ b/docs/site/pages/plugins/swiftui-pending-transaction.mdx
@@ -1,4 +1,3 @@
-
 ---
 title: SwiftUIPendingTransactionPlugin
 platform: ios


### PR DESCRIPTION
The extra newline on this page causes it not to show up in the sidebar of the `Plugins` section and also causes the header elements to be improperly rendered.