### PR TITLE
[Docs] Platform consolidation

### DIFF
--- a/docs/site/components/mdx-components.tsx
+++ b/docs/site/components/mdx-components.tsx
@@ -23,12 +23,19 @@ import {
   Tr,
   Td,
   Link as CLink,
+  Alert as ChakraAlert,
+  AlertTitle,
+  AlertDescription,
+  AlertOptions,
+  AlertIcon,
+  Box,
 } from '@chakra-ui/react';
 import { MDXProviderComponents } from '@mdx-js/react';
 import { withRouter, useRouter } from 'next/router';
 import { CodeHighlight } from './code-highlight';
 import { withBasePrefix } from './Image';
 import { PlayerTeam } from './PlayerTeam';
+import {AppContext} from "./Context";
 
 /**
  * Generic Tab Component that extends Chakra's Tab
@@ -67,7 +74,7 @@ const Tabs = (props: any) => {
   return (
     <ChakraTabs
       colorScheme="blue"
-      defaultIndex={props.defaultTab}
+      index={props.defaultTab}
       onChange={(index) => props.callback?.(index)}
     >
       <TabList>
@@ -226,6 +233,25 @@ export const InlineCode = (props: JSX.IntrinsicElements['code']) => {
   );
 };
 
+type ChakraAlertProps = React.PropsWithChildren<AlertOptions & {
+  title?: string;
+  description?: string;
+}>
+
+export const Alert = (props: ChakraAlertProps) => {
+  return (
+      <ChakraAlert status={props.status} variant='left-accent'>
+        <AlertIcon />
+        <Box flex={1}>
+          {props.title && <AlertTitle>{props.title}</AlertTitle>}
+          {props.description && <AlertDescription>{props.description}</AlertDescription>}
+          {props.children}
+        </Box>
+      </ChakraAlert>
+  );
+};
+
+
 /**
  * Anchor tab component wrapping Chakra's
  */
@@ -267,4 +293,8 @@ export const MDXComponents: MDXProviderComponents = {
   td: Td,
 
   inlineCode: InlineCode,
+
+  Alert,
+  AlertTitle,
+  AlertDescription,
 };

--- a/docs/site/components/mdx-components.tsx
+++ b/docs/site/components/mdx-components.tsx
@@ -24,9 +24,9 @@ import {
   Td,
   Link as CLink,
   Alert as ChakraAlert,
+  AlertStatus,
   AlertTitle,
   AlertDescription,
-  AlertOptions,
   AlertIcon,
   Box,
 } from '@chakra-ui/react';
@@ -233,7 +233,8 @@ export const InlineCode = (props: JSX.IntrinsicElements['code']) => {
   );
 };
 
-type ChakraAlertProps = React.PropsWithChildren<AlertOptions & {
+type ChakraAlertProps = React.PropsWithChildren<{
+  status?: AlertStatus;
   title?: string;
   description?: string;
 }>

--- a/docs/site/pages/assets/custom.mdx
+++ b/docs/site/pages/assets/custom.mdx
@@ -4,9 +4,10 @@ title: 'Custom Assets'
 
 # Custom Assets
 
-One of the conscious design decisions we made when building Player was to abstract away the actual asset implementation and open it up for users to bring their own when using Player. This way you can seamlessly integrate Player into your existing experiences and reuse UI assets you may have already built. Below we've outlined the way to build custom assets on the various platforms Player supports. 
+One of the conscious design decisions we made when building Player was to abstract away the actual asset implementation and open it up for users to bring their own when using Player. This way you can seamlessly integrate Player into your existing experiences and reuse UI assets you may have already built. Below we've outlined the way to build custom assets on the various platforms Player supports.
 
-## React
+<PlatformTabs>
+  <react>
 
 ### Create Your Asset
 
@@ -61,7 +62,8 @@ const CustomAssetComp = (props) => {
 
 This would automatically find the appropriate handler for the `props.header` asset and use that to render.
 
-## iOS
+  </react>
+  <ios>
 
 SwiftUI Player assets are made of 3 parts:
 
@@ -190,7 +192,7 @@ In either situation, your asset implementation needs only to override the view p
 
 ```swift
 class ActionAsset: UncontrolledAsset<ActionData> {
-		public override var view: AnyView { AnyView(ActionView(model: model)) }
+        public override var view: AnyView { AnyView(ActionView(model: model)) }
 }
 ```
 
@@ -230,11 +232,15 @@ In the latter case, it is recommended to extend the original asset, so as to avo
 
 ##### Why Would I Register my Asset as a Variant?
 
+
 1. Transform backed assets have functions that are attached to them, through shared JavaScript plugins. This simplifies setting data from the asset, by giving simple functions like `run` in the reference `ActionAsset` for example. Swift only asset types will not have any convenience functions.
 
 2. Registering as a variant allows you to maintain usage of the transform backed asset as well as your new asset, so both can be used by the same `SwiftUIPlayer` instance, including in the same flow. This also maintains the semantics of Player content, an `action` asset is always an `action` type of interaction, but with `metaData`, it can be displayed differently.
 
-## Android 
+
+
+  </ios>
+  <android>
 
 In order to render an asset a renderer for that type must be registered in the Android Player. If a renderer is found, then Player will delegate rendering when that type is encountered, otherwise Player will skip that node. Creating and registering such a renderer requires the following:
 
@@ -278,12 +284,12 @@ In most cases, there is some additional data that is used to make the rendering 
 
 ```kotlin
 class TextAsset(assetContext: AssetContext) : DecodableAsset<TextAsset.Data>(Data.serializer()) {
-   
+
     @Serializable
     data class Data(
        val value: String
     )
-    
+
 }
 ```
 
@@ -335,7 +341,7 @@ A helper is provided to reduce overhead with rendering an asset into a layout. `
 
 ```kotlin
 // title_container is a view extension referencing a FrameLayout in an XML layout
-data.title.render() into title_container 
+data.title.render() into title_container
 ```
 
 #### Styling
@@ -408,3 +414,7 @@ This asset will only be used when decoding a view in the JSON tree that is type 
 In this scenario, the custom action asset implementation would still have access to the transformed values of a regular action asset, such as the `run` method.
 
 When creating a new plugin, remember to register it when building the AndroidPlayer!
+
+
+  </android>
+</PlatformTabs>

--- a/docs/site/pages/assets/reference.mdx
+++ b/docs/site/pages/assets/reference.mdx
@@ -4,9 +4,10 @@ title: 'Reference Assets'
 
 # Reference Assets
 
-To help users get started with Player, we have created a minimal set of useable assets for React, iOS and Android. These reference assets showcase the design philosophy we encourage when building your own asset sets. While these components are functional we _do not_ recommend shipping them to production as they have not been tested to be production ready. 
+To help users get started with Player, we have created a minimal set of useable assets for React, iOS and Android. These reference assets showcase the design philosophy we encourage when building your own asset sets. While these components are functional we _do not_ recommend shipping them to production as they have not been tested to be production ready.
 
-## React
+<PlatformTabs>
+  <react>
 
 For the React Player, we ship a package (`@player-ui/reference-assets-plugin-react`) that provides the reference set of assets. Each asset package exposes a `Component`, type, and optional transform. They also export hooks for easily consuming the transformed component and supplying your own UI for a custom look and feel. These components are all then exposed via a plugin that can be added to Player like so:
 
@@ -23,8 +24,8 @@ const reactPlayer = new ReactPlayer({
 
 The reference assets + React player can be viewed in [Storybook](/storybook-demo)
 
-
-## iOS 
+  </react>
+  <ios>
 
 Alongside distributing the `PlayerUI` pod, there is a `PlayerUI/ReferenceAssets` subspec used as examples of how Player APIs work for building assets. This pod uses the shared TypeScript transform functions that the React and Android players use for their reference assets, ensuring consistent behavior across platforms. These assets can be loaded into Player like so:
 
@@ -44,7 +45,8 @@ struct MyApp: View {
 }
 ```
 
-## Android 
+  </ios>
+  <android>
 
 Alongside distributing the Android Player framework, there is a reference assets library used as an example of how Player APIs work for building assets. These are intended to serve as a reference, but can be used early on in development as a means of understanding how to work with Player. This asset set uses the shared TypeScript transform functions that the Web and Android players use for their reference assets, ensuring consistent behavior across platforms. These assets can be loaded into Player like so:
 
@@ -53,3 +55,6 @@ import com.intuit.player.android.reference.assets.ReferenceAssetsPlugin
 
 val player = AndroidPlayer(context, ReferenceAssetsPlugin())
 ```
+  </android>
+</PlatformTabs>
+

--- a/docs/site/pages/getting-started.mdx
+++ b/docs/site/pages/getting-started.mdx
@@ -4,27 +4,66 @@ title: 'Getting Started'
 
 # Getting Started
 
-Getting started with Player is simple. Below we have guides per platform on how to integrate Player into your platform of choice. 
-
-## React 
+Getting started with Player is simple.
 
 ### Install Dependencies
 
-The first dependency you'll need to pull in in the React Player itself. You can do this by running
+The first dependency you'll need to pull in is the Player itself. Additionally, you'll need an assets plugin to define any UI -- we'll use the reference assets as an example.
+
+<PlatformTabs>
+  <react>
+
+You can do this by running
 
 ```bash
 yarn add @player-ui/react
+yarn add @player-ui/reference-assets-plugin-react
 ```
 
-or 
+or
 
 ```bash
 npm install @player-ui/react
+npm install @player-ui/reference-assets-plugin-react
 ```
+  </react>
+  <ios>
+
+In your `Podfile` you'll need to add `PlayerUI` as a dependency and the `ReferenceAssets` plugin to use the base set of assets.
+
+```ruby
+source 'https://github.com/player-ui/player'
+
+target 'MyApp' do
+  # Add the pod to your target
+  pod 'PlayerUI'
+  pod 'PlayerUI/ReferenceAssets' # For example only
+end
+```
+  </ios>
+  <android>
+
+Configure the Android Player dependencies in your `build.gradle(.kts)` files.
+
+```kotlin
+dependencies {
+    // Android Player
+    implementation("com.intuit.player.android:player:$playerVersion")
+    // Optional - reference assets
+    implementation("com.intuit.player.android:assets:$playerVersion")
+}
+```
+  </android>
+</PlatformTabs>
+
+<Alert status="warning" description="The reference assets aren't intended for production use. They exist as an example of how to create assets and can be used to help get started." />
 
 ### Configuration
 
-Next, in your code you'll need to initialize Player. This is where you would also initialize any plugins you want to use with Player and create the configuration for Player itself. Below is a minimal example of this. 
+Next, in your code you'll need to initialize Player. This is where you would also initialize any plugins you want to use with Player and create the configuration for Player itself. Below is a minimal example of this.
+
+<PlatformTabs>
+  <react>
 
 ```javascript
 import { ReactPlayer } from '@player-ui/react';
@@ -36,43 +75,54 @@ const reactPlayer = new ReactPlayer({
   plugins: [new ReferenceAssetsPlugin()],
 });
 ```
+  </react>
+  <ios>
+
+`SwiftUIPlayer` is just a normal SwiftUI View and can be inserted anywhere in your hierarchy.
+
+```swift
+import PlayerUI
+
+var body: some View {
+  SwiftUIPlayer(
+    plugins: [ReferenceAssetsPlugin()],
+  )
+}
+```
+  </ios>
+
+  <android>
+
+```kotlin
+// create Android Player with reference assets plugin
+val player = AndroidPlayer(ReferenceAssetsPlugin())
+```
+  </android>
+</PlatformTabs>
 
 ### Render Content
+Now that you have a Player instance created. You'll need to start it with some [content](/content).
 
-Now that you have a Player instance created. You'll need to start it with some content.
+<PlatformTabs>
+
+  <react>
 
 ```javascript
 const content = {/* your content here */}
 reactPlayer.start(content);
 ```
 
-With Player running your content, you'll need to actually render out what is processes. To do this, you can use the React Player's component API to inster it into your React tree. 
+With Player running your content, you'll need to actually render out what is processes. To do this, you can use the React Player's component API to insert it into your React tree.
 
 ```javascript
 const MyApp = () => {
   return <reactPlayer.Component />;
 };
 ```
+  </react>
+  <ios>
 
-Congrats! You've got Player up and running. If you need additional functionality you can add more plugins to extend Player's functionality. Head over to the [Plugins](./plugins) section to take a look at the Plugins we've developed or take a look at the [Architecture](./architecture) section to see how you can write your own. 
-
-## iOS (Swift)
-
-### Install Dependencies
-
-In your `Podfile` you'll need to add `PlayerUI` as a dependency and the `ReferenceAssets` plugin to use the base set of assets. 
-
-```ruby
-target 'MyApp' do
-  # Add the pod to your target
-  pod 'PlayerUI'
-  pod 'PlayerUI/ReferenceAssets' # For example only
-end
-```
-
-### Configuration
-
-`SwiftUIPlayer` is just a normal SwiftUI View and can be inserted anywhere in your hierarchy. The flow will start automatically, and the result will update the `Binding<Result<CompletedState, PlayerError>?>` that you pass to it:
+Expanding on the `SwiftUIPlayer` creation above, providing a `flow` will start the Player automatically, and the `result` will update the `Binding<Result<CompletedState, PlayerError>?>` that you pass to it:
 
 ```swift
 import PlayerUI
@@ -89,112 +139,24 @@ struct MyApp: View {
   }
 }
 ```
+  </ios>
+  <android>
 
-## JVM/Android
-
-### Install Dependencies
-
-Configure the Android Player dependencies in your Gradle files. You'll also need to add a plugin that provides asset definitions and components. To get started, we are going to use the reference set provided by the Android Player. _Note: The reference asset set isn't intended for production use. It exists as an example of how to create an Android asset and can be used to help get started. _ 
-
-<Tabs>
-<Gradle language="Kotlin">
+To receive view updates, you must add a handler to render the views which are represented as `RenderableAsset`s.
 
 ```kotlin
-// Add Android Player dependencies
-dependencies {
-    // Android Player
-    implementation("com.intuit.player.android", "player", androidPlayerVersion)
-    // Optional - reference asset set
-    implementation("com.intuit.player.android", "assets", referenceAssetsVersion)
-}
-```
-
-</Gradle>  
-<Gradle language="Groovy">
-
-```groovy
-// Add Android Player dependencies
-dependencies {
-    // Android Player
-    implementation "com.intuit.player.android:player:$androidPlayerVersion"
-    // Optional - reference asset set
-    implementation "com.intuit.player.android:assets:$referenceAssetsVersion"
-}
-```
-
-</Gradle>
-<Maven>
-
-```xml
-<dependency>
-    <groupId>com.intuit.player.jvm</groupId>
-    <artifactId>core</artifactId>
-    <version>3.2.1</version>
-</dependency>
-```
-
-</Maven>
-</Tabs>
-
-### Configuration
-
-All you need to create an `AndroidPlayer` instance is the Android Context and any plugins you want.
-
-```kotlin
-// create Android Player with reference assets plugin
-val player = AndroidPlayer(context, ReferenceAssetsPlugin())
-```
-
-Once you have a Player, you must add a handler for view updates, which are represented as RenderableAssets. 
-
-```kotlin
-// handle view updates
+// handle view updates - should be done before starting the Player
 player.onUpdate { asset: RenderableAsset? ->
-    // render asset as View
-    val view: View = asset?.render()
-    // add view to screen
+    // render asset as View `into` view tree
+    asset?.render() into binding.playerContainer
 }
-```
 
-### Usage
-
-#### Basic
-With the Android Player and handler configured, all that's left is starting a flow. This is done by calling
-start with a JSON string containing your Player content.
-
-```kotlin
+// start Player
 player.start(content)
 ```
 
-When you're done with Player, release any native runtime memory used to instantiate Player or run the flow.
+Creating your own `AndroidPlayer` instance is fairly simple, but it grows in complexity when considering proper resources management and app orchestration. We provide a Fragment/ViewModel integration to make it easier to properly integrate into your app and account for these concerns. Check out the [PlayerViewModel](./player-view-model) section for more information.
+  </android>
+</PlatformTabs>
 
-```kotlin
-player.release()
-```
-
-#### ViewModel
-
-With the `PlayerViewModel` and `PlayerFragment`, the above orchestration is done for you. All that is needed is to provide concrete implementations of each and add the fragment to your app.
-
-##### PlayerViewModel
-The `PlayerViewModel` is an `AndroidViewModel` meaning it requires the actual Android `Application` as well as an `AsyncFlowIterator` to be supplied in the constructor. The AsyncFlowIterator is what tells Player which flows to run. This can be hardcoded into the view model or expected as an argument, as shown below.
-
-```kotlin
-class SimplePlayerViewModel(application: Application, flows: AsyncFlowIterator) : PlayerViewModel(application, flows) {
-    override val plugins = listOf(ReferenceAssetsPlugin())
-}
-```
-
-##### PlayerFragment
-
-The `PlayerFragment` is a simple Android `Fragment` that only requires a specific `PlayerViewModel` to be defined. If your view model requires the AsyncFlowIterator to be passed as part of the constructor, you can leverage the `PlayerViewModel.Factory` to produce it, as shown below.
-
-Specifically, this fragment takes a flow as an argument to the constructor and creates a single-flow `AsyncFlowIterator` instance using the pseudo-constructor helper.
-
-```kotlin
-class SimplePlayerFragment(override val flow: String) : PlayerFragment() {
-    override val playerViewModel by viewModels<SimplePlayerViewModel> {
-        PlayerViewModel.Factory(requireActivity().application, AsyncFlowIterator(flow), ::SimplePlayerViewModel)
-    }
-}
-```
+Congrats! You've got Player up and running. If you need additional functionality you can add more plugins to extend Player's functionality. Head over to the [Plugins](./plugins) section to take a look at the Plugins we've developed or take a look at the [Architecture](./architecture) section to see how you can write your own.

--- a/docs/site/pages/getting-started.mdx
+++ b/docs/site/pages/getting-started.mdx
@@ -155,7 +155,41 @@ player.onUpdate { asset: RenderableAsset? ->
 player.start(content)
 ```
 
-Creating your own `AndroidPlayer` instance is fairly simple, but it grows in complexity when considering proper resources management and app orchestration. We provide a Fragment/ViewModel integration to make it easier to properly integrate into your app and account for these concerns. Check out the [PlayerViewModel](./player-view-model) section for more information.
+When you're done with Player, release any native runtime memory used to instantiate Player or run the flow.
+
+```kotlin
+player.release()
+```
+
+Creating your own `AndroidPlayer` instance is fairly simple, but it grows in complexity when considering proper resources management and app orchestration. We provide a Fragment/ViewModel integration to make it easier to properly integrate into your app and account for these concerns. 
+
+#### ViewModel
+
+With the `PlayerViewModel` and `PlayerFragment`, the above orchestration is done for you. All that is needed is to provide concrete implementations of each and add the fragment to your app.
+
+##### PlayerViewModel
+
+The `PlayerViewModel` requires an `AsyncFlowIterator` to be supplied in the constructor. The AsyncFlowIterator is what tells Player which flows to run. This can be hardcoded into the view model or expected as an argument, as shown below.
+
+```kotlin
+class SimplePlayerViewModel(flows: AsyncFlowIterator) : PlayerViewModel(flows) {
+    override val plugins = listOf(ReferenceAssetsPlugin())
+}
+```
+
+##### PlayerFragment
+
+The `PlayerFragment` is a simple Android `Fragment` that only requires a specific `PlayerViewModel` to be defined. If your view model requires the `AsyncFlowIterator` to be passed as part of the constructor, you can leverage the `PlayerViewModel.Factory` to produce it, as shown below.
+
+Specifically, this fragment takes a flow as an argument to the constructor and creates a single-flow `AsyncFlowIterator` instance using the pseudo-constructor helper.
+
+```kotlin
+class SimplePlayerFragment(override val flow: String) : PlayerFragment() {
+    override val playerViewModel by viewModels<SimplePlayerViewModel> {
+        PlayerViewModel.Factory(AsyncFlowIterator(flow), ::SimplePlayerViewModel)
+    }
+}
+```
   </android>
 </PlatformTabs>
 


### PR DESCRIPTION
Organize common documentation to follow similar structure across platforms and use nested `PlatformTabs` to swap code blocks
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.6.1--canary.287.9035</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.6.1--canary.287.9035
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
