### PR TITLE
[Android] `AsyncHydrationTrackerPlugin`

### DIFF
--- a/android/demo/src/main/java/com/intuit/playerui/android/reference/demo/lifecycle/DemoPlayerViewModel.kt
+++ b/android/demo/src/main/java/com/intuit/playerui/android/reference/demo/lifecycle/DemoPlayerViewModel.kt
@@ -2,8 +2,11 @@ package com.intuit.playerui.android.reference.demo.lifecycle
 
 import com.intuit.playerui.android.AndroidPlayer
 import com.intuit.playerui.android.AndroidPlayer.Config
+import com.intuit.playerui.android.asset.SuspendableAsset.AsyncHydrationTrackerPlugin
+import com.intuit.playerui.android.asset.asyncHydrationTrackerPlugin
 import com.intuit.playerui.android.lifecycle.PlayerViewModel
 import com.intuit.playerui.android.reference.assets.ReferenceAssetsPlugin
+import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
 import com.intuit.playerui.core.managed.AsyncFlowIterator
 import com.intuit.playerui.core.player.state.PlayerFlowState
 import com.intuit.playerui.plugins.transactions.PendingTransactionPlugin
@@ -18,6 +21,7 @@ class DemoPlayerViewModel(iterator: AsyncFlowIterator) : PlayerViewModel(iterato
         CommonTypesPlugin(),
         ReferenceAssetsPlugin(),
         PendingTransactionPlugin(),
+        AsyncHydrationTrackerPlugin(),
     )
 
     override val config: Config = Config(
@@ -28,11 +32,16 @@ class DemoPlayerViewModel(iterator: AsyncFlowIterator) : PlayerViewModel(iterato
 
     public val playerFlowState: StateFlow<PlayerFlowState?> = _playerFlowState.asStateFlow()
 
+    @OptIn(ExperimentalPlayerApi::class)
     override fun apply(androidPlayer: AndroidPlayer) {
         super.apply(androidPlayer)
 
         androidPlayer.hooks.state.tap { state ->
             _playerFlowState.tryEmit(state)
+        }
+
+        androidPlayer.asyncHydrationTrackerPlugin!!.hooks.onHydrationComplete.tap(this::class.java.name) {
+            androidPlayer.logger.info("Done hydrating!!!!")
         }
     }
 }

--- a/android/player/src/main/java/com/intuit/playerui/android/asset/SuspendableAsset.kt
+++ b/android/player/src/main/java/com/intuit/playerui/android/asset/SuspendableAsset.kt
@@ -63,7 +63,6 @@ public abstract class SuspendableAsset<Data>(assetContext: AssetContext, seriali
     }
 
     private suspend fun View.doHydrate() = withContext(Dispatchers.Main) {
-        player.asyncHydrationTrackerPlugin?.trackHydration(this@SuspendableAsset)
         try {
             hydrate(getData())
             setTag(R.bool.view_hydrated, true)

--- a/android/player/src/main/java/com/intuit/playerui/android/asset/SuspendableAsset.kt
+++ b/android/player/src/main/java/com/intuit/playerui/android/asset/SuspendableAsset.kt
@@ -20,11 +20,9 @@ import com.intuit.playerui.core.player.PlayerException
 import com.intuit.playerui.core.player.state.inProgressState
 import com.intuit.playerui.core.plugins.findPlugin
 import com.intuit.playerui.core.utils.InternalPlayerApi
-import com.intuit.playerui.plugins.coroutines.flowScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
@@ -103,9 +101,11 @@ public abstract class SuspendableAsset<Data>(assetContext: AssetContext, seriali
             }
         }
         override fun apply(androidPlayer: AndroidPlayer) {
-            androidPlayer.onUpdate { _, _ -> synchronized(trackedHydrations) {
-                trackedHydrations.clear()
-            } }
+            androidPlayer.onUpdate { _, _ ->
+                synchronized(trackedHydrations) {
+                    trackedHydrations.clear()
+                }
+            }
         }
 
         public class Hooks {

--- a/android/player/src/main/java/com/intuit/playerui/android/asset/SuspendableAsset.kt
+++ b/android/player/src/main/java/com/intuit/playerui/android/asset/SuspendableAsset.kt
@@ -57,6 +57,7 @@ public abstract class SuspendableAsset<Data>(assetContext: AssetContext, seriali
     final override fun View.hydrate() {
         if (this is AsyncViewStub) return
 
+        player.asyncHydrationTrackerPlugin?.trackHydration(this@SuspendableAsset)
         setTag(R.bool.view_hydrated, false)
         hydrationScope.launch(Dispatchers.Main) { doHydrate() }
     }

--- a/android/player/src/main/java/com/intuit/playerui/android/asset/SuspendableAsset.kt
+++ b/android/player/src/main/java/com/intuit/playerui/android/asset/SuspendableAsset.kt
@@ -39,7 +39,7 @@ public abstract class SuspendableAsset<Data>(assetContext: AssetContext, seriali
 
     final override fun initView(): View {
         // ensure we pre-track hydration to ensure all assets are accounted for during async hydration
-        player.asyncHydrationTrackerPlugin?.hydrationDone(this@SuspendableAsset)
+        player.asyncHydrationTrackerPlugin?.trackHydration(this@SuspendableAsset)
         return AsyncViewStub(
             hydrationScope,
             hydrationScope.async { doInitView() },

--- a/android/player/src/main/java/com/intuit/playerui/android/asset/SuspendableAsset.kt
+++ b/android/player/src/main/java/com/intuit/playerui/android/asset/SuspendableAsset.kt
@@ -83,6 +83,7 @@ public abstract class SuspendableAsset<Data>(assetContext: AssetContext, seriali
 
         public fun trackHydration(asset: SuspendableAsset<*>) {
             synchronized(trackedHydrations) {
+                if (trackedHydrations.isEmpty()) hooks.onHydrationStarted.call()
                 trackedHydrations.add(asset.assetContext.id)
             }
         }
@@ -107,12 +108,19 @@ public abstract class SuspendableAsset<Data>(assetContext: AssetContext, seriali
         }
 
         public class Hooks {
+            public class OnHydrationStartedHook : SyncHook<(HookContext) -> Unit>() {
+                public fun call(): Unit = super.call { f, context ->
+                    f(context)
+                }
+            }
+
             public class OnHydrationCompleteHook : SyncHook<(HookContext) -> Unit>() {
                 public fun call(): Unit = super.call { f, context ->
                     f(context)
                 }
             }
 
+            public val onHydrationStarted: OnHydrationStartedHook = OnHydrationStartedHook()
             public val onHydrationComplete: OnHydrationCompleteHook = OnHydrationCompleteHook()
         }
     }

--- a/plugins/beacon/jvm/src/main/kotlin/com/intuit/playerui/plugins/beacon/BeaconPlugin.kt
+++ b/plugins/beacon/jvm/src/main/kotlin/com/intuit/playerui/plugins/beacon/BeaconPlugin.kt
@@ -2,7 +2,6 @@ package com.intuit.playerui.plugins.beacon
 
 import com.intuit.playerui.core.asset.Asset
 import com.intuit.playerui.core.bridge.getInvokable
-import com.intuit.playerui.core.bridge.runtime
 import com.intuit.playerui.core.bridge.runtime.Runtime
 import com.intuit.playerui.core.bridge.runtime.ScriptContext
 import com.intuit.playerui.core.bridge.runtime.add
@@ -13,7 +12,6 @@ import com.intuit.playerui.core.plugins.JSScriptPluginWrapper
 import com.intuit.playerui.core.plugins.Pluggable
 import com.intuit.playerui.core.plugins.findPlugin
 import com.intuit.playerui.plugins.settimeout.SetTimeoutPlugin
-import kotlinx.coroutines.launch
 import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -57,18 +55,17 @@ public class BeaconPlugin(override val plugins: List<JSPluginWrapper>) : JSScrip
         handlers.add(handler)
     }
 
+    // TODO: Convert to suspend method to ensure view scope is captured in a non-blocking way
     /** Fire a beacon event */
     public fun beacon(action: String, element: String, asset: Asset, data: Any? = null) {
-        runtime.scope.launch {
-            instance.getInvokable<Any?>("beacon")!!.invoke(
-                mapOf(
-                    "action" to action,
-                    "element" to element,
-                    "asset" to asset,
-                    "data" to data,
-                ),
-            )
-        }
+        instance.getInvokable<Any?>("beacon")!!.invoke(
+            mapOf(
+                "action" to action,
+                "element" to element,
+                "asset" to asset,
+                "data" to data,
+            ),
+        )
     }
 
     private companion object {


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->

# Release Notes

Introduction of `AsyncHydrationTrackerPlugin` to provide a mechanism for reacting when `SuspendableAsset` hydration is completely finished.

```kotlin
androidPlayer.asyncHydrationTrackerPlugin!!.hooks.onHydrationComplete.tap(this::class.java.name) {
    // process effects after hydration is complete
}
```