### PR TITLE
fix: help to improve docs links with relative path

### DIFF
--- a/docs/site/plugins/mdx-link-append-loader.js
+++ b/docs/site/plugins/mdx-link-append-loader.js
@@ -1,5 +1,9 @@
+const path = require('path');
+
 module.exports = function (source) {
   const filePath = this.resourcePath;
-  const newContent = `${source}\n\n---\n\n[Help to improve this page](https://github.dev/playerui/player/blob/main/${filePath})`;
+  const rootDir = this.rootContext;
+  const relativePath = path.relative(rootDir, filePath);
+  const newContent = `${source}\n\n---\n\n[Help to improve this page](https://github.dev/player-ui/player/blob/main/${relativePath})`;
   return newContent;
 };


### PR DESCRIPTION
### Description

Use relative paths for the `Help to improve this page` doc's links, otherwise we get the absolute path pointing to the Bazel output.

### Change Type

- [x] `patch`
- [ ] `minor`
- [ ] `major`