### PR TITLE
fix: missing docs/site on docs links

### DIFF
--- a/docs/site/plugins/mdx-link-append-loader.js
+++ b/docs/site/plugins/mdx-link-append-loader.js
@@ -4,6 +4,6 @@ module.exports = function (source) {
   const filePath = this.resourcePath;
   const rootDir = this.rootContext;
   const relativePath = path.relative(rootDir, filePath);
-  const newContent = `${source}\n\n---\n\n[Help to improve this page](https://github.dev/player-ui/player/blob/main/${relativePath})`;
+  const newContent = `${source}\n\n---\n\n[Help to improve this page](https://github.dev/player-ui/player/blob/main/docs/site/${relativePath})`;
   return newContent;
 };


### PR DESCRIPTION
### Description

Add missing `.../docs/site/...` fragment to the help to improve docs' links.

### Change Type

- [x] `patch`
- [ ] `minor`
- [ ] `major`