### PR TITLE
iOS: add asyncnodeplugin resource path to bazel.build zip

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -57,8 +57,7 @@ assemble_pod(
         "//core/make-flow:MakeFlow_Bundles_bundle_prod": "ios/packages/test-utils/Resources/",
         "//plugins/reference-assets/core:ReferenceAssetsPlugin_Bundles_bundle_prod": "ios/packages/reference-assets/Resources/js/",
         # Plugins
-        "//plugins/async-node/core:AsyncNodePlugin_Bundles_bundle_prod":
-            "ios/plugins/AsyncNodePlugin/Resources/",
+        "//plugins/async-node/core:AsyncNodePlugin_Bundles_bundle_prod": "ios/plugins/AsyncNodePlugin/Resources/",
         "//plugins/beacon/core:BeaconPlugin_Bundles_bundle_prod": "ios/plugins/BaseBeaconPlugin/Resources/",
         "//plugins/check-path/core:CheckPathPlugin_Bundles_bundle_prod": "ios/plugins/CheckPathPlugin/Resources/",
         "//plugins/common-types/core:CommonTypesPlugin_Bundles_bundle_prod": "ios/plugins/CommonTypesPlugin/Resources/",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -57,6 +57,8 @@ assemble_pod(
         "//core/make-flow:MakeFlow_Bundles_bundle_prod": "ios/packages/test-utils/Resources/",
         "//plugins/reference-assets/core:ReferenceAssetsPlugin_Bundles_bundle_prod": "ios/packages/reference-assets/Resources/js/",
         # Plugins
+        "//plugins/async-node/core:AsyncNodePlugin_Bundles_bundle_prod":
+            "ios/plugins/AsyncNodePlugin/Resources/",
         "//plugins/beacon/core:BeaconPlugin_Bundles_bundle_prod": "ios/plugins/BaseBeaconPlugin/Resources/",
         "//plugins/check-path/core:CheckPathPlugin_Bundles_bundle_prod": "ios/plugins/CheckPathPlugin/Resources/",
         "//plugins/common-types/core:CommonTypesPlugin_Bundles_bundle_prod": "ios/plugins/CommonTypesPlugin/Resources/",


### PR DESCRIPTION
To fix publishing error for iOS


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->