### PR TITLE
Expression Parser Strictness

### DIFF
--- a/core/player/src/expressions/evaluator.ts
+++ b/core/player/src/expressions/evaluator.ts
@@ -78,6 +78,9 @@ export interface HookOptions extends ExpressionContext {
    * The caller is responsible for handling the error.
    */
   throwErrors?: boolean;
+
+  /** Whether expressions should be parsed strictly or not */
+  strict?: boolean;
 }
 
 export type ExpressionEvaluatorOptions = Omit<
@@ -226,7 +229,8 @@ export class ExpressionEvaluator {
 
     try {
       storedAST =
-        this.expressionsCache.get(matchedExp) ?? parseExpression(matchedExp);
+        this.expressionsCache.get(matchedExp) ??
+        parseExpression(matchedExp, { strict: options.strict });
       this.expressionsCache.set(matchedExp, storedAST);
     } catch (e: any) {
       if (options.throwErrors || !this.hooks.onError.call(e)) {

--- a/core/player/src/expressions/parser.ts
+++ b/core/player/src/expressions/parser.ts
@@ -797,7 +797,7 @@ export function parseExpression(
       args.push(node);
     }
 
-    if (charIndex !== termination) {
+    if (strictMode && charIndex !== termination) {
       throwError(`Expected ${String.fromCharCode(termination)}`, index);
     }
 
@@ -929,7 +929,7 @@ export function parseExpression(
         nodes.push(node);
         // If we weren't able to find a binary expression and are out of room, then
         // the expression passed in probably has too much
-      } else if (index < length) {
+      } else if (strictMode && index < length) {
         throwError(`Unexpected "${exprI(index)}"`, index);
       }
     }


### PR DESCRIPTION
While Player is strict about syntactically invalid expressions, it should still be allowed to execute them if the implementation desires. This change exposes the Expression Parser's `strict` attribute on the Expression Evaluator's hook to allow it to be set via the `resolveOptions` hook. This change also changes the behavior around throwing those errors to only throw recoverable errors if `strict` is `true`. 
 
### Change Type (required)
Indicate the type of change your pull request is:

- [x] `patch`
- [ ] `minor`
- [ ] `major`

## Release Notes
Expose Expression Parser's strictness option via the `resolveOptions` hook
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.7.2--canary.315.10130</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.7.2--canary.315.10130
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
