### PR TITLE
Fix `commaNumber` Formatting when Using a Precision of 0

### DIFF
--- a/plugins/common-types/core/src/formats/__tests__/formats.test.ts
+++ b/plugins/common-types/core/src/formats/__tests__/formats.test.ts
@@ -68,6 +68,9 @@ describe('commaNumber', () => {
       expect(commaNumber.format?.(1000.999, { precision: 2 })).toBe('1,000.99');
       expect(commaNumber.format?.(1000, { precision: 2 })).toBe('1,000.00');
       expect(commaNumber.format?.(1000.1, { precision: 2 })).toBe('1,000.10');
+      expect(commaNumber.format?.(123456789, { precision: 0 })).toBe(
+        '123,456,789'
+      );
     });
 
     it('handles out of bounds', () => {

--- a/plugins/common-types/core/src/formats/index.ts
+++ b/plugins/common-types/core/src/formats/index.ts
@@ -115,7 +115,6 @@ export const commaNumber: FormatType<
 
     // Beautify
     preDecDigits = preDecDigits.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-
     if (preDecDigits === '' && firstDecimal === 0) {
       preDecDigits = '0';
     }
@@ -127,7 +126,10 @@ export const commaNumber: FormatType<
       retVal = `-${retVal}`;
     }
 
-    if (firstDecimal >= 0 || options?.precision !== undefined) {
+    if (
+      (firstDecimal >= 0 || options?.precision !== undefined) &&
+      postDecDigits !== ''
+    ) {
       retVal += `.${postDecDigits}`;
     }
 


### PR DESCRIPTION
### Change Type (required)
Indicate the type of change your pull request is:

- [x] `patch`
- [ ] `minor`
- [ ] `major`

## Release Notes
Common Types Plugin - Fix `commaNumber` Formatting when Using a Precision of 0 