### PR TITLE
update iOS contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,12 @@ CocoaPods does not directly integrate with `bazel`, when core targets are update
 ./tools/build_ios_bundles.sh
 ```
 This will query `bazel` for dependent targets, copy their output and regenerate the `.xcworkspace`.
+
+`bazel` does not process resources the same way CocoaPods does, so in order to share the same [mocks](https://github.com/player-ui/player/tree/main/plugins/reference-assets/mocks) as the other platforms, there is a [precompile script](https://github.com/player-ui/player/blob/main/PlayerUI.podspec#L84-L91) that generates a `.swift` file with the mocks. In order for this to work, `node` must be accessible in your environment. To verify this, run:
+```sh
+env node
+```
+
 ### Player
 For speed and consistency, this repo leverages `bazel` as it's main build tool. Check out the [bazel](https://bazel.build/) docs for more info.
 

--- a/tools/build_ios_bundles.sh
+++ b/tools/build_ios_bundles.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 git_root=$(git rev-parse --show-toplevel)
 
+# Build all bundle targets that we rely on
 "bazel" build `bazel query 'attr(name, "^.*_Bundles$", //...)' --output label 2>/dev/null`
+# explicitly build make-flow
+"bazel" build //core/make-flow/...
+# run yarn so make-flow is importable in node runtime
+yarn
+# Run pod install to generate xcworkspace
 cd "$git_root/xcode" && bundle exec pod install


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

- Updates the iOS contributing guide to call out node usage for precompile script
- Updates the `build_ios_bundles.sh` to do some additional setup to make precompile script more reliable from fresh clone

i tried rebasing #188 but something went very wrong

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->