### PR TITLE
Version Selector Fixes

### DIFF
--- a/docs/site/components/Navigation.tsx
+++ b/docs/site/components/Navigation.tsx
@@ -216,7 +216,21 @@ export const VersionSelector = () => {
       }}
       value={router.basePath || 'latest'}
       onChange={(e) => {
-        router.push(`${DOCS_BASE_URL}/${e.target.value}`);
+        const currentRoute = router.pathname
+        .split('/')
+        .filter((s) => {
+          // filter out empty string and url elements that include the version
+          if (
+            s &&
+            !['latest', 'next', ...released.map((r) => r.path)].includes(s)
+          ) {
+            return true;
+          }
+    
+          return false;
+        })
+        .join('/');
+        router.push(`${DOCS_BASE_URL}${e.target.value}/${currentRoute}`);
       }}
     >
       <option value="latest">Latest</option>


### PR DESCRIPTION
Fixes:
- Version selector not properly redirecting
- Active page being reset when the version is changed

### Change Type (required)

- [x] `patch`
- [ ] `minor`
- [ ] `major`

### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs

## Release Notes
Docs - Fix version selector not working and preserve route when changing versions