### PR TITLE
iOS: expose data controller onUpdate hook

### DIFF
--- a/ios/packages/core/Sources/Types/Core/BindingParser.swift
+++ b/ios/packages/core/Sources/Types/Core/BindingParser.swift
@@ -34,7 +34,7 @@ public class BindingParser {
 }
 
 /// A path in the data model
-public class BindingInstance {
+public class BindingInstance: Decodable {
     internal var value: JSValue?
 
     /// Create a BindingInstance, a path to data in the data model
@@ -51,6 +51,11 @@ public class BindingInstance {
     /// - Parameter value: The JSValue that represents a JavaScript BindingInstance
     public init(from value: JSValue?) {
         self.value = value
+    }
+
+    ///Create a BindingInstance from a decoder
+    required public init(from decoder: Decoder) throws {
+        value = try decoder.getJSValue()
     }
 
     /// Retrieve this Binding as an array

--- a/ios/packages/core/Sources/Types/Core/DataController.swift
+++ b/ios/packages/core/Sources/Types/Core/DataController.swift
@@ -16,6 +16,9 @@ open class BaseDataController {
     /// The JSValue that backs this wrapper
     public let value: JSValue
 
+    /// The hooks that can be tapped into
+    public let hooks: DataControllerHooks
+
     /**
     Construct a DataController from a JSValue
     - parameters:
@@ -23,6 +26,9 @@ open class BaseDataController {
     */
     public init(_ value: JSValue) {
         self.value = value
+        self.hooks = DataControllerHooks(
+            onUpdate: HookDecode<[Update]>(baseValue: self.value, name: "onUpdate")
+        )
     }
 
     /**

--- a/ios/packages/core/Sources/Types/Hooks/DataControllerHooks.swift
+++ b/ios/packages/core/Sources/Types/Hooks/DataControllerHooks.swift
@@ -1,0 +1,29 @@
+//
+//  DataControllerHooks.swift
+//  PlayerUI
+//
+//  Created by Zhao Xia Wu on 2024-04-08.
+//
+
+import Foundation
+import JavaScriptCore
+
+/**
+Hooks that can be tapped into for the DataController
+This lets users tap into events in the JS environment
+*/
+public struct DataControllerHooks {
+    /// Fired when the data changes
+    public var onUpdate: HookDecode<[Update]>
+}
+
+public struct Update: Decodable {
+    /** The updated binding */
+    var binding: BindingInstance
+    /** The old value */
+    var oldValue: AnyType
+    /** The new value */
+    var newValue: AnyType
+    /** Force the Update to be included even if no data changed */
+    var force: Bool?
+}

--- a/ios/packages/core/Sources/Types/Hooks/Hook.swift
+++ b/ios/packages/core/Sources/Types/Hooks/Hook.swift
@@ -96,10 +96,9 @@ public class HookDecode<T>: BaseJSHook where T: Decodable {
         - hook: A function to run when the JS hook is fired
      */
     public func tap(_ hook: @escaping (T) -> Void) {
-        let tapMethod: @convention(block) (JSValue?, JSValue?) -> Void = { value, value2 in
+        let tapMethod: @convention(block) (JSValue?) -> Void = { value in
             guard
                 let val = value,
-                let val2 = value2,
                 let hookValue = try? JSONDecoder().decode(T.self, from: val)
             else { return }
             hook(hookValue)
@@ -123,11 +122,13 @@ public class Hook2Decode<T, U>: BaseJSHook where T: Decodable, U: Decodable {
      */
     public func tap(_ hook: @escaping (T, U) -> Void) {
         let tapMethod: @convention(block) (JSValue?, JSValue?) -> Void = { value, value2 in
+
+            let decoder = JSONDecoder()
             guard
                 let val = value,
                 let val2 = value2,
-                let hookValue = try? JSONDecoder().decode(T.self, from: val),
-                let hookValue2 = try? JSONDecoder().decode(U.self, from: val2)
+                let hookValue = try? decoder.decode(T.self, from: val),
+                let hookValue2 = try? decoder.decode(U.self, from: val2)
             else { return }
             hook(hookValue, hookValue2)
         }

--- a/ios/packages/core/Sources/Types/Hooks/Hook.swift
+++ b/ios/packages/core/Sources/Types/Hooks/Hook.swift
@@ -85,6 +85,59 @@ public class Hook2<T, U>: BaseJSHook where T: CreatedFromJSValue, U: CreatedFrom
 
 /**
  This class represents an object in the JS runtime that can be tapped into
+ to receive JS events
+ */
+public class HookDecode<T>: BaseJSHook where T: Decodable {
+    /**
+     Attach a closure to the hook, so when the hook is fired in the JS runtime
+     we receive the event in the native runtime
+
+     - parameters:
+        - hook: A function to run when the JS hook is fired
+     */
+    public func tap(_ hook: @escaping (T) -> Void) {
+        let tapMethod: @convention(block) (JSValue?, JSValue?) -> Void = { value, value2 in
+            guard
+                let val = value,
+                let val2 = value2,
+                let hookValue = try? JSONDecoder().decode(T.self, from: val)
+            else { return }
+            hook(hookValue)
+        }
+
+        self.hook.invokeMethod("tap", withArguments: [name, JSValue(object: tapMethod, in: context) as Any])
+    }
+}
+
+/**
+ This class represents an object in the JS runtime that can be tapped into
+ to receive JS events that has 2 parameters
+ */
+public class Hook2Decode<T, U>: BaseJSHook where T: Decodable, U: Decodable {
+    /**
+     Attach a closure to the hook, so when the hook is fired in the JS runtime
+     we receive the event in the native runtime
+
+     - parameters:
+        - hook: A function to run when the JS hook is fired
+     */
+    public func tap(_ hook: @escaping (T, U) -> Void) {
+        let tapMethod: @convention(block) (JSValue?, JSValue?) -> Void = { value, value2 in
+            guard
+                let val = value,
+                let val2 = value2,
+                let hookValue = try? JSONDecoder().decode(T.self, from: val),
+                let hookValue2 = try? JSONDecoder().decode(U.self, from: val2)
+            else { return }
+            hook(hookValue, hookValue2)
+        }
+
+        self.hook.invokeMethod("tap", withArguments: [name, JSValue(object: tapMethod, in: context) as Any])
+    }
+}
+
+/**
+ This class represents an object in the JS runtime that can be tapped into
  and returns a promise that resolves when the asynchronous task is completed
  */
 public class AsyncHook<T>: BaseJSHook where T: CreatedFromJSValue {

--- a/ios/packages/core/Tests/HeadlessPlayerTests.swift
+++ b/ios/packages/core/Tests/HeadlessPlayerTests.swift
@@ -259,6 +259,7 @@ class HeadlessPlayerTests: XCTestCase {
         XCTAssertNotNil(player.state as? NotStartedState)
         player.hooks?.dataController.tap({ dataController in
             dataController.hooks.onUpdate.tap { updates in
+                XCTAssertEqual(updates.first?.binding.asString(), "count")
                 XCTAssertEqual(updates.first?.oldValue, AnyType.number(data: 0))
                 XCTAssertEqual(updates.first?.newValue, AnyType.number(data: 5))
                 updateExp.fulfill()

--- a/ios/packages/core/Tests/HeadlessPlayerTests.swift
+++ b/ios/packages/core/Tests/HeadlessPlayerTests.swift
@@ -250,6 +250,26 @@ class HeadlessPlayerTests: XCTestCase {
             }
         }
     }
+
+    func testDataControllerOnUpdate() {
+        let player = HeadlessPlayerImpl(plugins: [])
+
+        let updateExp = expectation(description: "Data Updated")
+
+        XCTAssertNotNil(player.state as? NotStartedState)
+        player.hooks?.dataController.tap({ dataController in
+            dataController.hooks.onUpdate.tap { updates in
+                XCTAssertEqual(updates.first?.oldValue, AnyType.number(data: 0))
+                XCTAssertEqual(updates.first?.newValue, AnyType.number(data: 5))
+                updateExp.fulfill()
+            }
+
+            dataController.set(transaction: ["count": 5])
+        })
+
+        player.start(flow: FlowData.COUNTER) { _ in}
+        wait(for: [updateExp], timeout: 1)
+    }
 }
 
 class FakePlugin: JSBasePlugin, NativePlugin {


### PR DESCRIPTION
expose on update hook so Swift plugins can recieve data changes


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->