### PR TITLE
Fix false positive binding with opening {

### DIFF
--- a/core/player/src/binding-grammar/__tests__/test-utils/ast-cases.ts
+++ b/core/player/src/binding-grammar/__tests__/test-utils/ast-cases.ts
@@ -185,6 +185,7 @@ export const INVALID_AST_PARSER_TESTS: Array<string> = [
   'foo.bar[',
   'foo.bar.{{nested.}',
   'foo.bar`not done()',
+  '{foo.bar',
 ];
 
 export const VALID_AST_PARSER_CUSTOM_TESTS: Array<[string, PathNode]> = [

--- a/core/player/src/binding-grammar/custom/index.ts
+++ b/core/player/src/binding-grammar/custom/index.ts
@@ -146,15 +146,13 @@ export const parse: Parser = (path) => {
   const nestedPath = (): PathNode | undefined => {
     if (ch === OPEN_CURL) {
       next(OPEN_CURL);
-      if (ch === OPEN_CURL) {
-        next(OPEN_CURL);
+      next(OPEN_CURL);
 
-        /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
-        const modelRef = parsePath();
-        next(CLOSE_CURL);
-        next(CLOSE_CURL);
-        return modelRef;
-      }
+      /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
+      const modelRef = parsePath();
+      next(CLOSE_CURL);
+      next(CLOSE_CURL);
+      return modelRef;
     }
   };
 


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.


Make sure to add:
  - Tests
  - Documentation Updates

-->
Fix #157. Require two adjacent { for a binding.

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [x] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->