### PR TITLE
[Android] Reorganize `PlayerFragment` state updates

### DIFF
--- a/android/demo/src/main/java/com/intuit/playerui/android/reference/demo/ui/base/BasePlayerFragment.kt
+++ b/android/demo/src/main/java/com/intuit/playerui/android/reference/demo/ui/base/BasePlayerFragment.kt
@@ -1,6 +1,5 @@
 package com.intuit.playerui.android.reference.demo.ui.base
 
-import android.graphics.drawable.GradientDrawable
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -19,7 +18,6 @@ import com.intuit.playerui.core.bridge.toJson
 import com.intuit.playerui.core.managed.AsyncFlowIterator
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 /** Simple [PlayerFragment] example that builds a [DemoPlayerViewModel] w/ a single flow iterator */
 abstract class BasePlayerFragment : PlayerFragment() {
@@ -35,16 +33,6 @@ abstract class BasePlayerFragment : PlayerFragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         StethoHelper.initializeDebugger(requireContext(), playerViewModel.player)
         return super.onCreateView(inflater, container, savedInstanceState)
-    }
-
-    private suspend fun toggleScreenShare(active: Boolean) = withContext(Dispatchers.Main) {
-        binding.playerCanvas.background = if (active) {
-            GradientDrawable().apply {
-                setStroke(30, resources.getColor(android.R.color.holo_green_light))
-            }
-        } else {
-            null
-        }
     }
 
     override fun buildFallbackView(exception: Exception): View? = currentPlayerCanvas

--- a/android/player/src/main/java/com/intuit/playerui/android/extensions/Into.kt
+++ b/android/player/src/main/java/com/intuit/playerui/android/extensions/Into.kt
@@ -6,12 +6,6 @@ import android.widget.FrameLayout
 import androidx.core.view.children
 import androidx.transition.Transition
 import androidx.transition.TransitionManager
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-
-internal suspend infix fun View?.intoOnMain(root: FrameLayout) = withContext(Dispatchers.Main) {
-    into(root)
-}
 
 /**
  * Helper method to replace the existing [FrameLayout] child

--- a/scripts/mvn-install.sh
+++ b/scripts/mvn-install.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -u -e -o pipefail
+
+# Find all the maven packages in the repo
+readonly DEPLOY_LABELS=$(bazel query --output=label 'kind("maven_publish rule", //...) - attr("tags", "\[.*do-not-publish.*\]", //...)')
+for pkg in $DEPLOY_LABELS ; do
+  bazel run "$pkg" --define=maven_repo="file://$HOME/.m2/repository"
+done


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

Currently,`playerViewModel.state` collection in `PlayerFragment` is a mix between UI updates and callback handling. This separates each to ensure the latest states take precedence for UI updates and such updates don't block the state callbacks.

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.7.3--canary.343.11262</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.7.3--canary.343.11262
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
