### PR TITLE
Parse multi node switch fixv1

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.com

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-registry=https://registry.npmjs.com

--- a/core/player/src/view/__tests__/view.test.ts
+++ b/core/player/src/view/__tests__/view.test.ts
@@ -70,6 +70,55 @@ describe('view', () => {
       expect(updated).toBe(resolved);
     });
 
+
+    test('works with no valid switch cases in an array', () => {
+      const model = withParser(new LocalModel({}), parseBinding);
+      const evaluator = new ExpressionEvaluator({ model });
+      const schema = new SchemaController();
+
+      const view = new ViewInstance(
+          {
+            id: 'test',
+            type: 'view',
+            title: [
+              {
+                staticSwitch: [
+                  {
+                    case: false,
+                    asset: {
+                      id: 'false-case',
+                      type: 'text',
+                      value: 'some text',
+                    },
+                  },
+                  {
+                    case: false,
+                    asset: {
+                      id: 'false-case-2',
+                      type: 'text',
+                      value: 'some text',
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        {
+          model,
+          parseBinding,
+          evaluator,
+          schema,
+        }
+      );
+
+      const resolved = view.update();
+
+      expect(resolved).toStrictEqual({
+        id: 'test',
+        type: 'view',
+      });
+    });
+
     it('does not return a field object if the case does not resolve an asset', () => {
       const model = withParser(
         new LocalModel({

--- a/core/player/src/view/__tests__/view.test.ts
+++ b/core/player/src/view/__tests__/view.test.ts
@@ -70,39 +70,38 @@ describe('view', () => {
       expect(updated).toBe(resolved);
     });
 
-
     test('works with no valid switch cases in an array', () => {
       const model = withParser(new LocalModel({}), parseBinding);
       const evaluator = new ExpressionEvaluator({ model });
       const schema = new SchemaController();
 
       const view = new ViewInstance(
-          {
-            id: 'test',
-            type: 'view',
-            title: [
-              {
-                staticSwitch: [
-                  {
-                    case: false,
-                    asset: {
-                      id: 'false-case',
-                      type: 'text',
-                      value: 'some text',
-                    },
+        {
+          id: 'test',
+          type: 'view',
+          title: [
+            {
+              staticSwitch: [
+                {
+                  case: false,
+                  asset: {
+                    id: 'false-case',
+                    type: 'text',
+                    value: 'some text',
                   },
-                  {
-                    case: false,
-                    asset: {
-                      id: 'false-case-2',
-                      type: 'text',
-                      value: 'some text',
-                    },
+                },
+                {
+                  case: false,
+                  asset: {
+                    id: 'false-case-2',
+                    type: 'text',
+                    value: 'some text',
                   },
-                ],
-              },
-            ],
-          },
+                },
+              ],
+            },
+          ],
+        },
         {
           model,
           parseBinding,

--- a/core/player/src/view/parser/index.ts
+++ b/core/player/src/view/parser/index.ts
@@ -128,6 +128,10 @@ export class Parser {
   ): Node.Node | null {
     const nodeType = this.hooks.determineNodeType.call(obj);
 
+    console.log('@@ PARSEOBJECT[obj]: ',obj)
+    console.log('@@ PARSEOBJECT[type]: ',type)
+    
+    //nodeType is what it should be checking on
     if (nodeType !== undefined) {
       const parsedNode = this.hooks.parseNode.call(
         obj,
@@ -173,6 +177,8 @@ export class Parser {
       const newValue = objEntries.reduce((accumulation, current): NestedObj => {
         const { children, ...rest } = accumulation;
         const [localKey, localValue] = current;
+        console.log('@@ PARSER LOCALKEY: ', localKey)
+        console.log('@@ PARSER LOCALVALUE: ', localValue)
         if (localKey === 'asset' && typeof localValue === 'object') {
           const assetAST = this.parseObject(
             localValue,
@@ -233,16 +239,21 @@ export class Parser {
             children: [...children, ...templateChildren],
           } as NestedObj;
         } else if (
-          localValue &&
-          this.hooks.determineNodeType.call(localValue) === NodeType.Switch
+          (localValue && 
+          this.hooks.determineNodeType.call(localValue) === NodeType.Switch) || localKey === 'staticSwitch'
         ) {
+          console.log('@@ PARSER[parseLocalObject] localValue: ',localValue)
+          console.log('@@ PARSER[parseLocalObject] DetermineNodeType: ',this.hooks.determineNodeType.call(localValue))
+
           const localSwitch = this.hooks.parseNode.call(
-            localValue,
+            localKey === 'staticSwitch' ? {"staticSwitch":localValue}:localValue,
             NodeType.Value,
             options,
             NodeType.Switch
           );
 
+
+          console.log('@@ PARSER[parseLocalObject] localSwitch: ',localSwitch)
           if (
             localSwitch &&
             localSwitch.type === NodeType.Value &&
@@ -288,13 +299,17 @@ export class Parser {
             });
           }
         } else if (localValue && Array.isArray(localValue)) {
+          console.log('@@ IN PARSER[multinode] [localValue]: ', localValue)
+          localValue.map((childValues)=>console.log("@@CHILDVALUES FOR LOCALVALUE^: ", childValues))
           const childValues = localValue
             .map((childVal) =>
               this.parseObject(childVal, NodeType.Value, options)
             )
             .filter((child): child is Node.Node => !!child);
+          
 
           if (childValues.length > 0) {
+            console.log('@@ PARSER in childValues: ',childValues)
             const multiNode = this.hooks.onCreateASTNode.call(
               {
                 type: NodeType.MultiNode,
@@ -310,7 +325,7 @@ export class Parser {
                 v.parent = multiNode;
               });
             }
-
+            console.log('@@ Parser: in multinode: ',multiNode)
             if (multiNode) {
               return {
                 ...rest,

--- a/core/player/src/view/parser/index.ts
+++ b/core/player/src/view/parser/index.ts
@@ -121,8 +121,8 @@ export class Parser {
     );
   }
 
-  private hasSwitchKey(localKey: string){
-    return localKey.toLocaleLowerCase() === ('staticswitch' || 'dynamicswitch')
+  private hasSwitchKey(localKey: string) {
+    return localKey === ('staticSwitch' || 'dynamicSwitch');
   }
 
   public parseObject(
@@ -132,7 +132,6 @@ export class Parser {
   ): Node.Node | null {
     const nodeType = this.hooks.determineNodeType.call(obj);
 
-    //nodeType is what it should be checking on
     if (nodeType !== undefined) {
       const parsedNode = this.hooks.parseNode.call(
         obj,
@@ -239,11 +238,15 @@ export class Parser {
             children: [...children, ...templateChildren],
           } as NestedObj;
         } else if (
-          (localValue && 
-          this.hooks.determineNodeType.call(localValue) === NodeType.Switch) || this.hasSwitchKey(localKey)
+          (localValue &&
+            this.hooks.determineNodeType.call(localValue) ===
+              NodeType.Switch) ||
+          this.hasSwitchKey(localKey)
         ) {
           const localSwitch = this.hooks.parseNode.call(
-            this.hasSwitchKey(localKey) ? {[localKey]:localValue}:localValue,
+            this.hasSwitchKey(localKey)
+              ? { [localKey]: localValue }
+              : localValue,
             NodeType.Value,
             options,
             NodeType.Switch
@@ -299,7 +302,6 @@ export class Parser {
               this.parseObject(childVal, NodeType.Value, options)
             )
             .filter((child): child is Node.Node => !!child);
-          
 
           if (childValues.length > 0) {
             const multiNode = this.hooks.onCreateASTNode.call(

--- a/core/player/src/view/parser/index.ts
+++ b/core/player/src/view/parser/index.ts
@@ -128,9 +128,6 @@ export class Parser {
   ): Node.Node | null {
     const nodeType = this.hooks.determineNodeType.call(obj);
 
-    console.log('@@ PARSEOBJECT[obj]: ',obj)
-    console.log('@@ PARSEOBJECT[type]: ',type)
-    
     //nodeType is what it should be checking on
     if (nodeType !== undefined) {
       const parsedNode = this.hooks.parseNode.call(
@@ -177,8 +174,7 @@ export class Parser {
       const newValue = objEntries.reduce((accumulation, current): NestedObj => {
         const { children, ...rest } = accumulation;
         const [localKey, localValue] = current;
-        console.log('@@ PARSER LOCALKEY: ', localKey)
-        console.log('@@ PARSER LOCALVALUE: ', localValue)
+
         if (localKey === 'asset' && typeof localValue === 'object') {
           const assetAST = this.parseObject(
             localValue,
@@ -242,9 +238,6 @@ export class Parser {
           (localValue && 
           this.hooks.determineNodeType.call(localValue) === NodeType.Switch) || localKey === 'staticSwitch'
         ) {
-          console.log('@@ PARSER[parseLocalObject] localValue: ',localValue)
-          console.log('@@ PARSER[parseLocalObject] DetermineNodeType: ',this.hooks.determineNodeType.call(localValue))
-
           const localSwitch = this.hooks.parseNode.call(
             localKey === 'staticSwitch' ? {"staticSwitch":localValue}:localValue,
             NodeType.Value,
@@ -252,8 +245,6 @@ export class Parser {
             NodeType.Switch
           );
 
-
-          console.log('@@ PARSER[parseLocalObject] localSwitch: ',localSwitch)
           if (
             localSwitch &&
             localSwitch.type === NodeType.Value &&
@@ -299,7 +290,6 @@ export class Parser {
             });
           }
         } else if (localValue && Array.isArray(localValue)) {
-          console.log('@@ IN PARSER[multinode] [localValue]: ', localValue)
           localValue.map((childValues)=>console.log("@@CHILDVALUES FOR LOCALVALUE^: ", childValues))
           const childValues = localValue
             .map((childVal) =>
@@ -309,7 +299,6 @@ export class Parser {
           
 
           if (childValues.length > 0) {
-            console.log('@@ PARSER in childValues: ',childValues)
             const multiNode = this.hooks.onCreateASTNode.call(
               {
                 type: NodeType.MultiNode,
@@ -325,7 +314,6 @@ export class Parser {
                 v.parent = multiNode;
               });
             }
-            console.log('@@ Parser: in multinode: ',multiNode)
             if (multiNode) {
               return {
                 ...rest,

--- a/core/player/src/view/parser/index.ts
+++ b/core/player/src/view/parser/index.ts
@@ -121,6 +121,10 @@ export class Parser {
     );
   }
 
+  private hasSwitchKey(localKey: string){
+    return localKey.toLocaleLowerCase() === ('staticswitch' || 'dynamicswitch')
+  }
+
   public parseObject(
     obj: object,
     type: Node.ChildrenTypes = NodeType.Value,
@@ -236,10 +240,10 @@ export class Parser {
           } as NestedObj;
         } else if (
           (localValue && 
-          this.hooks.determineNodeType.call(localValue) === NodeType.Switch) || localKey === 'staticSwitch'
+          this.hooks.determineNodeType.call(localValue) === NodeType.Switch) || this.hasSwitchKey(localKey)
         ) {
           const localSwitch = this.hooks.parseNode.call(
-            localKey === 'staticSwitch' ? {"staticSwitch":localValue}:localValue,
+            this.hasSwitchKey(localKey) ? {[localKey]:localValue}:localValue,
             NodeType.Value,
             options,
             NodeType.Switch

--- a/core/player/src/view/parser/index.ts
+++ b/core/player/src/view/parser/index.ts
@@ -290,7 +290,6 @@ export class Parser {
             });
           }
         } else if (localValue && Array.isArray(localValue)) {
-          localValue.map((childValues)=>console.log("@@CHILDVALUES FOR LOCALVALUE^: ", childValues))
           const childValues = localValue
             .map((childVal) =>
               this.parseObject(childVal, NodeType.Value, options)

--- a/core/player/src/view/plugins/switch.ts
+++ b/core/player/src/view/plugins/switch.ts
@@ -15,13 +15,11 @@ export default class SwitchPlugin implements ViewPlugin {
   private resolveSwitch(node: Node.Switch, options: Options): Node.Node {
     for (const switchCase of node.cases) {
       const isApplicable = options.evaluate(switchCase.case);
-      console.log('@@ resolveSwitch[isApplicable]',isApplicable)
       if (isApplicable) {
         return switchCase.value;
       }
     }
 
-    console.log('@@ resolveSwitch[node.cases] are false. should return empty node')
     return EMPTY_NODE;
   }
 
@@ -32,8 +30,6 @@ export default class SwitchPlugin implements ViewPlugin {
         return this.resolveSwitch(node, this.options);
       }
 
-      console.log('@@ ApplyParse onCreateASTNODE[ Returning node: ',node )
-      console.log('@@ ApplyParse onCreateASTNODE[ Returning nodeType: ['+node?.type+']')
       return node;
     });
 
@@ -43,7 +39,6 @@ export default class SwitchPlugin implements ViewPlugin {
         Object.prototype.hasOwnProperty.call(obj, 'dynamicSwitch') ||
         Object.prototype.hasOwnProperty.call(obj, 'staticSwitch')
       ) {
-        console.log('** DETERMINED switch nodetype:',obj)
         return NodeType.Switch;
       }
     });
@@ -57,7 +52,6 @@ export default class SwitchPlugin implements ViewPlugin {
         determinedNodeType: null | NodeType
       ) => {
         if (determinedNodeType === NodeType.Switch) {
-          console.log('@@ PARSENODE SWITCH:', obj)
           const dynamic = 'dynamicSwitch' in obj;
           const switchContent =
             'dynamicSwitch' in obj ? obj.dynamicSwitch : obj.staticSwitch;
@@ -118,11 +112,9 @@ export default class SwitchPlugin implements ViewPlugin {
     /** Switches resolved during the parsing phase are dynamic */
     resolver.hooks.beforeResolve.tap('switch', (node, options) => {
       if (node && node.type === NodeType.Switch && node.dynamic) {
-        console.log('@@ applyResolver | beforeResolve calling resolveSwitch', node)
         return this.resolveSwitch(node, options);
       }
 
-      console.log('@@ applyResolver not a switch', node)
       return node;
     });
   }

--- a/core/player/src/view/plugins/switch.ts
+++ b/core/player/src/view/plugins/switch.ts
@@ -34,7 +34,6 @@ export default class SwitchPlugin implements ViewPlugin {
     });
 
     parser.hooks.determineNodeType.tap('switch', (obj) => {
-      console.log('** determining switch nodetype:',obj)
       if (
         Object.prototype.hasOwnProperty.call(obj, 'dynamicSwitch') ||
         Object.prototype.hasOwnProperty.call(obj, 'staticSwitch')

--- a/core/player/src/view/plugins/switch.ts
+++ b/core/player/src/view/plugins/switch.ts
@@ -15,12 +15,13 @@ export default class SwitchPlugin implements ViewPlugin {
   private resolveSwitch(node: Node.Switch, options: Options): Node.Node {
     for (const switchCase of node.cases) {
       const isApplicable = options.evaluate(switchCase.case);
-
+      console.log('@@ resolveSwitch[isApplicable]',isApplicable)
       if (isApplicable) {
         return switchCase.value;
       }
     }
 
+    console.log('@@ resolveSwitch[node.cases] are false. should return empty node')
     return EMPTY_NODE;
   }
 
@@ -31,14 +32,18 @@ export default class SwitchPlugin implements ViewPlugin {
         return this.resolveSwitch(node, this.options);
       }
 
+      console.log('@@ ApplyParse onCreateASTNODE[ Returning node: ',node )
+      console.log('@@ ApplyParse onCreateASTNODE[ Returning nodeType: ['+node?.type+']')
       return node;
     });
 
     parser.hooks.determineNodeType.tap('switch', (obj) => {
+      console.log('** determining switch nodetype:',obj)
       if (
         Object.prototype.hasOwnProperty.call(obj, 'dynamicSwitch') ||
         Object.prototype.hasOwnProperty.call(obj, 'staticSwitch')
       ) {
+        console.log('** DETERMINED switch nodetype:',obj)
         return NodeType.Switch;
       }
     });
@@ -52,6 +57,7 @@ export default class SwitchPlugin implements ViewPlugin {
         determinedNodeType: null | NodeType
       ) => {
         if (determinedNodeType === NodeType.Switch) {
+          console.log('@@ PARSENODE SWITCH:', obj)
           const dynamic = 'dynamicSwitch' in obj;
           const switchContent =
             'dynamicSwitch' in obj ? obj.dynamicSwitch : obj.staticSwitch;
@@ -112,9 +118,11 @@ export default class SwitchPlugin implements ViewPlugin {
     /** Switches resolved during the parsing phase are dynamic */
     resolver.hooks.beforeResolve.tap('switch', (node, options) => {
       if (node && node.type === NodeType.Switch && node.dynamic) {
+        console.log('@@ applyResolver | beforeResolve calling resolveSwitch', node)
         return this.resolveSwitch(node, options);
       }
 
+      console.log('@@ applyResolver not a switch', node)
       return node;
     });
   }


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->
When multinodes contained switches; the switch would not evaluate correctly.


```
          id: 'foo',
          fields: [
            staticSwitch: [
              {
                case: '{{foo.baz}}',
                asset: {
                  id: 'input-1',
                  type: 'input',
                },
              },
              {
                case: '{{foo.bar}}',
                asset: {
                  id: 'input-2',
                  type: 'input',
                },
              },
            ],
          ],
``` 

when staticSwitches get evaluated to false; the asset should not live in the AST, however there was a bug that caused staticSwitches not to get read as a switch when they were inside of multinodes.


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->