### PR TITLE
Move collection of state onto Dispatchers.Default in PlayerFragment.kt

### DIFF
--- a/android/player/src/main/java/com/intuit/playerui/android/extensions/Into.kt
+++ b/android/player/src/main/java/com/intuit/playerui/android/extensions/Into.kt
@@ -6,7 +6,12 @@ import android.widget.FrameLayout
 import androidx.core.view.children
 import androidx.transition.Transition
 import androidx.transition.TransitionManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
+internal suspend infix fun View?.intoOnMain(root: FrameLayout) = withContext(Dispatchers.Main) {
+    into(root)
+}
 /**
  * Helper method to replace the existing [FrameLayout] child
  * with a specific [View]. It will hide the [root] if the


### PR DESCRIPTION
<!-- 
Make sure to add:
  - Tests
  - Documentation Updates

-->


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->
#Release Notes
Move collection of player view model state onto Dispatchers.Default in PlayerFragment.kt

### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

Background:

Prior to [this]( https://github.com/player-ui/player/pull/343/files  ) change, `handleAssetUpdate` would be called once and only once for each navigation / change in the asset view tree.  After the aforementioned change, there was a certain scenario (navigation to another view in the same flow) where `handleAssetUpdate` would be called twice once for the new view and another time for the previous view.  This resulted in odd scenarios on the UI where it would appear that a user briefly navigated to a new screen before returning to the original screen.  

I noticed that collecting the view state on anything other than Default.Dispatchers caused this change in behaviour, so this PR simply reverts that change from the linked PR + brings back the `intoOnMain`.   