### PR TITLE
[Android] Allowing timeout to be configured through PlayerRuntimeConfig

### DIFF
--- a/android/player/src/main/java/com/intuit/playerui/android/AndroidPlayer.kt
+++ b/android/player/src/main/java/com/intuit/playerui/android/AndroidPlayer.kt
@@ -317,6 +317,6 @@ public class AndroidPlayer private constructor(
     public data class Config(
         override var debuggable: Boolean = false,
         override var coroutineExceptionHandler: CoroutineExceptionHandler? = null,
-        override var timeout: Long = if (debuggable) Int.MAX_VALUE.toLong() else 5000
+        override var timeout: Long = if (debuggable) Int.MAX_VALUE.toLong() else 5000,
     ) : PlayerRuntimeConfig()
 }

--- a/android/player/src/main/java/com/intuit/playerui/android/AndroidPlayer.kt
+++ b/android/player/src/main/java/com/intuit/playerui/android/AndroidPlayer.kt
@@ -317,5 +317,6 @@ public class AndroidPlayer private constructor(
     public data class Config(
         override var debuggable: Boolean = false,
         override var coroutineExceptionHandler: CoroutineExceptionHandler? = null,
+        override var timeout: Long = if (debuggable) Int.MAX_VALUE.toLong() else 5000
     ) : PlayerRuntimeConfig()
 }

--- a/docs/site/pages/getting-started.mdx
+++ b/docs/site/pages/getting-started.mdx
@@ -123,8 +123,8 @@ val player = AndroidPlayer(
 )
 ```
 Apart from providing a list of plugins while setting up `AndroidPlayer`, you can also provide a `config` object that has the following options:
- - `debuggable` - Flag to indicate if this is a debug build
- - `coroutineExceptionHandler` - Custom coroutine exception handler
+ - `debuggable` - Indicates if the runtime is debuggable on android through chromium devtools, enabling this would let you set breakpoints in js code as you're running it on android.
+ - `coroutineExceptionHandler` - [CoroutineExceptionHandler](https://kotlinlang.org/docs/exception-handling.html#coroutineexceptionhandler) should handle all uncaught exceptions while using the runtime coroutine scope.
  - `timeout` - Timeout for the JS thread. If none is provided then it is set as `if (debuggable) Int.MAX_VALUE.toLong() else 5000`.
 
 

--- a/docs/site/pages/getting-started.mdx
+++ b/docs/site/pages/getting-started.mdx
@@ -115,8 +115,19 @@ var body: some View {
 
 ```kotlin
 // create Android Player with reference assets plugin
-val player = AndroidPlayer(ReferenceAssetsPlugin())
+val player = AndroidPlayer(
+    listOf(
+        ReferenceAssetsPlugin(),
+        // Any other plugins
+    )
+)
 ```
+Apart from providing a list of plugins while setting up `AndroidPlayer`, you can also provide a `config` object that has the following options:
+ - `debuggable` - Flag to indicate if this is a debug build
+ - `coroutineExceptionHandler` - Custom coroutine exception handler
+ - `timeout` - Timeout for the JS thread. If none is provided then it is set as `if (debuggable) Int.MAX_VALUE.toLong() else 5000`.
+
+
   </android>
 </PlatformTabs>
 

--- a/jvm/core/src/main/kotlin/com/intuit/playerui/core/bridge/runtime/PlayerRuntimeConfig.kt
+++ b/jvm/core/src/main/kotlin/com/intuit/playerui/core/bridge/runtime/PlayerRuntimeConfig.kt
@@ -6,4 +6,5 @@ import kotlinx.coroutines.CoroutineExceptionHandler
 public open class PlayerRuntimeConfig {
     public open var debuggable: Boolean = false
     public open var coroutineExceptionHandler: CoroutineExceptionHandler? = null
+    public open var timeout: Long = if (debuggable) Int.MAX_VALUE.toLong() else 5000
 }

--- a/jvm/j2v8/src/main/kotlin/com/intuit/playerui/j2v8/bridge/runtime/V8Runtime.kt
+++ b/jvm/j2v8/src/main/kotlin/com/intuit/playerui/j2v8/bridge/runtime/V8Runtime.kt
@@ -204,7 +204,7 @@ public data class J2V8RuntimeConfig(
     private val explicitExecutorService: ExecutorService? = null,
     override var debuggable: Boolean = false,
     override var coroutineExceptionHandler: CoroutineExceptionHandler? = null,
-    override var timeout: Long = if (debuggable) Int.MAX_VALUE.toLong() else 5000
+    override var timeout: Long = if (debuggable) Int.MAX_VALUE.toLong() else 5000,
 ) : PlayerRuntimeConfig() {
     public val executorService: ExecutorService by lazy {
         explicitExecutorService ?: Executors.newSingleThreadExecutor {

--- a/jvm/j2v8/src/main/kotlin/com/intuit/playerui/j2v8/bridge/runtime/V8Runtime.kt
+++ b/jvm/j2v8/src/main/kotlin/com/intuit/playerui/j2v8/bridge/runtime/V8Runtime.kt
@@ -204,6 +204,7 @@ public data class J2V8RuntimeConfig(
     private val explicitExecutorService: ExecutorService? = null,
     override var debuggable: Boolean = false,
     override var coroutineExceptionHandler: CoroutineExceptionHandler? = null,
+    override var timeout: Long = if (debuggable) Int.MAX_VALUE.toLong() else 5000
 ) : PlayerRuntimeConfig() {
     public val executorService: ExecutorService by lazy {
         explicitExecutorService ?: Executors.newSingleThreadExecutor {

--- a/jvm/j2v8/src/main/kotlin/com/intuit/playerui/j2v8/extensions/Lock.kt
+++ b/jvm/j2v8/src/main/kotlin/com/intuit/playerui/j2v8/extensions/Lock.kt
@@ -10,9 +10,8 @@ import kotlinx.coroutines.withTimeout
 
 internal suspend fun <Context : V8Value, T> Context.evaluateInJSThread(
     runtime: Runtime<V8Value>,
-    timeout: Long = 5000,
     block: suspend Context.() -> T,
-): T = withTimeout(timeout) {
+): T = withTimeout(runtime.config.timeout) {
     if (runtime.isReleased()) throw PlayerRuntimeException(runtime, "Runtime object has been released!")
     withContext(runtime.dispatcher) {
         runtime.scope.ensureActive()
@@ -22,7 +21,6 @@ internal suspend fun <Context : V8Value, T> Context.evaluateInJSThread(
 
 internal fun <Context : V8Value, T> Context.evaluateInJSThreadBlocking(
     runtime: Runtime<V8Value>,
-    timeout: Long = 5000,
     block: Context.() -> T,
 ): T {
     if (runtime.isReleased()) throw PlayerRuntimeException(runtime, "Runtime object has been released!")
@@ -32,19 +30,17 @@ internal fun <Context : V8Value, T> Context.evaluateInJSThreadBlocking(
     } else {
         runtime.checkBlockingThread(Thread.currentThread())
         runBlocking {
-            evaluateInJSThread(runtime, timeout, block)
+            evaluateInJSThread(runtime, block)
         }
     }
 }
 
 internal suspend fun <Context : V8Value, T> Context.evaluateInJSThreadIfDefined(
     runtime: Runtime<V8Value>,
-    timeout: Long = 5000,
     block: suspend Context.() -> T,
-): T? = mapUndefinedToNull()?.let { evaluateInJSThread(runtime, timeout, block) }
+): T? = mapUndefinedToNull()?.let { evaluateInJSThread(runtime, block) }
 
 internal fun <Context : V8Value, T> Context.evaluateInJSThreadIfDefinedBlocking(
     runtime: Runtime<V8Value>,
-    timeout: Long = 5000,
     block: Context.() -> T,
-): T? = mapUndefinedToNull()?.let { evaluateInJSThreadBlocking(runtime, timeout, block) }
+): T? = mapUndefinedToNull()?.let { evaluateInJSThreadBlocking(runtime, block) }


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->


### Change Type (required)
While trying to debug, the app would crash due to [this](https://github.com/player-ui/player/blob/main/jvm/j2v8/src/main/kotlin/com/intuit/playerui/j2v8/extensions/Lock.kt#L13) timeout. This PR moves the timeout to the `PlayerRuntimeConfig`.
<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs

NOTE: Happy to add some documentation around this. However, I cant find a suitable place in the docs site to add this. Please let me know whats the best place to add some documentation to.
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->