### PR TITLE
Choice Asset

### DIFF
--- a/docs/storybook/src/reference-assets/Choice.mdx
+++ b/docs/storybook/src/reference-assets/Choice.mdx
@@ -1,0 +1,17 @@
+import { Meta, Story } from "@storybook/addon-docs";
+import { Choice } from "@player-ui/reference-assets-plugin-react";
+import * as ChoiceStories from "./Choice.stories";
+
+<Meta title="Reference Assets/Choice" component={Choice} />
+
+# Choice Asset
+
+The choice asset is used to display a list of "choices" for the user to select from.
+
+<Story of={ChoiceStories.Basic} />
+
+## Validation
+
+Choices can include validations, with `errors` preventing users from advancing the flow.
+
+<Story of={ChoiceStories.Validation} />

--- a/docs/storybook/src/reference-assets/Choice.stories.tsx
+++ b/docs/storybook/src/reference-assets/Choice.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta } from "@storybook/react";
+import { createDSLStory } from "@player-ui/storybook-addon-player";
+import { Choice } from "@player-ui/reference-assets-plugin-react";
+
+const meta: Meta<typeof Choice> = {
+  title: "Reference Assets/Choice",
+  component: Choice,
+};
+
+export default meta;
+
+export const Basic = createDSLStory(
+  () =>
+    import(
+      "!!raw-loader!@player-ui/reference-assets-plugin-mocks/choice/choice-basic.tsx"
+    ),
+);
+
+export const Validation = createDSLStory(
+  () =>
+    import(
+      "!!raw-loader!@player-ui/reference-assets-plugin-mocks/choice/choice-validation.tsx"
+    ),
+);

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@mdx-js/rollup": "^3.0.1",
     "@monaco-editor/react": "^4.6.0",
     "@player-tools/cli": "0.5.2",
-    "@player-tools/dsl": "0.5.2",
+    "@player-tools/dsl": "0.6.1-next.2",
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-separator": "^1.0.3",
     "@radix-ui/react-slot": "^1.0.2",

--- a/plugins/reference-assets/components/src/index.test.tsx
+++ b/plugins/reference-assets/components/src/index.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { describe, test, expect } from "vitest";
 import { render, binding as b } from "@player-tools/dsl";
-import { Text, Action, Info, Collection, Input } from ".";
+import { Text, Action, Info, Collection, Input, Choice } from ".";
 
 describe("JSON serialization", () => {
   describe("text", () => {
@@ -154,6 +154,126 @@ describe("JSON serialization", () => {
                   type: "text",
                   value: "Continue",
                 },
+              },
+            },
+          },
+        ],
+      });
+    });
+  });
+
+  describe("choice", () => {
+    test("works for title and choices", async () => {
+      expect(
+        (
+          await render(
+            <Choice id="choice-without-note" binding={b`foo.bar`}>
+              <Choice.Title>This is a list of choices</Choice.Title>
+              <Choice.Items>
+                <Choice.Item id="item-1" value="Item 1">
+                  <Choice.Item.Label>Item 1</Choice.Item.Label>
+                </Choice.Item>
+                <Choice.Item id="item-2" value="Item 2">
+                  <Choice.Item.Label>Item 2</Choice.Item.Label>
+                </Choice.Item>
+              </Choice.Items>
+            </Choice>,
+          )
+        ).jsonValue,
+      ).toStrictEqual({
+        id: "choice-without-note",
+        type: "choice",
+        binding: "foo.bar",
+        title: {
+          asset: {
+            id: "choice-without-note-title",
+            type: "text",
+            value: "This is a list of choices",
+          },
+        },
+        items: [
+          {
+            id: "item-1",
+            value: "Item 1",
+            label: {
+              asset: {
+                id: "choice-without-note-items-0-label",
+                type: "text",
+                value: "Item 1",
+              },
+            },
+          },
+          {
+            id: "item-2",
+            value: "Item 2",
+            label: {
+              asset: {
+                id: "choice-without-note-items-1-label",
+                type: "text",
+                value: "Item 2",
+              },
+            },
+          },
+        ],
+      });
+    });
+
+    test("works with a note", async () => {
+      expect(
+        (
+          await render(
+            <Choice id="choice-with-note" binding={b`foo.bar`}>
+              <Choice.Title>This is a list of choices</Choice.Title>
+              <Choice.Note>This is a note</Choice.Note>
+              <Choice.Items>
+                <Choice.Item id="item-1" value="Item 1">
+                  <Choice.Item.Label>Item 1</Choice.Item.Label>
+                </Choice.Item>
+                <Choice.Item id="item-2" value="Item 2">
+                  <Choice.Item.Label>Item 2</Choice.Item.Label>
+                </Choice.Item>
+              </Choice.Items>
+            </Choice>,
+          )
+        ).jsonValue,
+      ).toStrictEqual({
+        id: "choice-with-note",
+        type: "choice",
+        binding: "foo.bar",
+        title: {
+          asset: {
+            id: "choice-with-note-title",
+            type: "text",
+            value: "This is a list of choices",
+          },
+        },
+        note: {
+          asset: {
+            id: "choice-with-note-note",
+            type: "text",
+            value: "This is a note",
+          },
+        },
+        items: [
+          {
+            id: "item-1",
+            value: "Item 1",
+            label: {
+              asset: {
+                id: "choice-with-note-items-0-label",
+                type: "text",
+                value: "Item 1",
+              },
+            },
+          },
+          {
+            id: "item-2",
+            value: "Item 2",
+            label: {
+              asset: {
+                id: "choice-with-note-items-1-label",
+                type: "text",
+                value: "Item 2",
               },
             },
           },

--- a/plugins/reference-assets/core/BUILD
+++ b/plugins/reference-assets/core/BUILD
@@ -16,6 +16,7 @@ js_pipeline(
     ],
     test_deps = [
         ":node_modules/@player-ui/asset-testing-library",
+        ":node_modules/@player-ui/common-types-plugin",
         "//:vitest_config",
     ],
     deps = [

--- a/plugins/reference-assets/core/package.json
+++ b/plugins/reference-assets/core/package.json
@@ -7,7 +7,8 @@
     "@player-ui/beacon-plugin": "workspace:*"
   },
   "devDependencies": {
-    "@player-ui/asset-testing-library": "workspace:*"
+    "@player-ui/asset-testing-library": "workspace:*",
+    "@player-ui/common-types-plugin": "workspace:*"
   },
   "peerDependencies": {
     "@player-ui/player": "workspace:*"

--- a/plugins/reference-assets/core/src/assets/choice/__tests__/transform.test.ts
+++ b/plugins/reference-assets/core/src/assets/choice/__tests__/transform.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import { runTransform } from "@player-ui/asset-testing-library";
+import { CommonTypesPlugin } from "@player-ui/common-types-plugin";
+import { choiceTransform } from "..";
+
+describe("choice transform", () => {
+  it("adds a clearSelection method that clears choice selection", async () => {
+    const choice = {
+      views: [
+        {
+          id: "choice",
+          type: "choice",
+          binding: "foo.bar",
+          items: [
+            {
+              id: "item-1",
+              value: "item-1",
+            },
+          ],
+        },
+      ],
+      data: {
+        foo: {
+          bar: "item-1",
+        },
+      },
+    };
+
+    const ref = runTransform("choice", choiceTransform, choice);
+
+    expect(ref.controllers?.data.get("foo.bar")).toBe("item-1");
+    ref.current?.clearSelection();
+    expect(ref.controllers?.data.get("foo.bar")).toBe(null);
+  });
+
+  it("adds a select method to each choice", async () => {
+    const choice = {
+      id: "choice",
+      type: "choice",
+      binding: "foo.bar",
+      items: [
+        {
+          id: "item-1",
+          value: "item-1",
+        },
+        {
+          id: "item-2",
+          value: "item-2",
+        },
+      ],
+    };
+
+    const ref = runTransform("choice", choiceTransform, choice);
+
+    expect(ref.controllers?.data.get("foo.bar")).toBeUndefined();
+
+    ref.current?.items[0].select();
+    expect(ref.controllers?.data.get("foo.bar")).toBe("item-1");
+
+    ref.current?.items[1].select();
+    expect(ref.controllers?.data.get("foo.bar")).toBe("item-2");
+  });
+
+  it("adds an unselect method to each choice", async () => {
+    const choice = {
+      id: "choice",
+      type: "choice",
+      binding: "foo.bar",
+      items: [
+        {
+          id: "item-1",
+          value: "item-1",
+        },
+        {
+          id: "item-2",
+          value: "item-2",
+        },
+      ],
+    };
+
+    const ref = runTransform("choice", choiceTransform, choice);
+
+    ref.current?.items[0].select();
+    expect(ref.controllers?.data.get("foo.bar")).toBe("item-1");
+    ref.current?.items[0].unselect();
+    expect(ref.controllers?.data.get("foo.bar")).toBe(null);
+
+    ref.current?.items[1].select();
+    expect(ref.controllers?.data.get("foo.bar")).toBe("item-2");
+    ref.current?.items[1].unselect();
+    expect(ref.controllers?.data.get("foo.bar")).toBe(null);
+  });
+
+  it("exposes validations", async () => {
+    const validations = [
+      {
+        type: "required",
+      },
+    ];
+
+    const choice = {
+      views: [
+        {
+          id: "choice",
+          type: "choice",
+          binding: "foo.bar",
+          items: [
+            {
+              id: "item-1",
+              value: "item-1",
+            },
+            {
+              id: "item-2",
+              value: "item-2",
+            },
+          ],
+        },
+      ],
+      schema: {
+        ROOT: {
+          foo: {
+            type: "FooType",
+          },
+        },
+        FooType: {
+          bar: {
+            type: "StringType",
+            validation: [
+              {
+                type: "required",
+                trigger: "load",
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const ref = runTransform("choice", choiceTransform, choice, [
+      new CommonTypesPlugin(),
+    ]);
+
+    expect(ref.current?.validation?.type).toBe(validations[0].type);
+  });
+});

--- a/plugins/reference-assets/core/src/assets/choice/index.ts
+++ b/plugins/reference-assets/core/src/assets/choice/index.ts
@@ -1,0 +1,2 @@
+export * from "./transform";
+export * from "./types";

--- a/plugins/reference-assets/core/src/assets/choice/transform.ts
+++ b/plugins/reference-assets/core/src/assets/choice/transform.ts
@@ -1,0 +1,55 @@
+import type { TransformFunction } from "@player-ui/player";
+import type {
+  ChoiceAsset,
+  TransformedChoice,
+  TransformedChoiceItem,
+} from "./types";
+
+/**
+ * Docs about the asset transform
+ */
+export const choiceTransform: TransformFunction<
+  ChoiceAsset,
+  TransformedChoice
+> = (asset, options) => {
+  const { items, binding, ...rest } = asset;
+
+  const assetHasBinding = binding !== undefined;
+
+  const currentValue = assetHasBinding
+    ? options.data.model.get(binding, {
+        includeInvalid: true,
+      })
+    : undefined;
+
+  const resetValue = () => {
+    if (assetHasBinding) {
+      return options.data.model.set([[binding, null]]);
+    }
+  };
+
+  const transformedChoiceItems: TransformedChoiceItem[] = (items || []).map(
+    (item, index) => ({
+      ...item,
+      id: item.id ?? `${asset.id}-choice-${index}`,
+      select() {
+        if (assetHasBinding) {
+          return options.data.model.set([[binding, item.value]]);
+        }
+      },
+      unselect: resetValue,
+    }),
+  );
+
+  return {
+    ...rest,
+    binding,
+    clearSelection: resetValue,
+    items: transformedChoiceItems,
+    value: currentValue,
+    validation: assetHasBinding
+      ? options.validation?.get(binding, { track: true })
+      : undefined,
+    dataType: assetHasBinding ? options.validation?.type(binding) : undefined,
+  };
+};

--- a/plugins/reference-assets/core/src/assets/choice/types.ts
+++ b/plugins/reference-assets/core/src/assets/choice/types.ts
@@ -1,0 +1,73 @@
+import type {
+  Asset,
+  AssetWrapper,
+  Binding,
+  ValidationResponse,
+  Schema,
+} from "@player-ui/player";
+import type { BeaconMetaData } from "@player-ui/beacon-plugin";
+
+/**
+ * A choice asset represents a single selection choice, often displayed as radio buttons in a web context.
+ * This will allow users to test out more complex flows than just inputs + buttons.
+ */
+export interface ChoiceAsset<AnyTextAsset extends Asset = Asset>
+  extends Asset<"choice"> {
+  /** A text-like asset for the choice's label */
+  title?: AssetWrapper<AnyTextAsset>;
+
+  /** Asset container for a note. */
+  note?: AssetWrapper<AnyTextAsset>;
+
+  /** The location in the data-model to store the data */
+  binding?: Binding;
+
+  /** The options to select from */
+  items?: Array<ChoiceItem>;
+
+  /** Optional additional data */
+  metaData?: BeaconMetaData;
+}
+
+export type ValueType = string | number | boolean | null;
+
+export interface ChoiceItem<AnyTextAsset extends Asset = Asset> {
+  /** The id associated with the choice item */
+  id: string;
+
+  /** A text-like asset for the choice's label */
+  label?: AssetWrapper<AnyTextAsset>;
+
+  /** The value of the input from the data-model */
+  value?: ValueType;
+}
+
+/** A stateful instance of a choice */
+export interface TransformedChoice extends ChoiceAsset {
+  /**
+   * A function to unselect all of the options
+   * This is typically used when selecting a placeholder value
+   */
+  clearSelection: () => void;
+
+  /** The transformed options to select from */
+  items?: Array<TransformedChoiceItem>;
+
+  /** The value of the selected choice from the data-model */
+  value?: ValueType;
+
+  /** Any validation associated with the current choice's value */
+  validation?: ValidationResponse;
+
+  /** The dataType defined from the schema */
+  dataType?: Schema.DataType;
+}
+
+/** A stateful instance of a Choice Item */
+export interface TransformedChoiceItem extends ChoiceItem {
+  /** The function that is called when a choice item is selected */
+  select: () => void;
+
+  /** The function that is called when a choice item is unSelected */
+  unselect: () => void;
+}

--- a/plugins/reference-assets/core/src/assets/index.ts
+++ b/plugins/reference-assets/core/src/assets/index.ts
@@ -4,3 +4,4 @@ export * from "./collection";
 export * from "./info";
 export * from "./text";
 export * from "./image";
+export * from "./choice";

--- a/plugins/reference-assets/core/src/plugin.ts
+++ b/plugins/reference-assets/core/src/plugin.ts
@@ -5,6 +5,7 @@ import {
   actionTransform,
   imageTransform,
   infoTransform,
+  choiceTransform,
 } from "./assets";
 
 /**
@@ -20,6 +21,7 @@ export class ReferenceAssetsPlugin implements PlayerPlugin {
         [{ type: "input" }, inputTransform],
         [{ type: "image" }, imageTransform],
         [{ type: "info" }, infoTransform],
+        [{ type: "choice" }, choiceTransform],
       ]),
     );
   }

--- a/plugins/reference-assets/mocks/BUILD
+++ b/plugins/reference-assets/mocks/BUILD
@@ -12,6 +12,7 @@ create_base_dsl_config(
 
 DSL_SRCS = glob([
     "action/*.tsx",
+    "choice/*.tsx",
     "collection/*.tsx",
     "image/*.tsx",
     "info/*.tsx",

--- a/plugins/reference-assets/mocks/choice/choice-basic.tsx
+++ b/plugins/reference-assets/mocks/choice/choice-basic.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { Choice } from "@player-ui/reference-assets-plugin-components";
+import { binding as b } from "@player-tools/dsl";
+import type { DSLFlow } from "@player-tools/dsl";
+
+const view1 = (
+  <Choice id="choice" binding={b`foo.bar`}>
+    <Choice.Title>This is a list of choices</Choice.Title>
+    <Choice.Note>This is a note</Choice.Note>
+    <Choice.Items>
+      <Choice.Item id="item-1" value="Item 1">
+        <Choice.Item.Label>Item 1</Choice.Item.Label>
+      </Choice.Item>
+      <Choice.Item id="item-2" value="Item 2">
+        <Choice.Item.Label>Item 2</Choice.Item.Label>
+      </Choice.Item>
+      <Choice.Item id="item-3" value="Item 3">
+        <Choice.Item.Label>Item 3</Choice.Item.Label>
+      </Choice.Item>
+    </Choice.Items>
+  </Choice>
+);
+
+const flow: DSLFlow = {
+  id: "choice-basic",
+  views: [view1],
+  navigation: {
+    BEGIN: "FLOW_1",
+    FLOW_1: {
+      startState: "VIEW_1",
+      VIEW_1: {
+        state_type: "VIEW",
+        ref: view1,
+        transitions: {
+          "*": "END_Done",
+        },
+      },
+      END_Done: {
+        state_type: "END",
+        outcome: "DONE",
+      },
+    },
+  },
+};
+
+export default flow;

--- a/plugins/reference-assets/mocks/choice/choice-validation.tsx
+++ b/plugins/reference-assets/mocks/choice/choice-validation.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import {
+  Choice,
+  Info,
+  Action,
+} from "@player-ui/reference-assets-plugin-components";
+import { binding as b } from "@player-tools/dsl";
+import type { DSLFlow } from "@player-tools/dsl";
+
+const schema = {
+  foo: {
+    bar: {
+      type: "StringType",
+      validation: [
+        {
+          type: "required",
+        },
+      ],
+    },
+  },
+};
+
+const view1 = (
+  <Info id="choice-validation">
+    <Info.Title>Some validations can prevent users from advancing</Info.Title>
+    <Info.PrimaryInfo>
+      <Choice id="choice" binding={b`foo.bar`}>
+        <Choice.Title>This is a list of choices with validation</Choice.Title>
+        <Choice.Note>You must select an option to proceed!</Choice.Note>
+        <Choice.Items>
+          <Choice.Item id="item-1" value="Item 1">
+            <Choice.Item.Label>Item 1</Choice.Item.Label>
+          </Choice.Item>
+          <Choice.Item id="item-2" value="Item 2">
+            <Choice.Item.Label>Item 2</Choice.Item.Label>
+          </Choice.Item>
+          <Choice.Item id="item-3" value="Item 3">
+            <Choice.Item.Label>Item 3</Choice.Item.Label>
+          </Choice.Item>
+        </Choice.Items>
+      </Choice>
+    </Info.PrimaryInfo>
+    <Info.Actions>
+      <Action value="Next">
+        <Action.Label>Continue</Action.Label>
+      </Action>
+    </Info.Actions>
+  </Info>
+);
+
+const flow: DSLFlow = {
+  id: "choice-validation",
+  views: [view1],
+  schema,
+  navigation: {
+    BEGIN: "FLOW_1",
+    FLOW_1: {
+      startState: "VIEW_1",
+      VIEW_1: {
+        state_type: "VIEW",
+        ref: view1,
+        transitions: {
+          "*": "END_Done",
+        },
+      },
+      END_Done: {
+        state_type: "END",
+        outcome: "DONE",
+      },
+    },
+  },
+};
+
+export default flow;

--- a/plugins/reference-assets/react/src/__tests__/integration.test.tsx
+++ b/plugins/reference-assets/react/src/__tests__/integration.test.tsx
@@ -1,4 +1,4 @@
-import { describe, test, vitest, expect } from "vitest";
+import { describe, test, vitest, expect, beforeEach } from "vitest";
 import React from "react";
 import {
   screen,
@@ -18,48 +18,141 @@ configure({
 });
 
 describe("Integration tests", () => {
-  test("input beacons the correct custom data value", async () => {
-    const handler = vitest.fn();
-    const beaconPlugin = new BeaconPlugin({ callback: handler });
+  describe("Input", () => {
+    test("beacons the correct custom data value", async () => {
+      const handler = vitest.fn();
+      const beaconPlugin = new BeaconPlugin({ callback: handler });
 
-    const rp = new ReactPlayer({
-      plugins: [beaconPlugin, new ReferenceAssetsPlugin()],
+      const rp = new ReactPlayer({
+        plugins: [beaconPlugin, new ReferenceAssetsPlugin()],
+      });
+
+      const flow = makeFlow({
+        id: "first_view",
+        type: "input",
+        binding: "foo.bar",
+        metaData: { beacon: { custom_data: "{{foo.bar}}" } },
+      });
+
+      render(
+        <React.Suspense fallback="fallback">
+          <rp.Component />
+        </React.Suspense>,
+      );
+
+      await act(async () => {
+        rp.start(flow);
+      });
+
+      const viewNode = await screen.findByTestId("first_view");
+
+      act(() => {
+        fireEvent.change(viewNode, { target: { value: "new value" } });
+      });
+
+      act(() => {
+        fireEvent.blur(viewNode, { target: { value: "new value" } });
+      });
+
+      await waitFor(() => {
+        expect(handler.mock.calls).toHaveLength(2);
+      });
+
+      expect(handler.mock.calls[1][0]).toMatchObject({
+        assetId: "first_view",
+        data: { custom_data: "new value" },
+      });
+    });
+  });
+
+  describe("Choice", () => {
+    let handler, beaconPlugin, rp, items, flow;
+
+    beforeEach(async () => {
+      handler = vitest.fn();
+      beaconPlugin = new BeaconPlugin({ callback: handler });
+
+      rp = new ReactPlayer({
+        plugins: [beaconPlugin, new ReferenceAssetsPlugin()],
+      });
+
+      items = [
+        {
+          id: "item-1",
+          value: "Item 1",
+          label: {
+            asset: {
+              id: "choice-without-note-items-0-label",
+              type: "text",
+              value: "Item 1",
+            },
+          },
+        },
+        {
+          id: "item-2",
+          value: "Item 2",
+          label: {
+            asset: {
+              id: "choice-without-note-items-1-label",
+              type: "text",
+              value: "Item 2",
+            },
+          },
+        },
+      ];
+
+      flow = makeFlow({
+        id: "choice",
+        type: "choice",
+        binding: "foo.bar",
+        metaData: { beacon: { custom_data: "{{foo.bar}}" } },
+        items,
+      });
+
+      render(
+        <React.Suspense fallback="fallback">
+          <rp.Component />
+        </React.Suspense>,
+      );
+
+      await act(async () => {
+        rp.start(flow);
+      });
     });
 
-    const flow = makeFlow({
-      id: "first_view",
-      type: "input",
-      binding: "foo.bar",
-      metaData: { beacon: { custom_data: "{{foo.bar}}" } },
+    test("beacon handler is called on each item click", async () => {
+      for (const item of items) {
+        const itemNode = await screen.findByTestId(item.id);
+
+        act(() => {
+          fireEvent.click(itemNode);
+        });
+
+        await waitFor(() => {
+          expect(handler.mock.calls).toHaveLength(2);
+        });
+
+        expect(handler.mock.calls[1][0]).toMatchObject({
+          assetId: "choice",
+          action: "clicked",
+        });
+      }
     });
 
-    render(
-      <React.Suspense fallback="fallback">
-        <rp.Component />
-      </React.Suspense>,
-    );
+    test("each item is set to checked on click", async () => {
+      for (const item of items) {
+        let itemNode;
 
-    await act(async () => {
-      rp.start(flow);
-    });
+        itemNode = await screen.findByTestId(item.id);
+        expect(itemNode.checked).toEqual(false);
 
-    const viewNode = await screen.findByTestId("first_view");
+        act(() => {
+          fireEvent.click(itemNode);
+        });
 
-    act(() => {
-      fireEvent.change(viewNode, { target: { value: "new value" } });
-    });
-
-    act(() => {
-      fireEvent.blur(viewNode, { target: { value: "new value" } });
-    });
-
-    await waitFor(() => {
-      expect(handler.mock.calls).toHaveLength(2);
-    });
-
-    expect(handler.mock.calls[1][0]).toMatchObject({
-      assetId: "first_view",
-      data: { custom_data: "new value" },
+        itemNode = await screen.findByTestId(item.id);
+        expect(itemNode.checked).toEqual(true);
+      }
     });
   });
 });

--- a/plugins/reference-assets/react/src/assets/choice/Choice.tsx
+++ b/plugins/reference-assets/react/src/assets/choice/Choice.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { ReactAsset } from "@player-ui/react";
+import type { TransformedChoice } from "@player-ui/reference-assets-plugin";
+import { ChoiceItem } from "../../components/ChoiceItem";
+import { Label } from "../../components/Label";
+import type { ChoiceItemProps } from "../../components/ChoiceItem";
+
+import { useChoiceItems } from "./hooks";
+
+/** A Choice */
+export const Choice = (props: TransformedChoice) => {
+  const { validation, title, id, note } = props;
+  const choiceItemProps: Array<ChoiceItemProps> = useChoiceItems(props);
+
+  const renderChoices = () =>
+    choiceItemProps.map((choiceItemProp) => (
+      <ChoiceItem key={choiceItemProp.id} {...choiceItemProp} />
+    ));
+
+  return (
+    <div className="grid w-full max-w-sm items-center gap-3">
+      {title && (
+        <Label htmlFor={id}>
+          <ReactAsset {...title} />
+        </Label>
+      )}
+      <div
+        id={props.id}
+        className="grid gap-2"
+        aria-invalid={Boolean(validation)}
+        aria-describedby={validation ? `${id}-validation` : undefined}
+      >
+        {renderChoices()}
+      </div>
+      {validation && (
+        <Label
+          id={`${id}-validation`}
+          className="text-[0.8rem] font-medium text-destructive"
+        >
+          {validation.message}
+        </Label>
+      )}
+      {note && (
+        <Label className="text-[0.8rem] text-muted-foreground">
+          <ReactAsset {...note} />
+        </Label>
+      )}
+    </div>
+  );
+};
+
+export default Choice;

--- a/plugins/reference-assets/react/src/assets/choice/hooks.tsx
+++ b/plugins/reference-assets/react/src/assets/choice/hooks.tsx
@@ -1,0 +1,34 @@
+import { useBeacon } from "@player-ui/beacon-plugin-react";
+import type {
+  TransformedChoice,
+  TransformedChoiceItem,
+} from "@player-ui/reference-assets-plugin";
+import type { ChoiceItemProps } from "../../components/ChoiceItem";
+
+/** Hook to get the props for all choice asset items */
+export const useChoiceItems = (
+  props: TransformedChoice,
+): Array<ChoiceItemProps> => {
+  const beacon = useBeacon({
+    asset: props,
+    action: "clicked",
+    element: "choice",
+  });
+
+  return (
+    props.items?.map((item: TransformedChoiceItem) => {
+      const { id, value, label } = item;
+      return {
+        id,
+        label,
+        name: props.id,
+        value: (value ?? "").toString(),
+        checked: value === props.value,
+        onChange: () => {
+          beacon();
+          item.select();
+        },
+      };
+    }) ?? []
+  );
+};

--- a/plugins/reference-assets/react/src/assets/choice/index.ts
+++ b/plugins/reference-assets/react/src/assets/choice/index.ts
@@ -1,0 +1,2 @@
+export * from "./Choice";
+export * from "./hooks";

--- a/plugins/reference-assets/react/src/assets/index.tsx
+++ b/plugins/reference-assets/react/src/assets/index.tsx
@@ -4,3 +4,4 @@ export * from "./collection";
 export * from "./action";
 export * from "./info";
 export * from "./image";
+export * from "./choice";

--- a/plugins/reference-assets/react/src/components/ChoiceItem.tsx
+++ b/plugins/reference-assets/react/src/components/ChoiceItem.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { ReactAsset } from "@player-ui/react";
+import { Input as InputComp } from "./Input";
+import { Label } from "./Label";
+import type { ChoiceItem as ChoiceItemType } from "@player-ui/reference-assets-plugin";
+
+export type ChoiceItemProps = React.InputHTMLAttributes<HTMLInputElement> &
+  Pick<ChoiceItemType, "label">;
+
+/** A choice item */
+export const ChoiceItem = (props: ChoiceItemProps) => {
+  const { label, id, ...rest } = props;
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <InputComp
+        type="radio"
+        className="h-fit w-fit shadow-none"
+        id={id}
+        {...rest}
+      />
+      {label && (
+        <Label htmlFor={id}>
+          <ReactAsset {...label} />
+        </Label>
+      )}
+    </div>
+  );
+};
+
+export default ChoiceItem;

--- a/plugins/reference-assets/react/src/plugin.tsx
+++ b/plugins/reference-assets/react/src/plugin.tsx
@@ -12,9 +12,10 @@ import type {
   CollectionAsset,
   ActionAsset,
   InfoAsset,
+  ChoiceAsset,
 } from "@player-ui/reference-assets-plugin";
 import { ReferenceAssetsPlugin as ReferenceAssetsCorePlugin } from "@player-ui/reference-assets-plugin";
-import { Input, Text, Collection, Action, Info, Image } from "./assets";
+import { Input, Text, Collection, Action, Info, Image, Choice } from "./assets";
 
 /**
  * A plugin to register the base reference assets
@@ -23,7 +24,7 @@ export class ReferenceAssetsPlugin
   implements
     ReactPlayerPlugin,
     ExtendedPlayerPlugin<
-      [InputAsset, TextAsset, ActionAsset, CollectionAsset],
+      [InputAsset, TextAsset, ActionAsset, CollectionAsset, ChoiceAsset],
       [InfoAsset]
     >
 {
@@ -38,6 +39,7 @@ export class ReferenceAssetsPlugin
         ["info", Info],
         ["collection", Collection],
         ["image", Image],
+        ["choice", Choice],
       ]),
     );
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,8 +76,8 @@ importers:
         specifier: 0.5.2
         version: 0.5.2(@babel/core@7.24.5)(@oclif/config@1.18.17)(@swc/core@1.5.7)(@types/node@18.19.33)(@types/react@18.3.2)(jsonc-parser@2.3.1)
       '@player-tools/dsl':
-        specifier: 0.5.2
-        version: 0.5.2(@swc/core@1.5.7)(@types/node@18.19.33)(@types/react@18.3.2)(react@18.3.1)
+        specifier: 0.6.1-next.2
+        version: 0.6.1-next.2(@swc/core@1.5.7)(@types/node@18.19.33)(@types/react@18.3.2)(react@18.3.1)
       '@radix-ui/react-label':
         specifier: ^2.0.2
         version: 2.0.2(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)
@@ -863,6 +863,9 @@ importers:
       '@player-ui/asset-testing-library':
         specifier: workspace:*
         version: link:../../../tools/asset-testing-library/core
+      '@player-ui/common-types-plugin':
+        specifier: workspace:*
+        version: link:../../common-types/core
 
   plugins/reference-assets/mocks:
     dependencies:
@@ -5253,6 +5256,36 @@ packages:
       - '@types/node'
     dev: false
 
+  /@player-tools/dsl@0.6.1-next.2(@swc/core@1.5.7)(@types/node@18.19.33)(@types/react@18.3.2)(react@18.3.1):
+    resolution: {integrity: sha512-h31+f3gbs//7TDbtMu2yqNwbMUErAofoR5n8W+60arqTnGRDYBHXJ5UbG3QqZFMRhZwcBhBCR49ZvX98dFj3uQ==, tarball: https://registry.npmjs.org/@player-tools/dsl/-/dsl-0.6.1-next.2.tgz}
+    peerDependencies:
+      '@types/react': ^18.2.51
+      react: ^18.2.0
+    dependencies:
+      '@player-ui/player': 0.7.3
+      '@player-ui/types': 0.7.3
+      '@types/mkdirp': 1.0.2
+      '@types/react': 18.3.2
+      chalk: 4.1.2
+      command-line-application: 0.10.1
+      dequal: 2.0.3
+      fs-extra: 10.1.0
+      globby: 11.1.0
+      jsonc-parser: 2.3.1
+      mkdirp: 1.0.4
+      react: 18.3.1
+      react-json-reconciler: 2.0.0(react@18.3.1)
+      source-map-js: 1.2.0
+      tapable-ts: 0.2.4
+      ts-node: 10.9.2(@swc/core@1.5.7)(@types/node@18.19.33)(typescript@5.4.5)
+      tslib: 2.6.2
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+    dev: false
+
   /@player-tools/json-language-service@0.5.2:
     resolution: {integrity: sha512-vpXjJ3irqQMwdwQWzzB4vNl7Reskq9XSXXj+M61G0ZLTScXRZa83hLeRgTYHfsuW39IWu0AYufHNgbR6uDZi9A==, tarball: https://registry.npmjs.org/@player-tools/json-language-service/-/json-language-service-0.5.2.tgz}
     dependencies:
@@ -5336,6 +5369,15 @@ packages:
       sorted-array: 2.0.4
     dev: false
 
+  /@player-ui/partial-match-registry@0.7.3:
+    resolution: {integrity: sha512-3Lo5jFKGQ6QkUagrhu9guAepA5eChz2YRDNru+5SSxR2CfcMfDUdTfPAkhUyjU/fB9Re7FUPtNSX4FOyt4YKPg==, tarball: https://registry.npmjs.org/@player-ui/partial-match-registry/-/partial-match-registry-0.7.3.tgz}
+    dependencies:
+      '@babel/runtime': 7.15.4
+      '@types/dlv': 1.1.4
+      dlv: 1.1.3
+      sorted-array: 2.0.4
+    dev: false
+
   /@player-ui/player@0.7.2-next.4:
     resolution: {integrity: sha512-TqdoMz/GDYPBeAEIIoK7GM3+oRJTN4g71HG8lOV2BxzTb2cwvyddRlUz6A0E/JSnkG9D0lR8ommv3w7bcKYpqA==, tarball: https://registry.npmjs.org/@player-ui/player/-/player-0.7.2-next.4.tgz}
     dependencies:
@@ -5355,8 +5397,33 @@ packages:
       ts-nested-error: 1.2.1
     dev: false
 
+  /@player-ui/player@0.7.3:
+    resolution: {integrity: sha512-nZ9KdGgnVVZwxNHM9pzcgiH7ikUSAVcGS5CCNMJQflUlM4C+thhlytGtMUMuSjgnFN7q7ZFzWL4qQlsVgmgOqg==, tarball: https://registry.npmjs.org/@player-ui/player/-/player-0.7.3.tgz}
+    dependencies:
+      '@babel/runtime': 7.15.4
+      '@player-ui/partial-match-registry': 0.7.3
+      '@player-ui/types': 0.7.3
+      '@types/parsimmon': 1.10.9
+      arr-flatten: 1.1.0
+      dequal: 2.0.3
+      ebnf: 1.9.1
+      error-polyfill: 0.1.3
+      p-defer: 3.0.0
+      parsimmon: 1.18.1
+      queue-microtask: 1.2.3
+      tapable-ts: 0.2.4
+      timm: 1.7.1
+      ts-nested-error: 1.2.1
+    dev: false
+
   /@player-ui/types@0.7.2-next.4:
     resolution: {integrity: sha512-wvKlmu+ZJSVT5fs/vHHwpv4KhgZmqinJBvHhttU4LHzqrEauaRcS/DVCItABXt6ABxhIakPInnxQtH1xCwdDyQ==, tarball: https://registry.npmjs.org/@player-ui/types/-/types-0.7.2-next.4.tgz}
+    dependencies:
+      '@babel/runtime': 7.15.4
+    dev: false
+
+  /@player-ui/types@0.7.3:
+    resolution: {integrity: sha512-Uqk14S4UmMM3O36TXt/PwYI9JY5aNYF1A3v/2wT9+gKv0RPZTXrs2N6MFXW8RopH/XeUwuunThVCpRZCsFiUMg==, tarball: https://registry.npmjs.org/@player-ui/types/-/types-0.7.3.tgz}
     dependencies:
       '@babel/runtime': 7.15.4
     dev: false

--- a/tools/asset-testing-library/core/src/index.ts
+++ b/tools/asset-testing-library/core/src/index.ts
@@ -1,4 +1,10 @@
-import type { TransformFunction, Asset, Flow, View } from "@player-ui/player";
+import type {
+  TransformFunction,
+  Asset,
+  Flow,
+  View,
+  PlayerPlugin,
+} from "@player-ui/player";
 import { Player } from "@player-ui/player";
 import { AssetTransformPlugin } from '@player-ui/asset-transform-plugin';
 import { makeFlow } from '@player-ui/make-flow';
@@ -12,10 +18,15 @@ export function runTransform<
 >(
   type: string,
   transform: TransformFunction<BaseAssetType, TransformedAssetType>,
-  content: BaseAssetType | Flow | Array<View>
+  content: BaseAssetType | Flow | Array<View>,
+  additionalPlugins: Array<PlayerPlugin> = [],
 ) {
+
   const player = new Player({
-    plugins: [new AssetTransformPlugin([[{ type }, transform]])],
+    plugins: [
+      ...additionalPlugins,
+      new AssetTransformPlugin([[{ type }, transform]]),
+    ],
   });
 
   player.start(makeFlow(content));


### PR DESCRIPTION
<!-- 

Make sure to add:
  - Tests
  - Documentation Updates

-->
### Changes Made

- Added core support for the new reference asset - choice. (From https://github.com/player-ui/player/issues/181) "A choice asset represents a single selection choice, often displayed as radio buttons in a web context. This will allow users to test out more complex flows than just inputs + buttons."

#### Additional Changes:

- Extended `runTransform` to accept an `additionalPlugins` parameter to simplify testing for users of Player.

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->