### PR TITLE
get storybook rendering again

### DIFF
--- a/tools/addon-storybook/src/addons/events/index.tsx
+++ b/tools/addon-storybook/src/addons/events/index.tsx
@@ -66,6 +66,7 @@ const ExtraCells = (event: EventType) => {
 export const EventsPanel = (props: EventsPanelProps) => {
   const events = useSelector<StateType, EventType[]>((state) => state.events);
   const contentType = useContentKind();
+  const darkMode = useDarkMode();
 
   if (!props.active) {
     return null;

--- a/tools/addon-storybook/src/dsl/transpile.ts
+++ b/tools/addon-storybook/src/dsl/transpile.ts
@@ -10,7 +10,7 @@ async function setup() {
 
   initializedPromise = initialize({
     worker: true,
-    wasmURL: "https://unpkg.com/esbuild-wasm@0.19.9/esbuild.wasm",
+    wasmURL: "https://unpkg.com/esbuild-wasm@0.19.12/esbuild.wasm",
   });
 
   return initializedPromise;


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

- undefined variable -> pull `darkMode` from hook, was probably lost in a rebase
- bump wasmURL version because it was getting a mismatch and erroring so Suspense never resolved

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->