### PR TITLE
Player 8901 - Fix typings for onAsyncNode hook

### DIFF
--- a/plugins/async-node/core/src/index.test.ts
+++ b/plugins/async-node/core/src/index.test.ts
@@ -382,7 +382,7 @@ test('should call onAsyncNode hook when async node is encountered', async () => 
 
   // Call the deferredResolve with type 'Async'
   if (deferredResolve) {
-    //we are passing the objects variable to the deferredResolve function and then expecting the type of the object to be 'Async'
+    // we are passing the objects variable to the deferredResolve function and then expecting the type of the object to be 'Async'
     const objects = [
       {
         asset: {
@@ -393,12 +393,13 @@ test('should call onAsyncNode hook when async node is encountered', async () => 
       },
       {
         id: 'another-async',
-        type: 'Async',
+        type: NodeType.Async,
         async: true,
       },
     ];
     deferredResolve(objects);
-    const types = objects.map(obj => obj.asset ? obj.asset.type : obj.type);
-    expect(types).toContain('Async');
+    const types = objects.map((obj) => (obj.asset ? obj.asset.type : obj.type));
+    // eslint-disable-next-line jest/no-conditional-expect
+    expect(types).toContain(NodeType.Async);
   }
 });

--- a/plugins/async-node/core/src/index.test.ts
+++ b/plugins/async-node/core/src/index.test.ts
@@ -1,9 +1,7 @@
 import type { Node, InProgressState } from '@player-ui/player';
-import { NodeType, Player } from '@player-ui/player';
+import { Player } from '@player-ui/player';
 import { waitFor } from '@testing-library/react';
 import { AsyncNodePlugin } from './index';
-import { any } from 'parsimmon';
-import { type } from 'node:os';
 
 jest.useFakeTimers();
 
@@ -45,7 +43,7 @@ test('replaces async nodes with provided node', async () => {
 
   let deferredResolve: ((value: any) => void) | undefined;
 
-  plugin.hooks.onAsyncNode.tap('test', async (node: Node.Async) => {
+  plugin.hooks.onAsyncNode.tap('test', async (node: Node.Node) => {
     return new Promise((resolve) => {
       deferredResolve = resolve;
     });
@@ -169,7 +167,7 @@ test('replaces async nodes with chained multiNodes', async () => {
 
   let deferredResolve: ((value: any) => void) | undefined;
 
-  plugin.hooks.onAsyncNode.tap('test', async (node: Node.Async) => {
+  plugin.hooks.onAsyncNode.tap('test', async (node: Node.Node) => {
     return new Promise((resolve) => {
       deferredResolve = resolve;
     });
@@ -264,7 +262,7 @@ test('replaces async nodes with chained multiNodes singular', async () => {
 
   let deferredResolve: ((value: any) => void) | undefined;
 
-  plugin.hooks.onAsyncNode.tap('test', async (node: Node.Async) => {
+  plugin.hooks.onAsyncNode.tap('test', async (node: Node.Node) => {
     return new Promise((resolve) => {
       deferredResolve = resolve;
     });
@@ -341,65 +339,4 @@ test('replaces async nodes with chained multiNodes singular', async () => {
   expect(view?.actions[0].asset.type).toBe('action');
   expect(view?.actions[1].asset.type).toBe('text');
   expect(view?.actions[2].asset.type).toBe('text');
-});
-
-test('should call onAsyncNode hook when async node is encountered', async () => {
-  const plugin = new AsyncNodePlugin();
-
-  let deferredResolve: ((value: any) => void) | undefined;
-
-  // Call the tap method of the onAsyncNode hook
- plugin.hooks.onAsyncNode.tap('test', async (node: Node.Async) => {
-    return new Promise((resolve) => {
-      deferredResolve = resolve;
-    });
-  });
-
-  let updateNumber = 0;
-
-  const player = new Player({ plugins: [plugin] });
-
-  player.hooks.viewController.tap('async-node-test', (vc) => {
-    vc.hooks.view.tap('async-node-test', (view) => {
-      view.hooks.onUpdate.tap('async-node-test', (update) => {
-        updateNumber++;
-      });
-    });
-  });
-
-  player.start(basicFRFWithActions as any);
-
-  let view = (player.getState() as InProgressState).controllers.view.currentView
-    ?.lastUpdate;
-
-  expect(view).toBeDefined();
-  expect(view?.actions[1]).toBeUndefined();
-
-  await waitFor(() => {
-    expect(updateNumber).toBe(1);
-    expect(deferredResolve).toBeDefined();
-  });
-
-  // Call the deferredResolve with type 'Async'
-  if (deferredResolve) {
-    // we are passing the objects variable to the deferredResolve function and then expecting the type of the object to be 'Async'
-    const objects = [
-      {
-        asset: {
-          id: 'value-1',
-          type: 'text',
-          value: '1st value in the multinode',
-        },
-      },
-      {
-        id: 'another-async',
-        type: NodeType.Async,
-        async: true,
-      },
-    ];
-    deferredResolve(objects);
-    const types = objects.map((obj) => (obj.asset ? obj.asset.type : obj.type));
-    // eslint-disable-next-line jest/no-conditional-expect
-    expect(types).toContain(NodeType.Async);
-  }
 });

--- a/plugins/async-node/core/src/index.test.ts
+++ b/plugins/async-node/core/src/index.test.ts
@@ -1,8 +1,6 @@
 import type { Node, InProgressState } from '@player-ui/player';
-import { NodeType, Player } from '@player-ui/player';
+import { Player } from '@player-ui/player';
 import { waitFor } from '@testing-library/react';
-import { any } from 'parsimmon';
-import { type } from 'node:os';
 import { AsyncNodePlugin } from './index';
 
 jest.useFakeTimers();

--- a/plugins/async-node/core/src/index.test.ts
+++ b/plugins/async-node/core/src/index.test.ts
@@ -1,9 +1,9 @@
 import type { Node, InProgressState } from '@player-ui/player';
 import { NodeType, Player } from '@player-ui/player';
 import { waitFor } from '@testing-library/react';
-import { AsyncNodePlugin } from './index';
 import { any } from 'parsimmon';
 import { type } from 'node:os';
+import { AsyncNodePlugin } from './index';
 
 jest.useFakeTimers();
 
@@ -345,12 +345,13 @@ test('replaces async nodes with chained multiNodes singular', async () => {
 
 test('should call onAsyncNode hook when async node is encountered', async () => {
   const plugin = new AsyncNodePlugin();
-  // Mock function to check the node passed to the hook
-  const mockFn = jest.fn();
-
-  // Call the tap method of the onAsyncNode hook
+  let localNode: Node.Async;
   plugin.hooks.onAsyncNode.tap('test', async (node: Node.Async) => {
-    mockFn(node);
+    if (node !== null) {
+      // assigns node value to a local variable
+      localNode = node;
+    }
+
     return new Promise((resolve) => {
       resolve('Promise resolved');
     });
@@ -361,10 +362,7 @@ test('should call onAsyncNode hook when async node is encountered', async () => 
   player.start(basicFRFWithActions as any);
 
   await waitFor(() => {
-    expect(mockFn).toHaveBeenCalledTimes(1);
-    // Check that the mock function was called with the correct async node
-    expect(mockFn).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'async' })
-    );
+    expect(localNode.id).toStrictEqual('uhh');
+    expect(localNode.type).toStrictEqual('async');
   });
 });

--- a/plugins/async-node/core/src/index.test.ts
+++ b/plugins/async-node/core/src/index.test.ts
@@ -345,61 +345,26 @@ test('replaces async nodes with chained multiNodes singular', async () => {
 
 test('should call onAsyncNode hook when async node is encountered', async () => {
   const plugin = new AsyncNodePlugin();
-
-  let deferredResolve: ((value: any) => void) | undefined;
+  // Mock function to check the node passed to the hook
+  const mockFn = jest.fn();
 
   // Call the tap method of the onAsyncNode hook
- plugin.hooks.onAsyncNode.tap('test', async (node: Node.Async) => {
+  plugin.hooks.onAsyncNode.tap('test', async (node: Node.Async) => {
+    mockFn(node);
     return new Promise((resolve) => {
-      deferredResolve = resolve;
+      resolve('Promise resolved');
     });
   });
-
-  let updateNumber = 0;
 
   const player = new Player({ plugins: [plugin] });
 
-  player.hooks.viewController.tap('async-node-test', (vc) => {
-    vc.hooks.view.tap('async-node-test', (view) => {
-      view.hooks.onUpdate.tap('async-node-test', (update) => {
-        updateNumber++;
-      });
-    });
-  });
-
   player.start(basicFRFWithActions as any);
 
-  let view = (player.getState() as InProgressState).controllers.view.currentView
-    ?.lastUpdate;
-
-  expect(view).toBeDefined();
-  expect(view?.actions[1]).toBeUndefined();
-
   await waitFor(() => {
-    expect(updateNumber).toBe(1);
-    expect(deferredResolve).toBeDefined();
+    expect(mockFn).toHaveBeenCalledTimes(1);
+    // Check that the mock function was called with the correct async node
+    expect(mockFn).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'async' })
+    );
   });
-
-  // Call the deferredResolve with type 'Async'
-  if (deferredResolve) {
-    // we are passing the objects variable to the deferredResolve function and then expecting the type of the object to be 'Async'
-    const objects = [
-      {
-        asset: {
-          id: 'value-1',
-          type: 'text',
-          value: '1st value in the multinode',
-        },
-      },
-      {
-        id: 'another-async',
-        type: NodeType.Async,
-        async: true,
-      },
-    ];
-    deferredResolve(objects);
-    const types = objects.map((obj) => (obj.asset ? obj.asset.type : obj.type));
-    // eslint-disable-next-line jest/no-conditional-expect
-    expect(types).toContain(NodeType.Async);
-  }
 });

--- a/plugins/async-node/core/src/index.test.ts
+++ b/plugins/async-node/core/src/index.test.ts
@@ -1,7 +1,9 @@
 import type { Node, InProgressState } from '@player-ui/player';
-import { Player } from '@player-ui/player';
+import { NodeType, Player } from '@player-ui/player';
 import { waitFor } from '@testing-library/react';
 import { AsyncNodePlugin } from './index';
+import { any } from 'parsimmon';
+import { type } from 'node:os';
 
 jest.useFakeTimers();
 
@@ -43,7 +45,7 @@ test('replaces async nodes with provided node', async () => {
 
   let deferredResolve: ((value: any) => void) | undefined;
 
-  plugin.hooks.onAsyncNode.tap('test', async (node: Node.Node) => {
+  plugin.hooks.onAsyncNode.tap('test', async (node: Node.Async) => {
     return new Promise((resolve) => {
       deferredResolve = resolve;
     });
@@ -167,7 +169,7 @@ test('replaces async nodes with chained multiNodes', async () => {
 
   let deferredResolve: ((value: any) => void) | undefined;
 
-  plugin.hooks.onAsyncNode.tap('test', async (node: Node.Node) => {
+  plugin.hooks.onAsyncNode.tap('test', async (node: Node.Async) => {
     return new Promise((resolve) => {
       deferredResolve = resolve;
     });
@@ -262,7 +264,7 @@ test('replaces async nodes with chained multiNodes singular', async () => {
 
   let deferredResolve: ((value: any) => void) | undefined;
 
-  plugin.hooks.onAsyncNode.tap('test', async (node: Node.Node) => {
+  plugin.hooks.onAsyncNode.tap('test', async (node: Node.Async) => {
     return new Promise((resolve) => {
       deferredResolve = resolve;
     });
@@ -339,4 +341,65 @@ test('replaces async nodes with chained multiNodes singular', async () => {
   expect(view?.actions[0].asset.type).toBe('action');
   expect(view?.actions[1].asset.type).toBe('text');
   expect(view?.actions[2].asset.type).toBe('text');
+});
+
+test('should call onAsyncNode hook when async node is encountered', async () => {
+  const plugin = new AsyncNodePlugin();
+
+  let deferredResolve: ((value: any) => void) | undefined;
+
+  // Call the tap method of the onAsyncNode hook
+ plugin.hooks.onAsyncNode.tap('test', async (node: Node.Async) => {
+    return new Promise((resolve) => {
+      deferredResolve = resolve;
+    });
+  });
+
+  let updateNumber = 0;
+
+  const player = new Player({ plugins: [plugin] });
+
+  player.hooks.viewController.tap('async-node-test', (vc) => {
+    vc.hooks.view.tap('async-node-test', (view) => {
+      view.hooks.onUpdate.tap('async-node-test', (update) => {
+        updateNumber++;
+      });
+    });
+  });
+
+  player.start(basicFRFWithActions as any);
+
+  let view = (player.getState() as InProgressState).controllers.view.currentView
+    ?.lastUpdate;
+
+  expect(view).toBeDefined();
+  expect(view?.actions[1]).toBeUndefined();
+
+  await waitFor(() => {
+    expect(updateNumber).toBe(1);
+    expect(deferredResolve).toBeDefined();
+  });
+
+  // Call the deferredResolve with type 'Async'
+  if (deferredResolve) {
+    // we are passing the objects variable to the deferredResolve function and then expecting the type of the object to be 'Async'
+    const objects = [
+      {
+        asset: {
+          id: 'value-1',
+          type: 'text',
+          value: '1st value in the multinode',
+        },
+      },
+      {
+        id: 'another-async',
+        type: NodeType.Async,
+        async: true,
+      },
+    ];
+    deferredResolve(objects);
+    const types = objects.map((obj) => (obj.asset ? obj.asset.type : obj.type));
+    // eslint-disable-next-line jest/no-conditional-expect
+    expect(types).toContain(NodeType.Async);
+  }
 });

--- a/plugins/async-node/core/src/index.ts
+++ b/plugins/async-node/core/src/index.ts
@@ -17,7 +17,7 @@ export * from './types';
  */
 export class AsyncNodePlugin implements PlayerPlugin {
   public readonly hooks = {
-    onAsyncNode: new AsyncParallelBailHook<[Node.Async], any>(),
+    onAsyncNode: new AsyncParallelBailHook<[Node.Node], Node.Node>(),
   };
 
   name = 'AsyncNode';

--- a/plugins/async-node/core/src/index.ts
+++ b/plugins/async-node/core/src/index.ts
@@ -17,7 +17,7 @@ export * from './types';
  */
 export class AsyncNodePlugin implements PlayerPlugin {
   public readonly hooks = {
-    onAsyncNode: new AsyncParallelBailHook<[Node.Node], Node.Node>(),
+    onAsyncNode: new AsyncParallelBailHook<[Node.Async], any>(),
   };
 
   name = 'AsyncNode';


### PR DESCRIPTION
<!-- 
Made following changes to plugins/async-node/core/src/index.ts : 
onAsyncNode: new AsyncParallelBailHook<[Node.Async], any>() 
-->

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [x] `minor`
- [ ] `major`

Test case passes locally:
![image](https://github.com/player-ui/player/assets/171299777/9920d918-57d1-4bf9-9d13-ef4bbb166d04)



### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs