### PR TITLE
iOS ReferenceAssetsPlugin: check registry type instead of player type

### DIFF
--- a/plugins/reference-assets/swiftui/Sources/ReferenceAssetsPlugin.swift
+++ b/plugins/reference-assets/swiftui/Sources/ReferenceAssetsPlugin.swift
@@ -15,12 +15,12 @@ public class ReferenceAssetsPlugin: JSBasePlugin, NativePlugin {
        - player: The `HeadlessPlayer` that is applying this plugin
     */
     public func apply<P>(player: P) where P: HeadlessPlayer {
-        if let player = player as? SwiftUIPlayer {
-            player.assetRegistry.register("action", asset: ActionAsset.self)
-            player.assetRegistry.register("text", asset: TextAsset.self)
-            player.assetRegistry.register("collection", asset: CollectionAsset.self)
-            player.assetRegistry.register("input", asset: InputAsset.self)
-            player.assetRegistry.register("info", asset: InfoAsset.self)
+        if let registry = player.assetRegistry as? SwiftUIRegistry {
+            registry.register("action", asset: ActionAsset.self)
+            registry.register("text", asset: TextAsset.self)
+            registry.register("collection", asset: CollectionAsset.self)
+            registry.register("input", asset: InputAsset.self)
+            registry.register("info", asset: InfoAsset.self)
         }
     }
     /**

--- a/plugins/reference-assets/swiftui/ViewInspector/SwiftUI/ActionAssetTests.swift
+++ b/plugins/reference-assets/swiftui/ViewInspector/SwiftUI/ActionAssetTests.swift
@@ -18,10 +18,7 @@ import ViewInspector
 @testable import PlayerUIBeaconPlugin
 
 class ActionAssetTests: SwiftUIAssetUnitTestCase {
-    override func register(registry: SwiftUIRegistry) {
-        registry.register("action", asset: ActionAsset.self)
-        registry.register("text", asset: TextAsset.self)
-    }
+    override open func plugins() -> [NativePlugin] { [ReferenceAssetsPlugin()] }
 
     func setup() {
         XCUIApplication().terminate()

--- a/plugins/reference-assets/swiftui/ViewInspector/SwiftUI/CollectionAssetTests.swift
+++ b/plugins/reference-assets/swiftui/ViewInspector/SwiftUI/CollectionAssetTests.swift
@@ -17,10 +17,7 @@ import SwiftUI
 @testable import PlayerUISwiftUI
 
 class CollectionAssetTests: SwiftUIAssetUnitTestCase {
-    override func register(registry: SwiftUIRegistry) {
-        registry.register("collection", asset: CollectionAsset.self)
-        registry.register("text", asset: TextAsset.self)
-    }
+    override open func plugins() -> [NativePlugin] { [ReferenceAssetsPlugin()] }
 
     func testDecoding() async throws {
         let json = """

--- a/plugins/reference-assets/swiftui/ViewInspector/SwiftUI/InfoAssetTests.swift
+++ b/plugins/reference-assets/swiftui/ViewInspector/SwiftUI/InfoAssetTests.swift
@@ -17,11 +17,7 @@ import XCTest
 @testable import PlayerUISwiftUI
 
 class InfoAssetTests: SwiftUIAssetUnitTestCase {
-    override func register(registry: SwiftUIRegistry) {
-        registry.register("info", asset: InfoAsset.self)
-        registry.register("text", asset: TextAsset.self)
-        registry.register("action", asset: ActionAsset.self)
-    }
+    override open func plugins() -> [NativePlugin] { [ReferenceAssetsPlugin()] }
 
     func testDecoding() async throws {
         let json = """

--- a/plugins/reference-assets/swiftui/ViewInspector/SwiftUI/InputAssetTests.swift
+++ b/plugins/reference-assets/swiftui/ViewInspector/SwiftUI/InputAssetTests.swift
@@ -20,10 +20,7 @@ import JavaScriptCore
 
 
 class InputAssetTests: SwiftUIAssetUnitTestCase {
-    override func register(registry: SwiftUIRegistry) {
-        registry.register("input", asset: InputAsset.self)
-        registry.register("text", asset: TextAsset.self)
-    }
+    override open func plugins() -> [NativePlugin] { [ReferenceAssetsPlugin()] }
 
     func testDecoding() async throws {
         let json = """

--- a/plugins/reference-assets/swiftui/ViewInspector/SwiftUI/TextAssetTests.swift
+++ b/plugins/reference-assets/swiftui/ViewInspector/SwiftUI/TextAssetTests.swift
@@ -16,9 +16,8 @@ import SwiftUI
 @testable import PlayerUITestUtilities
 
 class TextAssetTests: SwiftUIAssetUnitTestCase {
-    override func register(registry: SwiftUIRegistry) {
-        registry.register("text", asset: TextAsset.self)
-    }
+    override open func plugins() -> [NativePlugin] { [ReferenceAssetsPlugin()] }
+
     func testAssetDecoding() async throws {
         let json = """
         {


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

Change `ReferenceAssetsPlugin` to check against registry type to register assets, instead of Player type. This allows asset registration to work with `SwiftUIAssetTestHelper` or `SwiftUIAssetUniTestCase` for the `getAsset` helper.

resolves #325 

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->