### PR TITLE
stamp podspec again with version

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,5 @@
-# load("@rules_player//cocoapods:cocoapod.bzl", "pod_push")
-# load("@rules_player//internal:stamp.bzl", "stamp")
 load("//tools/ios:util.bzl", "assemble_pod")
+load("@rules_player//internal:defs.bzl", "stamp")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
@@ -86,17 +85,18 @@ js_library(
 )
 
 # # Update the version in the podspec
-# stamp(
-#     name = "PlayerUI_Podspec",
-#     files = ["//:PlayerUI.podspec"],
-#     stable = True,
-#     substitutions = {
-#         "0.0.1-placeholder": "{STABLE_VERSION}",
-#     },
-# )
+stamp(
+    name = "PlayerUI_Podspec",
+    files = ["//:PlayerUI.podspec"],
+    stable = True,
+    substitutions = {
+        "0.0.1-placeholder": "{STABLE_VERSION}",
+    },
+    stamp = -1,
+)
 
 exports_files([
-    "PlayerUI.podspec",
+    "PlayerUI.podspec"
 ])
 
 assemble_pod(
@@ -186,7 +186,7 @@ assemble_pod(
         "//plugins/types-provider/ios:PlayerUITypesProviderPlugin_Sources": "plugins/types-provider/ios/",
         "//plugins/types-provider/core:core_native_bundle": "plugins/types-provider/ios/Resources/",
     },
-    podspec = ":PlayerUI.podspec",
+    podspec = ":PlayerUI_Podspec",
 )
 
 # # Push podspec to specs repo

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,7 @@ bazel_dep(name = "rules_player")
 git_override(
     remote = "https://github.com/player-ui/rules_player.git",
     # bazel-6 branch
-    commit = "e71339c96deeec1f4976fbc04815143ee23d8541",
+    commit = "ebb436079557ab5dab2c48c6081282c4459b8b47",
     module_name = "rules_player",
 )
 # local_path_override(module_name = "rules_player", path = "../rules_player")


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->
Reenable stamping for podspec with updated `stamp` rule

This should put iOS back in publishing parity with `main`

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->