### PR TITLE
Update CONTRIBUTING.md to include python dependency.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ If the changes are larger (API design, architecture, etc), [opening an issue](ht
 * [Ruby >= 2.6 && <= 3.0](https://github.com/rbenv/rbenv)
 
 * [Android NDK >= 19.2.5345600, <= 21](https://github.com/android/ndk/wiki/Unsupported-Downloads#r19c). Any version > 21 will not work, period. You'll need to add `ANDROID_NDK_HOME` to your environment manually.
+* Python < 3 (recommended 2.7.18) - you can use [pyenv](https://realpython.com/intro-to-pyenv/) to manage different python versions with ease. 
 
 * [Signed Commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification). For convenience it is recommended to set git to sign all commits by default as mentioned [here](https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key)
 


### PR DESCRIPTION
While trying to run OSS android, a few of us ran into an issue

`ModuleNotFoundError: No module named 'six.moves'`

This happens when your default python version is >= 3

<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
- [x] `skip-release`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->


### Does your PR have any documentation updates?
- [x] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->