### PR TITLE
Fix binding tracking for validations within nested multi-nodes

### DIFF
--- a/core/player/src/__tests__/validation.test.ts
+++ b/core/player/src/__tests__/validation.test.ts
@@ -171,6 +171,67 @@ const simpleExpressionFlow: Flow = {
   },
 };
 
+const flowWithMultiNode: Flow = {
+  id: 'test-flow',
+  views: [
+    {
+      id: 'view-1',
+      type: 'view',
+      multiNode: [
+        {
+          nestedMultiNode: [
+            {
+              asset: {
+                type: 'asset-type',
+                id: 'nested-asset',
+                binding: 'data.foo',
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  data: {},
+  schema: {
+    ROOT: {
+      data: {
+        type: 'DataType',
+      },
+    },
+    DataType: {
+      foo: {
+        type: 'CatType',
+        validation: [
+          {
+            type: 'names',
+            names: ['frodo', 'sam'],
+            trigger: 'navigation',
+            severity: 'warning',
+          },
+        ],
+      },
+    },
+  },
+  navigation: {
+    BEGIN: 'FLOW_1',
+    FLOW_1: {
+      startState: 'VIEW_1',
+      VIEW_1: {
+        state_type: 'VIEW',
+        ref: 'view-1',
+        transitions: {
+          '*': 'END_1',
+        },
+      },
+      END_1: {
+        state_type: 'END',
+        outcome: 'test',
+      },
+    },
+  },
+};
+
 const flowWithThings: Flow = {
   id: 'test-flow',
   views: [
@@ -783,6 +844,14 @@ describe('validation', () => {
 
       await waitFor(() =>
         expect(validationController?.getBindings().size).toStrictEqual(6)
+      );
+    });
+
+    it('track bindings in nested multi nodes', async () => {
+      player.start(flowWithMultiNode);
+
+      await waitFor(() =>
+        expect(validationController?.getBindings().size).toStrictEqual(1)
       );
     });
   });

--- a/core/player/src/controllers/validation/binding-tracker.ts
+++ b/core/player/src/controllers/validation/binding-tracker.ts
@@ -1,5 +1,6 @@
 import type { Validation } from '@player-ui/types';
 import type { ViewPlugin, Resolver, Node, ViewInstance } from '../../view';
+import { NodeType } from '../../view';
 import type {
   BindingInstance,
   BindingLike,
@@ -67,25 +68,15 @@ export class ValidationBindingTrackerViewPlugin
 
     let lastViewUpdateChangeSet: Set<BindingInstance> | undefined;
 
-    const nodeTree = new Map<Node.Node, Set<Node.Node>>();
-
     /** Map of node to all bindings in children */
-    let lastComputedBindingTree = new Map<Node.Node, Set<BindingInstance>>();
+    const lastComputedBindingTree = new Map<Node.Node, Set<BindingInstance>>();
     let currentBindingTree = new Map<Node.Node, Set<BindingInstance>>();
 
     /** Map of registered section nodes to bindings */
     const lastSectionBindingTree = new Map<Node.Node, Set<BindingInstance>>();
 
-    /** Add the given child to the parent's tree. Create the parent entry if none exists */
-    function addToTree(child: Node.Node, parent: Node.Node) {
-      if (nodeTree.has(parent)) {
-        nodeTree.get(parent)?.add(child);
-
-        return;
-      }
-
-      nodeTree.set(parent, new Set([child]));
-    }
+    /** Map of resolved nodes to their original nodes. */
+    const resolvedNodeMap: Map<Node.Node, Node.Node> = new Map();
 
     resolver.hooks.beforeUpdate.tap(CONTEXT, (changes) => {
       lastViewUpdateChangeSet = changes;
@@ -214,46 +205,66 @@ export class ValidationBindingTrackerViewPlugin
       };
     });
 
-    resolver.hooks.afterNodeUpdate.tap(CONTEXT, (node, parent, update) => {
-      if (parent) {
-        addToTree(node, parent);
-      }
+    resolver.hooks.afterNodeUpdate.tap(
+      CONTEXT,
+      (originalNode, parent, update) => {
+        // Compute the new tree for this node
+        // If it's not-updated, use the last known value
 
-      // Compute the new tree for this node
-      // If it's not-updated, use the last known value
+        const { updated, node: resolvedNode } = update;
+        resolvedNodeMap.set(resolvedNode, originalNode);
 
-      if (update.updated) {
-        const newlyComputed = new Set(tracked.get(node));
-        nodeTree.get(node)?.forEach((child) => {
-          currentBindingTree.get(child)?.forEach((b) => newlyComputed.add(b));
-        });
-        currentBindingTree.set(node, newlyComputed);
-      } else {
-        currentBindingTree.set(
-          node,
-          lastComputedBindingTree.get(node) ?? new Set()
-        );
-      }
+        if (updated) {
+          const newlyComputed = new Set(tracked.get(originalNode));
+          if (resolvedNode.type === NodeType.MultiNode) {
+            resolvedNode.values.forEach((value) =>
+              currentBindingTree
+                .get(value)
+                ?.forEach((b) => newlyComputed.add(b))
+            );
+          }
 
-      if (node === resolver.root) {
-        this.trackedBindings = new Set(currentBindingTree.get(node));
-        lastComputedBindingTree = currentBindingTree;
+          if ('children' in resolvedNode && resolvedNode.children) {
+            resolvedNode.children.forEach((child) => {
+              currentBindingTree
+                .get(child.value)
+                ?.forEach((b) => newlyComputed.add(b));
+            });
+          }
 
-        lastSectionBindingTree.clear();
-        sections.forEach((nodeSet, sectionNode) => {
-          const temp = new Set<BindingInstance>();
-          nodeSet.forEach((n) => {
-            tracked.get(n)?.forEach(temp.add, temp);
+          currentBindingTree.set(resolvedNode, newlyComputed);
+        } else {
+          currentBindingTree.set(
+            resolvedNode,
+            lastComputedBindingTree.get(originalNode) ?? new Set()
+          );
+        }
+
+        if (originalNode === resolver.root) {
+          this.trackedBindings = new Set(currentBindingTree.get(resolvedNode));
+          lastComputedBindingTree.clear();
+          currentBindingTree.forEach((value, key) => {
+            const node = resolvedNodeMap.get(key);
+            if (node) {
+              lastComputedBindingTree.set(node, value);
+            }
           });
-          lastSectionBindingTree.set(sectionNode, temp);
-        });
 
-        nodeTree.clear();
-        tracked.clear();
-        sections.clear();
-        currentBindingTree = new Map();
+          lastSectionBindingTree.clear();
+          sections.forEach((nodeSet, sectionNode) => {
+            const temp = new Set<BindingInstance>();
+            nodeSet.forEach((n) => {
+              tracked.get(n)?.forEach(temp.add, temp);
+            });
+            lastSectionBindingTree.set(sectionNode, temp);
+          });
+
+          tracked.clear();
+          sections.clear();
+          currentBindingTree = new Map();
+        }
       }
-    });
+    );
   }
 
   apply(view: ViewInstance) {


### PR DESCRIPTION
### What is being fixed
Because the `afterNodeUpdate` tap from the resolver doesn't always pass the original parent of the node, the `addToTree` logic would fail to recreate the original tree structure of the nodes that were nested in multiple multi-nodes. This caused some bindings not to get tracked properly and allow the navigation controller to proceed even when there were blocking errors present. To fix this the following changes were made:

- During the `afterNodeUpdate` tap in `binding-tracker`, the `currentBindingTree` now uses the resolved nodes as the keys, and uses the `children` and `values` properties to get the child nodes instead of tracking it using the old `addToTree` function.
- In order to be compatible with the other taps and maps that still use the original node instead of the resolved one, the `resolvedNodeMap` was added to map the resolved nodes back to their originals. The `lastComputedBindingTree` is then setup by mapping the keys from `currentBindingTree` back to their original nodes. 

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [X] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->


### Does your PR have any documentation updates?
- [ ] Updated docs
- [X] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->