### PR TITLE
Bazel 6 jvm add footer in info comp

### DIFF
--- a/plugins/reference-assets/core/src/assets/info/types.ts
+++ b/plugins/reference-assets/core/src/assets/info/types.ts
@@ -13,6 +13,9 @@ export interface InfoAsset extends Asset<"info"> {
 
   /** List of actions to show at the bottom of the page */
   actions?: Array<AssetWrapper>;
+
+  /** Footer to show at the bottom of the page below the actions info */
+  footer?: AssetWrapper;
 }
 
 export interface InfoAssetTransform extends InfoAsset {

--- a/plugins/reference-assets/mocks/info/info-basic.tsx
+++ b/plugins/reference-assets/mocks/info/info-basic.tsx
@@ -13,6 +13,7 @@ const view1 = (
         <Action.Label>Back</Action.Label>
       </Action>
     </Info.Actions>
+    <Info.Footer>Footer text</Info.Footer>
   </Info>
 );
 

--- a/plugins/reference-assets/mocks/info/info-dynamic-flow.tsx
+++ b/plugins/reference-assets/mocks/info/info-dynamic-flow.tsx
@@ -13,6 +13,7 @@ const view1 = (
         <Action.Label>Back</Action.Label>
       </Action>
     </Info.Actions>
+    <Info.Footer>Footer text</Info.Footer>
   </Info>
 );
 

--- a/plugins/reference-assets/mocks/info/info-modal-flow.tsx
+++ b/plugins/reference-assets/mocks/info/info-modal-flow.tsx
@@ -10,6 +10,7 @@ const view1 = (
         <Action.Label>Continue</Action.Label>
       </Action>
     </Info.Actions>
+    <Info.Footer>Footer text</Info.Footer>
   </Info>
 );
 

--- a/plugins/reference-assets/react/src/assets/info/Info.tsx
+++ b/plugins/reference-assets/react/src/assets/info/Info.tsx
@@ -36,6 +36,11 @@ export const Info = (props: InfoAssetTransform) => {
                 <ReactAsset key={a.asset.id} {...a} />
               ))}
             </div>
+            <div>
+              {props.footer && (
+                <ReactAsset {...props.footer} />
+              )}
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Bazel 6 jvm add footer in info comp 

All tests passing in local
![image](https://github.com/player-ui/player/assets/171299777/4b2934a2-3e5f-4cb2-ab51-e90fe36803d5)


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->