### PR TITLE
This PR enables to add footer component to info reference asset in android

### DIFF
--- a/plugins/reference-assets/android/src/androidTest/java/com/intuit/playerui/android/reference/assets/info/InfoTest.kt
+++ b/plugins/reference-assets/android/src/androidTest/java/com/intuit/playerui/android/reference/assets/info/InfoTest.kt
@@ -22,6 +22,8 @@ class InfoTest : AssetTest("reference-assets") {
     private fun verifyAndProceed(view: Int, action: PlayerAction? = null) {
         val infoTitle = currentView?.findViewById<FrameLayout>(R.id.info_title) ?: throw AssertionError("current view is null")
         val infoActions = currentView?.findViewById<LinearLayout>(R.id.info_actions) ?: throw AssertionError("current view is null")
+        val infoFooter =
+            currentView?.findViewById<FrameLayout>(R.id.info_footer) ?: throw AssertionError("current view is null")
 
         infoTitle[0].shouldBeView<TextView> {
             assertEquals("View $view", text.toString())
@@ -34,6 +36,10 @@ class InfoTest : AssetTest("reference-assets") {
                 performClick()
                 blockUntilRendered()
             }
+        }
+
+        infoFooter[0].shouldBeView<TextView> {
+            assertEquals("Footer Text", text.toString())
         }
     }
 

--- a/plugins/reference-assets/android/src/main/java/com/intuit/playerui/android/reference/assets/info/Info.kt
+++ b/plugins/reference-assets/android/src/main/java/com/intuit/playerui/android/reference/assets/info/Info.kt
@@ -17,6 +17,7 @@ class Info(assetContext: AssetContext) : SuspendableAsset<Info.Data>(assetContex
         val title: RenderableAsset? = null,
         val primaryInfo: RenderableAsset? = null,
         val actions: List<RenderableAsset?> = emptyList(),
+        val footer: RenderableAsset? = null,
     )
 
     override suspend fun initView(data: Data) = LayoutInflater.from(context).inflate(R.layout.info, null).rootView
@@ -27,5 +28,6 @@ class Info(assetContext: AssetContext) : SuspendableAsset<Info.Data>(assetContex
         data.actions.filterNotNull().map {
             it.render()
         } into findViewById(R.id.info_actions)
+        data.footer?.render() into findViewById(R.id.info_footer)
     }
 }

--- a/plugins/reference-assets/android/src/main/res/layout/info.xml
+++ b/plugins/reference-assets/android/src/main/res/layout/info.xml
@@ -33,4 +33,14 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/info_primary_info" />
 
+    <FrameLayout
+            android:id="@+id/info_footer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/info_actions" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/plugins/reference-assets/components/src/index.test.tsx
+++ b/plugins/reference-assets/components/src/index.test.tsx
@@ -100,6 +100,7 @@ describe("JSON serialization", () => {
                   <Action.Label>Continue</Action.Label>
                 </Action>
               </Info.Actions>
+              <Info.Footer>Footer Text</Info.Footer>
             </Info>,
           )
         ).jsonValue,
@@ -158,6 +159,13 @@ describe("JSON serialization", () => {
             },
           },
         ],
+        footer: {
+          asset: {
+            id: "info-view-footer",
+            type: "text",
+            value: "Footer Text",
+          },
+        },
       });
     });
   });

--- a/plugins/reference-assets/mocks/info/info-modal-flow.tsx
+++ b/plugins/reference-assets/mocks/info/info-modal-flow.tsx
@@ -10,6 +10,7 @@ const view1 = (
         <Action.Label>Continue</Action.Label>
       </Action>
     </Info.Actions>
+    <Info.Footer>Footer Text</Info.Footer>
   </Info>
 );
 
@@ -24,6 +25,7 @@ const view2 = (
         <Action.Label>Dismiss</Action.Label>
       </Action>
     </Info.Actions>
+    <Info.Footer>Footer Text</Info.Footer>
   </Info>
 );
 
@@ -35,6 +37,7 @@ const view3 = (
         <Action.Label>Next</Action.Label>
       </Action>
     </Info.Actions>
+    <Info.Footer>Footer Text</Info.Footer>
   </Info>
 );
 


### PR DESCRIPTION
Bazel 6 android base add footer to info reference asset

### Change Type (required)
Indicate the type of change your pull request is:

Please find test results:

All Tests passed in local : 
https://app.buildbuddy.io/invocation/aae39ed3-dde9-40ee-9518-af24a07eb123

![image](https://github.com/user-attachments/assets/95d92341-b426-4d0d-a305-87df85384a11)

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`

### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
