### PR TITLE
working bazel test //core/player:player_eslint

### DIFF
--- a/core/player/src/view/__tests__/view.test.ts
+++ b/core/player/src/view/__tests__/view.test.ts
@@ -80,6 +80,54 @@ describe("view", () => {
       expect(updated).toBe(resolved);
     });
 
+    test("works with no valid switch cases in an array", () => {
+      const model = withParser(new LocalModel({}), parseBinding);
+      const evaluator = new ExpressionEvaluator({ model });
+      const schema = new SchemaController();
+
+      const view = new ViewInstance(
+        {
+          id: "test",
+          type: "view",
+          title: {
+            staticSwitch: [
+              {
+                case: false,
+                asset: {
+                  id: "false-case",
+                  type: "text",
+                  value: "some text",
+                },
+              },
+              {
+                case: false,
+                asset: {
+                  id: "false-case-2",
+                  type: "text",
+                  value: "some text",
+                },
+              },
+            ],
+          },
+        } as any,
+        {
+          model,
+          parseBinding,
+          evaluator,
+          schema,
+        },
+      );
+
+      const pluginOptions = toNodeResolveOptions(view.resolverOptions);
+      new SwitchPlugin(pluginOptions).apply(view);
+      new StringResolverPlugin().apply(view);
+      const resolved = view.update();
+
+      expect(resolved).toStrictEqual({
+        id: "test",
+        type: "view",
+      });
+    });
     it("does not return a field object if the case does not resolve an asset", () => {
       const model = withParser(
         new LocalModel({


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

Static switch test  for false cases
### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->