### PR TITLE
apply strategy from pr builds to main & release builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -482,7 +482,7 @@ workflows:
 
       - build_ios:
           requires:
-            - setup
+            - build
 
       - android_test:
           requires:
@@ -513,7 +513,7 @@ workflows:
 
       - build_ios:
           requires:
-            - setup
+            - build
 
       - android_test:
           requires:


### PR DESCRIPTION
Ensure we build core native bundles before iOS so it can surely pull from the cache