### PR TITLE
Log debug info for npm next release

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -19,6 +19,8 @@ elif [ "$RELEASE_TYPE" == "release" ] && [ "$CURRENT_BRANCH" == "main" ]; then
   NPM_TAG=latest
 fi
 
+echo "Publishing NPM Packages using tag: ${NPM_TAG} from release type: ${RELEASE_TYPE} on branch: ${CURRENT_BRANCH}"
+
 for pkg in $PKG_NPM_LABELS ; do
   bazel run --config=release -- ${pkg}.publish --access public --tag ${NPM_TAG}
 done


### PR DESCRIPTION
Trying to debug why NPM is publishing to `latest` instead of `next` 