### PR TITLE
Fixed switch parsing syntax issue for dynamic switches

### DIFF
--- a/core/player/src/view/__tests__/view.test.ts
+++ b/core/player/src/view/__tests__/view.test.ts
@@ -81,7 +81,7 @@ describe("view", () => {
       expect(updated).toBe(resolved);
     });
 
-    test("works with no valid switch cases in an array", () => {
+    test("works with no valid static switch cases in an array", () => {
       const model = withParser(new LocalModel({}), parseBinding);
       const evaluator = new ExpressionEvaluator({ model });
       const schema = new SchemaController();
@@ -130,6 +130,60 @@ describe("view", () => {
 
       expect(resolved).toStrictEqual({
         id: "test",
+        type: "view",
+      });
+    });
+
+    test("works with no valid dynamic switch cases in an array", () => {
+      const model = withParser(new LocalModel({}), parseBinding);
+      const evaluator = new ExpressionEvaluator({ model });
+      const schema = new SchemaController();
+
+      const view = new ViewInstance(
+        {
+          id: "test",
+          type: "view",
+          title: [
+            {
+              dynamicSwitch: [
+                {
+                  case: false,
+                  asset: {
+                    id: "false-case",
+                    type: "text",
+                    value: "some text",
+                  },
+                },
+                {
+                  case: false,
+                  asset: {
+                    id: "false-case-2",
+                    type: "text",
+                    value: "some text",
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        {
+          model,
+          parseBinding,
+          evaluator,
+          schema,
+        },
+      );
+
+      const pluginOptions = toNodeResolveOptions(view.resolverOptions);
+      new SwitchPlugin(pluginOptions).apply(view);
+      new MultiNodePlugin().apply(view);
+      new StringResolverPlugin().apply(view);
+
+      const resolved = view.update();
+
+      expect(resolved).toStrictEqual({
+        id: "test",
+        title: [],
         type: "view",
       });
     });

--- a/core/player/src/view/parser/utils.ts
+++ b/core/player/src/view/parser/utils.ts
@@ -17,7 +17,7 @@ export function hasTemplateValues(obj: any, localKey: string) {
 
 /** Check to see if the string is a valid switch key */
 export function hasSwitchKey(localKey: string) {
-  return localKey === ("staticSwitch" || "dynamicSwitch");
+  return localKey === "staticSwitch" || localKey === "dynamicSwitch";
 }
 
 /** Check to see if the string is a valid template key */


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

Fixed switch parsing syntax issue for dynamic switches.

https://jira.intuit.com/browse/PLAYA-9067?filter=-1

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->