### PR TITLE
Async node android

### DIFF
--- a/jvm/core/src/main/kotlin/com/intuit/playerui/core/bridge/hooks/NodeAsyncParallelBailHook1.kt
+++ b/jvm/core/src/main/kotlin/com/intuit/playerui/core/bridge/hooks/NodeAsyncParallelBailHook1.kt
@@ -4,10 +4,8 @@ import com.intuit.hooks.AsyncParallelBailHook
 import com.intuit.hooks.BailResult
 import com.intuit.hooks.HookContext
 import com.intuit.playerui.core.bridge.Node
-import com.intuit.playerui.core.bridge.NodeWrapper
 import com.intuit.playerui.core.bridge.serialization.serializers.NodeWrapperSerializer
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 

--- a/jvm/core/src/main/kotlin/com/intuit/playerui/core/bridge/hooks/NodeAsyncParallelBailHook1.kt
+++ b/jvm/core/src/main/kotlin/com/intuit/playerui/core/bridge/hooks/NodeAsyncParallelBailHook1.kt
@@ -1,0 +1,32 @@
+package com.intuit.playerui.core.bridge.hooks
+
+import com.intuit.hooks.AsyncParallelBailHook
+import com.intuit.hooks.BailResult
+import com.intuit.hooks.HookContext
+import com.intuit.playerui.core.bridge.Node
+import com.intuit.playerui.core.bridge.NodeWrapper
+import com.intuit.playerui.core.bridge.serialization.serializers.NodeWrapperSerializer
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@Serializable(with = NodeAsyncParallelBailHook1.Serializer::class)
+public class NodeAsyncParallelBailHook1<T1, R : Any>(override val node: Node, serializer1: KSerializer<T1>) : AsyncParallelBailHook<(HookContext, T1) -> BailResult<R>, R>(), AsyncNodeHook<R> {
+
+    init { init(serializer1) }
+
+    override suspend fun callAsync(context: HookContext, serializedArgs: Array<Any?>): R {
+        require(serializedArgs.size == 1)
+        val (p1) = serializedArgs
+        return call(10) { f, _ ->
+            f(context, p1 as T1)
+        } as R
+    }
+
+    /** The return type serializer is never used, but in order to generate the serializer with @Serializable for [NodeAsyncParallelBailHook1], it's needed */
+    internal class Serializer<T1, R : Any>(private val serializer1: KSerializer<T1>, `_`: KSerializer<R>) : NodeWrapperSerializer<NodeAsyncParallelBailHook1<T1, R>>({
+        NodeAsyncParallelBailHook1(it, serializer1)
+    })
+}

--- a/jvm/core/src/main/kotlin/com/intuit/playerui/core/bridge/hooks/NodeAsyncParallelBailHook1.kt
+++ b/jvm/core/src/main/kotlin/com/intuit/playerui/core/bridge/hooks/NodeAsyncParallelBailHook1.kt
@@ -15,14 +15,17 @@ import kotlinx.serialization.Serializable
 @Serializable(with = NodeAsyncParallelBailHook1.Serializer::class)
 public class NodeAsyncParallelBailHook1<T1, R : Any>(override val node: Node, serializer1: KSerializer<T1>) : AsyncParallelBailHook<(HookContext, T1) -> BailResult<R>, R>(), AsyncNodeHook<R> {
 
-    init { init(serializer1) }
+    init {
+        init(serializer1)
+    }
 
     override suspend fun callAsync(context: HookContext, serializedArgs: Array<Any?>): R {
-        require(serializedArgs.size == 1)
+        require(serializedArgs.size == 1) { "Expected exactly one argument, but got ${serializedArgs.size}" }
         val (p1) = serializedArgs
-        return call(10) { f, _ ->
+        val result = call(10) { f, _ ->
             f(context, p1 as T1)
         } as R
+        return result
     }
 
     /** The return type serializer is never used, but in order to generate the serializer with @Serializable for [NodeAsyncParallelBailHook1], it's needed */

--- a/jvm/core/src/main/kotlin/com/intuit/playerui/core/bridge/hooks/NodeHook.kt
+++ b/jvm/core/src/main/kotlin/com/intuit/playerui/core/bridge/hooks/NodeHook.kt
@@ -16,6 +16,7 @@ internal interface NodeHook<R> : NodeWrapper {
 
     @OptIn(ExperimentalSerializationApi::class)
     fun init(vararg serializers: KSerializer<*>) {
+        println("NodeHook initialized with node: $node")
         node.getInvokable<Any?>("tap")?.invoke(
             mapOf("name" to "name", "context" to true),
             Invokable { args ->

--- a/jvm/core/src/main/kotlin/com/intuit/playerui/core/bridge/hooks/NodeHook.kt
+++ b/jvm/core/src/main/kotlin/com/intuit/playerui/core/bridge/hooks/NodeHook.kt
@@ -4,19 +4,18 @@ import com.intuit.hooks.HookContext
 import com.intuit.playerui.core.bridge.Invokable
 import com.intuit.playerui.core.bridge.Node
 import com.intuit.playerui.core.bridge.NodeWrapper
+import com.intuit.playerui.core.bridge.Promise
 import com.intuit.playerui.core.bridge.getInvokable
 import com.intuit.playerui.core.utils.InternalPlayerApi
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.capturedKClass
-import com.intuit.playerui.core.bridge.Promise
 
 /** Contains common logic for configuring a [NodeHook] to tap any JS hook */
 internal interface NodeHook<R> : NodeWrapper {
 
     @OptIn(ExperimentalSerializationApi::class)
     fun init(vararg serializers: KSerializer<*>) {
-        println("NodeHook initialized with node: $node")
         node.getInvokable<Any?>("tap")?.invoke(
             mapOf("name" to "name", "context" to true),
             Invokable { args ->

--- a/jvm/core/src/main/kotlin/com/intuit/playerui/core/bridge/hooks/NodeHook.kt
+++ b/jvm/core/src/main/kotlin/com/intuit/playerui/core/bridge/hooks/NodeHook.kt
@@ -9,6 +9,7 @@ import com.intuit.playerui.core.utils.InternalPlayerApi
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.capturedKClass
+import com.intuit.playerui.core.bridge.Promise
 
 /** Contains common logic for configuring a [NodeHook] to tap any JS hook */
 internal interface NodeHook<R> : NodeWrapper {
@@ -36,6 +37,15 @@ internal interface NodeHook<R> : NodeWrapper {
     }
 
     fun call(context: HookContext, serializedArgs: Array<Any?>): R
+}
+
+internal interface AsyncNodeHook<R : Any> : NodeHook<Promise> {
+    override fun call(context: HookContext, serializedArgs: Array<Any?>): Promise = node.runtime.Promise { resolve, reject ->
+        val result = callAsync(context, serializedArgs)
+        resolve(result)
+    }
+
+    suspend fun callAsync(context: HookContext, serializedArgs: Array<Any?>): R
 }
 
 @InternalPlayerApi

--- a/jvm/core/src/test/kotlin/com/intuit/playerui/core/bridge/PromiseTest.kt
+++ b/jvm/core/src/test/kotlin/com/intuit/playerui/core/bridge/PromiseTest.kt
@@ -8,7 +8,7 @@ import com.intuit.playerui.core.player.state.PlayerFlowState
 import com.intuit.playerui.utils.normalizeStackTraceElements
 import com.intuit.playerui.utils.test.PromiseUtils
 import com.intuit.playerui.utils.test.RuntimeTest
-import com.intuit.player.jvm.utils.test.runBlockingTest
+import com.intuit.playerui.utils.test.runBlockingTest
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.builtins.serializer

--- a/jvm/core/src/test/kotlin/com/intuit/playerui/core/bridge/PromiseTest.kt
+++ b/jvm/core/src/test/kotlin/com/intuit/playerui/core/bridge/PromiseTest.kt
@@ -1,5 +1,6 @@
 package com.intuit.playerui.core.bridge
 
+import com.intuit.playerui.core.bridge.runtime.add
 import com.intuit.playerui.core.bridge.runtime.serialize
 import com.intuit.playerui.core.player.PlayerException
 import com.intuit.playerui.core.player.PlayerFlowStatus
@@ -226,18 +227,17 @@ internal class PromiseTest : RuntimeTest(), PromiseUtils {
     fun testPromiseConstructor() = runBlockingTest {
         runtime.execute(
             """
-            class TestClass {
-                name = 'foo';
-                constructor(promise) {
-                    promise.then((value) => {
-                        this.name = value;
-                    });
-                };
-            }""",
+        class TestClass {
+            name = 'foo';
+            constructor(promise) {
+                promise.then((value) => {
+                    this.name = value;
+                });
+            };
+        }""",
         )
         val promise = runtime.Promise<String> { jsRes, _ ->
-            val result = "bar"
-            jsRes(result)
+            jsRes("bar")
         }
         runtime.add("myPromise", promise)
         val value = runtime.execute("new TestClass(myPromise)") as Node

--- a/jvm/core/src/test/kotlin/com/intuit/playerui/core/bridge/PromiseTest.kt
+++ b/jvm/core/src/test/kotlin/com/intuit/playerui/core/bridge/PromiseTest.kt
@@ -227,17 +227,18 @@ internal class PromiseTest : RuntimeTest(), PromiseUtils {
     fun testPromiseConstructor() = runBlockingTest {
         runtime.execute(
             """
-        class TestClass {
-            name = 'foo';
-            constructor(promise) {
-                promise.then((value) => {
-                    this.name = value;
-                });
-            };
-        }""",
+            class TestClass {
+                name = 'foo';
+                constructor(promise) {
+                    promise.then((value) => {
+                        this.name = value;
+                    });
+                };
+            }""",
         )
         val promise = runtime.Promise<String> { jsRes, _ ->
-            jsRes("bar")
+            val result = "bar"
+            jsRes(result)
         }
         runtime.add("myPromise", promise)
         val value = runtime.execute("new TestClass(myPromise)") as Node

--- a/jvm/core/src/test/kotlin/com/intuit/playerui/core/bridge/PromiseTest.kt
+++ b/jvm/core/src/test/kotlin/com/intuit/playerui/core/bridge/PromiseTest.kt
@@ -8,8 +8,10 @@ import com.intuit.playerui.core.player.state.PlayerFlowState
 import com.intuit.playerui.utils.normalizeStackTraceElements
 import com.intuit.playerui.utils.test.PromiseUtils
 import com.intuit.playerui.utils.test.RuntimeTest
+import com.intuit.player.jvm.utils.test.runBlockingTest
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -218,5 +220,28 @@ internal class PromiseTest : RuntimeTest(), PromiseUtils {
         caught as Throwable
         assertEquals(exception.message, caught.message)
         assertEquals(exception.stackTrace.normalizeStackTraceElements(), caught.stackTrace.normalizeStackTraceElements())
+    }
+
+    @TestTemplate
+    fun testPromiseConstructor() = runBlockingTest {
+        runtime.execute(
+            """
+            class TestClass {
+                name = 'foo';
+                constructor(promise) {
+                    promise.then((value) => {
+                        this.name = value;
+                    });
+                };
+            }""",
+        )
+        val promise = runtime.Promise<String> { jsRes, _ ->
+            val result = "bar"
+            jsRes(result)
+        }
+        runtime.add("myPromise", promise)
+        val value = runtime.execute("new TestClass(myPromise)") as Node
+        promise.toCompletable(String.serializer()).await()
+        assertEquals("bar", value["name"])
     }
 }

--- a/jvm/dependencies/common.bzl
+++ b/jvm/dependencies/common.bzl
@@ -24,4 +24,5 @@ test_deps = [
     "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_test",
     "//jvm/testutils",
     # We don't publish this, so we need to specify it manually as a common test dep (can remove once we publish host and include in testutils)
+    "//jvm/hermes:hermes-host",
 ]

--- a/jvm/dependencies/common.bzl
+++ b/jvm/dependencies/common.bzl
@@ -24,5 +24,4 @@ test_deps = [
     "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_test",
     "//jvm/testutils",
     # We don't publish this, so we need to specify it manually as a common test dep (can remove once we publish host and include in testutils)
-    "//jvm/hermes:hermes-host",
 ]

--- a/jvm/hermes/src/main/jni/JHermesRuntime.h
+++ b/jvm/hermes/src/main/jni/JHermesRuntime.h
@@ -17,6 +17,7 @@ public:
     static local_ref<jhybridobject> create(alias_ref<jclass>, bool intl = true, bool microtaskQueue = false) {
         auto config = hermes::vm::RuntimeConfig::Builder()
             .withIntl(intl)
+            .withES6Class(true)
             .withMicrotaskQueue(microtaskQueue)
             .build();
 

--- a/plugins/async-node/jvm/BUILD
+++ b/plugins/async-node/jvm/BUILD
@@ -1,0 +1,10 @@
+load("//plugins:defs.bzl", "kt_player_plugin")
+load(":deps.bzl", "main_deps", "main_exports", "main_resources")
+
+kt_player_plugin(
+    name = "async-node",
+    main_deps = main_deps,
+    main_exports = main_exports,
+    main_resources = main_resources,
+    test_package = "com.intuit.playerui.plugins.asyncnode",
+)

--- a/plugins/async-node/jvm/api/async-node.api
+++ b/plugins/async-node/jvm/api/async-node.api
@@ -1,0 +1,21 @@
+public final class com/intuit/player/jvm/plugins/asyncnode/AsyncNodePlugin : com/intuit/player/jvm/core/plugins/JSScriptPluginWrapper {
+	public field hooks Lcom/intuit/player/jvm/plugins/asyncnode/AsyncNodePlugin$Hooks;
+	public fun <init> ()V
+	public fun apply (Lcom/intuit/player/jvm/core/bridge/runtime/Runtime;)V
+	public final fun getHooks ()Lcom/intuit/player/jvm/plugins/asyncnode/AsyncNodePlugin$Hooks;
+	public final fun setHooks (Lcom/intuit/player/jvm/plugins/asyncnode/AsyncNodePlugin$Hooks;)V
+}
+
+public final class com/intuit/player/jvm/plugins/asyncnode/AsyncNodePlugin$Hooks : com/intuit/player/jvm/core/bridge/NodeWrapper {
+	public static final field Companion Lcom/intuit/player/jvm/plugins/asyncnode/AsyncNodePlugin$Hooks$Companion;
+	public fun getNode ()Lcom/intuit/player/jvm/core/bridge/Node;
+	public final fun getOnAsyncNode ()Lcom/intuit/player/jvm/core/bridge/hooks/NodeAsyncParallelBailHook1;
+}
+
+public final class com/intuit/player/jvm/plugins/asyncnode/AsyncNodePlugin$Hooks$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/intuit/player/jvm/plugins/asyncnode/AsyncNodePluginKt {
+	public static final fun getAsyncNodePlugin (Lcom/intuit/player/jvm/core/player/Player;)Lcom/intuit/player/jvm/plugins/asyncnode/AsyncNodePlugin;
+}

--- a/plugins/async-node/jvm/deps.bzl
+++ b/plugins/async-node/jvm/deps.bzl
@@ -1,14 +1,9 @@
-maven = [
-    "com.intuit.player:core-bridge:1.0.0",
-]
-
 main_exports = [
     "//jvm/core",
 ]
 
 main_deps = main_exports + [
     "//jvm:kotlin_serialization",
-    "//plugins/set-time-out/jvm:set-time-out",
 ]
 
 main_resources = [

--- a/plugins/async-node/jvm/deps.bzl
+++ b/plugins/async-node/jvm/deps.bzl
@@ -1,0 +1,16 @@
+maven = [
+    "com.intuit.player:core-bridge:1.0.0",
+]
+
+main_exports = [
+    "//jvm/core",
+]
+
+main_deps = main_exports + [
+    "//jvm:kotlin_serialization",
+    "//plugins/set-time-out/jvm:set-time-out",
+]
+
+main_resources = [
+    "//plugins/async-node/core:core_native_bundle",
+]

--- a/plugins/async-node/jvm/src/main/kotlin/com/intuit/playerui/plugins/asyncnode/AsyncNodePlugin.kt
+++ b/plugins/async-node/jvm/src/main/kotlin/com/intuit/playerui/plugins/asyncnode/AsyncNodePlugin.kt
@@ -4,6 +4,7 @@ import com.intuit.playerui.core.bridge.Node
 import com.intuit.playerui.core.bridge.NodeWrapper
 import com.intuit.playerui.core.bridge.hooks.NodeAsyncParallelBailHook1
 import com.intuit.playerui.core.bridge.runtime.Runtime
+import com.intuit.playerui.core.bridge.runtime.ScriptContext
 import com.intuit.playerui.core.bridge.serialization.serializers.GenericSerializer
 import com.intuit.playerui.core.bridge.serialization.serializers.NodeSerializableField
 import com.intuit.playerui.core.bridge.serialization.serializers.NodeSerializer
@@ -22,8 +23,8 @@ public class AsyncNodePlugin : JSScriptPluginWrapper(pluginName, sourcePath = bu
     public lateinit var hooks: Hooks
 
     override fun apply(runtime: Runtime<*>) {
-        runtime.execute(script)
-        instance = runtime.buildInstance("(new $name())")
+        runtime.load(ScriptContext(script, bundledSourcePath))
+        instance = runtime.buildInstance("(new $pluginName({plugins: [new AsyncNodePlugin.AsyncNodePluginPlugin()]}))")
         hooks = instance.getSerializable("hooks", Hooks.serializer()) ?: throw PlayerException("AsyncNodePlugin is not loaded correctly")
     }
 
@@ -35,10 +36,10 @@ public class AsyncNodePlugin : JSScriptPluginWrapper(pluginName, sourcePath = bu
     }
 
     private companion object {
-        private const val bundledSourcePath = "async-node-plugin.js"
-        private const val pluginName = "AsyncNodePlugin"
+        private const val bundledSourcePath = "plugins/async-node/core/dist/AsyncNodePlugin.native.js"
+        private const val pluginName = "AsyncNodePlugin.AsyncNodePlugin"
     }
 }
 
-/** Convenience getter to find the first [PubSubPlugin] registered to the [Player] */
+/** Convenience getter to find the first [AsyncNodePlugin] registered to the [Player] */
 public val Player.asyncNodePlugin: AsyncNodePlugin? get() = findPlugin()

--- a/plugins/async-node/jvm/src/main/kotlin/com/intuit/playerui/plugins/asyncnode/AsyncNodePlugin.kt
+++ b/plugins/async-node/jvm/src/main/kotlin/com/intuit/playerui/plugins/asyncnode/AsyncNodePlugin.kt
@@ -1,0 +1,44 @@
+package com.intuit.playerui.plugins.asyncnode
+
+import com.intuit.playerui.core.bridge.Node
+import com.intuit.playerui.core.bridge.NodeWrapper
+import com.intuit.playerui.core.bridge.hooks.NodeAsyncParallelBailHook1
+import com.intuit.playerui.core.bridge.runtime.Runtime
+import com.intuit.playerui.core.bridge.serialization.serializers.GenericSerializer
+import com.intuit.playerui.core.bridge.serialization.serializers.NodeSerializableField
+import com.intuit.playerui.core.bridge.serialization.serializers.NodeSerializer
+import com.intuit.playerui.core.bridge.serialization.serializers.NodeWrapperSerializer
+import com.intuit.playerui.core.player.Player
+import com.intuit.playerui.core.player.PlayerException
+import com.intuit.playerui.core.plugins.JSScriptPluginWrapper
+import com.intuit.playerui.core.plugins.findPlugin
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+
+public class AsyncNodePlugin : JSScriptPluginWrapper(pluginName, sourcePath = bundledSourcePath) {
+
+    public lateinit var hooks: Hooks
+
+    override fun apply(runtime: Runtime<*>) {
+        runtime.execute(script)
+        instance = runtime.buildInstance("(new $name())")
+        hooks = instance.getSerializable("hooks", Hooks.serializer()) ?: throw PlayerException("AsyncNodePlugin is not loaded correctly")
+    }
+
+    @Serializable(with = Hooks.Serializer::class)
+    public class Hooks internal constructor(override val node: Node) : NodeWrapper {
+        /** The hook right before the View starts resolving. Attach anything custom here */
+        public val onAsyncNode: NodeAsyncParallelBailHook1<Node, List<Map<String, Any?>>> by NodeSerializableField(NodeAsyncParallelBailHook1.serializer(NodeSerializer(), ListSerializer(MapSerializer(String.serializer(), GenericSerializer()))))
+        internal object Serializer : NodeWrapperSerializer<Hooks>(AsyncNodePlugin::Hooks)
+    }
+
+    private companion object {
+        private const val bundledSourcePath = "async-node-plugin.js"
+        private const val pluginName = "AsyncNodePlugin"
+    }
+}
+
+/** Convenience getter to find the first [PubSubPlugin] registered to the [Player] */
+public val Player.asyncNodePlugin: AsyncNodePlugin? get() = findPlugin()

--- a/plugins/async-node/jvm/src/test/kotlin/com/intuit/playerui/plugins/asyncnode/AsyncNodePluginTest.kt
+++ b/plugins/async-node/jvm/src/test/kotlin/com/intuit/playerui/plugins/asyncnode/AsyncNodePluginTest.kt
@@ -138,7 +138,7 @@ internal class AsyncNodePluginTest : PlayerTest() {
             player.start(asyncNodeFlowSimple)
         }
         Assertions.assertTrue(count == 2)
-        Assertions.assertTrue((update?.get("actions") as List<*>).size == 3)
+        Assertions.assertEquals(3, update?.getList("actions")?.size)
     }
 
     @TestTemplate
@@ -153,9 +153,11 @@ internal class AsyncNodePluginTest : PlayerTest() {
                     2 -> {
                         Assertions.assertEquals(1, (asset?.get("actions") as List<*>).size)
                     }
+
                     3 -> {
                         Assertions.assertEquals(2, (asset?.get("actions") as List<*>).size)
                     }
+
                     4 -> {
                         Assertions.assertEquals(4, (asset?.get("actions") as List<*>).size)
                     }
@@ -180,6 +182,7 @@ internal class AsyncNodePluginTest : PlayerTest() {
                         ),
                     ),
                 )
+
                 2 -> BailResult.Bail(
                     listOf(
                         mapOf(
@@ -195,6 +198,7 @@ internal class AsyncNodePluginTest : PlayerTest() {
                         ),
                     ),
                 )
+
                 else -> BailResult.Bail(
                     listOf(
                         mapOf(

--- a/plugins/async-node/jvm/src/test/kotlin/com/intuit/playerui/plugins/asyncnode/AsyncNodePluginTest.kt
+++ b/plugins/async-node/jvm/src/test/kotlin/com/intuit/playerui/plugins/asyncnode/AsyncNodePluginTest.kt
@@ -1,0 +1,217 @@
+package com.intuit.playerui.plugins.asyncnode
+
+import com.intuit.hooks.BailResult
+import com.intuit.playerui.core.asset.Asset
+import com.intuit.playerui.utils.test.PlayerTest
+import com.intuit.playerui.utils.test.runBlockingTest
+import io.mockk.junit5.MockKExtension
+import kotlinx.coroutines.*
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+internal class AsyncNodePluginTest : PlayerTest() {
+
+    val asyncNodeFlowSimple =
+        """{
+          "id": "counter-flow",
+          "views": [
+            {
+              "id": 'action',
+              "actions": [
+                {
+                  "id": "next-label-action",
+                  "type": "action",
+                  "value": "{{foo.bar}}",
+                  "async": true,
+                },
+              ],
+            },
+          ],
+          "navigation": {
+            "BEGIN": "FLOW_1",
+            "FLOW_1": {
+              "startState": "VIEW_1",
+              "VIEW_1": {
+                "state_type": "VIEW",
+                "ref": "action",
+                "transitions": {
+                  "*": "END_Done"
+                }
+              },
+              "END_Done": {
+                "state_type": "END",
+                "outcome": "done",
+                "param": {
+                  "someKey": "someValue"
+                },
+                "extraKey": "extraValue",
+                "extraObject": {
+                  "someInt": 1
+                }
+              }
+            }
+          }
+        }""".trimMargin()
+
+    override val plugins = listOf(AsyncNodePlugin())
+
+    private val plugin get() = player.asyncNodePlugin
+
+    @TestTemplate
+    fun `plugin is not null`() = Assertions.assertNotNull(plugin)
+
+    @TestTemplate
+    fun `async node hook is tappable`() = runBlockingTest {
+        var update: Asset? = null
+        plugin?.hooks?.onAsyncNode?.tap("") { _, node ->
+            BailResult.Bail(
+                listOf(
+                    mapOf(
+                        "asset" to mapOf(
+                            "id" to "asset-1",
+                            "type" to "text",
+                            "value" to "New asset!"
+                        )
+                    )
+                )
+            )
+        }
+        var count = 0
+        suspendCancellableCoroutine { cont ->
+            player.hooks.view.tap { v ->
+                v?.hooks?.onUpdate?.tap { asset ->
+                    count ++
+                    update = asset
+                    if (count == 2) cont.resume(true) {}
+                }
+            }
+            player.start(asyncNodeFlowSimple)
+        }
+        Assertions.assertTrue(count == 2)
+        Assertions.assertTrue((update?.get("actions") as List<*>).isNotEmpty())
+    }
+
+    @TestTemplate
+    fun `replace async node with multiNode`() = runBlockingTest {
+        var update: Asset? = null
+        plugin?.hooks?.onAsyncNode?.tap("") { _, node ->
+            BailResult.Bail(
+                listOf(
+                    mapOf(
+                        "asset" to mapOf(
+                            "id" to "asset-1",
+                            "type" to "text",
+                            "value" to "New asset!"
+                        )
+                    ),
+                    mapOf(
+                        "asset" to mapOf(
+                            "id" to "asset-2",
+                            "type" to "text",
+                            "value" to "New asset!"
+                        )
+                    )
+                )
+            )
+        }
+        var count = 0
+        suspendCancellableCoroutine { cont ->
+            player.hooks.view.tap { v ->
+                v?.hooks?.onUpdate?.tap { asset ->
+                    count ++
+                    update = asset
+                    if (count == 2) cont.resume(true) {}
+                }
+            }
+            player.start(asyncNodeFlowSimple)
+        }
+        Assertions.assertTrue(count == 2)
+        Assertions.assertTrue((update?.get("actions") as List<*>).size == 2)
+    }
+
+    @TestTemplate
+    fun `chain async test`() = runBlockingTest {
+        var asyncTaps = 0
+        var updateNumber = 0
+        player.hooks.view.tap { v ->
+            v?.hooks?.onUpdate?.tap { asset ->
+                updateNumber ++
+                when (updateNumber) {
+                    1 -> {}
+                    2 -> {
+                        Assertions.assertEquals(1, (asset?.get("actions") as List<*>).size)
+                    }
+                    3 -> {
+                        Assertions.assertEquals(2, (asset?.get("actions") as List<*>).size)
+                    }
+                    4 -> {
+                        Assertions.assertEquals(4, (asset?.get("actions") as List<*>).size)
+                    }
+                }
+            }
+        }
+        plugin?.hooks?.onAsyncNode?.tap("") { _, node ->
+            asyncTaps ++
+            when (asyncTaps) {
+                1 -> BailResult.Bail(
+                    listOf(
+                        mapOf(
+                            "asset" to mapOf(
+                                "id" to "asset-1",
+                                "type" to "text",
+                                "value" to "New asset!"
+                            )
+                        ),
+                        mapOf(
+                            "id" to "another-async",
+                            "async" to true
+                        )
+                    )
+                )
+                2 -> BailResult.Bail(
+                    listOf(
+                        mapOf(
+                            "asset" to mapOf(
+                                "id" to "asset-2",
+                                "type" to "text",
+                                "value" to "Another new asset!"
+                            )
+                        ),
+                        mapOf(
+                            "id" to "yet-another",
+                            "async" to true
+                        )
+                    )
+                )
+                else -> BailResult.Bail(
+                    listOf(
+                        mapOf(
+                            "asset" to mapOf(
+                                "id" to "asset-3",
+                                "type" to "text",
+                                "value" to "Third new asset!"
+                            )
+                        ),
+                        mapOf(
+                            "asset" to mapOf(
+                                "id" to "asset-4",
+                                "type" to "text",
+                                "value" to "Fourth new asset!"
+                            )
+                        )
+                    )
+                )
+            }
+        }
+
+        player.start(asyncNodeFlowSimple)
+
+        suspendCancellableCoroutine { cont ->
+            while (updateNumber < 4) runBlocking { delay(5) }
+            if (updateNumber == 4) cont.resume(true) {}
+        }
+        Assertions.assertTrue(true)
+    }
+}


### PR DESCRIPTION
This PR accommodates to this requirement https://github.com/player-ui/player/issues/459 i.e Port internal async node plugin implementation to android

### Change Type (required)
Indicate the type of change your pull request is:
Added a new component as per the following plugins/async-node
├── core
│   ├── BUILD
│   ├── src
│   └── package.json
└── jvm
    ├── BUILD
    ├── deps.bzl
    ├── src/main/kotlin/com/intuit/playerui/plugins/asyncnode
    │   └── AsyncNodePlugin.kt
    └── src/test/kotlin/com/intuit/playerui/plugins/asyncnode
        └── AsyncNodePluginTest.kt

All tests are passing in local : 
![image](https://github.com/user-attachments/assets/66b1faf1-386b-491d-a5dc-62759727ab09)

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs