### PR TITLE
[CI] Swap release script to use `config=ci`

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -23,12 +23,12 @@ echo "Publishing NPM Packages using tag: ${NPM_TAG} from release type: ${RELEASE
 readonly PKG_NPM_LABELS=`bazel query --output=label 'kind("npm_package rule", //...) - attr("tags", "\[.*do-not-publish.*\]", //...)'`
 
 for pkg in $PKG_NPM_LABELS ; do
-  bazel run --config=release -- ${pkg}.publish --access public --tag ${NPM_TAG}
+  bazel run --config=ci -- ${pkg}.publish --access public --tag ${NPM_TAG}
 done
 
 # Rebuild to stamp the release podspec
-bazel build --config=release //:PlayerUI_Podspec //:PlayerUI_Pod
-bazel run --config=release //:ios_publish
+bazel build --config=ci //:PlayerUI_Podspec //:PlayerUI_Pod
+bazel run --config=ci //:ios_publish
 
 # Maven Central publishing
 MVN_RELEASE_TYPE=snapshot
@@ -47,13 +47,13 @@ bazel run @rules_player//distribution:staged-maven-deploy -- "$MVN_RELEASE_TYPE"
 # Docs publishing
 echo "Publishing Docs with release type: ${RELEASE_TYPE} on branch: ${CURRENT_BRANCH}"
 if [ "$RELEASE_TYPE" == "next" ] && [ "$CURRENT_BRANCH" == "main" ]; then
- STABLE_DOCS_BASE_PATH=next bazel run --verbose_failures --config=release //docs:gh_deploy -- --dest_dir next
+ STABLE_DOCS_BASE_PATH=next bazel run --verbose_failures --config=ci //docs:gh_deploy -- --dest_dir next
 elif [ "$RELEASE_TYPE" == "release" ] && [ "$CURRENT_BRANCH" == "main" ]; then
- STABLE_DOCS_BASE_PATH=latest bazel run --verbose_failures --config=release //docs:gh_deploy -- --dest_dir latest
+ STABLE_DOCS_BASE_PATH=latest bazel run --verbose_failures --config=ci //docs:gh_deploy -- --dest_dir latest
 fi
 
 # Also deploy to the versioned folder for main releases
 if [ "$RELEASE_TYPE" == "release" ]; then
   SEMVER_MAJOR=$(cat VERSION | cut -d. -f1)
-  STABLE_DOCS_BASE_PATH=$SEMVER_MAJOR bazel run --verbose_failures --config=release //docs:gh_deploy -- --dest_dir "$SEMVER_MAJOR"
+  STABLE_DOCS_BASE_PATH=$SEMVER_MAJOR bazel run --verbose_failures --config=ci //docs:gh_deploy -- --dest_dir "$SEMVER_MAJOR"
 fi


### PR DESCRIPTION
The latest `next` release on `main` failed to build the docs because it ran out of resources:

[![`//docs:gh_deploy` CI failure](https://github.com/user-attachments/assets/92e7bb18-897c-4d4b-a95b-25554306e559)](https://app.circleci.com/pipelines/github/player-ui/player/3173/workflows/86e56545-8827-4e8f-9683-2f1e6af008f0/jobs/16579)

This PR swaps `config=release` with `config=ci` because that flag contains the [resource constraints](https://github.com/player-ui/player/blob/28d0e47bc661d9c18cc64621c589d37c73ae6eee/.bazelrc#L50-L52) and also includes `--config=release`.