### PR TITLE
externalize @player-ui/player from native bundles

### DIFF
--- a/core/make-flow/BUILD
+++ b/core/make-flow/BUILD
@@ -2,16 +2,21 @@ load("@rules_player//javascript:defs.bzl", "js_pipeline")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:defs.bzl", "NATIVE_BUILD_DEPS", "tsup_config", "vitest_config")
 
+NATIVE_BUNDLE = "MakeFlow"
+
 npm_link_all_packages(name = "node_modules")
 
-tsup_config(name = "tsup_config")
+tsup_config(
+    name = "tsup_config",
+    native_bundle = NATIVE_BUNDLE,
+)
 
 vitest_config(name = "vitest_config")
 
 js_pipeline(
     package_name = "@player-ui/make-flow",
     build_deps = NATIVE_BUILD_DEPS,
-    native_bundle = "MakeFlow",
+    native_bundle = NATIVE_BUNDLE,
     deps = [
         ":node_modules/@player-ui/types",
     ],

--- a/core/partial-match-registry/BUILD
+++ b/core/partial-match-registry/BUILD
@@ -1,14 +1,19 @@
 load("@rules_player//javascript:defs.bzl", "js_pipeline")
 load("//tools:defs.bzl", "NATIVE_BUILD_DEPS", "tsup_config", "vitest_config")
 
-tsup_config(name = "tsup_config")
+NATIVE_BUNDLE = "Registry"
+
+tsup_config(
+    name = "tsup_config",
+    native_bundle = NATIVE_BUNDLE,
+)
 
 vitest_config(name = "vitest_config")
 
 js_pipeline(
     package_name = "@player-ui/partial-match-registry",
     build_deps = NATIVE_BUILD_DEPS,
-    native_bundle = "Registry",
+    native_bundle = NATIVE_BUNDLE,
     deps = [
         "//:node_modules/@types/dlv",
         "//:node_modules/dlv",

--- a/core/player/BUILD
+++ b/core/player/BUILD
@@ -2,16 +2,22 @@ load("@rules_player//javascript:defs.bzl", "js_pipeline")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:defs.bzl", "NATIVE_BUILD_DEPS", "tsup_config", "vitest_config")
 
+# TODO: Would be nice to macro all the native things to avoid missing this setup (consequence is bundling Player in a plugin bundle)
+NATIVE_BUNDLE = "Player"
+
 npm_link_all_packages(name = "node_modules")
 
-tsup_config(name = "tsup_config")
+tsup_config(
+    name = "tsup_config",
+    native_bundle = NATIVE_BUNDLE,
+)
 
 vitest_config(name = "vitest_config")
 
 js_pipeline(
     package_name = "@player-ui/player",
     build_deps = NATIVE_BUILD_DEPS,
-    native_bundle = "Player",
+    native_bundle = NATIVE_BUNDLE,
     test_deps = [
         ":node_modules/@player-ui/make-flow",
         "//:vitest_config",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "ebnf": "^1.9.0",
     "error-polyfill": "^0.1.3",
     "esbuild-wasm": "^0.19.8",
+    "esbuild-plugin-external-global": "^1.0.1",
     "eslint": "^8.54.0",
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-react": "^7.33.2",

--- a/plugins/async-node/core/BUILD
+++ b/plugins/async-node/core/BUILD
@@ -2,16 +2,21 @@ load("@rules_player//javascript:defs.bzl", "js_pipeline")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:defs.bzl", "NATIVE_BUILD_DEPS", "tsup_config", "vitest_config")
 
+NATIVE_BUNDLE = "AsyncNodePlugin"
+
 npm_link_all_packages(name = "node_modules")
 
-tsup_config(name = "tsup_config")
+tsup_config(
+    name = "tsup_config",
+    native_bundle = NATIVE_BUNDLE,
+)
 
 vitest_config(name = "vitest_config")
 
 js_pipeline(
     package_name = "@player-ui/async-node-plugin",
     build_deps = NATIVE_BUILD_DEPS,
-    native_bundle = "AsyncNodePlugin",
+    native_bundle = NATIVE_BUNDLE,
     peer_deps = [
         ":node_modules/@player-ui/player",
     ],

--- a/plugins/beacon/core/BUILD
+++ b/plugins/beacon/core/BUILD
@@ -2,16 +2,21 @@ load("@rules_player//javascript:defs.bzl", "js_pipeline")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:defs.bzl", "NATIVE_BUILD_DEPS", "tsup_config", "vitest_config")
 
+NATIVE_BUNDLE = "BeaconPlugin"
+
 npm_link_all_packages(name = "node_modules")
 
-tsup_config(name = "tsup_config")
+tsup_config(
+    name = "tsup_config",
+    native_bundle = NATIVE_BUNDLE,
+)
 
 vitest_config(name = "vitest_config")
 
 js_pipeline(
     package_name = "@player-ui/beacon-plugin",
     build_deps = NATIVE_BUILD_DEPS,
-    native_bundle = "BeaconPlugin",
+    native_bundle = NATIVE_BUNDLE,
     peer_deps = [
         ":node_modules/@player-ui/player",
     ],

--- a/plugins/check-path/core/BUILD
+++ b/plugins/check-path/core/BUILD
@@ -2,16 +2,21 @@ load("@rules_player//javascript:defs.bzl", "js_pipeline")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:defs.bzl", "NATIVE_BUILD_DEPS", "tsup_config", "vitest_config")
 
+NATIVE_BUNDLE = "CheckPathPlugin"
+
 npm_link_all_packages(name = "node_modules")
 
-tsup_config(name = "tsup_config")
+tsup_config(
+    name = "tsup_config",
+    native_bundle = NATIVE_BUNDLE,
+)
 
 vitest_config(name = "vitest_config")
 
 js_pipeline(
     package_name = "@player-ui/check-path-plugin",
     build_deps = NATIVE_BUILD_DEPS,
-    native_bundle = "CheckPathPlugin",
+    native_bundle = NATIVE_BUNDLE,
     peer_deps = [
         ":node_modules/@player-ui/player",
     ],

--- a/plugins/common-expressions/core/BUILD
+++ b/plugins/common-expressions/core/BUILD
@@ -2,16 +2,21 @@ load("@rules_player//javascript:defs.bzl", "js_pipeline")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:defs.bzl", "NATIVE_BUILD_DEPS", "tsup_config", "vitest_config")
 
+NATIVE_BUNDLE = "CommonExpressionsPlugin"
+
 npm_link_all_packages(name = "node_modules")
 
-tsup_config(name = "tsup_config")
+tsup_config(
+    name = "tsup_config",
+    native_bundle = NATIVE_BUNDLE,
+)
 
 vitest_config(name = "vitest_config")
 
 js_pipeline(
     package_name = "@player-ui/common-expressions-plugin",
     build_deps = NATIVE_BUILD_DEPS,
-    native_bundle = "CommonExpressionsPlugin",
+    native_bundle = NATIVE_BUNDLE,
     peer_deps = [
         ":node_modules/@player-ui/player",
     ],

--- a/plugins/common-types/core/BUILD
+++ b/plugins/common-types/core/BUILD
@@ -2,16 +2,21 @@ load("@rules_player//javascript:defs.bzl", "js_pipeline")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:defs.bzl", "NATIVE_BUILD_DEPS", "tsup_config", "vitest_config")
 
+NATIVE_BUNDLE = "CommonTypesPlugin"
+
 npm_link_all_packages(name = "node_modules")
 
-tsup_config(name = "tsup_config")
+tsup_config(
+    name = "tsup_config",
+    native_bundle = NATIVE_BUNDLE,
+)
 
 vitest_config(name = "vitest_config")
 
 js_pipeline(
     package_name = "@player-ui/common-types-plugin",
     build_deps = NATIVE_BUILD_DEPS,
-    native_bundle = "CommonTypesPlugin",
+    native_bundle = NATIVE_BUNDLE,
     peer_deps = [
         ":node_modules/@player-ui/player",
     ],

--- a/plugins/computed-properties/core/BUILD
+++ b/plugins/computed-properties/core/BUILD
@@ -2,16 +2,21 @@ load("@rules_player//javascript:defs.bzl", "js_pipeline")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:defs.bzl", "NATIVE_BUILD_DEPS", "tsup_config", "vitest_config")
 
+NATIVE_BUNDLE = "ComputedPropertiesPlugin"
+
 npm_link_all_packages(name = "node_modules")
 
-tsup_config(name = "tsup_config")
+tsup_config(
+    name = "tsup_config",
+    native_bundle = NATIVE_BUNDLE,
+)
 
 vitest_config(name = "vitest_config")
 
 js_pipeline(
     package_name = "@player-ui/computed-properties-plugin",
     build_deps = NATIVE_BUILD_DEPS,
-    native_bundle = "ComputedPropertiesPlugin",
+    native_bundle = NATIVE_BUNDLE,
     peer_deps = [
         ":node_modules/@player-ui/player",
     ],

--- a/plugins/expression/core/BUILD
+++ b/plugins/expression/core/BUILD
@@ -2,16 +2,21 @@ load("@rules_player//javascript:defs.bzl", "js_pipeline")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:defs.bzl", "NATIVE_BUILD_DEPS", "tsup_config", "vitest_config")
 
+NATIVE_BUNDLE = "ExpressionPlugin"
+
 npm_link_all_packages(name = "node_modules")
 
-tsup_config(name = "tsup_config")
+tsup_config(
+    name = "tsup_config",
+    native_bundle = NATIVE_BUNDLE,
+)
 
 vitest_config(name = "vitest_config")
 
 js_pipeline(
     package_name = "@player-ui/expression-plugin",
     build_deps = NATIVE_BUILD_DEPS,
-    native_bundle = "ExpressionPlugin",
+    native_bundle = NATIVE_BUNDLE,
     peer_deps = [
         ":node_modules/@player-ui/player",
     ],

--- a/plugins/external-action/core/BUILD
+++ b/plugins/external-action/core/BUILD
@@ -2,16 +2,21 @@ load("@rules_player//javascript:defs.bzl", "js_pipeline")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:defs.bzl", "NATIVE_BUILD_DEPS", "tsup_config", "vitest_config")
 
+NATIVE_BUNDLE = "ExternalActionPlugin"
+
 npm_link_all_packages(name = "node_modules")
 
-tsup_config(name = "tsup_config")
+tsup_config(
+    name = "tsup_config",
+    native_bundle = NATIVE_BUNDLE,
+)
 
 vitest_config(name = "vitest_config")
 
 js_pipeline(
     package_name = "@player-ui/external-action-plugin",
     build_deps = NATIVE_BUILD_DEPS,
-    native_bundle = "ExternalActionPlugin",
+    native_bundle = NATIVE_BUNDLE,
     peer_deps = [
         ":node_modules/@player-ui/player",
     ],

--- a/plugins/markdown/core/BUILD
+++ b/plugins/markdown/core/BUILD
@@ -2,16 +2,21 @@ load("@rules_player//javascript:defs.bzl", "js_pipeline")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:defs.bzl", "NATIVE_BUILD_DEPS", "tsup_config", "vitest_config")
 
+NATIVE_BUNDLE = "MarkdownPlugin"
+
 npm_link_all_packages(name = "node_modules")
 
-tsup_config(name = "tsup_config")
+tsup_config(
+    name = "tsup_config",
+    native_bundle = NATIVE_BUNDLE,
+)
 
 vitest_config(name = "vitest_config")
 
 js_pipeline(
     package_name = "@player-ui/markdown-plugin",
     build_deps = NATIVE_BUILD_DEPS,
-    native_bundle = "MarkdownPlugin",
+    native_bundle = NATIVE_BUNDLE,
     peer_deps = [
         ":node_modules/@player-ui/player",
         ":node_modules/@player-ui/types",

--- a/plugins/metrics/core/BUILD
+++ b/plugins/metrics/core/BUILD
@@ -2,16 +2,21 @@ load("@rules_player//javascript:defs.bzl", "js_pipeline")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:defs.bzl", "NATIVE_BUILD_DEPS", "tsup_config", "vitest_config")
 
+NATIVE_BUNDLE = "MetricsPlugin"
+
 npm_link_all_packages(name = "node_modules")
 
-tsup_config(name = "tsup_config")
+tsup_config(
+    name = "tsup_config",
+    native_bundle = NATIVE_BUNDLE,
+)
 
 vitest_config(name = "vitest_config")
 
 js_pipeline(
     package_name = "@player-ui/metrics-plugin",
     build_deps = NATIVE_BUILD_DEPS,
-    native_bundle = "MetricsPlugin",
+    native_bundle = NATIVE_BUNDLE,
     peer_deps = [
         ":node_modules/@player-ui/player",
     ],

--- a/plugins/partial-match-fingerprint/core/BUILD
+++ b/plugins/partial-match-fingerprint/core/BUILD
@@ -2,16 +2,21 @@ load("@rules_player//javascript:defs.bzl", "js_pipeline")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:defs.bzl", "NATIVE_BUILD_DEPS", "tsup_config", "vitest_config")
 
+NATIVE_BUNDLE = "PartialMatchFingerprintPlugin"
+
 npm_link_all_packages(name = "node_modules")
 
-tsup_config(name = "tsup_config")
+tsup_config(
+    name = "tsup_config",
+    native_bundle = NATIVE_BUNDLE,
+)
 
 vitest_config(name = "vitest_config")
 
 js_pipeline(
     package_name = "@player-ui/partial-match-fingerprint-plugin",
     build_deps = NATIVE_BUILD_DEPS,
-    native_bundle = "PartialMatchFingerprintPlugin",
+    native_bundle = NATIVE_BUNDLE,
     peer_deps = [
         ":node_modules/@player-ui/player",
     ],

--- a/plugins/pubsub/core/BUILD
+++ b/plugins/pubsub/core/BUILD
@@ -2,16 +2,21 @@ load("@rules_player//javascript:defs.bzl", "js_pipeline")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:defs.bzl", "NATIVE_BUILD_DEPS", "tsup_config", "vitest_config")
 
+NATIVE_BUNDLE = "PubSubPlugin"
+
 npm_link_all_packages(name = "node_modules")
 
-tsup_config(name = "tsup_config")
+tsup_config(
+    name = "tsup_config",
+    native_bundle = NATIVE_BUNDLE,
+)
 
 vitest_config(name = "vitest_config")
 
 js_pipeline(
     package_name = "@player-ui/pubsub-plugin",
     build_deps = NATIVE_BUILD_DEPS,
-    native_bundle = "PubSubPlugin",
+    native_bundle = NATIVE_BUNDLE,
     peer_deps = [
         ":node_modules/@player-ui/player",
     ],

--- a/plugins/reference-assets/core/BUILD
+++ b/plugins/reference-assets/core/BUILD
@@ -2,16 +2,21 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:defs.bzl", "NATIVE_BUILD_DEPS", "tsup_config", "vitest_config")
 load("@rules_player//player:defs.bzl", "js_xlr_pipeline")
 
+NATIVE_BUNDLE = "ReferenceAssetsPlugin"
+
 npm_link_all_packages(name = "node_modules")
 
-tsup_config(name = "tsup_config")
+tsup_config(
+    name = "tsup_config",
+    native_bundle = NATIVE_BUNDLE,
+)
 
 vitest_config(name = "vitest_config")
 
 js_xlr_pipeline(
     package_name = "@player-ui/reference-assets-plugin",
     build_deps = NATIVE_BUILD_DEPS,
-    native_bundle = "ReferenceAssetsPlugin",
+    native_bundle = NATIVE_BUNDLE,
     peer_deps = [
         ":node_modules/@player-ui/player",
     ],

--- a/plugins/stage-revert-data/core/BUILD
+++ b/plugins/stage-revert-data/core/BUILD
@@ -2,16 +2,21 @@ load("@rules_player//javascript:defs.bzl", "js_pipeline")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:defs.bzl", "NATIVE_BUILD_DEPS", "tsup_config", "vitest_config")
 
+NATIVE_BUNDLE = "StageRevertDataPlugin"
+
 npm_link_all_packages(name = "node_modules")
 
-tsup_config(name = "tsup_config")
+tsup_config(
+    name = "tsup_config",
+    native_bundle = NATIVE_BUNDLE,
+)
 
 vitest_config(name = "vitest_config")
 
 js_pipeline(
     package_name = "@player-ui/stage-revert-data-plugin",
     build_deps = NATIVE_BUILD_DEPS,
-    native_bundle = "StageRevertDataPlugin",
+    native_bundle = NATIVE_BUNDLE,
     peer_deps = [
         ":node_modules/@player-ui/player",
     ],

--- a/plugins/types-provider/core/BUILD
+++ b/plugins/types-provider/core/BUILD
@@ -2,16 +2,21 @@ load("@rules_player//javascript:defs.bzl", "js_pipeline")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:defs.bzl", "NATIVE_BUILD_DEPS", "tsup_config", "vitest_config")
 
+NATIVE_BUNDLE = "TypesProviderPlugin"
+
 npm_link_all_packages(name = "node_modules")
 
-tsup_config(name = "tsup_config")
+tsup_config(
+    name = "tsup_config",
+    native_bundle = NATIVE_BUNDLE,
+)
 
 vitest_config(name = "vitest_config")
 
 js_pipeline(
     package_name = "@player-ui/types-provider-plugin",
     build_deps = NATIVE_BUILD_DEPS,
-    native_bundle = "TypesProviderPlugin",
+    native_bundle = NATIVE_BUNDLE,
     peer_deps = [
         ":node_modules/@player-ui/player",
     ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,6 +261,9 @@ importers:
       error-polyfill:
         specifier: ^0.1.3
         version: 0.1.3
+      esbuild-plugin-external-global:
+        specifier: ^1.0.1
+        version: 1.0.1
       esbuild-wasm:
         specifier: ^0.19.8
         version: 0.19.12
@@ -10534,6 +10537,10 @@ packages:
 
   /esbuild-plugin-alias@0.2.1:
     resolution: {integrity: sha512-jyfL/pwPqaFXyKnj8lP8iLk6Z0m099uXR45aSN8Av1XD4vhvQutxxPzgA2bTcAwQpa1zCXDcWOlhFgyP3GKqhQ==, tarball: https://registry.npmjs.org/esbuild-plugin-alias/-/esbuild-plugin-alias-0.2.1.tgz}
+    dev: false
+
+  /esbuild-plugin-external-global@1.0.1:
+    resolution: {integrity: sha512-NDzYHRoShpvLqNcrgV8ZQh61sMIFAry5KLTQV83BPG5iTXCCu7h72SCfJ97bW0GqtuqDD/1aqLbKinI/rNgUsg==, tarball: https://registry.npmjs.org/esbuild-plugin-external-global/-/esbuild-plugin-external-global-1.0.1.tgz}
     dev: false
 
   /esbuild-register@3.5.0(esbuild@0.19.8):

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -2,6 +2,7 @@ load("@aspect_rules_js//js:defs.bzl", "js_library")
 
 exports_files([
     "tsup.config.ts.tmpl",
+    "tsup.config.native.ts.tmpl",
     "vitest.config.ts.tmpl",
 ])
 

--- a/tools/defs.bzl
+++ b/tools/defs.bzl
@@ -4,9 +4,10 @@ NATIVE_BUILD_DEPS = [
     "//:tsup_config",
     "//:typings",
     "//:node_modules/@swc/core",
+    "//:node_modules/esbuild-plugin-external-global",
 ]
 
-def tsup_config(name):
+def tsup_config(name, native_bundle = False):
     prefix = "../" * len(native.package_name().split("/"))
 
     expand_template(
@@ -15,7 +16,7 @@ def tsup_config(name):
         substitutions = {
             "%PREFIX%": prefix,
         },
-        template = "//tools:tsup.config.ts.tmpl",
+        template = "//tools:tsup.config.native.ts.tmpl" if native_bundle else "//tools:tsup.config.ts.tmpl",
     )
 
 def vitest_config(name):

--- a/tools/tsup.config.native.ts.tmpl
+++ b/tools/tsup.config.native.ts.tmpl
@@ -1,0 +1,12 @@
+import { createConfig } from "%PREFIX%tsup.config";
+import ESBuildPluginExternalGlobal from "esbuild-plugin-external-global";
+
+const overrides: any = {};
+if (process.env.PLAYER_NATIVE_BUNDLE) {
+    overrides.esbuildPlugins = [ESBuildPluginExternalGlobal.externalGlobalPlugin({
+       // TODO: Would be cool to automatically populate this given all the native bundles we create
+      "@player-ui/player": "globalThis.Player",
+    })];
+}
+
+export default createConfig(overrides);

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,7 +6,7 @@ import path from "path";
 // https://github.com/reduxjs/redux/blob/c9e06506f88926e252daf5275495eba0c04bf8e3/tsup.config.ts#L2
 // https://blog.isquaredsoftware.com/2023/08/esm-modernization-lessons/
 
-export function createConfig() {
+export function createConfig(overrides: Options = {}) {
   return defineConfig((options: Options) => {
     const pkgJson = JSON.parse(fs.readFileSync("package.json", "utf8"));
 
@@ -14,6 +14,7 @@ export function createConfig() {
       entry: [pkgJson.main],
       sourcemap: true,
       ...options,
+      ...overrides,
     };
 
     if (process.env.PLAYER_NATIVE_BUNDLE) {


### PR DESCRIPTION
Currently, the plugin native bundles contain an entire copy of Player - this PR externalizes the Player from the native bundles, reducing size burden of the native bundles.

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->