### PR TITLE
Android/JVM - expose constantController

### DIFF
--- a/android/player/src/main/java/com/intuit/playerui/android/AndroidPlayer.kt
+++ b/android/player/src/main/java/com/intuit/playerui/android/AndroidPlayer.kt
@@ -90,16 +90,6 @@ public class AndroidPlayer private constructor(
 
     override val logger: TapableLogger by player::logger
 
-    public fun AndroidPlayer.addConstants(data: Map<String, Any>, namespace: String) = player.constantsController.addConstants(data, namespace)
-
-    public fun AndroidPlayer.getConstants(key: Any, namespace: String, fallback: Any? = null) = player.constantsController.getConstants(key, namespace)
-
-    public fun AndroidPlayer.setTemporaryValues(data: Any, namespace: String) = player.constantsController.setTemporaryValues(data, namespace)
-
-    public fun AndroidPlayer.clearTemporaryValues() = player.constantsController.clearTemporaryValues()
-
-    public val constantsController: ConstantsController by player::constantsController
-
     public class Hooks internal constructor(hooks: Player.Hooks) : Player.Hooks by hooks {
         public class ContextHook : SyncWaterfallHook<(HookContext, Context) -> Context, Context>() {
             public fun call(context: Context): Context = super.call(

--- a/android/player/src/main/java/com/intuit/playerui/android/AndroidPlayer.kt
+++ b/android/player/src/main/java/com/intuit/playerui/android/AndroidPlayer.kt
@@ -90,6 +90,8 @@ public class AndroidPlayer private constructor(
 
     override val logger: TapableLogger by player::logger
 
+    override val constantsController: ConstantsController by player::constantsController
+
     public class Hooks internal constructor(hooks: Player.Hooks) : Player.Hooks by hooks {
         public class ContextHook : SyncWaterfallHook<(HookContext, Context) -> Context, Context>() {
             public fun call(context: Context): Context = super.call(

--- a/android/player/src/main/java/com/intuit/playerui/android/AndroidPlayer.kt
+++ b/android/player/src/main/java/com/intuit/playerui/android/AndroidPlayer.kt
@@ -18,6 +18,7 @@ import com.intuit.playerui.core.bridge.Completable
 import com.intuit.playerui.core.bridge.format
 import com.intuit.playerui.core.bridge.runtime.PlayerRuntimeConfig
 import com.intuit.playerui.core.bridge.serialization.format.registerContextualSerializer
+import com.intuit.playerui.core.constants.ConstantsController
 import com.intuit.playerui.core.logger.TapableLogger
 import com.intuit.playerui.core.player.HeadlessPlayer
 import com.intuit.playerui.core.player.Player
@@ -88,6 +89,16 @@ public class AndroidPlayer private constructor(
     )
 
     override val logger: TapableLogger by player::logger
+
+    public fun AndroidPlayer.addConstants(data: Map<String, Any>, namespace: String) = player.constantsController.addConstants(data, namespace)
+
+    public fun AndroidPlayer.getConstants(key: Any, namespace: String, fallback: Any? = null) = player.constantsController.getConstants(key, namespace)
+
+    public fun AndroidPlayer.setTemporaryValues(data: Any, namespace: String) = player.constantsController.setTemporaryValues(data, namespace)
+
+    public fun AndroidPlayer.clearTemporaryValues() = player.constantsController.clearTemporaryValues()
+
+    public val constantsController: ConstantsController by player::constantsController
 
     public class Hooks internal constructor(hooks: Player.Hooks) : Player.Hooks by hooks {
         public class ContextHook : SyncWaterfallHook<(HookContext, Context) -> Context, Context>() {

--- a/jvm/core/src/main/kotlin/com/intuit/playerui/core/constants/ConstantsController.kt
+++ b/jvm/core/src/main/kotlin/com/intuit/playerui/core/constants/ConstantsController.kt
@@ -22,7 +22,7 @@ public class ConstantsController(override val node: Node) : NodeWrapper {
      * @param namespace namespace values were loaded under (defined in the plugin)
      * @param fallback Optional - if key doesn't exist in namespace what to return (will return unknown if not provided)
      */
-    public fun getConstants(key: Any, namespace: String, fallback: Any? = null): Any? {
+    public fun getConstants(key: String, namespace: String, fallback: Any? = null): Any? {
         return node.getInvokable<Any?>("getConstants")?.invoke(key, namespace, fallback)
     }
 

--- a/jvm/core/src/main/kotlin/com/intuit/playerui/core/constants/ConstantsController.kt
+++ b/jvm/core/src/main/kotlin/com/intuit/playerui/core/constants/ConstantsController.kt
@@ -1,0 +1,46 @@
+package com.intuit.playerui.core.constants
+import com.intuit.playerui.core.bridge.Node
+import com.intuit.playerui.core.bridge.NodeWrapper
+import com.intuit.playerui.core.bridge.getInvokable
+import com.intuit.playerui.core.bridge.serialization.serializers.NodeWrapperSerializer
+import kotlinx.serialization.Serializable
+
+@Serializable(with = ConstantsController.Serializer::class)
+public class ConstantsController(override val node: Node) : NodeWrapper {
+    /**
+     * Function to add constants to the providers store
+     * @param data values to add to the constants store
+     * @param namespace namespace to add the constants under
+     */
+    public fun addConstants(data: Map<String, Any>, namespace: String) {
+        node.getInvokable<Unit>("addConstants")?.invoke(data, namespace)
+    }
+
+    /**
+     * Function to retrieve constants from the providers store
+     * @param key Key used for the store access
+     * @param namespace namespace values were loaded under (defined in the plugin)
+     * @param fallback Optional - if key doesn't exist in namespace what to return (will return unknown if not provided)
+     */
+    public fun getConstants(key: Any, namespace: String, fallback: Any? = null): Any? {
+        return node.getInvokable<Any?>("getConstants")?.invoke(key, namespace, fallback)
+    }
+
+    /**
+     * Function to set values to temporarily override certain keys in the permanent store
+     * @param data values to override store with
+     * @param namespace namespace to override
+     */
+    public fun setTemporaryValues(data: Any, namespace: String) {
+        node.getInvokable<Unit>("setTemporaryValues")?.invoke(data, namespace)
+    }
+
+    /**
+     * Clears any temporary values that were previously set
+     */
+    public fun clearTemporaryValues() {
+        node.getInvokable<Unit>("clearTemporaryValues")?.invoke()
+    }
+
+    internal object Serializer : NodeWrapperSerializer<ConstantsController>(::ConstantsController)
+}

--- a/jvm/core/src/main/kotlin/com/intuit/playerui/core/player/HeadlessPlayer.kt
+++ b/jvm/core/src/main/kotlin/com/intuit/playerui/core/player/HeadlessPlayer.kt
@@ -78,7 +78,7 @@ public constructor(
 
     override val hooks: Hooks by NodeSerializableField(Hooks.serializer(), NodeSerializableField.CacheStrategy.Full)
 
-    public val constantsController: ConstantsController by NodeSerializableField(ConstantsController.serializer(), NodeSerializableField.CacheStrategy.Full)
+    override val constantsController: ConstantsController by NodeSerializableField(ConstantsController.serializer(), NodeSerializableField.CacheStrategy.Full)
 
     override val state: PlayerFlowState get() = if (player.isReleased()) {
         ReleasedState

--- a/jvm/core/src/main/kotlin/com/intuit/playerui/core/player/HeadlessPlayer.kt
+++ b/jvm/core/src/main/kotlin/com/intuit/playerui/core/player/HeadlessPlayer.kt
@@ -11,6 +11,7 @@ import com.intuit.playerui.core.bridge.runtime.ScriptContext
 import com.intuit.playerui.core.bridge.runtime.add
 import com.intuit.playerui.core.bridge.runtime.runtimeFactory
 import com.intuit.playerui.core.bridge.serialization.serializers.NodeSerializableField
+import com.intuit.playerui.core.constants.ConstantsController
 import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
 import com.intuit.playerui.core.logger.TapableLogger
 import com.intuit.playerui.core.player.HeadlessPlayer.Companion.bundledSource
@@ -76,6 +77,8 @@ public constructor(
     override val logger: TapableLogger by NodeSerializableField(TapableLogger.serializer(), NodeSerializableField.CacheStrategy.Full)
 
     override val hooks: Hooks by NodeSerializableField(Hooks.serializer(), NodeSerializableField.CacheStrategy.Full)
+
+    public val constantsController: ConstantsController by NodeSerializableField(ConstantsController.serializer(), NodeSerializableField.CacheStrategy.Full)
 
     override val state: PlayerFlowState get() = if (player.isReleased()) {
         ReleasedState

--- a/jvm/core/src/main/kotlin/com/intuit/playerui/core/player/Player.kt
+++ b/jvm/core/src/main/kotlin/com/intuit/playerui/core/player/Player.kt
@@ -6,6 +6,7 @@ import com.intuit.playerui.core.bridge.NodeWrapper
 import com.intuit.playerui.core.bridge.hooks.NodeSyncHook1
 import com.intuit.playerui.core.bridge.serialization.serializers.NodeSerializableField
 import com.intuit.playerui.core.bridge.serialization.serializers.NodeWrapperSerializer
+import com.intuit.playerui.core.constants.ConstantsController
 import com.intuit.playerui.core.data.DataController
 import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
 import com.intuit.playerui.core.expressions.ExpressionController
@@ -32,6 +33,8 @@ import kotlin.coroutines.EmptyCoroutineContext
 public abstract class Player : Pluggable {
 
     public abstract val logger: TapableLogger
+
+    public abstract val constantsController: ConstantsController
 
     /**
      * Expose [PlayerHooks] which allow consumers to plug

--- a/jvm/core/src/test/kotlin/com/intuit/playerui/core/player/HeadlessPlayerTest.kt
+++ b/jvm/core/src/test/kotlin/com/intuit/playerui/core/player/HeadlessPlayerTest.kt
@@ -458,7 +458,6 @@ internal class HeadlessPlayerTest : PlayerTest(), ThreadUtils {
 
     @TestTemplate
     fun `test constantsController get and set`() = runBlockingTest {
-        player.start(simpleFlowString)
         val constantsController = player.constantsController
 
         val data = mapOf(
@@ -504,7 +503,6 @@ internal class HeadlessPlayerTest : PlayerTest(), ThreadUtils {
 
     @TestTemplate
     fun `test constantsController temp override functionality`() = runBlockingTest {
-        player.start(simpleFlowString)
         val constantsController = player.constantsController
 
         // Add initial constants


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

Android provide access to Player with [AssetContext](https://github.com/player-ui/player/blob/bfd6a11a8d6c7138daec4724a8f08e9d9c4b370b/android/player/src/main/java/com/intuit/playerui/android/AssetContext.kt#L19-L23)

Usage: 
assetContext.player.constantsController.getConstants()

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.8.1--canary.489.16892</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.8.1--canary.489.16892
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

# Release Notes

Expose the core Player [constantsController](https://github.com/player-ui/player/blob/9efce22c0cf315568213f7d2811b81096c1806df/core/player/src/player.ts#L91) to Android/JVM consumers

AndroidPlayer provides top-level api and plugins access including `constantsController` with [AssetContext](https://github.com/player-ui/player/blob/bfd6a11a8d6c7138daec4724a8f08e9d9c4b370b/android/player/src/main/java/com/intuit/playerui/android/AssetContext.kt#L19-L23)

Sample usage: 
`assetContext.player.constantsController.getConstants(key, namespace)`