### PR TITLE
fix:no matching toolchains:ninja_toolchain

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -50,6 +50,9 @@ common:ci --build_metadata=ROLE=CI --workspace_status_command=./scripts/workspac
 common:ci --local_cpu_resources=8
 common:ci --local_ram_resources=15000
 common:ci --config="release"
+common:ci --experimental_remote_build_event_upload=minimal 
+common:ci --nolegacy_important_outputs
+
 # Circle macos.m1.large.gen1 8 cores 12gb ram
 common:ci-mac --config=ci --local_cpu_resources=8 --local_ram_resources=11000
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -48,7 +48,7 @@ common:ci --build_metadata=ROLE=CI --workspace_status_command=./scripts/workspac
 
 # Circle xlarge has 8 CPU cores/16GB mem
 common:ci --local_cpu_resources=8
-common:ci --local_ram_resources=14000
+common:ci --local_ram_resources=15000
 common:ci --config="release"
 common:ci --experimental_remote_build_event_upload=minimal 
 common:ci --nolegacy_important_outputs

--- a/.bazelrc
+++ b/.bazelrc
@@ -48,7 +48,7 @@ common:ci --build_metadata=ROLE=CI --workspace_status_command=./scripts/workspac
 
 # Circle xlarge has 8 CPU cores/16GB mem
 common:ci --local_cpu_resources=8
-common:ci --local_ram_resources=15000
+common:ci --local_ram_resources=14000
 common:ci --config="release"
 common:ci --experimental_remote_build_event_upload=minimal 
 common:ci --nolegacy_important_outputs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,6 +235,8 @@ jobs:
       - attach_workspace:
           at: ~/player
 
+      - run: bazel test --config=ci -- //third_party/hermes/hello:test
+
       - run: bazel test --config=ci -- $(bazel query 'kind(".*_test", //...) except filter("ios|swiftui", //...)') -//android/demo:android_instrumentation_test
 
       - run: bazel test --config=ci --//android/player:runtime=hermes -- $(bazel query 'kind(".*_test", //...) except filter("ios|swiftui", //...)') -//android/demo:android_instrumentation_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,9 +235,9 @@ jobs:
       - attach_workspace:
           at: ~/player
 
-      - run: |
-          bazel test --config=ci -- $(bazel query 'kind(".*_test", //...) except filter("ios|swiftui", //...)') -//android/demo:android_instrumentation_test
-          bazel test --config=ci --//android/player:runtime=hermes -- $(bazel query 'kind(".*_test", //...) except filter("ios|swiftui", //...)') -//android/demo:android_instrumentation_test
+      - run: bazel test --config=ci -- $(bazel query 'kind(".*_test", //...) except filter("ios|swiftui", //...)') -//android/demo:android_instrumentation_test
+
+      - run: bazel test --config=ci --//android/player:runtime=hermes -- $(bazel query 'kind(".*_test", //...) except filter("ios|swiftui", //...)') -//android/demo:android_instrumentation_test
 
       - run:
           when: always

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,7 +21,7 @@ bazel_dep(name = "rules_pkg", version = "1.0.1")
 bazel_dep(name = "aspect_rules_ts", version = "2.4.2")
 
 # C++
-bazel_dep(name = "rules_foreign_cc", version = "0.10.1")
+bazel_dep(name = "rules_foreign_cc", version = "0.11.1")
 bazel_dep(name = "googletest", version = "1.14.0")
 
 ####### Node.js version #########


### PR DESCRIPTION
fix for build error: 
```
BUILD.bazel:35:6: While resolving toolchains for target @fbjni//:host: No matching toolchains found for types 
@rules_foreign_cc~0.10.1//toolchains:ninja_toolchain.
To debug, rerun with --toolchain_resolution_debug='@rules_foreign_cc~0.10.1//toolchains:ninja_toolchain'
```
solution:
upgrade `rules_foreign_cc` to the latest version
https://github.com/bazelbuild/rules_foreign_cc/releases/tag/0.11.1 
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->