### PR TITLE
Update JS target to es2020

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -13,6 +13,7 @@ export function createConfig() {
     const defaultOptions: Options = {
       entry: [pkgJson.main],
       sourcemap: true,
+      target: "es2020",
       ...options,
     };
 


### PR DESCRIPTION
Update JS target to ES2020 to remove unneeded polyfils 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.8.1--canary.491.16941</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.8.1--canary.491.16941
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
