### PR TITLE
Allow Skipping Build During Setup Phase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,6 @@ jobs:
     executor: minimal
     steps:
       - checkout
-
       - restore_cache:
           keys:
             - v1-dependencies-{ { checksum "package.json" }}
@@ -108,6 +107,14 @@ jobs:
           root: .
           paths:
             - .
+
+  skip-build:
+    executor: base
+    steps:
+      - attach_workspace:
+          at: ~/player
+
+      - run: rec=$(npx auto label | grep "skip-build" || true); if [ "$rec" ]; then circleci-agent step halt; fi
 
   build:
     executor: base
@@ -386,6 +393,18 @@ workflows:
           requires:
             - setup
 
+      - skip-build:
+          name: skip-build
+          filters:
+            branches:
+              ignore:
+                - main
+                - /version-.*/
+            tags:
+              ignore: /.*/
+          requires:
+            - setup
+
       - build:
           name: build-trunk
           filters:
@@ -394,6 +413,7 @@ workflows:
                 - /pull\/.*/
           requires:
             - bazelrc
+            - skip-build
 
       - build:
           name: build-fork
@@ -402,7 +422,7 @@ workflows:
               only:
                 - /pull\/.*/
           requires:
-            - setup
+            - skip-build
 
       - build_ios:
           name: build-ios-trunk


### PR DESCRIPTION
For changes that don't touch a release artifact, it seems wasteful for the whole pipeline to run. This allows the `skip-build` tag to be used to allow circle to bail on the rest of the pipline after a project is checked out. 


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->