### PR TITLE
iOS: move HeadlessPlayerImpl from PlayerUIInternalTestUtilities to PlayerUITestUtilitiesCore

### DIFF
--- a/ios/core/BUILD.bazel
+++ b/ios/core/BUILD.bazel
@@ -8,7 +8,7 @@ ios_pipeline(
         "//plugins/partial-match-fingerprint/core:core_native_bundle"
     ],
     deps = ["@swiftpkg_swift_hooks//:Sources_SwiftHooks", "//ios/logger:PlayerUILogger"],
-    test_deps = ["//ios/internal-test-utils:PlayerUIInternalTestUtilities"],
+    test_deps = ["//ios/test-utils-core:PlayerUITestUtilitiesCore", "//ios/internal-test-utils:PlayerUIInternalTestUtilities"],
     hasUnitTests = True,
     hasViewInspectorTests = False,
     test_host = "//ios/demo:PlayerUIDemo"

--- a/ios/core/Tests/FlowStateTests.swift
+++ b/ios/core/Tests/FlowStateTests.swift
@@ -10,6 +10,7 @@ import XCTest
 import JavaScriptCore
 @testable import PlayerUI
 @testable import PlayerUIInternalTestUtilities
+@testable import PlayerUITestUtilitiesCore
 
 class FlowStateTests: XCTestCase {
     func testViewFlowState() {

--- a/ios/core/Tests/HeadlessPlayerTests.swift
+++ b/ios/core/Tests/HeadlessPlayerTests.swift
@@ -11,6 +11,7 @@ import XCTest
 import JavaScriptCore
 @testable import PlayerUI
 @testable import PlayerUIInternalTestUtilities
+@testable import PlayerUITestUtilitiesCore
 
 class HeadlessPlayerTests: XCTestCase {
     func testViewId() {

--- a/ios/core/Tests/Types/Core/ExpressionEvaluatorTests.swift
+++ b/ios/core/Tests/Types/Core/ExpressionEvaluatorTests.swift
@@ -11,6 +11,7 @@ import XCTest
 
 @testable import PlayerUI
 @testable import PlayerUIInternalTestUtilities
+@testable import PlayerUITestUtilitiesCore
 
 class ExpressionEvaluatorTests: XCTestCase {
     func testExpressionEvaluator() {

--- a/ios/core/Tests/utilities/JSLoggerTests.swift
+++ b/ios/core/Tests/utilities/JSLoggerTests.swift
@@ -11,6 +11,7 @@ import XCTest
 
 @testable import PlayerUI
 @testable import PlayerUIInternalTestUtilities
+@testable import PlayerUITestUtilitiesCore
 
 class JSLoggerTests: XCTestCase {
     func testJSLogger() {

--- a/ios/core/Tests/utilities/JSValueExtensionsTests.swift
+++ b/ios/core/Tests/utilities/JSValueExtensionsTests.swift
@@ -11,6 +11,7 @@ import XCTest
 import JavaScriptCore
 @testable import PlayerUI
 @testable import PlayerUIInternalTestUtilities
+@testable import PlayerUITestUtilitiesCore
 
 class JSValueExtensionsTests: XCTestCase {
     let context: JSContext = JSContext()

--- a/ios/swiftui/BUILD.bazel
+++ b/ios/swiftui/BUILD.bazel
@@ -9,7 +9,8 @@ ios_pipeline(
     ],
     test_deps = [
         "//plugins/reference-assets/swiftui:PlayerUIReferenceAssets",
-        "//ios/internal-test-utils:PlayerUIInternalTestUtilities"
+        "//ios/internal-test-utils:PlayerUIInternalTestUtilities",
+        "//ios/test-utils-core:PlayerUITestUtilitiesCore"
     ],
     hasUnitTests = True,
     hasViewInspectorTests = True,

--- a/ios/swiftui/Tests/ManagedPlayer/ManagedPlayerViewModelTests.swift
+++ b/ios/swiftui/Tests/ManagedPlayer/ManagedPlayerViewModelTests.swift
@@ -14,6 +14,7 @@ import JavaScriptCore
 @testable import PlayerUI
 @testable import PlayerUISwiftUI
 @testable import PlayerUIInternalTestUtilities
+@testable import PlayerUITestUtilitiesCore
 
 class ManagedPlayerViewModelTests: XCTestCase {
     let flow1 = FlowData.COUNTER

--- a/ios/test-utils-core/Sources/utilities/HeadlessPlayerImpl.swift
+++ b/ios/test-utils-core/Sources/utilities/HeadlessPlayerImpl.swift
@@ -1,17 +1,20 @@
 import JavaScriptCore
+
 import PlayerUI
+#if SWIFT_PACKAGE
 import PlayerUILogger
+#endif
 
-class HeadlessPlayerImpl: HeadlessPlayer {
-    var assetRegistry: BaseAssetRegistry<TestWrapper>
-    var hooks: HeadlessHooks?
-    var logger = TapableLogger()
+open class HeadlessPlayerImpl: HeadlessPlayer {
+    public var assetRegistry: BaseAssetRegistry<TestWrapper>
+    public var hooks: HeadlessHooks?
+    public var logger = TapableLogger()
 
-    var jsPlayerReference: JSValue?
+    public var jsPlayerReference: JSValue?
 
     let match = PartialMatchFingerprintPlugin()
 
-    init(plugins: [NativePlugin], context: JSContext = JSContext()) {
+    public init(plugins: [NativePlugin], context: JSContext = JSContext()) {
         assetRegistry = BaseAssetRegistry<TestWrapper>(logger: logger)
         jsPlayerReference = setupPlayer(context: context, plugins: plugins + [match])
         assetRegistry.partialMatchRegistry = match
@@ -21,16 +24,16 @@ class HeadlessPlayerImpl: HeadlessPlayer {
     }
 }
 
-class HeadlessHooks: CoreHooks {
-    var flowController: Hook<FlowController>
+public class HeadlessHooks: CoreHooks {
+    public var flowController: Hook<FlowController>
 
-    var viewController: Hook<ViewController>
+    public var viewController: Hook<ViewController>
 
-    var dataController: Hook<DataController>
+    public var dataController: Hook<DataController>
 
-    var state: Hook<BaseFlowState>
+    public var state: Hook<BaseFlowState>
 
-    required init(from value: JSValue) {
+    required public init(from value: JSValue) {
         flowController = Hook(baseValue: value, name: "flowController")
         viewController = Hook(baseValue: value, name: "viewController")
         dataController = Hook(baseValue: value, name: "dataController")
@@ -38,17 +41,17 @@ class HeadlessHooks: CoreHooks {
     }
 }
 
-class TestAssetType: PlayerAsset, Decodable {
+public class TestAssetType: PlayerAsset, Decodable {
     var rawValue: JSValue?
-    var id: String
-    var type: String
+    public var id: String
+    public var type: String
     var value: String?
     struct Data: Decodable {
         var id: String
         var type: String
         var value: String?
     }
-    required init(from decoder: Decoder) throws {
+    required public init(from decoder: Decoder) throws {
         let data = try decoder.singleValueContainer().decode(Data.self)
         id = data.id
         type = data.type
@@ -56,12 +59,12 @@ class TestAssetType: PlayerAsset, Decodable {
     }
 }
 
-class TestWrapper: AssetContainer, Decodable {
+public class TestWrapper: AssetContainer, Decodable {
     public enum CodingKeys: String, CodingKey {
         case asset
     }
-    var asset: TestAssetType?
-    required init(forAsset: TestAssetType) {
+    public var asset: TestAssetType?
+    required public init(forAsset: TestAssetType) {
         self.asset = forAsset
     }
 

--- a/plugins/async-node/ios/BUILD.bazel
+++ b/plugins/async-node/ios/BUILD.bazel
@@ -9,7 +9,8 @@ ios_pipeline(
 
     test_deps = [
 	"//plugins/reference-assets/swiftui:PlayerUIReferenceAssets",
-	"//ios/internal-test-utils:PlayerUIInternalTestUtilities"
+	"//ios/internal-test-utils:PlayerUIInternalTestUtilities",
+        "//ios/test-utils-core:PlayerUITestUtilitiesCore"
     ],
 
     hasUnitTests = True,

--- a/plugins/async-node/ios/Tests/AsynNodePluginTests.swift
+++ b/plugins/async-node/ios/Tests/AsynNodePluginTests.swift
@@ -11,7 +11,7 @@ import SwiftUI
 import JavaScriptCore
 
 @testable import PlayerUI
-@testable import PlayerUIInternalTestUtilities
+@testable import PlayerUITestUtilitiesCore
 @testable import PlayerUIReferenceAssets
 @testable import PlayerUIAsyncNodePlugin
 

--- a/plugins/check-path/ios/Tests/CheckPathPluginTests.swift
+++ b/plugins/check-path/ios/Tests/CheckPathPluginTests.swift
@@ -12,6 +12,7 @@ import JavaScriptCore
 
 @testable import PlayerUI
 @testable import PlayerUIInternalTestUtilities
+@testable import PlayerUITestUtilitiesCore
 @testable import PlayerUICheckPathPlugin
 
 class CheckPathPluginTests: XCTestCase {

--- a/plugins/computed-properties/ios/Tests/ComputedPropertiesPluginTests.swift
+++ b/plugins/computed-properties/ios/Tests/ComputedPropertiesPluginTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import XCTest
 import JavaScriptCore
 @testable import PlayerUI
-@testable import PlayerUIInternalTestUtilities
+@testable import PlayerUITestUtilitiesCore
 @testable import PlayerUIComputedPropertiesPlugin
 
 class ComputedPropertiesPluginTests: XCTestCase {

--- a/plugins/console-logger/ios/Tests/PrintLoggerPluginTests.swift
+++ b/plugins/console-logger/ios/Tests/PrintLoggerPluginTests.swift
@@ -12,7 +12,7 @@ import XCTest
 @testable import PlayerUI
 @testable import PlayerUIPrintLoggerPlugin
 @testable import PlayerUILogger
-@testable import PlayerUIInternalTestUtilities
+@testable import PlayerUITestUtilitiesCore
 
 class PrintLoggerPluginTests: XCTestCase {
     func testPrintLogger() {

--- a/plugins/external-action/ios/Tests/ExternalActionPluginTests.swift
+++ b/plugins/external-action/ios/Tests/ExternalActionPluginTests.swift
@@ -10,7 +10,7 @@ import Foundation
 import XCTest
 import JavaScriptCore
 @testable import PlayerUI
-@testable import PlayerUIInternalTestUtilities
+@testable import PlayerUITestUtilitiesCore
 @testable import PlayerUIExternalActionPlugin
 
 // swiftlint:disable type_body_length

--- a/plugins/pubsub/ios/Tests/PubSubPluginTests.swift
+++ b/plugins/pubsub/ios/Tests/PubSubPluginTests.swift
@@ -10,7 +10,7 @@ import Foundation
 import XCTest
 import JavaScriptCore
 @testable import PlayerUI
-@testable import PlayerUIInternalTestUtilities
+@testable import PlayerUITestUtilitiesCore
 @testable import PlayerUIPubSubPlugin
 
 class PubSubPluginTests: XCTestCase {

--- a/plugins/stage-revert-data/ios/Tests/StageRevertDataPluginTests.swift
+++ b/plugins/stage-revert-data/ios/Tests/StageRevertDataPluginTests.swift
@@ -1,7 +1,7 @@
 import Foundation
 import XCTest
 @testable import PlayerUI
-@testable import PlayerUIInternalTestUtilities
+@testable import PlayerUITestUtilitiesCore
 @testable import PlayerUIStageRevertDataPlugin
 
 class StageRevertDataPluginTests: XCTestCase {

--- a/tools/ios/util.bzl
+++ b/tools/ios/util.bzl
@@ -3,7 +3,7 @@ load("@rules_pkg//:mappings.bzl", "pkg_files", "strip_prefix")
 load("@rules_player//ios:defs.bzl", "ios_pipeline")
 
 default_dependencies = ["//ios/core:PlayerUI"]
-default_test_dependencies = ["//ios/internal-test-utils:PlayerUIInternalTestUtilities"]
+default_test_dependencies = ["//ios/internal-test-utils:PlayerUIInternalTestUtilities", "//ios/test-utils-core:PlayerUITestUtilitiesCore"]
 test_host = "//ios/demo:PlayerUIDemo"
 
 def ios_plugin(name, resources = [], deps = [], test_deps = []):


### PR DESCRIPTION
Move HeadlessPlayerImpl PlayerUITestUtilitiesCore so it can be exposed and used by test helpers in FTR

### Change Type (required)
Indicate the type of change your pull request is:


- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.8.1--canary.500.17272</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.8.1--canary.500.17272
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
