### PR TITLE
[skip ci] Update CircleCI Config to use Bazelrc During next/release Builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -500,10 +500,16 @@ workflows:
               only:
                 - main
                 - /version-.*/
+    
+      - bazelrc:
+          context:
+            - Build
+          requires:
+            - setup
 
       - build:
           requires:
-            - setup
+            - bazelrc
 
       - build_ios:
           requires:
@@ -526,11 +532,17 @@ workflows:
             - coverage
             - build_ios
 
-  release:
+  full_release:
     when:
       equal: [release, << pipeline.parameters.GHA_Action >>]
     jobs:
       - setup
+
+      - bazelrc:
+          context:
+            - Build
+          requires:
+            - setup
 
       - build:
           requires:
@@ -538,7 +550,7 @@ workflows:
 
       - build_ios:
           requires:
-            - build
+            - bazelrc
 
       - android_test:
           requires:


### PR DESCRIPTION
### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
- [x] `N/A`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

## Release Notes
Use custom bazelrc during next/release builds off of main branch closing #502 