### PR TITLE
Fix js Package Releases

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -23,7 +23,7 @@ echo "Publishing NPM Packages using tag: ${NPM_TAG} from release type: ${RELEASE
 readonly PKG_NPM_LABELS=`bazel query --output=label 'kind("npm_package rule", //...) - attr("tags", "\[.*do-not-publish.*\]", //...)'`
 
 for pkg in $PKG_NPM_LABELS ; do
-  bazel run --config=ci -- ${pkg}.publish --access public --tag ${NPM_TAG}
+  bazel run --config=ci -- ${pkg}.npm-publish --access public --tag ${NPM_TAG}
 done
 
 # Rebuild to stamp the release podspec


### PR DESCRIPTION
NPM publish target changed when the js rules were updated but didn't get caught.


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.9.1--canary.507.17377</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.9.1--canary.507.17377
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
