### PR TITLE
iOS: Expand AnyType to handle deeply nested AnyType for beacon encoding

### DIFF
--- a/ios/core/Sources/Types/Assets/BaseAssetRegistry.swift
+++ b/ios/core/Sources/Types/Assets/BaseAssetRegistry.swift
@@ -166,6 +166,9 @@ open class BaseAssetRegistry<WrapperType>: PlayerRegistry where
     public func decode(_ value: JSValue) throws -> WrapperType.AssetType {
         assert(Thread.isMainThread, "decoder must be accessed from main")
         typealias Shim = RegistryDecodeShim<WrapperType.AssetType>
+        if let context = AnyTypeDecodingContext(value) {
+            return try context.inject(to: decoder).decode(Shim.self, from: value).asset
+        }
         return try decoder.decode(Shim.self, from: value).asset
     }
 
@@ -177,6 +180,10 @@ open class BaseAssetRegistry<WrapperType>: PlayerRegistry where
      */
     public func decodeWrapper(_ value: JSValue) throws -> WrapperType {
         assert(Thread.isMainThread, "decoder must be accessed from main")
+        if let context = AnyTypeDecodingContext(value) {
+            return try context.inject(to: decoder).decode(WrapperType.self, from: value)
+        }
+
         return try decoder.decode(WrapperType.self, from: value)
     }
 }
@@ -187,6 +194,18 @@ public struct RegistryDecodeShim<Asset>: Decodable {
     public init(from decoder: Decoder) throws {
         let decodeFunction: DecodeAssetFunction<Asset> = try decoder.getDecodeAssetFunction()
         asset = try decodeFunction(decoder)
+    }
+}
+
+extension AnyTypeDecodingContext {
+    init?(_ value: JSValue) {
+        guard
+            let obj = value.toObject(),
+            let data = try? JSONSerialization.data(withJSONObject: obj)
+        else {
+            return nil
+        }
+        self.init(rawData: data)
     }
 }
 

--- a/ios/core/Tests/Types/Generic/AnyTypeTests.swift
+++ b/ios/core/Tests/Types/Generic/AnyTypeTests.swift
@@ -197,17 +197,18 @@ class AnyTypeTests: XCTestCase {
     }
 
     func testAnyDictionaryDataWithDeepNestedTypes() {
-        let string = "{\"key2\":1,\"key\":[{\"nestedKey\": \"nestedValue\"}]}"
+        let string = "{\"container\":{\"key2\":1,\"key\":[{\"nestedKey\": \"nestedValue\"}]}}"
         guard
             let data = string.data(using: .utf8),
             let anyType = try? AnyTypeDecodingContext(rawData: string.data(using: .utf8)!).inject(to: JSONDecoder()).decode(AnyType.self, from: data)
         else { return XCTFail("could not decode") }
         switch anyType {
         case .anyDictionary(let result):
-            let nestedArray = result["key"] as? [Any]
+            let container = result["container"] as? [String: Any]
+            let nestedArray = container?["key"] as? [Any]
             let nestedDict = nestedArray?.first as? [String: Any]
             XCTAssertEqual("nestedValue", nestedDict?["nestedKey"] as? String)
-            XCTAssertEqual(1, result["key2"] as? Double)
+            XCTAssertEqual(1, container?["key2"] as? Double)
         default:
             XCTFail("data was not dictionary")
         }
@@ -279,6 +280,7 @@ class AnyTypeTests: XCTestCase {
         XCTAssertNotEqual(AnyType.numberArray(data: [1, 2]).hashValue, 0)
         XCTAssertNotEqual(AnyType.booleanArray(data: [false, true]).hashValue, 0)
         XCTAssertNotEqual(AnyType.anyDictionary(data: ["key": false, "key2": 1]).hashValue, 0)
+        XCTAssertNotEqual(AnyType.anyArray(data: [1, false]).hashValue, 0)
         XCTAssertNotEqual(AnyType.unknownData.hashValue, 0)
     }
 

--- a/ios/core/Tests/Types/Generic/AnyTypeTests.swift
+++ b/ios/core/Tests/Types/Generic/AnyTypeTests.swift
@@ -251,7 +251,8 @@ class AnyTypeTests: XCTestCase {
         XCTAssertEqual("[1,2]", doEncode(AnyType.numberArray(data: [1, 2])))
         XCTAssertEqual("[false,true]", doEncode(AnyType.booleanArray(data: [false, true])))
         XCTAssertEqual("{\"a\":false,\"b\":1}", doEncode(AnyType.anyDictionary(data: ["a": false, "b": 1])))
-        XCTAssertEqual("{\"container\":{\"key\":[{\"nestedKey\":\"nestedValue\"}],\"key2\":1}}", doEncode(AnyType.anyDictionary(data: ["container": AnyType.anyDictionary(data: ["key2": 1, "key": AnyType.anyArray(data: [["nestedKey": "nestedValue"]])])])))
+        XCTAssertEqual("[1,\"a\",true]", doEncode(AnyType.anyArray(data: [1, "a", true])))
+        XCTAssertEqual("{\"key\":[{\"nestedKey\":\"nestedValue\"},1,{}],\"key2\":1}", doEncode(AnyType.anyDictionary(data: ["key2": 1, "key": AnyType.anyArray(data: [["nestedKey": "nestedValue"], 1, [:] as Any])])))
     }
 
     func doEncode(_ data: AnyType) -> String? {
@@ -280,7 +281,7 @@ class AnyTypeTests: XCTestCase {
         XCTAssertNotEqual(AnyType.numberArray(data: [1, 2]).hashValue, 0)
         XCTAssertNotEqual(AnyType.booleanArray(data: [false, true]).hashValue, 0)
         XCTAssertNotEqual(AnyType.anyDictionary(data: ["key": false, "key2": 1]).hashValue, 0)
-        XCTAssertNotEqual(AnyType.anyArray(data: [1, false]).hashValue, 0)
+        XCTAssertNotEqual(AnyType.anyArray(data: [1, "a", true]).hashValue, 0)
         XCTAssertNotEqual(AnyType.unknownData.hashValue, 0)
     }
 
@@ -297,6 +298,7 @@ class AnyTypeTests: XCTestCase {
         XCTAssertEqual(AnyType.numberArray(data: [1, 2]), AnyType.numberArray(data: [1, 2]))
         XCTAssertEqual(AnyType.booleanArray(data: [false, true]), AnyType.booleanArray(data: [false, true]))
         XCTAssertEqual(AnyType.anyDictionary(data: ["key": false, "key2": 1]), AnyType.anyDictionary(data: ["key": false, "key2": 1]))
+        XCTAssertEqual(AnyType.anyArray(data: [1, "a", true]), AnyType.anyArray(data: [1, "a", true]))
         XCTAssertNotEqual(AnyType.unknownData, AnyType.string(data: "test"))
     }
 

--- a/ios/core/Tests/Types/Generic/AnyTypeTests.swift
+++ b/ios/core/Tests/Types/Generic/AnyTypeTests.swift
@@ -250,6 +250,7 @@ class AnyTypeTests: XCTestCase {
         XCTAssertEqual("[1,2]", doEncode(AnyType.numberArray(data: [1, 2])))
         XCTAssertEqual("[false,true]", doEncode(AnyType.booleanArray(data: [false, true])))
         XCTAssertEqual("{\"a\":false,\"b\":1}", doEncode(AnyType.anyDictionary(data: ["a": false, "b": 1])))
+        XCTAssertEqual("{\"key\":[{\"nestedKey\":\"nestedValue\"}],\"key2\":1}", doEncode(AnyType.anyDictionary(data: ["key2": 1, "key": AnyType.anyArray(data: [["nestedKey": "nestedValue"]])])))
     }
 
     func doEncode(_ data: AnyType) -> String? {

--- a/ios/core/Tests/Types/Generic/AnyTypeTests.swift
+++ b/ios/core/Tests/Types/Generic/AnyTypeTests.swift
@@ -251,7 +251,7 @@ class AnyTypeTests: XCTestCase {
         XCTAssertEqual("[1,2]", doEncode(AnyType.numberArray(data: [1, 2])))
         XCTAssertEqual("[false,true]", doEncode(AnyType.booleanArray(data: [false, true])))
         XCTAssertEqual("{\"a\":false,\"b\":1}", doEncode(AnyType.anyDictionary(data: ["a": false, "b": 1])))
-        XCTAssertEqual("{\"key\":[{\"nestedKey\":\"nestedValue\"}],\"key2\":1}", doEncode(AnyType.anyDictionary(data: ["key2": 1, "key": AnyType.anyArray(data: [["nestedKey": "nestedValue"]])])))
+        XCTAssertEqual("{\"container\":{\"key\":[{\"nestedKey\":\"nestedValue\"}],\"key2\":1}}", doEncode(AnyType.anyDictionary(data: ["container": AnyType.anyDictionary(data: ["key2": 1, "key": AnyType.anyArray(data: [["nestedKey": "nestedValue"]])])])))
     }
 
     func doEncode(_ data: AnyType) -> String? {


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

`AnyType` decoded as a part of the asset tree did not have `AnyTypeDecodingContext` to allow for `[String: Any]` decoding, that context is now added in `BaseRegistry` when decoding the asset tree

Including complex metadata for beacons would not reencode when passing the beacon from Swift to JSC in all scenarios. 

```json
{
  "asset": {
    "id": "action-1",
    "type": "action",
    "exp": "{{count}} = {{count}} + 1",
    "label": {
      "asset": {
        "id": "action-label-1",
        "type": "text",
        "value": "Clicked {{count}} times"
      }
    },
    "metaData": {
      "beacon": {
        "array": [{
          "key": "value"
        }],
        "string": "value"
      }
    }
  }
}
```

In this scenario, this metadata would be [decoded by the ActionAsset](https://github.com/player-ui/player/blob/main/plugins/reference-assets/swiftui/Sources/SwiftUI/ActionAsset.swift#L25), which includes `AnyType` for the [beacon metadata](https://github.com/player-ui/player/blob/main/ios/core/Sources/Types/Assets/Wrappers.swift#L89). When sending this decoded type through `BeaconContext.beacon`, the encoding was failing for the nested keys, as the entire `beacon` key would be decoded as `AnyType` with `.anyDictionary([String: Any])`. Encoding the `Any` values failed.

`CustomEncodable` did not work against `Any`, so instead, I decode `Any` as `AnyType` which is then encodable, and can be used as the backing type for encoding


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->