### PR TITLE
ios: enhance tapable logger to handle variadic args from the JS log

### DIFF
--- a/ios/core/Sources/Player/HeadlessPlayer.swift
+++ b/ios/core/Sources/Player/HeadlessPlayer.swift
@@ -190,11 +190,12 @@ public extension HeadlessPlayer {
         JSGarbageCollect(context.jsGlobalContextRef)
         JSUtilities.polyfill(context)
         attachExceptionHandler(to: context)
-        let trace = JSValue(object: logger.getJSLogFor(level: .trace), in: context)
-        let debug = JSValue(object: logger.getJSLogFor(level: .debug), in: context)
-        let info = JSValue(object: logger.getJSLogFor(level: .info), in: context)
-        let warn = JSValue(object: logger.getJSLogFor(level: .warning), in: context)
-        let error = JSValue(object: logger.getJSLogFor(level: .error), in: context)
+        let trace = logger.getJSLogFor(level: .trace, context)
+        let debug = logger.getJSLogFor(level: .debug, context)
+        let info = logger.getJSLogFor(level: .info, context)
+        let warn = logger.getJSLogFor(level: .warning, context)
+        let error = logger.getJSLogFor(level: .error, context)
+
         for plugin in plugins {
             if let plugin = plugin as? JSBasePlugin, plugin.context != context {
                 plugin.context = context

--- a/ios/core/Tests/utilities/JSLoggerTests.swift
+++ b/ios/core/Tests/utilities/JSLoggerTests.swift
@@ -24,23 +24,23 @@ class JSLoggerTests: XCTestCase {
         let warningExpect = expectation(description: "warning message logged")
         let errorExpect = expectation(description: "error message logged")
         player.logger.hooks.trace.tap(name: "test") { message in
-            guard message == "\"Message\"" else { return }
+            guard (message as? [String] ?? []).first == "Message" else { return }
             traceExpect.fulfill()
         }
         player.logger.hooks.debug.tap(name: "test") { message in
-            guard message == "\"Message\"" else { return }
+            guard (message as? [String] ?? []).first == "Message" else { return }
             debugExpect.fulfill()
         }
         player.logger.hooks.info.tap(name: "test") { message in
-            guard message == "\"Message\"" else { return }
+            guard (message as? [String] ?? []).first == "Message" else { return }
             infoExpect.fulfill()
         }
         player.logger.hooks.warn.tap(name: "test") { message in
-            guard message == "\"Message\"" else { return }
+            guard (message as? [String] ?? []).first == "Message" else { return }
             warningExpect.fulfill()
         }
-        player.logger.hooks.error.tap(name: "test") { message in
-            guard message.0 == "\"Message\"" else { return }
+        player.logger.hooks.error.tap(name: "test") {
+            guard ($0.0 as? [String] ?? []).first == "Message" else { return }
             errorExpect.fulfill()
         }
 

--- a/ios/logger/Sources/TapableLogger.swift
+++ b/ios/logger/Sources/TapableLogger.swift
@@ -15,7 +15,7 @@ public class TapableLogger {
      Creates a new TapableLogger
      */
     public init() {
-        hooks.convertJSValue.tap(name: "TapableLogger") {[weak self] value in
+        hooks.convertJSValue.tap(name: "TapableLogger") { [weak self] value in
             guard let converted = self?.convertJSValue(value) else { return .skip }
             return .bail(converted)
         }
@@ -24,67 +24,51 @@ public class TapableLogger {
     /**
      Logs a `trace` level message
      - parameters:
-        - message: The message to log
+        - message: The message(s) to log
      */
-    public func t(_ message: @autoclosure () -> String) {
-        log(level: .trace, message: message())
+    public func t(_ messages: Any...) {
+        log(level: .trace, messages: messages)
     }
 
     /**
      Logs a `debug` level message
      - parameters:
-        - message: The message to log
+        - message: The message(s) to log
      */
-    public func d(_ message: @autoclosure () -> String) {
-        log(level: .debug, message: message())
+    public func d(_ messages: Any...) {
+        log(level: .debug, messages: messages)
     }
 
     /**
-     Logs an`info` level message
+     Logs an `info` level message
      - parameters:
-        - message: The message to log
+        - message: The message(s) to log
      */
-    public func i(_ message: @autoclosure () -> String) {
-        log(level: .info, message: message())
+    public func i(_ messages: Any...) {
+        log(level: .info, messages: messages)
     }
 
     /**
      Logs a `warning` level message
      - parameters:
-        - message: The message to log
+        - message: The message(s) to log
      */
-    public func w(_ message: @autoclosure () -> String) {
-        log(level: .warning, message: message())
+    public func w(_ messages: Any...) {
+        log(level: .warning, messages: messages)
     }
 
     /**
      Logs an `error` level message
      - parameters:
-        - message: The message to log
+        - message: The message(s) to log
      */
-    public func e(_ message: @autoclosure () -> String) {
-        log(level: .error, message: message())
-    }
-
-    /**
-     Logs an `error` level message
-     - parameters:
-        - message: The message to log
-        - error: An associated error object
-     */
-    public func e(_ message: @autoclosure () -> String, _ error: Error) {
+    public func e(_ messages: Any..., er error: Error? = nil) {
         guard LogLevel.error.shouldLog(currentLevel: logLevel) else { return }
-        hooks.error.call((message(), error))
-    }
-
-    /**
-     Logs an `error` level message
-     - parameters:
-        - error: An error object to log
-     */
-    public func e(_ error: Error) {
-        guard LogLevel.error.shouldLog(currentLevel: logLevel) else { return }
-        hooks.error.call((nil, error))
+        if let error = error {
+            hooks.error.call((messages, error))
+        } else {
+            hooks.error.call((messages, nil))
+        }
     }
 
     /// Function signature for log messages from the JS layer
@@ -96,93 +80,77 @@ public class TapableLogger {
         - level: The log level to create the function for
      - returns: A `JSLogFunction` to be used in JavaScriptCore
      */
-    public func getJSLogFor(level: LogLevel) -> JSLogFunction {
+    public func getJSLogFor(level: LogLevel, _ context: JSContext) -> JSValue {
+
+        // function generator that takes varadic parameters and forwards the arguments into an array
+        guard let restWrapper = context.evaluateScript("(fn) => (...args) => fn(args)") else {
+            return JSValue()
+        }
+
         let logFn: JSLogFunction = { [weak self] val in
             guard let message = self?.hooks.convertJSValue.call(val) else { return }
-            self?.log(level: level, message: message)
+            self?.log(level: level, messages: message)
         }
 
-        return logFn
+        // converts Obj-c object to JSValue
+        let jsCallback = JSValue(object: logFn, in: context)
+
+        return restWrapper.call(withArguments: [jsCallback as Any])
     }
 
-    /**
-     Logs a message with at the given log level
-     - parameters:
-        - level: The level to log the message as
-        - message: The message to log
-     */
-    internal func log(level: LogLevel, message: @autoclosure () -> String) {
+
+    internal func log(level: LogLevel, messages: [Any]) {
         guard level.shouldLog(currentLevel: logLevel) else { return }
-        // use a computed var here because `hooks.nnn.call` takes an autoclosure
-        // and may not actually want this string to be built
-        var prefixedMessage: String { "\(hooks.prefixMessage.call(level) ?? "")\(message())" }
+
         switch level {
-        case .trace: hooks.trace.call(prefixedMessage)
-        case .debug: hooks.debug.call(prefixedMessage)
-        case .info: hooks.info.call(prefixedMessage)
-        case .warning: hooks.warn.call(prefixedMessage)
-        case .error: hooks.error.call((prefixedMessage, nil))
+        case .trace: hooks.trace.call(messages)
+        case .debug: hooks.debug.call(messages)
+        case .info: hooks.info.call(messages)
+        case .warning: hooks.warn.call(messages)
+        case .error: hooks.error.call((messages, nil))
         }
     }
 
+    // other methods remain unchanged
     /**
-     A default implementation to use for converting `JSValue` to string when logging from JavaScriptCore
+     A default implementation to use for converting `JSValue` to `[Any]` when logging from JavaScriptCore
      - parameters:
         - value: The JSValue to convert
-     - returns: A String if it can be converted
+     - returns: An array of Any
      */
-    internal func convertJSValue(_ value: JSValue) -> String? {
+    internal func convertJSValue(_ value: JSValue) -> [Any]? {
         guard
             !value.isUndefined
         else { return nil }
-        return value.context.objectForKeyedSubscript("JSON")?.invokeMethod("stringify", withArguments: [value])?.toString()
+
+        // return as aAray if JSValue can be converted to array otherwise return object in an Array
+        return value.isArray ? value.toArray() : [value.toObject()]
     }
 }
 
-public extension TapableLogger {
-    ///  Taps all log levels with the supplied callback.
-    func tapLogs(name: String = "alllogs", callback: @escaping (String) -> Void) {
-        let formatter = DateFormatter.logging
-        hooks.prefixMessage.tap(name: name) { level in .bail("[\(formatter.string(from: Date())) \(level)] ") }
-        hooks.trace.tap(name: name, callback)
-        hooks.debug.tap(name: name, callback)
-        hooks.info.tap(name: name, callback)
-        hooks.warn.tap(name: name, callback)
-        hooks.error.tap(name: name, { (err) in
-            guard let msg = err.error.map({ "\(err.message ?? "error:") \($0.localizedDescription)" }) ?? err.message else {
-                assert(false, "nothing to log?")
-                return
-            }
-            callback(msg)
-        })
-    }
-}
-
-private extension DateFormatter {
-    static let logging: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "HH:mm:ss.SSS"
-        return formatter
-    }()
-}
 /**
  Hooks to allow tapping into logger lifecycle
  */
 public class LoggerHooks {
-    public typealias ErrorMessage = (message: String?, error: Error?)
+    public typealias ErrorMessage = (message: [Any]?, error: Error?)
+
     /// Called for trace level messages
-    public let trace = SyncHook<String>()
+    public let trace = SyncHook<[Any]>()
+
     /// Called for debug level messages
-    public let debug = SyncHook<String>()
+    public let debug = SyncHook<[Any]>()
+
     /// Called for info level messages
-    public let info = SyncHook<String>()
+    public let info = SyncHook<[Any]>()
+
     /// Called for warning level messages
-    public let warn = SyncHook<String>()
+    public let warn = SyncHook<[Any]>()
+
     /// Called for error level messages
     public let error = SyncHook<ErrorMessage>()
 
-    /// Called to convert a JSValue from the core player into a string before logging
-    public let convertJSValue = SyncBailHook<JSValue, String>()
+    /// Called to convert a JSValue from the core player into `[Any]` before logging
+    public let convertJSValue = SyncBailHook<JSValue, [Any]>()
 
     /// Called to get a logging prefix for a given log level for a log message
     public let prefixMessage = SyncBailHook<LogLevel, String>()

--- a/ios/logger/Sources/TapableLogger.swift
+++ b/ios/logger/Sources/TapableLogger.swift
@@ -73,13 +73,9 @@ public class TapableLogger {
      - message: The message(s) to log
      - error: An associated error object
      */
-    public func e(_ messages: Any..., er error: Error? = nil) {
+    public func e(_ messages: Any..., er error: Error) {
         guard LogLevel.error.shouldLog(currentLevel: logLevel) else { return }
-        if let error = error {
             hooks.error.call((messages, error))
-        } else {
-            hooks.error.call((messages, nil))
-        }
     }
 
     /**

--- a/ios/logger/Sources/TapableLogger.swift
+++ b/ios/logger/Sources/TapableLogger.swift
@@ -60,7 +60,18 @@ public class TapableLogger {
     /**
      Logs an `error` level message
      - parameters:
-        - message: The message(s) to log
+     - error: An error object to log
+     */
+    public func e(_ error: Error) {
+        guard LogLevel.error.shouldLog(currentLevel: logLevel) else { return }
+        hooks.error.call((nil, error))
+    }
+
+    /**
+     Logs an `error` level message
+     - parameters:
+     - message: The message(s) to log
+     - error: An associated error object
      */
     public func e(_ messages: Any..., er error: Error? = nil) {
         guard LogLevel.error.shouldLog(currentLevel: logLevel) else { return }
@@ -69,6 +80,15 @@ public class TapableLogger {
         } else {
             hooks.error.call((messages, nil))
         }
+    }
+
+    /**
+     Logs an `error` level message
+     - parameters:
+     - message: The message(s) to log
+     */
+    public func e(_ messages: Any...) {
+        log(level: .error, messages: messages)
     }
 
     /// Function signature for log messages from the JS layer
@@ -151,7 +171,4 @@ public class LoggerHooks {
 
     /// Called to convert a JSValue from the core player into `[Any]` before logging
     public let convertJSValue = SyncBailHook<JSValue, [Any]>()
-
-    /// Called to get a logging prefix for a given log level for a log message
-    public let prefixMessage = SyncBailHook<LogLevel, String>()
 }

--- a/ios/logger/Sources/TapableLogger.swift
+++ b/ios/logger/Sources/TapableLogger.swift
@@ -144,7 +144,7 @@ public class TapableLogger {
         else { return nil }
 
         // return as aAray if JSValue can be converted to array otherwise return object in an Array
-        return value.isArray ? value.toArray() : [value.toObject()]
+        return value.isArray ? value.toArray() : [value.toObject() as Any]
     }
 }
 

--- a/ios/logger/Tests/TapableLoggerTests.swift
+++ b/ios/logger/Tests/TapableLoggerTests.swift
@@ -61,9 +61,6 @@ class TapableLoggerTests: XCTestCase {
     func testMessage() {
         let logger = TapableLogger()
         logger.logLevel = .info
-        logger.hooks.prefixMessage.tap(name: "test") { (level) -> BailResult<String?> in
-            return .bail("[Test][\(level)]: ")
-        }
 
         let logExpect = expectation(description: "Prefixed message logged")
         logger.hooks.info.tap(name: "test") { (message) in

--- a/ios/swiftui/Tests/SwiftUIRegistryTests.swift
+++ b/ios/swiftui/Tests/SwiftUIRegistryTests.swift
@@ -26,12 +26,14 @@ class SwiftUIRegistryTests: XCTestCase {
         operationSkipped.expectedFulfillmentCount = 2
         let logger = TapableLogger()
         logger.logLevel = .trace
-        logger.hooks.trace.tap(name: "test", { message in
-            guard message.contains("Duplicate Registration skipped for") else { return }
+        logger.hooks.trace.tap(name: "test", { messages in
+            let message: String = (messages as? [String] ?? []).first ?? ""
+            guard  message.contains("Duplicate Registration skipped for") else { return }
             operationSkipped.fulfill()
         })
 
-        logger.hooks.warn.tap(name: "test", { message in
+        logger.hooks.warn.tap(name: "test", { messages in
+            let message: String = (messages as? [String] ?? []).first ?? ""
             guard message.contains("Overriding registration for match") else { return }
             override.fulfill()
         })

--- a/plugins/console-logger/ios/Sources/PrintLoggerPlugin.swift
+++ b/plugins/console-logger/ios/Sources/PrintLoggerPlugin.swift
@@ -35,10 +35,14 @@ public class PrintLoggerPlugin: NativePlugin {
     public func apply<P>(player: P) where P: HeadlessPlayer {
         player.logger.logLevel = logLevel
         player.logger.hooks.prefixMessage.tap(name: pluginName) { .bail("[Player] [\($0.description)]: ") }
-        player.logger.hooks.trace.tap(name: pluginName, { print($0) })
-        player.logger.hooks.debug.tap(name: pluginName, { print($0) })
-        player.logger.hooks.info.tap(name: pluginName, { print($0) })
-        player.logger.hooks.warn.tap(name: pluginName, { print($0) })
-        player.logger.hooks.error.tap(name: pluginName, { print($0 ?? "", $1?.localizedDescription ?? "") })
+
+        let prefixedMessage = player.logger.hooks.prefixMessage.call(logLevel) ?? ""
+
+        player.logger.hooks.trace.tap(name: pluginName, { print("\(prefixedMessage)\(($0))" ) })
+        player.logger.hooks.debug.tap(name: pluginName, { print("\(prefixedMessage)\(($0))" ) })
+        player.logger.hooks.info.tap(name: pluginName, { print("\(prefixedMessage)\(($0))" ) })
+        player.logger.hooks.warn.tap(name: pluginName, { print("\(prefixedMessage)\(($0))" ) })
+        player.logger.hooks.error.tap(name: pluginName, { print("\(prefixedMessage)\(($0))", $1?.localizedDescription ?? "") })
     }
 }
+

--- a/plugins/console-logger/ios/Sources/PrintLoggerPlugin.swift
+++ b/plugins/console-logger/ios/Sources/PrintLoggerPlugin.swift
@@ -34,9 +34,9 @@ public class PrintLoggerPlugin: NativePlugin {
      */
     public func apply<P>(player: P) where P: HeadlessPlayer {
         player.logger.logLevel = logLevel
-        player.logger.hooks.prefixMessage.tap(name: pluginName) { .bail("[Player] [\($0.description)]: ") }
 
-        let prefixedMessage = player.logger.hooks.prefixMessage.call(logLevel) ?? ""
+        /// logging prefix for a given log level before the log message
+        let prefixedMessage = "[Player] [\(logLevel)]: "
 
         player.logger.hooks.trace.tap(name: pluginName, { print("\(prefixedMessage)\(($0))" ) })
         player.logger.hooks.debug.tap(name: pluginName, { print("\(prefixedMessage)\(($0))" ) })

--- a/plugins/console-logger/ios/Sources/PrintLoggerPlugin.swift
+++ b/plugins/console-logger/ios/Sources/PrintLoggerPlugin.swift
@@ -42,7 +42,7 @@ public class PrintLoggerPlugin: NativePlugin {
         player.logger.hooks.debug.tap(name: pluginName, { print("\(prefixedMessage)\(($0))" ) })
         player.logger.hooks.info.tap(name: pluginName, { print("\(prefixedMessage)\(($0))" ) })
         player.logger.hooks.warn.tap(name: pluginName, { print("\(prefixedMessage)\(($0))" ) })
-        player.logger.hooks.error.tap(name: pluginName, { print("\(prefixedMessage)\(($0))", $1?.localizedDescription ?? "") })
+        player.logger.hooks.error.tap(name: pluginName, { print("\(prefixedMessage)\((String(describing: $0)))", $1?.localizedDescription ?? "") })
     }
 }
 

--- a/plugins/console-logger/ios/Tests/PrintLoggerPluginTests.swift
+++ b/plugins/console-logger/ios/Tests/PrintLoggerPluginTests.swift
@@ -16,12 +16,24 @@ import XCTest
 
 class PrintLoggerPluginTests: XCTestCase {
     func testPrintLogger() {
+        let logExpect = expectation(description: "Prefixed message logged")
+
         let player = HeadlessPlayerImpl(plugins: [PrintLoggerPlugin(level: .trace)])
         XCTAssertEqual(LogLevel.trace, player.logger.logLevel)
-        player.logger.t("Message")
+
+        player.logger.hooks.trace.tap(name: "test") { (message) in
+            XCTAssertEqual("Message 1", (message as? [String])?.first)
+            XCTAssertEqual("Message 2", (message as? [String])?[1])
+            XCTAssertEqual("Message 3", (message as? [String])?[2])
+            logExpect.fulfill()
+        }
+        
+        player.logger.t("Message 1", "Message 2", "Message 3")
         player.logger.d("Message")
         player.logger.i("Message")
         player.logger.w("Message")
         player.logger.e("Message")
+
+        wait(for: [logExpect], timeout: 1)
     }
 }


### PR DESCRIPTION
https://github.com/player-ui/player/issues/523



### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`

### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

# Release Notes
Prefixing message with the format `[Player] [\(logLevel)]:`  moved out of the Tapable logger and moved to PrintLoggerPlugin. Any consumers using their own LoggerPlugin will need to append the logLevel if they want to print it 

Before
```swift
public class CustomLoggingPlugin: NativePlugin {
    
    public let pluginName = "CustomLoggingPlugin"

    public func apply<P>(player: P) where P: HeadlessPlayer {
        guard let player = player as? SwiftUIPlayer else { return }
        player.logger.logLevel = .trace
        player.logger.hooks.trace.tap(name: pluginName, { print("Custom message")\(($0))" ) })
        ...
    }
```

After
```swift
public class CustomLoggingPlugin: NativePlugin {
    
    public let pluginName = "CustomLoggingPlugin"

    public func apply<P>(player: P) where P: HeadlessPlayer {
        guard let player = player as? SwiftUIPlayer else { return }
        player.logger.logLevel = .trace
        let prefixedMessage = "[Player] [trace]: "
        player.logger.hooks.trace.tap(name: pluginName, { print("\(prefixedMessage) Custom message \(($0))" ) })
        ...
    }
```


## Breaking Changes

Any usage of the `player.logger.hooks` taps will have breaking changes in the callback because the calls have been changed to provide a `[Any]` type instead of `String` so it can be returned in the form of messages instead of a single message. Unless nothing is done in the callback to access the value but just to print it, there should be breaking changes


Example:
```swift

// this should be no breaking change
player.logger.hooks.trace.tap(name: "log", { print("\(($0))" ) })

// if `values` should be accessed in anyway, i.e want the first value, or want to seperate the values
 player.logger.hooks.debug.tap(name: "log") { values in
            // values is of type [Any], if you want to print only the first value
            print("\((message as? [String])?.first))" )
        }
```
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.9.2--canary.524.17782</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.9.2--canary.524.17782
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
