### PR TITLE
remove unneeded HTML report generation steps from build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,11 +215,7 @@ jobs:
           when: always
           command: |
             mkdir -p _ios_coverage/lcov
-            mkdir -p _ios_coverage/html
             cp -r $(bazel info output_path)/_coverage/_coverage_report.dat _ios_coverage/lcov/
-            genhtml --branch-coverage --output-directory=_ios_coverage/html/ "$(bazel info output_path)/_coverage/_coverage_report.dat"
-            zip -r _ios_coverage/html.zip _ios_coverage/html/
-            rm -r _ios_coverage/html/
 
       - persist_to_workspace:
           root: .


### PR DESCRIPTION
don't need to generate the HTML formatted coverage reports from genhtml, only the `_coverage_report.dat` is needed for codecov 


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->