### PR TITLE
JVM ConsoleLoggerPlugin

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -139,7 +139,7 @@ maven.install(
         "com.intuit.hooks:hooks:0.15.0",
 
         # Testing
-        "io.mockk:mockk:1.9.3",
+        "io.mockk:mockk:1.12.0",
         "org.amshove.kluent:kluent:1.68",
         "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0",
 

--- a/jvm/hermes/deps.bzl
+++ b/jvm/hermes/deps.bzl
@@ -7,6 +7,7 @@ main_deps = main_exports + [
     "@maven//:com_facebook_fbjni_fbjni_java_only",
     "@maven//:com_facebook_soloader_soloader",
     "//plugins/set-time-out/jvm:set-time-out",
+    "//plugins/console-logger/jvm:console-logger"
 ]
 
 # TODO: These should probably just be dependencies of headless

--- a/jvm/hermes/src/main/kotlin/com/intuit/playerui/hermes/bridge/runtime/HermesRuntime.kt
+++ b/jvm/hermes/src/main/kotlin/com/intuit/playerui/hermes/bridge/runtime/HermesRuntime.kt
@@ -27,6 +27,7 @@ import com.intuit.playerui.jsi.Value
 import com.intuit.playerui.jsi.serialization.format.JSIFormat
 import com.intuit.playerui.jsi.serialization.format.JSIFormatConfiguration
 import com.intuit.playerui.jsi.serialization.serializers.JSIValueContainerSerializer
+import com.intuit.playerui.plugins.consolelogger.ConsoleLoggerPlugin
 import com.intuit.playerui.plugins.settimeout.SetTimeoutPlugin
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -198,7 +199,7 @@ public object Hermes : PlayerRuntimeFactory<Config> {
         loadHermesJni()
         val config = Config().apply(block)
         // TODO: Move SetTimeoutPlugin to HeadlessPlayer init once cyclical dep is handled (split out headless impl)
-        return HermesRuntime.create(config).also(SetTimeoutPlugin(config.coroutineExceptionHandler)::apply)
+        return HermesRuntime.create(config).also(SetTimeoutPlugin(config.coroutineExceptionHandler)::apply).also(ConsoleLoggerPlugin(override = true)::apply)
     }
 
     override fun toString(): String = name

--- a/plugins/console-logger/jvm/BUILD.bazel
+++ b/plugins/console-logger/jvm/BUILD.bazel
@@ -1,0 +1,9 @@
+load("//plugins:defs.bzl", "kt_player_plugin")
+load(":deps.bzl", "main_deps", "main_exports")
+
+kt_player_plugin(
+    name = "console-logger",
+    main_deps = main_deps,
+    main_exports = main_exports,
+    test_package = "com.intuit.playerui.plugins.consolelogger",
+)

--- a/plugins/console-logger/jvm/deps.bzl
+++ b/plugins/console-logger/jvm/deps.bzl
@@ -1,0 +1,7 @@
+maven = []
+
+main_exports = [
+    "//jvm/core",
+]
+
+main_deps = main_exports

--- a/plugins/console-logger/jvm/src/main/kotlin/com/intuit/playerui/plugins/consolelogger/ConsoleLoggerPlugin.kt
+++ b/plugins/console-logger/jvm/src/main/kotlin/com/intuit/playerui/plugins/consolelogger/ConsoleLoggerPlugin.kt
@@ -18,31 +18,33 @@ public class ConsoleLoggerPlugin(private val logger: LoggerPlugin? = null, priva
     @OptIn(ExperimentalPlayerApi::class)
     override fun apply(runtime: Runtime<*>) {
         if (override || !runtime.contains("console")) {
-            runtime.add("console", mapOf(
-                "log" to Invokable { args ->
-                    logger?.debug(*args) ?: printToConsole(*args)
-                },
-                "debug" to Invokable { args ->
-                    logger?.debug(*args) ?: printToConsole(*args)
-                },
-                "warn" to Invokable { args ->
-                    logger?.warn(*args) ?: printToConsole(*args)
-                },
-                "info" to Invokable { args ->
-                    logger?.info(*args) ?: printToConsole(*args)
-                },
-                "error" to Invokable { args ->
-                    logger?.error(*args) ?: printToConsole(*args)
-                },
-                "trace" to Invokable { args ->
-                    logger?.trace(*args) ?: printToConsole(*args)
-                },
-            ))
+            runtime.add(
+                "console",
+                mapOf(
+                    "log" to Invokable { args ->
+                        logger?.debug(*args) ?: printToConsole(*args)
+                    },
+                    "debug" to Invokable { args ->
+                        logger?.debug(*args) ?: printToConsole(*args)
+                    },
+                    "warn" to Invokable { args ->
+                        logger?.warn(*args) ?: printToConsole(*args)
+                    },
+                    "info" to Invokable { args ->
+                        logger?.info(*args) ?: printToConsole(*args)
+                    },
+                    "error" to Invokable { args ->
+                        logger?.error(*args) ?: printToConsole(*args)
+                    },
+                    "trace" to Invokable { args ->
+                        logger?.trace(*args) ?: printToConsole(*args)
+                    },
+                ),
+            )
         }
     }
 
     private fun printToConsole(vararg args: Any?) {
-
     }
 
     override fun apply(player: Player) {

--- a/plugins/console-logger/jvm/src/main/kotlin/com/intuit/playerui/plugins/consolelogger/ConsoleLoggerPlugin.kt
+++ b/plugins/console-logger/jvm/src/main/kotlin/com/intuit/playerui/plugins/consolelogger/ConsoleLoggerPlugin.kt
@@ -1,0 +1,51 @@
+package com.intuit.playerui.plugins.consolelogger
+
+import com.intuit.playerui.core.bridge.Invokable
+import com.intuit.playerui.core.bridge.runtime.Runtime
+import com.intuit.playerui.core.bridge.runtime.add
+import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
+import com.intuit.playerui.core.player.Player
+import com.intuit.playerui.core.plugins.LoggerPlugin
+import com.intuit.playerui.core.plugins.PlayerPlugin
+import com.intuit.playerui.core.plugins.RuntimePlugin
+
+/** [RuntimePlugin] that adds a `console.log` implementation into a the [Runtime] if it doesn't exist */
+public class ConsoleLoggerPlugin(private val logger: LoggerPlugin? = null, private val override: Boolean = false) :
+    RuntimePlugin, PlayerPlugin {
+
+    private var player: Player? = null
+
+    @OptIn(ExperimentalPlayerApi::class)
+    override fun apply(runtime: Runtime<*>) {
+        if (override || !runtime.contains("console")) {
+            runtime.add("console", mapOf(
+                "log" to Invokable { args ->
+                    logger?.debug(*args) ?: printToConsole(*args)
+                },
+                "debug" to Invokable { args ->
+                    logger?.debug(*args) ?: printToConsole(*args)
+                },
+                "warn" to Invokable { args ->
+                    logger?.warn(*args) ?: printToConsole(*args)
+                },
+                "info" to Invokable { args ->
+                    logger?.info(*args) ?: printToConsole(*args)
+                },
+                "error" to Invokable { args ->
+                    logger?.error(*args) ?: printToConsole(*args)
+                },
+                "trace" to Invokable { args ->
+                    logger?.trace(*args) ?: printToConsole(*args)
+                },
+            ))
+        }
+    }
+
+    private fun printToConsole(vararg args: Any?) {
+
+    }
+
+    override fun apply(player: Player) {
+        this.player = player
+    }
+}

--- a/plugins/console-logger/jvm/src/main/kotlin/com/intuit/playerui/plugins/consolelogger/ConsoleLoggerPlugin.kt
+++ b/plugins/console-logger/jvm/src/main/kotlin/com/intuit/playerui/plugins/consolelogger/ConsoleLoggerPlugin.kt
@@ -45,6 +45,7 @@ public class ConsoleLoggerPlugin(private val logger: LoggerPlugin? = null, priva
     }
 
     private fun printToConsole(vararg args: Any?) {
+        println(args.joinToString(", "))
     }
 
     override fun apply(player: Player) {

--- a/plugins/console-logger/jvm/src/main/kotlin/com/intuit/playerui/plugins/consolelogger/ConsoleLoggerPlugin.kt
+++ b/plugins/console-logger/jvm/src/main/kotlin/com/intuit/playerui/plugins/consolelogger/ConsoleLoggerPlugin.kt
@@ -3,7 +3,6 @@ package com.intuit.playerui.plugins.consolelogger
 import com.intuit.playerui.core.bridge.Invokable
 import com.intuit.playerui.core.bridge.runtime.Runtime
 import com.intuit.playerui.core.bridge.runtime.add
-import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
 import com.intuit.playerui.core.player.Player
 import com.intuit.playerui.core.plugins.LoggerPlugin
 import com.intuit.playerui.core.plugins.PlayerPlugin

--- a/plugins/console-logger/jvm/src/main/kotlin/com/intuit/playerui/plugins/consolelogger/ConsoleLoggerPlugin.kt
+++ b/plugins/console-logger/jvm/src/main/kotlin/com/intuit/playerui/plugins/consolelogger/ConsoleLoggerPlugin.kt
@@ -15,29 +15,28 @@ public class ConsoleLoggerPlugin(private val logger: LoggerPlugin? = null, priva
 
     private var player: Player? = null
 
-    @OptIn(ExperimentalPlayerApi::class)
     override fun apply(runtime: Runtime<*>) {
         if (override || !runtime.contains("console")) {
             runtime.add(
                 "console",
                 mapOf(
                     "log" to Invokable { args ->
-                        logger?.debug(*args) ?: printToConsole(*args)
+                        logger?.debug(*args) ?: player?.logger?.debug(*args) ?: printToConsole(*args)
                     },
                     "debug" to Invokable { args ->
-                        logger?.debug(*args) ?: printToConsole(*args)
+                        logger?.debug(*args) ?: player?.logger?.debug(*args) ?: printToConsole(*args)
                     },
                     "warn" to Invokable { args ->
-                        logger?.warn(*args) ?: printToConsole(*args)
+                        logger?.warn(*args) ?: player?.logger?.warn(*args) ?: printToConsole(*args)
                     },
                     "info" to Invokable { args ->
-                        logger?.info(*args) ?: printToConsole(*args)
+                        logger?.info(*args) ?: player?.logger?.info(*args) ?: printToConsole(*args)
                     },
                     "error" to Invokable { args ->
-                        logger?.error(*args) ?: printToConsole(*args)
+                        logger?.error(*args) ?: player?.logger?.error(*args) ?: printToConsole(*args)
                     },
                     "trace" to Invokable { args ->
-                        logger?.trace(*args) ?: printToConsole(*args)
+                        logger?.trace(*args) ?: player?.logger?.trace(*args) ?: printToConsole(*args)
                     },
                 ),
             )

--- a/plugins/console-logger/jvm/src/test/kotlin/com/intuit/playerui/plugins/consolelogger/ConsoleLoggerPluginTest.kt
+++ b/plugins/console-logger/jvm/src/test/kotlin/com/intuit/playerui/plugins/consolelogger/ConsoleLoggerPluginTest.kt
@@ -1,26 +1,20 @@
 package com.intuit.playerui.plugins.consolelogger
 
-import com.intuit.playerui.core.bridge.runtime.add
 import com.intuit.playerui.core.plugins.LoggerPlugin
 import com.intuit.playerui.utils.test.RuntimeTest
 import com.intuit.playerui.utils.test.runBlockingTest
-import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestTemplate
 import org.junit.jupiter.api.extension.ExtendWith
 
 @ExtendWith(MockKExtension::class)
 internal class ConsoleLoggerPluginTest : RuntimeTest() {
 
-    @MockK(relaxed = true) lateinit var logger: LoggerPlugin
-
-    @BeforeEach
-    fun setup() {
-    }
+    @MockK(relaxed = true)
+    lateinit var logger: LoggerPlugin
 
     @TestTemplate fun `log works as intended`() = runBlockingTest {
         ConsoleLoggerPlugin(logger, true).apply(runtime)
@@ -70,4 +64,3 @@ internal class ConsoleLoggerPluginTest : RuntimeTest() {
         verify(exactly = 1) { logger.trace("Hello world") }
     }
 }
-

--- a/plugins/console-logger/jvm/src/test/kotlin/com/intuit/playerui/plugins/consolelogger/ConsoleLoggerPluginTest.kt
+++ b/plugins/console-logger/jvm/src/test/kotlin/com/intuit/playerui/plugins/consolelogger/ConsoleLoggerPluginTest.kt
@@ -1,18 +1,74 @@
 package com.intuit.playerui.plugins.consolelogger
 
+import com.intuit.playerui.core.plugins.LoggerPlugin
 import com.intuit.playerui.utils.test.RuntimeTest
 import com.intuit.playerui.utils.test.runBlockingTest
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
 
+@ExtendWith(MockKExtension::class)
 internal class ConsoleLoggerPluginTest : RuntimeTest() {
 
-    @TestTemplate fun `works as intended`() = runBlockingTest {
-        val exceptions = mutableListOf<Throwable>()
-        ConsoleLoggerPlugin(null, true).apply(runtime)
+    @MockK(relaxed = true) lateinit var logger: LoggerPlugin
+    @MockK lateinit var mockFunction: (Array<Any>?) -> Unit
+
+    @BeforeEach
+    fun setup() {
+        every { logger.debug(*anyVararg()) } answers {}
+    }
+
+    @TestTemplate fun `log works as intended`() = runBlockingTest {
+        ConsoleLoggerPlugin(logger, true).apply(runtime)
         Assertions.assertNotNull(runtime["console"])
 
+        runtime.execute("console.log('Hello world')")
+        verify(exactly = 1) { logger.debug(arrayOf("Hello world")) }
+    }
 
+    @TestTemplate fun `debug works as intended`() = runBlockingTest {
+        ConsoleLoggerPlugin(logger, true).apply(runtime)
+        Assertions.assertNotNull(runtime["console"])
+
+        runtime.execute("console.debug('Hello world')")
+        verify(exactly = 1) { logger.debug(arrayOf("Hello world")) }
+    }
+
+    @TestTemplate fun `info works as intended`() = runBlockingTest {
+        ConsoleLoggerPlugin(logger, true).apply(runtime)
+        Assertions.assertNotNull(runtime["console"])
+
+        runtime.execute("console.info('Hello world')")
+        verify(exactly = 1) { logger.info(arrayOf("Hello world")) }
+    }
+
+    @TestTemplate fun `warning works as intended`() = runBlockingTest {
+        ConsoleLoggerPlugin(logger, true).apply(runtime)
+        Assertions.assertNotNull(runtime["console"])
+
+        runtime.execute("console.warn('Hello world')")
+        verify(exactly = 1) { logger.warn(arrayOf("Hello world")) }
+    }
+
+    @TestTemplate fun `error works as intended`() = runBlockingTest {
+        ConsoleLoggerPlugin(logger, true).apply(runtime)
+        Assertions.assertNotNull(runtime["console"])
+
+        runtime.execute("console.error('Hello world')")
+        verify(exactly = 1) { logger.error(arrayOf("Hello world")) }
+    }
+
+    @TestTemplate fun `trace works as intended`() = runBlockingTest {
+        ConsoleLoggerPlugin(logger, true).apply(runtime)
+        Assertions.assertNotNull(runtime["console"])
+
+        runtime.execute("console.trace('Hello world')")
+        verify(exactly = 1) { logger.trace(arrayOf("Hello world")) }
     }
 }
 

--- a/plugins/console-logger/jvm/src/test/kotlin/com/intuit/playerui/plugins/consolelogger/ConsoleLoggerPluginTest.kt
+++ b/plugins/console-logger/jvm/src/test/kotlin/com/intuit/playerui/plugins/consolelogger/ConsoleLoggerPluginTest.kt
@@ -1,0 +1,18 @@
+package com.intuit.playerui.plugins.consolelogger
+
+import com.intuit.playerui.utils.test.RuntimeTest
+import com.intuit.playerui.utils.test.runBlockingTest
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.TestTemplate
+
+internal class ConsoleLoggerPluginTest : RuntimeTest() {
+
+    @TestTemplate fun `works as intended`() = runBlockingTest {
+        val exceptions = mutableListOf<Throwable>()
+        ConsoleLoggerPlugin(null, true).apply(runtime)
+        Assertions.assertNotNull(runtime["console"])
+
+
+    }
+}
+

--- a/plugins/console-logger/jvm/src/test/kotlin/com/intuit/playerui/plugins/consolelogger/ConsoleLoggerPluginTest.kt
+++ b/plugins/console-logger/jvm/src/test/kotlin/com/intuit/playerui/plugins/consolelogger/ConsoleLoggerPluginTest.kt
@@ -38,12 +38,12 @@ internal class ConsoleLoggerPluginTest : RuntimeTest() {
         verify(exactly = 1) { logger.debug("Hello world", mapOf("foo" to "bar")) }
     }
 
-    /*@TestTemplate fun `info works as intended`() = runBlockingTest {
+    @TestTemplate fun `info works as intended`() = runBlockingTest {
         ConsoleLoggerPlugin(logger, true).apply(runtime)
         Assertions.assertNotNull(runtime["console"])
 
-        runtime.execute("console.info('Hello world')")
-        verify(exactly = 1) { logger.info("Hello world") }
+        runtime.execute("console.info('Hello world', 'this is a log', {'foo': 'bar'})")
+        verify(exactly = 1) { logger.info("Hello world", "this is a log", mapOf("foo" to "bar")) }
     }
 
     @TestTemplate fun `warning works as intended`() = runBlockingTest {
@@ -68,6 +68,6 @@ internal class ConsoleLoggerPluginTest : RuntimeTest() {
 
         runtime.execute("console.trace('Hello world')")
         verify(exactly = 1) { logger.trace("Hello world") }
-    }*/
+    }
 }
 

--- a/plugins/console-logger/jvm/src/test/kotlin/com/intuit/playerui/plugins/consolelogger/ConsoleLoggerPluginTest.kt
+++ b/plugins/console-logger/jvm/src/test/kotlin/com/intuit/playerui/plugins/consolelogger/ConsoleLoggerPluginTest.kt
@@ -1,5 +1,6 @@
 package com.intuit.playerui.plugins.consolelogger
 
+import com.intuit.playerui.core.bridge.runtime.add
 import com.intuit.playerui.core.plugins.LoggerPlugin
 import com.intuit.playerui.utils.test.RuntimeTest
 import com.intuit.playerui.utils.test.runBlockingTest
@@ -16,35 +17,33 @@ import org.junit.jupiter.api.extension.ExtendWith
 internal class ConsoleLoggerPluginTest : RuntimeTest() {
 
     @MockK(relaxed = true) lateinit var logger: LoggerPlugin
-    @MockK lateinit var mockFunction: (Array<Any>?) -> Unit
 
     @BeforeEach
     fun setup() {
-        every { logger.debug(*anyVararg()) } answers {}
     }
 
     @TestTemplate fun `log works as intended`() = runBlockingTest {
         ConsoleLoggerPlugin(logger, true).apply(runtime)
         Assertions.assertNotNull(runtime["console"])
 
-        runtime.execute("console.log('Hello world')")
-        verify(exactly = 1) { logger.debug(arrayOf("Hello world")) }
+        runtime.execute("console.log('Hello world', 'this is a log', {'foo': 'bar'})")
+        verify(exactly = 1) { logger.debug("Hello world", "this is a log", mapOf("foo" to "bar")) }
     }
 
     @TestTemplate fun `debug works as intended`() = runBlockingTest {
         ConsoleLoggerPlugin(logger, true).apply(runtime)
         Assertions.assertNotNull(runtime["console"])
 
-        runtime.execute("console.debug('Hello world')")
-        verify(exactly = 1) { logger.debug(arrayOf("Hello world")) }
+        runtime.execute("console.debug('Hello world', {'foo': 'bar'})")
+        verify(exactly = 1) { logger.debug("Hello world", mapOf("foo" to "bar")) }
     }
 
-    @TestTemplate fun `info works as intended`() = runBlockingTest {
+    /*@TestTemplate fun `info works as intended`() = runBlockingTest {
         ConsoleLoggerPlugin(logger, true).apply(runtime)
         Assertions.assertNotNull(runtime["console"])
 
         runtime.execute("console.info('Hello world')")
-        verify(exactly = 1) { logger.info(arrayOf("Hello world")) }
+        verify(exactly = 1) { logger.info("Hello world") }
     }
 
     @TestTemplate fun `warning works as intended`() = runBlockingTest {
@@ -52,7 +51,7 @@ internal class ConsoleLoggerPluginTest : RuntimeTest() {
         Assertions.assertNotNull(runtime["console"])
 
         runtime.execute("console.warn('Hello world')")
-        verify(exactly = 1) { logger.warn(arrayOf("Hello world")) }
+        verify(exactly = 1) { logger.warn("Hello world") }
     }
 
     @TestTemplate fun `error works as intended`() = runBlockingTest {
@@ -60,7 +59,7 @@ internal class ConsoleLoggerPluginTest : RuntimeTest() {
         Assertions.assertNotNull(runtime["console"])
 
         runtime.execute("console.error('Hello world')")
-        verify(exactly = 1) { logger.error(arrayOf("Hello world")) }
+        verify(exactly = 1) { logger.error("Hello world") }
     }
 
     @TestTemplate fun `trace works as intended`() = runBlockingTest {
@@ -68,7 +67,7 @@ internal class ConsoleLoggerPluginTest : RuntimeTest() {
         Assertions.assertNotNull(runtime["console"])
 
         runtime.execute("console.trace('Hello world')")
-        verify(exactly = 1) { logger.trace(arrayOf("Hello world")) }
-    }
+        verify(exactly = 1) { logger.trace("Hello world") }
+    }*/
 }
 


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

This PR makes available a JVM ConsoleLoggerPlugin that can be added to any supported JS runtime in for the JVM, forwarding all console logs to a provided logger


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.9.2--canary.552.18572</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.9.2--canary.552.18572
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
