### PR TITLE
clear registry when transitioning to non view state

### DIFF
--- a/ios/swiftui/Sources/SwiftUIPlayer.swift
+++ b/ios/swiftui/Sources/SwiftUIPlayer.swift
@@ -79,6 +79,16 @@ public struct SwiftUIPlayer: View, HeadlessPlayer {
             for plugin in allPlugins { plugin.apply(player: player) }
             registry.partialMatchRegistry = partialMatchPlugin
 
+            hooks.flowController.tap { flowController in
+                flowController.hooks.flow.tap { flow in
+                    flow.hooks.transition.tap { [weak self] _, newState in
+                        if (newState.value as? NavigationFlowViewState) == nil {
+                            self?.registry.resetView(releasePartialMatch: false)
+                        }
+                    }
+                }
+            }
+
             hooks.viewController.tap { [weak self] controller in
                 guard let self = self, self.player == playerValue else { return }
                 self.onViewController(controller)


### PR DESCRIPTION
When going from a view state to an external state to another view state, the content from first view shows momentarily before showing content of new view state, by resetting the view we prevent this from happening

similar behaviour occurs when a view going to an END state and shows a modal and previous view is still present before showing new content

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.10.1--canary.564.18899</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.10.1--canary.564.18899
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
