### PR TITLE
Data change listener fix

### DIFF
--- a/plugins/common-expressions/core/src/expressions/index.ts
+++ b/plugins/common-expressions/core/src/expressions/index.ts
@@ -53,7 +53,7 @@ export const isNotEmpty: ExpressionHandler<[unknown], boolean> = (ctx, val) => {
 
 export const concat = withoutContext((...args: Array<unknown>) => {
   if (args.every((v) => Array.isArray(v))) {
-    const arrayArgs = args as Array<Array<unknown>>;
+    const arrayArgs = args.map((a) => structuredClone(a)) as Array<Array<unknown>>;
 
     return arrayArgs.reduce((merged, next) => {
       merged.push(...next);

--- a/plugins/common-expressions/core/src/expressions/index.ts
+++ b/plugins/common-expressions/core/src/expressions/index.ts
@@ -53,7 +53,9 @@ export const isNotEmpty: ExpressionHandler<[unknown], boolean> = (ctx, val) => {
 
 export const concat = withoutContext((...args: Array<unknown>) => {
   if (args.every((v) => Array.isArray(v))) {
-    const arrayArgs = args.map((a) => structuredClone(a)) as Array<Array<unknown>>;
+    const arrayArgs = args.map((a) => structuredClone(a)) as Array<
+      Array<unknown>
+    >;
 
     return arrayArgs.reduce((merged, next) => {
       merged.push(...next);

--- a/plugins/common-expressions/core/src/expressions/index.ts
+++ b/plugins/common-expressions/core/src/expressions/index.ts
@@ -53,14 +53,13 @@ export const isNotEmpty: ExpressionHandler<[unknown], boolean> = (ctx, val) => {
 
 export const concat = withoutContext((...args: Array<unknown>) => {
   if (args.every((v) => Array.isArray(v))) {
-    const arrayArgs = args.map((a) => structuredClone(a)) as Array<
-      Array<unknown>
-    >;
+    const merged: Array<unknown> = [];
 
-    return arrayArgs.reduce((merged, next) => {
+    args.forEach((next) => {
       merged.push(...next);
-      return merged;
     });
+
+    return merged;
   }
 
   return args.reduce((merged: any, next) => merged + (next ?? ""), "");

--- a/plugins/data-change-listener/core/BUILD
+++ b/plugins/data-change-listener/core/BUILD
@@ -17,7 +17,7 @@ js_pipeline(
         ":node_modules/@player-ui/asset-transform-plugin",
         ":node_modules/@player-ui/common-types-plugin",
         ":node_modules/@player-ui/partial-match-registry",
-        ":node_modules/@player-ui/reference-assets-plugin-react",
+        ":node_modules/@player-ui/reference-assets-plugin",
         ":node_modules/@player-ui/common-expressions-plugin",
         "//:node_modules/@testing-library/react",
         "//:vitest_config",

--- a/plugins/data-change-listener/core/BUILD
+++ b/plugins/data-change-listener/core/BUILD
@@ -17,6 +17,8 @@ js_pipeline(
         ":node_modules/@player-ui/asset-transform-plugin",
         ":node_modules/@player-ui/common-types-plugin",
         ":node_modules/@player-ui/partial-match-registry",
+        ":node_modules/@player-ui/reference-assets-plugin-react",
+        ":node_modules/@player-ui/common-expressions-plugin",
         "//:node_modules/@testing-library/react",
         "//:vitest_config",
     ],

--- a/plugins/data-change-listener/core/package.json
+++ b/plugins/data-change-listener/core/package.json
@@ -9,7 +9,7 @@
     "@player-ui/partial-match-registry": "workspace:*",
     "@player-ui/asset-transform-plugin": "workspace:*",
     "@player-ui/common-types-plugin": "workspace:*",
-    "@player-ui/reference-assets-plugin-react": "workspace:*",
+    "@player-ui/reference-assets-plugin": "workspace:*",
     "@player-ui/common-expressions-plugin": "workspace:*"
   }
 }

--- a/plugins/data-change-listener/core/package.json
+++ b/plugins/data-change-listener/core/package.json
@@ -8,6 +8,8 @@
   "devDependencies": {
     "@player-ui/partial-match-registry": "workspace:*",
     "@player-ui/asset-transform-plugin": "workspace:*",
-    "@player-ui/common-types-plugin": "workspace:*"
+    "@player-ui/common-types-plugin": "workspace:*",
+    "@player-ui/reference-assets-plugin-react": "workspace:*",
+    "@player-ui/common-expressions-plugin": "workspace:*"
   }
 }

--- a/plugins/data-change-listener/core/src/__tests__/index.test.ts
+++ b/plugins/data-change-listener/core/src/__tests__/index.test.ts
@@ -10,7 +10,7 @@ import { CommonTypesPlugin } from "@player-ui/common-types-plugin";
 import { AssetTransformPlugin } from "@player-ui/asset-transform-plugin";
 import { Registry } from "@player-ui/partial-match-registry";
 import { DataChangeListenerPlugin } from "../index";
-import { ReferenceAssetsPlugin } from "@player-ui/reference-assets-plugin-react";
+import { ReferenceAssetsPlugin } from "@player-ui/reference-assets-plugin";
 import { CommonExpressionsPlugin } from "@player-ui/common-expressions-plugin";
 
 /** Test transform function to add validation to asset */
@@ -569,7 +569,7 @@ describe("Data-Change-Listener with array modification", () => {
     return player.getState() as InProgressState;
   }
 
-  it("should call expression evaluator when an array that is tracked changes", () => {
+  it("should call expression evaluator and data change listener when an array that is tracked changes", () => {
     player = new Player({
       plugins: [
         new CommonTypesPlugin(),
@@ -610,7 +610,7 @@ describe("Data-Change-Listener with array modification", () => {
     expect(testExpression).toHaveBeenCalledWith("array has changed 1,2,3,4");
   });
 
-  it("should call expression evaluator when count is tracked changes", () => {
+  it("should call expression evaluator and data change listener when count is changes", () => {
     player = new Player({
       plugins: [
         new CommonTypesPlugin(),

--- a/plugins/data-change-listener/core/src/__tests__/index.test.ts
+++ b/plugins/data-change-listener/core/src/__tests__/index.test.ts
@@ -466,7 +466,7 @@ describe("Data-Change-Listener with array modification", () => {
             asset: {
               id: "action",
               type: "action",
-              exp: "concat({{array}}, [4])",
+              exp: "{{array}} = concat({{array}}, [4])",
               label: {
                 asset: {
                   id: "actions-0-label",
@@ -607,7 +607,7 @@ describe("Data-Change-Listener with array modification", () => {
       1, 2, 3, 4,
     ]);
 
-    expect(testExpression).toHaveBeenCalledWith("array has changed");
+    expect(testExpression).toHaveBeenCalledWith("array has changed 1,2,3,4");
   });
 
   it("should call expression evaluator when count is tracked changes", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -823,9 +823,9 @@ importers:
       '@player-ui/partial-match-registry':
         specifier: workspace:*
         version: link:../../../core/partial-match-registry
-      '@player-ui/reference-assets-plugin-react':
+      '@player-ui/reference-assets-plugin':
         specifier: workspace:*
-        version: link:../../reference-assets/react
+        version: link:../../reference-assets/core
 
   plugins/data-filter/core:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -814,12 +814,18 @@ importers:
       '@player-ui/asset-transform-plugin':
         specifier: workspace:*
         version: link:../../asset-transform/core
+      '@player-ui/common-expressions-plugin':
+        specifier: workspace:*
+        version: link:../../common-expressions/core
       '@player-ui/common-types-plugin':
         specifier: workspace:*
         version: link:../../common-types/core
       '@player-ui/partial-match-registry':
         specifier: workspace:*
         version: link:../../../core/partial-match-registry
+      '@player-ui/reference-assets-plugin-react':
+        specifier: workspace:*
+        version: link:../../reference-assets/react
 
   plugins/data-filter/core:
     dependencies:


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->
# Release Notes
Fixed an issue in `common-exprssion-plugin` where the array update via concat didn't trigger the `data-change-listener`  and view update

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.10.3--canary.572.19773</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.10.3--canary.572.19773
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
