### PR TITLE
iOS: JavascriptCore Exceptions when finding classes

### DIFF
--- a/ios/core/Sources/Player/HeadlessPlayer.swift
+++ b/ios/core/Sources/Player/HeadlessPlayer.swift
@@ -356,7 +356,11 @@ internal extension JSContext {
         var splitPath = path.split(separator: ".")
         var value = objectForKeyedSubscript(splitPath.remove(at: 0))
         for segment in splitPath {
-            value = value?.objectForKeyedSubscript(segment)
+            if value?.isUndefined != true, value?.hasProperty(segment) == true {
+                value = value?.objectForKeyedSubscript(segment)
+            } else {
+                return nil
+            }
         }
         return value
     }


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

When reusing a `JSContext` that had already loaded JS classes, JavascriptCore would throw exceptions when walking through the dot separated classnames as JSValue can be non-nil with an underlying `undefined` value. Adding a check for `isUndefined` lets us short circuit the classname reference recursion and skip back to resource loading.

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.10.2--canary.577.19320</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.10.2--canary.577.19320
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
