### PR TITLE
[WIP] Initial Pass at Runtime Flag Architecture 

### DIFF
--- a/core/player/src/controllers/flags/__tests__/index.test.ts
+++ b/core/player/src/controllers/flags/__tests__/index.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { FlagController } from "../controller";
+import { PlayerFlags } from "../types";
+
+describe("Controller Functionality", () => {
+  const mockFlags: PlayerFlags = {
+    duplicateIDLogLevel: "error",
+  };
+
+  it("Basic Functionality", () => {
+    const controller = new FlagController(mockFlags);
+
+    expect(controller.getFlag("duplicateIDLogLevel")).toBe("error");
+
+    controller.updateFlags({ duplicateIDLogLevel: "debug" });
+
+    expect(controller.getFlag("duplicateIDLogLevel")).toBe("debug");
+  });
+
+  it("Hooks", () => {
+    const controller = new FlagController(mockFlags);
+
+    controller.hooks.overrideFlag.tap("test", (value, key) => {
+      expect(value).toBe("error");
+      expect(key).toBe("duplicateIDLogLevel");
+
+      return "warning";
+    });
+
+    expect(controller.getFlag("duplicateIDLogLevel")).toBe("warning");
+  });
+});

--- a/core/player/src/controllers/flags/controller.ts
+++ b/core/player/src/controllers/flags/controller.ts
@@ -1,0 +1,32 @@
+import dlv from "dlv";
+
+import { PlayerFlags, Flag, DefaultFlags } from "./types";
+import { SyncWaterfallHook } from "tapable-ts";
+
+export class FlagController {
+  private flags: PlayerFlags;
+
+  constructor(flags?: PlayerFlags) {
+    this.flags = { ...DefaultFlags, ...flags };
+  }
+
+  /** Hooks for the FlagsController */
+  public readonly hooks: {
+    /** Allow a plugin or integration to dynamically change a flag without setting it globally */
+    overrideFlag: SyncWaterfallHook<[any, string]>;
+  } = {
+    overrideFlag: new SyncWaterfallHook(),
+  };
+
+  public updateFlags(newFlags: Partial<PlayerFlags>): void {
+    this.flags = {
+      ...this.flags,
+      ...newFlags,
+    };
+  }
+
+  public getFlag<T>(flag: Flag): T {
+    const configuredFlag = dlv(this.flags, flag) as PlayerFlags[Flag];
+    return this.hooks.overrideFlag.call(configuredFlag, flag);
+  }
+}

--- a/core/player/src/controllers/flags/index.ts
+++ b/core/player/src/controllers/flags/index.ts
@@ -1,0 +1,2 @@
+export * from "./controller";
+export * from "./types";

--- a/core/player/src/controllers/flags/types.ts
+++ b/core/player/src/controllers/flags/types.ts
@@ -1,0 +1,17 @@
+import { Severity } from "../../logger";
+
+/** Configuration for runtime Player behavior */
+export interface PlayerFlags {
+  /** What log level duplicate ID errors during view resolution should be raised as */
+  duplicateIDLogLevel: Severity;
+
+  /** Log level for when there are cache conflicts in view resolution (usually related to duplicate IDs) */
+  cacheConflictLogLevel: Severity;
+}
+
+export const DefaultFlags: PlayerFlags = {
+  duplicateIDLogLevel: "error",
+  cacheConflictLogLevel: "info",
+};
+
+export type Flag = keyof PlayerFlags;

--- a/core/player/src/controllers/index.ts
+++ b/core/player/src/controllers/index.ts
@@ -3,3 +3,4 @@ export * from "./validation";
 export * from "./view";
 export * from "./data/controller";
 export * from "./constants";
+export * from "./flags";

--- a/core/player/src/controllers/view/controller.ts
+++ b/core/player/src/controllers/view/controller.ts
@@ -12,6 +12,7 @@ import type { DataController } from "../data/controller";
 import { AssetTransformCorePlugin } from "./asset-transform";
 import type { TransformRegistry } from "./types";
 import type { BindingInstance } from "../../binding";
+import { FlagController } from "../flags";
 
 export interface ViewControllerOptions {
   /** Where to get data from */
@@ -22,11 +23,22 @@ export interface ViewControllerOptions {
 
   /** A flow-controller instance to listen for view changes */
   flowController: FlowController;
+
+  /** A FlagController instance to  */
+  flagController: FlagController;
 }
 
 /** A controller to manage updating/switching views */
 export class ViewController {
-  public readonly hooks = {
+  public readonly hooks: {
+    /** Do any processing before the `View` instance is created */
+    resolveView: SyncWaterfallHook<
+      [View | undefined, string, NavigationFlowViewState],
+      Record<string, any>
+    >;
+    // The hook right before the View starts resolving. Attach anything custom here
+    view: SyncHook<[ViewInstance], Record<string, any>>;
+  } = {
     /** Do any processing before the `View` instance is created */
     resolveView: new SyncWaterfallHook<
       [View | undefined, string, NavigationFlowViewState]
@@ -156,7 +168,7 @@ export class ViewController {
     }
   }
 
-  public onView(state: NavigationFlowViewState) {
+  public onView(state: NavigationFlowViewState): void {
     const viewId = state.ref;
 
     const source = this.hooks.resolveView.call(

--- a/core/player/src/view/resolver/__tests__/edgecases.test.ts
+++ b/core/player/src/view/resolver/__tests__/edgecases.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect, vitest } from "vitest";
+import { describe, it, expect, vitest, MockedFunction } from "vitest";
 import { replaceAt, set, omit } from "timm";
 import { BindingParser } from "../../../binding";
 import { ExpressionEvaluator } from "../../../expressions";
 import { LocalModel, withParser } from "../../../data";
 import { SchemaController } from "../../../schema";
-import type { Logger } from "../../../logger";
+import type { Logger, LogFn } from "../../../logger";
 import { TapableLogger } from "../../../logger";
 import { Resolver } from "..";
 import type { Node } from "../../parser";
@@ -14,6 +14,7 @@ import {
   MultiNodePlugin,
   AssetPlugin,
 } from "../../plugins";
+import { FlagController } from "../../../controllers";
 
 describe("Dynamic AST Transforms", () => {
   const content = {
@@ -58,6 +59,7 @@ describe("Dynamic AST Transforms", () => {
         model: withParser(model, bindingParser.parse),
       }),
       schema: new SchemaController(),
+      flagController: new FlagController(),
     });
 
     // basic transform to change the asset
@@ -168,6 +170,7 @@ describe("Dynamic AST Transforms", () => {
         model: withParser(model, bindingParser.parse),
       }),
       schema: new SchemaController(),
+      flagController: new FlagController(),
     });
 
     resolver.update();
@@ -237,6 +240,7 @@ describe("Dynamic AST Transforms", () => {
         model: withParser(model, bindingParser.parse),
       }),
       schema: new SchemaController(),
+      flagController: new FlagController(),
     });
 
     let inputNode: Node.Node | undefined;
@@ -290,6 +294,7 @@ describe("Dynamic AST Transforms", () => {
         model: withParser(model, bindingParser.parse),
       }),
       schema: new SchemaController(),
+      flagController: new FlagController(),
     });
 
     let parent;
@@ -387,6 +392,7 @@ describe("Duplicate IDs", () => {
       }),
       schema: new SchemaController(),
       logger,
+      flagController: new FlagController(),
     });
 
     new StringResolverPlugin().applyResolver(resolver);
@@ -397,7 +403,7 @@ describe("Duplicate IDs", () => {
     expect(testLogger.error).toBeCalledWith(
       "Cache conflict: Found Asset/View nodes that have conflicting ids: action-1, may cause cache issues.",
     );
-    (testLogger.error as jest.Mock).mockClear();
+    (testLogger.error as MockedFunction<LogFn>).mockClear();
 
     expect(firstUpdate).toStrictEqual({
       id: "action",
@@ -484,6 +490,7 @@ describe("Duplicate IDs", () => {
       }),
       schema: new SchemaController(),
       logger,
+      flagController: new FlagController(),
     });
 
     new StringResolverPlugin().applyResolver(resolver);
@@ -494,7 +501,7 @@ describe("Duplicate IDs", () => {
     expect(testLogger.info).toBeCalledWith(
       "Cache conflict: Found Value nodes that have conflicting ids: value-1, may cause cache issues. To improve performance make value node IDs globally unique.",
     );
-    (testLogger.info as jest.Mock).mockClear();
+    (testLogger.info as MockedFunction<LogFn>).mockClear();
     expect(firstUpdate).toStrictEqual(content);
 
     resolver.update();
@@ -535,6 +542,7 @@ describe("AST caching", () => {
         model: withParser(model, bindingParser.parse),
       }),
       schema: new SchemaController(),
+      flagController: new FlagController(),
     });
 
     const resolvedNodes: any[] = [];
@@ -602,6 +610,7 @@ describe("Root AST Immutability", () => {
         model: withParser(model, bindingParser.parse),
       }),
       schema: new SchemaController(),
+      flagController: new FlagController(),
     });
     let finalNode;
 

--- a/core/player/src/view/resolver/index.ts
+++ b/core/player/src/view/resolver/index.ts
@@ -9,12 +9,13 @@ import type {
   Updates,
 } from "../../data";
 import { DependencyModel, withParser } from "../../data";
-import type { Logger } from "../../logger";
+import type { Logger, Severity } from "../../logger";
 import type { Node } from "../parser";
 import { NodeType } from "../parser";
 import { caresAboutDataChanges, toNodeResolveOptions } from "./utils";
 import type { Resolve } from "./types";
 import { getNodeID } from "../parser/utils";
+import { FlagController } from "../../controllers";
 
 export * from "./types";
 export * from "./utils";
@@ -58,7 +59,51 @@ const withContext = (model: DataModelWithParser): DataModelWithParser => {
  * It combines the ability to mutate ast nodes before resolving, as well as the mutating the resolved objects while parsing
  */
 export class Resolver {
-  public readonly hooks = {
+  public readonly hooks: {
+    /** A hook to allow skipping of the resolution tree for a specific node */
+    skipResolve: SyncWaterfallHook<
+      [boolean, Node.Node, Resolve.NodeResolveOptions],
+      Record<string, any>
+    >;
+    /** An event emitted before calculating the next update */
+    beforeUpdate: SyncHook<
+      [Set<BindingInstance> | undefined],
+      Record<string, any>
+    >;
+    /** An event emitted after calculating the next update */
+    afterUpdate: SyncHook<[any], Record<string, any>>;
+    /** The options passed to a node to resolve it to an object */
+    resolveOptions: SyncWaterfallHook<
+      [Resolve.NodeResolveOptions, Node.Node],
+      Record<string, any>
+    >;
+    /** A hook to transform the AST node into a new AST node before resolving it */
+    beforeResolve: SyncWaterfallHook<
+      [Node.Node | null, Resolve.NodeResolveOptions],
+      Record<string, any>
+    >;
+    /**
+     * A hook to transform an AST node into it's resolved value.
+     * This runs _before_ any children are resolved
+     */
+    resolve: SyncWaterfallHook<
+      [any, Node.Node, Resolve.NodeResolveOptions],
+      Record<string, any>
+    >;
+    /**
+     * A hook to transform the resolved value of an AST node.
+     * This runs _after_ all children nodes are resolved
+     */
+    afterResolve: SyncWaterfallHook<
+      [any, Node.Node, Resolve.NodeResolveOptions],
+      Record<string, any>
+    >;
+    /** Called at the very end of a node's tree being updated */
+    afterNodeUpdate: SyncHook<
+      [Node.Node, Node.Node | undefined, NodeUpdate],
+      Record<string, any>
+    >;
+  } = {
     /** A hook to allow skipping of the resolution tree for a specific node */
     skipResolve: new SyncWaterfallHook<
       [boolean, Node.Node, Resolve.NodeResolveOptions]
@@ -141,7 +186,7 @@ export class Resolver {
     this.idCache = new Set();
   }
 
-  public getSourceNode(convertedAST: Node.Node) {
+  public getSourceNode(convertedAST: Node.Node): Node.Node | undefined {
     return this.ASTMap.get(convertedAST);
   }
 
@@ -167,8 +212,26 @@ export class Resolver {
     return updated.value;
   }
 
-  public getResolveCache() {
+  public getResolveCache(): Map<Node.Node, Resolve.ResolvedNode> {
     return new Map(this.resolveCache);
+  }
+
+  /** Use flags to determine how to log the message */
+  private logCacheIssue(id: string, type: NodeType): void {
+    let message: string | undefined;
+    let loglevel: Severity | undefined;
+
+    if (type === NodeType.Asset || type === NodeType.View) {
+      loglevel = this.options.flagController.getFlag("duplicateIDLogLevel");
+      message = `Cache conflict: Found Asset/View nodes that have conflicting ids: ${id}, may cause cache issues.`;
+    } else if (type === NodeType.Value) {
+      loglevel = this.options.flagController.getFlag("cacheConflictLogLevel");
+      message = `Cache conflict: Found Value nodes that have conflicting ids: ${id}, may cause cache issues. To improve performance make value node IDs globally unique.`;
+    }
+
+    if (message && loglevel) {
+      this.logger?.[loglevel]?.(message);
+    }
   }
 
   private getPreviousResult(node: Node.Node): Resolve.ResolvedNode | undefined {
@@ -184,15 +247,7 @@ export class Resolver {
         // Only log this conflict once to cut down on noise
         // May want to swap this to logging when we first see the id -- which may not be the first render
         if (isFirstUpdate) {
-          if (node.type === NodeType.Asset || node.type === NodeType.View) {
-            this.logger?.error(
-              `Cache conflict: Found Asset/View nodes that have conflicting ids: ${id}, may cause cache issues.`,
-            );
-          } else if (node.type === NodeType.Value) {
-            this.logger?.info(
-              `Cache conflict: Found Value nodes that have conflicting ids: ${id}, may cause cache issues. To improve performance make value node IDs globally unique.`,
-            );
-          }
+          this.logCacheIssue(id, node.type);
         }
 
         // Don't use anything from a prev result if there's a duplicate id detected

--- a/core/player/src/view/resolver/types.ts
+++ b/core/player/src/view/resolver/types.ts
@@ -14,7 +14,7 @@ import type {
   DataModelOptions,
 } from "../../data";
 import type { ConstantsProvider } from "../../controllers/constants";
-import type { TransitionFunction } from "../../controllers";
+import type { FlagController, TransitionFunction } from "../../controllers";
 import type { ExpressionEvaluator, ExpressionType } from "../../expressions";
 import type { ValidationResponse } from "../../validator";
 import type { Logger } from "../../logger";
@@ -97,6 +97,9 @@ export declare namespace Resolve {
   export interface BaseOptions {
     /** A logger to use */
     logger?: Logger;
+
+    /** Used for getting runtime configuration */
+    flagController: FlagController;
 
     /** Utils for various useful operations */
     utils?: PlayerUtils;

--- a/core/player/src/view/view.ts
+++ b/core/player/src/view/view.ts
@@ -74,7 +74,13 @@ class CrossfieldProvider implements ValidationProvider {
 
 /** A stateful view instance from an content */
 export class ViewInstance implements ValidationProvider {
-  public hooks = {
+  public hooks: {
+    onUpdate: SyncHook<[ViewType], Record<string, any>>;
+    parser: SyncHook<[Parser], Record<string, any>>;
+    resolver: SyncHook<[Resolver], Record<string, any>>;
+    onTemplatePluginCreated: SyncHook<[TemplatePlugin], Record<string, any>>;
+    templatePlugin: SyncHook<[TemplatePlugin], Record<string, any>>;
+  } = {
     onUpdate: new SyncHook<[ViewType]>(),
     parser: new SyncHook<[Parser]>(),
     resolver: new SyncHook<[Resolver]>(),
@@ -102,13 +108,13 @@ export class ViewInstance implements ValidationProvider {
     });
   }
 
-  public updateAsync() {
+  public updateAsync(): void {
     const update = this.resolver?.update();
     this.lastUpdate = update;
     this.hooks.onUpdate.call(update);
   }
 
-  public update(changes?: Set<BindingInstance>) {
+  public update(changes?: Set<BindingInstance>): any {
     if (this.rootNode === undefined) {
       /** On initialization of the view, also create a validation parser */
       this.validationProvider = new CrossfieldProvider(
@@ -148,7 +154,9 @@ export class ViewInstance implements ValidationProvider {
     return update;
   }
 
-  getValidationsForBinding(binding: BindingInstance) {
+  getValidationsForBinding(
+    binding: BindingInstance,
+  ): ValidationObject[] | undefined {
     return this.validationProvider?.getValidationsForBinding(binding);
   }
 }


### PR DESCRIPTION
# Background

Player strives to be as configurable as possible and primarily achieves this through it's plugin architecture. While this does allow almost any aspect of Player's behavior to be configured, there are still some parts of Player's internal working that users of Player don't have access to. These are things like how strict Player is while running and how it should recover from state errors. For the most part the Player team has made assumptions on how users of Player would want Player to work but in pursuit of fulfilling Player's goal of customizability and configurability we should allow this behavior to be customizable. 


# Implementation Details 
[WIP]

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [x] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

## Release Notes
Add the ability to statically/dynamically configure Player's runtime behavior via "flags". Flags are held in a `FlagController` class that can either get flag configuration via Player's initial configuration, dynamically at runtime via a function to set new flags, or even more dynamically by tapping a hook on the controller to override the value of any specific flag(s). 