### PR TITLE
Update  to explicitly call out the default value for dataPath

### DIFF
--- a/docs/site/src/content/docs/plugins/multiplatform/shared-constants.mdx
+++ b/docs/site/src/content/docs/plugins/multiplatform/shared-constants.mdx
@@ -23,7 +23,7 @@ const constantsPlugin = new ConstantsPlugin({
     prop2: "B",
   },
   namespace: "constants",
-  dataPath: "data.constants",
+  dataPath: "data.props",
 });
 
 const player = new Player({
@@ -42,8 +42,21 @@ constantsPlugin.getConstants("prop1"); // 'A'
 
 ### Overriding Values in Content
 
-The `dataPath` configuration option enables content to override specific values for a particular flow:
+The `dataPath` configuration option allows content to override specific values for a particular flow:
 
+```json
+{
+  "data": {
+    "props": {
+      "prop1": "B"
+    }
+  }
+}
+```
+
+using a similar query for `prop1`, the value in the content takes precidence and would return `B`.
+
+If no `dataPath` is defined, then it defaults to `constants` and you can still do this
 ```json
 {
   "data": {
@@ -53,8 +66,6 @@ The `dataPath` configuration option enables content to override specific values 
   }
 }
 ```
-
-using a similar query for `prop1`, the value in the content takes precidence and would return `B`.
 
 ### Fallback Values
 

--- a/docs/site/src/content/docs/plugins/multiplatform/shared-constants.mdx
+++ b/docs/site/src/content/docs/plugins/multiplatform/shared-constants.mdx
@@ -42,7 +42,7 @@ constantsPlugin.getConstants("prop1"); // 'A'
 
 ### Overriding Values in Content
 
-The `dataPath` configuration option allows content to override specific values for a particular flow:
+By default, data can be provided in the `constants` path of the `data` object to override the constants that the plugin was initialized with. This can be overridden though via the `dataPath` configuration option. In the above example, `dataPath` was initialized with the path `data.props` therefore the following code snippet could be used to override the `prop1` constant:
 
 ```json
 {


### PR DESCRIPTION
The docs used the word "enable" that made us think that if a `dataPath` isnt provided, the constants will not be overridable through content. However, looking at the [code](https://github.com/player-ui/player/blob/7e2c1a691ea8e0aae1f2c412d145dcb4749d7164/plugins/shared-constants/core/src/index.ts#L45) thats not true.



<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
- [x] `N/A`


### Does your PR have any documentation updates?
- [x] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->

## Release Notes

Updated docs for Shared Constants Plugin to highlight the default dataPath used for overriding values