### PR TITLE
[WIP] Update FlowManager in Managed Player state if a new one is passed in

### DIFF
--- a/react/player/src/manager/managed-player.tsx
+++ b/react/player/src/manager/managed-player.tsx
@@ -243,7 +243,7 @@ export const usePersistentStateMachine = (options: {
     return unsub;
   }, []);
 
-  return { managedState, state };
+  return { state, managedState };
 };
 
 /**
@@ -252,7 +252,9 @@ export const usePersistentStateMachine = (options: {
  *
  * `suspense` must be enabled to wait for results in flight.
  */
-export const ManagedPlayer = (props: ManagedPlayerProps) => {
+export const ManagedPlayer = (
+  props: ManagedPlayerProps,
+): React.ReactElement | null => {
   const { withRequestTime, RequestTimeMetricsPlugin } = useRequestTime();
 
   const { state, managedState } = usePersistentStateMachine({
@@ -283,6 +285,12 @@ export const ManagedPlayer = (props: ManagedPlayerProps) => {
       }
     };
   }, [props.manager, state?.context.reactPlayer.player, state?.value]);
+
+  React.useEffect(() => {
+    if (managedState.state) {
+      managedState.state.context.manager = props.manager;
+    }
+  }, [props.manager]);
 
   if (state?.value === "error") {
     if (props.fallbackComponent) {


### PR DESCRIPTION
If a new `FlowManager` instance is passed in while a `MangedPlayer` instance is running, when managed player transitions it will be using the old flow manager instance.  

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

## Release Notes
TBD