### PR TITLE
Expose onStart player hook for Android

### DIFF
--- a/jvm/core/src/main/kotlin/com/intuit/playerui/core/player/Player.kt
+++ b/jvm/core/src/main/kotlin/com/intuit/playerui/core/player/Player.kt
@@ -10,6 +10,7 @@ import com.intuit.playerui.core.constants.ConstantsController
 import com.intuit.playerui.core.data.DataController
 import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
 import com.intuit.playerui.core.expressions.ExpressionController
+import com.intuit.playerui.core.flow.Flow
 import com.intuit.playerui.core.flow.FlowController
 import com.intuit.playerui.core.flow.FlowResult
 import com.intuit.playerui.core.logger.TapableLogger
@@ -60,10 +61,14 @@ public abstract class Player : Pluggable {
         /** The hook that creates and manages data */
         public val dataController: NodeSyncHook1<DataController>
 
+        /** Manages validations (schema and x-field ) */
         public val validationController: NodeSyncHook1<ValidationController>
 
         /** A that's called for state changes in the flow execution */
         public val state: NodeSyncHook1<out PlayerFlowState>
+
+        /** A hook to access the current flow */
+        public val onStart: NodeSyncHook1<Flow>
 
         public companion object {
             internal interface HooksByNode : Hooks, NodeWrapper
@@ -77,6 +82,7 @@ public abstract class Player : Pluggable {
                 override val dataController: NodeSyncHook1<DataController> by NodeSerializableField(NodeSyncHook1.serializer(DataController.serializer()))
                 override val validationController: NodeSyncHook1<ValidationController> by NodeSerializableField(NodeSyncHook1.serializer(ValidationController.serializer()))
                 override val state: NodeSyncHook1<out PlayerFlowState> by NodeSerializableField(NodeSyncHook1.serializer(PlayerFlowState.serializer()))
+                override val onStart: NodeSyncHook1<Flow> by NodeSerializableField(NodeSyncHook1.serializer(Flow.serializer()))
             }
 
             internal object Serializer : KSerializer<Hooks> by NodeWrapperSerializer(Hooks::invoke) as KSerializer<Hooks>

--- a/jvm/core/src/test/kotlin/com/intuit/playerui/core/player/PlayerHooksTest.kt
+++ b/jvm/core/src/test/kotlin/com/intuit/playerui/core/player/PlayerHooksTest.kt
@@ -3,6 +3,7 @@ package com.intuit.playerui.core.player
 import com.intuit.playerui.core.NodeBaseTest
 import com.intuit.playerui.core.bridge.hooks.NodeSyncHook1
 import com.intuit.playerui.core.data.DataController
+import com.intuit.playerui.core.flow.Flow
 import com.intuit.playerui.core.flow.FlowController
 import com.intuit.playerui.core.player.state.PlayerFlowState
 import com.intuit.playerui.core.view.ViewController
@@ -25,6 +26,9 @@ internal class PlayerHooksTest : NodeBaseTest() {
     @MockK
     private lateinit var state: NodeSyncHook1<PlayerFlowState>
 
+    @MockK
+    private lateinit var onStart: NodeSyncHook1<Flow>
+
     private val hooks by lazy {
         Player.Hooks(node)
     }
@@ -36,6 +40,7 @@ internal class PlayerHooksTest : NodeBaseTest() {
         every { node.getSerializable<NodeSyncHook1<ViewController>>("viewController", any()) } returns vc
         every { node.getSerializable<NodeSyncHook1<DataController>>("dataController", any()) } returns dc
         every { node.getSerializable<NodeSyncHook1<PlayerFlowState>>("state", any()) } returns state
+        every { node.getSerializable<NodeSyncHook1<Flow>>("onStart", any()) } returns onStart
         every { node.nativeReferenceEquals(any()) } returns true
     }
 
@@ -60,5 +65,10 @@ internal class PlayerHooksTest : NodeBaseTest() {
     @Test
     fun state() {
         assertNotNull(hooks.state)
+    }
+
+    @Test
+    fun onStart() {
+        assertNotNull(hooks.onStart)
     }
 }


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->


### Change Type (required)
Expose onStart player hook for Android.

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [x] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->