### PR TITLE
Making Node.snapshot `public`

### DIFF
--- a/jvm/core/src/main/kotlin/com/intuit/playerui/core/bridge/Node.kt
+++ b/jvm/core/src/main/kotlin/com/intuit/playerui/core/bridge/Node.kt
@@ -165,7 +165,7 @@ public fun Node.getSymbol(key: String): String? {
 
 /** Decode a [Node] entirely as a snapshot of its current data. Will allow for additional data access after a [Node]s runtime has been released */
 @ExperimentalPlayerApi
-internal fun Node.snapshot(): Map<String, Any?> = entries.associate { (key, value) ->
+public fun Node.snapshot(): Map<String, Any?> = entries.associate { (key, value) ->
     key to when (value) {
         is Node -> value.snapshot()
         is Function<*> -> null


### PR DESCRIPTION
This PR marks `Node.snapshot` as `public`. Since it was already displayed marked as an experimental API, I decided not to add any docs around it as I am not sure if its intended to be advertised.  

<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->

## Release Notes
Making `Node.Snapshot`  public. This utility can be used to decode a `Node` entirely as a snapshot of its current data.
