### PR TITLE
Expose metrics plugin hooks android

### DIFF
--- a/jvm/core/src/main/kotlin/com/intuit/playerui/core/bridge/hooks/NodeSyncHook.kt
+++ b/jvm/core/src/main/kotlin/com/intuit/playerui/core/bridge/hooks/NodeSyncHook.kt
@@ -52,3 +52,29 @@ public class NodeSyncHook2<T1, T2>(override val node: Node, private val serializ
         NodeSyncHook2(it, serializer1, serializer2)
     })
 }
+
+@Serializable(with = NodeSyncHook3.Serializer::class)
+public class NodeSyncHook3<T1, T2, T3>(override val node: Node, private val serializer1: KSerializer<T1>, private val serializer2: KSerializer<T2>, private val serializer3: KSerializer<T3>) : SyncHook<(HookContext, T1?, T2?, T3?) -> Unit>(), NodeHook<Unit> {
+
+    init { init(serializer1, serializer2, serializer3) }
+    override fun call(context: HookContext, serializedArgs: Array<Any?>) {
+        require(serializedArgs.size == 3)
+        val (p1, p2, p3) = serializedArgs
+        call { f, _ ->
+            f(
+                context,
+                p1 as? T1,
+                p2 as? T2,
+                p3 as? T3,
+            )
+        }
+    }
+    public fun tap(name: String, callback: (T1?, T2?, T3?) -> Unit): String? = super.tap(name) { _, p1, p2, p3 -> callback(p1, p2, p3) }
+    public inline fun tap(noinline callback: (T1?, T2?, T3?) -> Unit): String? = tap(callingStackTraceElement.toString(), callback)
+
+    public inline fun tap(noinline callback: (HookContext, T1?, T2?, T3?) -> Unit): String? = tap(callingStackTraceElement.toString(), callback)
+
+    internal class Serializer<T1, T2, T3>(private val serializer1: KSerializer<T1>, private val serializer2: KSerializer<T2>, private val serializer3: KSerializer<T3>) : NodeWrapperSerializer<NodeSyncHook3<T1, T2, T3>>({
+        NodeSyncHook3(it, serializer1, serializer2, serializer3)
+    })
+}

--- a/plugins/metrics/jvm/src/main/kotlin/com/intuit/playerui/plugins/metrics/Metrics.kt
+++ b/plugins/metrics/jvm/src/main/kotlin/com/intuit/playerui/plugins/metrics/Metrics.kt
@@ -8,6 +8,7 @@ import com.intuit.playerui.core.bridge.serialization.serializers.PolymorphicNode
 import com.intuit.playerui.core.player.PlayerException
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.nullable
 import kotlinx.serialization.builtins.serializer
 
@@ -59,6 +60,9 @@ public sealed class NodeMetrics(override val node: Node) : Timing(node) {
 public class RenderMetrics(override val node: Node) : NodeMetrics(node) {
     /** Timing representing the initial render */
     public val render: Timing by NodeSerializableField(Timing.serializer())
+
+    /** An array of timings representing updates to the view */
+    public val updates: List<Timing> by NodeSerializableField(ListSerializer(Timing.serializer()))
 
     internal object Serializer : NodeWrapperSerializer<RenderMetrics>(::RenderMetrics)
 }

--- a/plugins/metrics/jvm/src/main/kotlin/com/intuit/playerui/plugins/metrics/MetricsPlugin.kt
+++ b/plugins/metrics/jvm/src/main/kotlin/com/intuit/playerui/plugins/metrics/MetricsPlugin.kt
@@ -1,20 +1,30 @@
 package com.intuit.playerui.plugins.metrics
 
 import com.intuit.playerui.core.bridge.Node
+import com.intuit.playerui.core.bridge.NodeWrapper
 import com.intuit.playerui.core.bridge.getInvokable
+import com.intuit.playerui.core.bridge.hooks.NodeSyncHook1
+import com.intuit.playerui.core.bridge.hooks.NodeSyncHook3
 import com.intuit.playerui.core.bridge.runtime.Runtime
 import com.intuit.playerui.core.bridge.runtime.ScriptContext
 import com.intuit.playerui.core.bridge.runtime.add
+import com.intuit.playerui.core.bridge.serialization.serializers.NodeSerializableField
+import com.intuit.playerui.core.bridge.serialization.serializers.NodeWrapperSerializer
 import com.intuit.playerui.core.player.Player
+import com.intuit.playerui.core.player.PlayerException
 import com.intuit.playerui.core.plugins.JSScriptPluginWrapper
 import com.intuit.playerui.core.plugins.PlayerPlugin
 import com.intuit.playerui.core.plugins.findPlugin
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.serializer
 
 public typealias RenderEndHandler = (Timing?, RenderMetrics?, PlayerFlowMetrics?) -> Unit
 
 public class MetricsPlugin(
     private val handler: RenderEndHandler,
 ) : JSScriptPluginWrapper(pluginName, sourcePath = bundledSourcePath) {
+
+    public lateinit var hooks: Hooks
 
     override fun apply(runtime: Runtime<*>) {
         runtime.load(ScriptContext(script, bundledSourcePath))
@@ -32,6 +42,22 @@ public class MetricsPlugin(
             ),
         )
         instance = runtime.buildInstance("(new $name(handlers))")
+        hooks = instance.getSerializable("hooks", Hooks.serializer())
+            ?: throw PlayerException("MetricsPlugin is not loaded correctly")
+    }
+
+    @Serializable(Hooks.Serializer::class)
+    public class Hooks internal constructor(override val node: Node) : NodeWrapper {
+        public val onFlowBegin: NodeSyncHook1<PlayerFlowMetrics>
+            by NodeSerializableField(NodeSyncHook1.serializer(PlayerFlowMetrics.serializer()))
+
+        public val onFlowEnd: NodeSyncHook1<PlayerFlowMetrics>
+            by NodeSerializableField(NodeSyncHook1.serializer(PlayerFlowMetrics.serializer()))
+
+        public val onRenderEnd: NodeSyncHook3<Timing, RenderMetrics, PlayerFlowMetrics>
+            by NodeSerializableField(NodeSyncHook3.serializer(Timing.serializer(), RenderMetrics.serializer(), PlayerFlowMetrics.serializer()))
+
+        internal object Serializer : NodeWrapperSerializer<Hooks>(::Hooks)
     }
 
     public fun renderEnd(): Unit = instance.getInvokable<Unit>("renderEnd")!!()


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->


### Change Type (required)
Expose onFlowBegin, onFlowEnd, onRenderEnd metrics plugin hooks for Android

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [x] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->