### PR TITLE
expose data change listener ondelete hook

### DIFF
--- a/plugins/data-change-listener/core/src/index.ts
+++ b/plugins/data-change-listener/core/src/index.ts
@@ -231,7 +231,7 @@ export class DataChangeListenerPlugin implements PlayerPlugin {
       });
     };
 
-    player.hooks.dataController.tap(this.name, (dc: DataController) =>
+    player.hooks.dataController.tap(this.name, (dc: DataController) => {
       dc.hooks.onUpdate.tap(this.name, (updates, options) => {
         const { silent = false } = options || {};
         if (silent) return;
@@ -241,8 +241,11 @@ export class DataChangeListenerPlugin implements PlayerPlugin {
             ?.getAll().length;
         });
         onFieldUpdateHandler(validUpdates.map((t) => t.binding));
-      }),
-    );
+      });
+      dc.hooks.onDelete.tap(this.name, (binding) => {
+        onFieldUpdateHandler([binding]);
+      });
+    });
 
     /**
      * Adding an interceptor instead of tapping to make intention clear.  This plugin is not going to change the resolution of a view


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->