### PR TITLE
iOS: expose metrics plugin hooks

### DIFF
--- a/ios/core/Sources/Types/Hooks/Hook.swift
+++ b/ios/core/Sources/Types/Hooks/Hook.swift
@@ -139,6 +139,37 @@ public class Hook2Decode<T, U>: BaseJSHook where T: Decodable, U: Decodable {
 
 /**
  This class represents an object in the JS runtime that can be tapped into
+ to receive JS events that has 3 parameters
+ */
+public class Hook3Decode<T, U, S>: BaseJSHook where T: Decodable, U: Decodable, S: Decodable {
+    /**
+     Attach a closure to the hook, so when the hook is fired in the JS runtime
+     we receive the event in the native runtime
+
+     - parameters:
+     - hook: A function to run when the JS hook is fired
+     */
+    public func tap(_ hook: @escaping (T, U, S) -> Void) {
+        let tapMethod: @convention(block) (JSValue?, JSValue?, JSValue?) -> Void = { value, value2, value3 in
+
+            let decoder = JSONDecoder()
+            guard
+                let val = value,
+                let val2 = value2,
+                let val3 = value3,
+                let hookValue = try? decoder.decode(T.self, from: val),
+                let hookValue2 = try? decoder.decode(U.self, from: val2),
+                let hookValue3 = try? decoder.decode(S.self, from: val3)
+            else { return }
+            hook(hookValue, hookValue2, hookValue3)
+        }
+
+        self.hook.invokeMethod("tap", withArguments: [name, JSValue(object: tapMethod, in: context) as Any])
+    }
+}
+
+/**
+ This class represents an object in the JS runtime that can be tapped into
  and returns a promise that resolves when the asynchronous task is completed
  */
 public class AsyncHook<T>: BaseJSHook where T: CreatedFromJSValue {
@@ -220,4 +251,3 @@ public class AsyncHook2<T, U>: BaseJSHook where T: CreatedFromJSValue, U: Create
         self.hook.invokeMethod("tap", withArguments: [name, JSValue(object: tapMethod, in: context) as Any])
     }
 }
-


### PR DESCRIPTION
Expose the following hooks for iOS Metrics plugin:
onRenderEnd
onFlowBegin
onFlowEnd

Add Hook3Decode to support onRenderEnd which recieves 3 parameters from the js hook

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->