### PR TITLE
Expose FlowInstance afterTransition hook for jvm

### DIFF
--- a/jvm/core/src/main/kotlin/com/intuit/playerui/core/flow/FlowInstance.kt
+++ b/jvm/core/src/main/kotlin/com/intuit/playerui/core/flow/FlowInstance.kt
@@ -57,6 +57,9 @@ public class FlowInstance(override val node: Node) : NodeWrapper, Transition {
         public val transition: NodeSyncHook2<NamedState?, NamedState>
             by NodeSerializableField(NodeSyncHook2.serializer(NamedState.serializer().nullable, NamedState.serializer()))
 
+        public val afterTransition: NodeSyncHook1<FlowInstance>
+            by NodeSerializableField(NodeSyncHook1.serializer(FlowInstance.serializer()))
+
         internal object Serializer : NodeWrapperSerializer<Hooks>(::Hooks)
     }
 

--- a/jvm/core/src/test/kotlin/com/intuit/playerui/core/flow/FlowControllerIntegrationTest.kt
+++ b/jvm/core/src/test/kotlin/com/intuit/playerui/core/flow/FlowControllerIntegrationTest.kt
@@ -7,6 +7,7 @@ import com.intuit.playerui.utils.test.PlayerTest
 import com.intuit.playerui.utils.test.runBlockingTest
 import com.intuit.playerui.utils.test.simpleFlowString
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.TestTemplate
 
@@ -16,6 +17,7 @@ internal class FlowControllerIntegrationTest : PlayerTest() {
     fun `test flow controller`() {
         var pendingTransition: Pair<NamedState?, String?>? = null
         var completedTransition: Pair<NamedState?, NamedState?>? = null
+        var flowInstanceAfterTransition: FlowInstance? = null
 
         player.hooks.flowController.tap { flowController ->
             flowController?.hooks?.flow?.tap { flow ->
@@ -30,6 +32,11 @@ internal class FlowControllerIntegrationTest : PlayerTest() {
                     // do code cov w/ from, to, & pendingTransaction.second
                     if (pendingTransition?.first?.name != from?.name) pendingTransition = null
                     completedTransition = from to to
+                }
+
+                flow?.hooks?.afterTransition?.tap { flowInstance ->
+                    player.logger.info("completed transition $flowInstance")
+                    flowInstanceAfterTransition = flowInstance
                 }
             }
         }
@@ -47,6 +54,7 @@ internal class FlowControllerIntegrationTest : PlayerTest() {
         assertEquals("*", pendingTransition?.second)
         assertEquals("VIEW_1", completedTransition?.first?.name)
         assertEquals("END_Done", completedTransition?.second?.name)
+        assertNotNull(flowInstanceAfterTransition)
     }
 
     @TestTemplate


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->


### Change Type (required)

Expose FlowInstance afterTransition hook for jvm

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [x] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->