### PR TITLE
enable blocking logs by default

### DIFF
--- a/jvm/core/src/main/kotlin/com/intuit/playerui/core/player/HeadlessPlayer.kt
+++ b/jvm/core/src/main/kotlin/com/intuit/playerui/core/player/HeadlessPlayer.kt
@@ -130,17 +130,15 @@ public constructor(
 
         // we only have access to the logger after we have the player instance
         logger.info("Player created using $runtime")
-        if (runtime.config.debuggable) {
-            runtime.checkBlockingThread = {
-                if (name == "main") {
-                    scope.launch {
-                        logger.warn(
-                            "Main thread is blocking on JS runtime access: $this",
-                            stackTrace.joinToString("\n") {
-                                "\tat $it"
-                            }.replaceFirst("\tat ", "\n"),
-                        )
-                    }
+        runtime.checkBlockingThread = {
+            if (name == "main") {
+                scope.launch {
+                    logger.warn(
+                        "Main thread is blocking on JS runtime access: $this",
+                        stackTrace.joinToString("\n") {
+                            "\tat $it"
+                        }.replaceFirst("\tat ", "\n"),
+                    )
                 }
             }
         }


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

Enable logs to identify main thread blocking operations, ensuring JS access in JVM is done exclusively off main thread


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.10.5--canary.613.21050</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.10.5--canary.613.21050
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
