### PR TITLE
Adding compose hydrationScope and wrapContent by default

### DIFF
--- a/android/demo/src/androidTest/java/com/intuit/playerui/android/reference/demo/test/assets/badge/BadgeUITest.kt
+++ b/android/demo/src/androidTest/java/com/intuit/playerui/android/reference/demo/test/assets/badge/BadgeUITest.kt
@@ -12,9 +12,9 @@ class BadgeUITest : ComposeUITest("badge") {
     fun basic() {
         launchMock("badge-all")
 
-        androidComposeRule.onNodeWithText("INFO")
+        androidComposeRule.onNodeWithText("INFO", useUnmergedTree = true)
             .assertExists()
-        androidComposeRule.onNodeWithText("ERROR")
+        androidComposeRule.onNodeWithText("ERROR", useUnmergedTree = true)
             .assertExists()
         player.shouldBeAtState<InProgressState>()
     }

--- a/android/player/src/main/java/com/intuit/playerui/android/asset/RenderableAsset.kt
+++ b/android/player/src/main/java/com/intuit/playerui/android/asset/RenderableAsset.kt
@@ -126,6 +126,7 @@ public constructor(public val assetContext: AssetContext) : NodeWrapper {
             // implementation to throw [StaleViewException] to signify that the view is out of sync.
             // This can only be done from invalidateView, so we have a guarantee that the view has
             // already been removed from the cache.
+            // TODO: shows a warning of running on the JS thread
             !cachedAssetContext.asset.nativeReferenceEquals(asset) ->
                 try {
                     cachedView.also(::rehydrate)

--- a/android/player/src/main/java/com/intuit/playerui/android/ui/PlayerFragment.kt
+++ b/android/player/src/main/java/com/intuit/playerui/android/ui/PlayerFragment.kt
@@ -180,7 +180,7 @@ public abstract class PlayerFragment : Fragment(), ManagedPlayerState.Listener {
      */
     protected open fun handleAssetUpdate(asset: RenderableAsset?, animateTransition: Boolean) {
         renderingJob?.cancel("handling new update")
-        renderingJob = lifecycleScope.launch(Dispatchers.Default) {
+        renderingJob = lifecycleScope.launch(if (asset is SuspendableAsset<*>) Dispatchers.Default else Dispatchers.Main) {
             whenStarted { // TODO: This'll go away when we can call a suspend version of this
                 try {
                     renderIntoPlayerCanvas(asset, animateTransition)

--- a/android/player/src/main/java/com/intuit/playerui/android/ui/PlayerFragment.kt
+++ b/android/player/src/main/java/com/intuit/playerui/android/ui/PlayerFragment.kt
@@ -180,7 +180,7 @@ public abstract class PlayerFragment : Fragment(), ManagedPlayerState.Listener {
      */
     protected open fun handleAssetUpdate(asset: RenderableAsset?, animateTransition: Boolean) {
         renderingJob?.cancel("handling new update")
-        renderingJob = lifecycleScope.launch(if (asset is SuspendableAsset<*>) Dispatchers.Default else Dispatchers.Main) {
+        renderingJob = lifecycleScope.launch(Dispatchers.Default) {
             whenStarted { // TODO: This'll go away when we can call a suspend version of this
                 try {
                     renderIntoPlayerCanvas(asset, animateTransition)

--- a/plugins/reference-assets/android/src/main/java/com/intuit/playerui/android/reference/assets/action/Action.kt
+++ b/plugins/reference-assets/android/src/main/java/com/intuit/playerui/android/reference/assets/action/Action.kt
@@ -44,7 +44,7 @@ class Action(assetContext: AssetContext) : ComposableAsset<Action.Data>(assetCon
         val scope = rememberCoroutineScope()
         Button(
             onClick = {
-                composeHydrationScope?.launch { 
+                composeHydrationScope?.launch {
                     withContext(Dispatchers.Default) {
                         beacon("clicked", "button")
                         player.commitPendingTransaction()

--- a/plugins/reference-assets/android/src/main/java/com/intuit/playerui/android/reference/assets/action/Action.kt
+++ b/plugins/reference-assets/android/src/main/java/com/intuit/playerui/android/reference/assets/action/Action.kt
@@ -26,6 +26,9 @@ import kotlinx.serialization.Serializable
 
 class Action(assetContext: AssetContext) : ComposableAsset<Action.Data>(assetContext, Data.serializer()) {
 
+    /** Actions should be full width  on native*/
+    override fun wrapContent(): Boolean = false
+
     @Serializable
     data class Data(
         val label: RenderableAsset? = null,
@@ -41,10 +44,12 @@ class Action(assetContext: AssetContext) : ComposableAsset<Action.Data>(assetCon
         val scope = rememberCoroutineScope()
         Button(
             onClick = {
-                beacon("clicked", "button")
-                player.commitPendingTransaction()
-                scope.launch {
-                    data.run()
+                composeHydrationScope?.launch { 
+                    withContext(Dispatchers.Default) {
+                        beacon("clicked", "button")
+                        player.commitPendingTransaction()
+                        data.run()
+                    }
                 }
             },
             modifier = Modifier.fillMaxWidth().testTag("action"),


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->