### PR TITLE
move renderIntoPlayerCanvas onto the correct thread

### DIFF
--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -61,7 +61,7 @@ git_repository(
     build_file = "//third_party/rn:react_native.BUILD",
     patches = ["//patches:react_native.loosen_host_function_params.patch"],
     remote = "https://github.com/facebook/react-native",
-    commit = "31f9d45074f069151c155836335e0edff87f70bd"
+    commit = "1299ef7be0fe9daf8274b7b2a7c49078723fc533"
 )
 
 http_archive(

--- a/android/player/src/main/java/com/intuit/playerui/android/ui/PlayerFragment.kt
+++ b/android/player/src/main/java/com/intuit/playerui/android/ui/PlayerFragment.kt
@@ -180,14 +180,16 @@ public abstract class PlayerFragment : Fragment(), ManagedPlayerState.Listener {
      */
     protected open fun handleAssetUpdate(asset: RenderableAsset?, animateTransition: Boolean) {
         renderingJob?.cancel("handling new update")
-        renderingJob = lifecycleScope.launch(if (asset is SuspendableAsset<*>) Dispatchers.Default else Dispatchers.Main) {
+        renderingJob = lifecycleScope.launch {
             whenStarted { // TODO: This'll go away when we can call a suspend version of this
-                try {
-                    renderIntoPlayerCanvas(asset, animateTransition)
-                } catch (exception: Exception) {
-                    if (exception is CancellationException) throw exception
-                    exception.printStackTrace()
-                    playerViewModel.fail("Error rendering asset", exception)
+                withContext(if (asset is SuspendableAsset<*>) Dispatchers.Default else Dispatchers.Main) {
+                    try {
+                        renderIntoPlayerCanvas(asset, animateTransition)
+                    } catch (exception: Exception) {
+                        if (exception is CancellationException) throw exception
+                        exception.printStackTrace()
+                        playerViewModel.fail("Error rendering asset", exception)
+                    }
                 }
             }
         }

--- a/jvm/hermes/src/main/kotlin/com/intuit/playerui/hermes/extensions/Lock.kt
+++ b/jvm/hermes/src/main/kotlin/com/intuit/playerui/hermes/extensions/Lock.kt
@@ -63,6 +63,7 @@ internal fun <T> Runtime<*>.evaluateInJSThreadBlocking(
         block(currentRuntimeThreadContext)
     } else {
         try {
+            runtime.checkBlockingThread(Thread.currentThread())
             runBlocking {
                 evaluateInJSThread { block() }
             }


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

`whenStarted` was automatically swapping to main dispatcher, this PR shifts the work to the dispatcher it was originally intended to run on


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->