### PR TITLE
Fully disable cache for forked builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -27,32 +27,14 @@ common --experimental_google_legacy_api
 build --noincremental_dexing --fat_apk_cpu=armeabi-v7a,arm64-v8a,x86,x86_64
 mobile-install --start=warm
 
-build --bes_results_url=https://app.buildbuddy.io/invocation/
-build --bes_backend=grpcs://remote.buildbuddy.io
-build --remote_cache=grpcs://remote.buildbuddy.io
-build --experimental_remote_cache_compression
-build --experimental_remote_cache_async
-build --remote_download_toplevel
-build --remote_timeout=3600
-build --build_metadata=REPO_URL=https://github.com/player-ui/player.git
-
-test --bes_results_url=https://app.buildbuddy.io/invocation/
-test --bes_backend=grpcs://remote.buildbuddy.io
-test --remote_cache=grpcs://remote.buildbuddy.io
-test --experimental_remote_cache_compression
-test --experimental_remote_cache_async
-test --remote_download_toplevel
-test --remote_timeout=3600
-test --build_metadata=REPO_URL=https://github.com/player-ui/player.git
-
-coverage --bes_results_url=https://app.buildbuddy.io/invocation/
-coverage --bes_backend=grpcs://remote.buildbuddy.io
-coverage --remote_cache=grpcs://remote.buildbuddy.io
-coverage --experimental_remote_cache_compression
-coverage --experimental_remote_cache_async
-coverage --remote_download_toplevel
-coverage --remote_timeout=3600
-coverage --build_metadata=REPO_URL=https://github.com/player-ui/player.git
+common --bes_results_url=https://app.buildbuddy.io/invocation/
+common --bes_backend=grpcs://remote.buildbuddy.io
+common --remote_cache=grpcs://remote.buildbuddy.io
+common --experimental_remote_cache_compression
+common --experimental_remote_cache_async
+common --remote_download_toplevel
+common --remote_timeout=3600
+common --build_metadata=REPO_URL=https://github.com/player-ui/player.git
 
 common:ci --build_metadata=ROLE=CI
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -27,14 +27,32 @@ common --experimental_google_legacy_api
 build --noincremental_dexing --fat_apk_cpu=armeabi-v7a,arm64-v8a,x86,x86_64
 mobile-install --start=warm
 
-common --bes_results_url=https://app.buildbuddy.io/invocation/
-common --bes_backend=grpcs://remote.buildbuddy.io
-common --remote_cache=grpcs://remote.buildbuddy.io
-common --experimental_remote_cache_compression
-common --experimental_remote_cache_async
-common --remote_download_toplevel
-common --remote_timeout=3600
-common --build_metadata=REPO_URL=https://github.com/player-ui/player.git
+build --bes_results_url=https://app.buildbuddy.io/invocation/
+build --bes_backend=grpcs://remote.buildbuddy.io
+build --remote_cache=grpcs://remote.buildbuddy.io
+build --experimental_remote_cache_compression
+build --experimental_remote_cache_async
+build --remote_download_toplevel
+build --remote_timeout=3600
+build --build_metadata=REPO_URL=https://github.com/player-ui/player.git
+
+test --bes_results_url=https://app.buildbuddy.io/invocation/
+test --bes_backend=grpcs://remote.buildbuddy.io
+test --remote_cache=grpcs://remote.buildbuddy.io
+test --experimental_remote_cache_compression
+test --experimental_remote_cache_async
+test --remote_download_toplevel
+test --remote_timeout=3600
+test --build_metadata=REPO_URL=https://github.com/player-ui/player.git
+
+coverage --bes_results_url=https://app.buildbuddy.io/invocation/
+coverage --bes_backend=grpcs://remote.buildbuddy.io
+coverage --remote_cache=grpcs://remote.buildbuddy.io
+coverage --experimental_remote_cache_compression
+coverage --experimental_remote_cache_async
+coverage --remote_download_toplevel
+coverage --remote_timeout=3600
+coverage --build_metadata=REPO_URL=https://github.com/player-ui/player.git
 
 common:ci --build_metadata=ROLE=CI
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,12 +273,6 @@ jobs:
             sudo mkdir /opt/bazelisk-v1.11.0 && \
             sudo mv bazelisk /opt/bazelisk-v1.11.0 && \
             sudo ln -s /opt/bazelisk-v1.11.0/bazelisk /usr/local/bin/bazel
-      
-      - run: |
-          echo "build --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >> .bazelrc.local
-          echo "test --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >> .bazelrc.local
-          echo "coverage --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >> .bazelrc.local
-          echo "common --remote_upload_local_results" >> .bazelrc.local
 
       - run:
           name: Install Android tools

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,19 @@ jobs:
           root: .
           paths:
             - .
+  bazelrc_fork:
+    executor: minimal
+    steps:
+      - attach_workspace:
+          at: ~/player
+      - run: |
+          echo "common --bes_results_url=''" >> .bazelrc.local
+          echo "common --bes_backend=''" >> .bazelrc.local
+          echo "common --remote_cache=''" >> .bazelrc.local
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
 
   build:
     executor: base
@@ -386,14 +399,11 @@ workflows:
           requires:
             - setup
 
-      - bazelrc:
-          name: bazelrc_fork
+      - bazelrc_fork:
           filters:
             branches:
               only:
                 - /pull\/.*/
-          context:
-            - BuildFork
           requires:
             - setup
 


### PR DESCRIPTION
Since passing secrets to forked builds is fully disabled, completely disable cache for those builds. 

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->