### PR TITLE
iOS Anytype make unknowndata equatable

### DIFF
--- a/ios/core/Sources/Types/Generic/AnyType.swift
+++ b/ios/core/Sources/Types/Generic/AnyType.swift
@@ -101,6 +101,7 @@ extension AnyType: Equatable {
         case (.booleanArray(let lhv), .booleanArray(let rhv)): return lhv == rhv
         case (.anyDictionary(let lhv), .anyDictionary(let rhv)): return (lhv as NSDictionary).isEqual(to: rhv)
         case (.anyArray(let lhv), .anyArray(let rhv)): return (lhv as NSArray).isEqual(to: rhv)
+        case (.unknownData, .unknownData): return true
         default: return false
         }
     }

--- a/ios/core/Tests/Types/Generic/AnyTypeTests.swift
+++ b/ios/core/Tests/Types/Generic/AnyTypeTests.swift
@@ -300,6 +300,7 @@ class AnyTypeTests: XCTestCase {
         XCTAssertEqual(AnyType.anyDictionary(data: ["key": false, "key2": 1]), AnyType.anyDictionary(data: ["key": false, "key2": 1]))
         XCTAssertEqual(AnyType.anyArray(data: [1, "a", true]), AnyType.anyArray(data: [1, "a", true]))
         XCTAssertNotEqual(AnyType.unknownData, AnyType.string(data: "test"))
+        XCTAssertEqual(AnyType.unknownData, AnyType.unknownData)
     }
 
     func testDecodingContext() throws {


### PR DESCRIPTION
reopening because last one had unsigned commits

Should be able to return true when asserting two unknown data AnyTypes 
fix for getting XCTAssertEqual failed: ("unknownData") is not equal to ("unknownData")

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->