### PR TITLE
update core async node plugins to catch and handle errors

### DIFF
--- a/docs/site/src/content/docs/plugins/multiplatform/async-node.mdx
+++ b/docs/site/src/content/docs/plugins/multiplatform/async-node.mdx
@@ -166,6 +166,22 @@ const player = new ReactPlayer({
   </Fragment>
   <Fragment slot='ios'>
 
+### Error Handling
+
+By default, errors happening during the `onAsyncNode` hook bubble up as player flow failures. These errors can come from the taps themselves, or from parsing the result of those taps within the core plugin. Use the `onAsyncNodeError` to catch these errors and handle them gracefully. Even if the error is handled, it will be logged by the player logger. The return on the hook will determine what gets rendered in the view. To render nothing, return `null`
+
+```js
+const asyncNodePlugin = new AsyncNodePlugin({
+  plugins: [new AsyncNodePluginPlugin()],
+});
+
+asyncNodePlugin.hooks.onAsyncNodeError.tap("handleAsyncError", (error, node) => {
+  // Do something to handle the error in the background
+
+  return null;
+});
+```
+
 ### CocoaPods
 
 Add the subspec to your `Podfile`

--- a/justfile
+++ b/justfile
@@ -45,7 +45,7 @@ alias maven-install := mvn-install
 
 [doc('Build and run the Android demo app in an emulator')]
 start-android-demo:
-  bazel mobile-install //android/demo:demo
+  bazel run //android/demo:install
 
 [doc('Generate and open the xcodeproj for Player')]
 dev-ios:

--- a/jvm/core/src/main/kotlin/com/intuit/playerui/core/bridge/hooks/NodeSyncBailHook2.kt
+++ b/jvm/core/src/main/kotlin/com/intuit/playerui/core/bridge/hooks/NodeSyncBailHook2.kt
@@ -31,8 +31,11 @@ public class NodeSyncBailHook2<T1, T2, R>(
 
     public inline fun tap(noinline callback: (HookContext, T1?, T2?) -> BailResult<R>): String? = tap(callingStackTraceElement.toString(), callback)
 
-    internal class Serializer<T1, T2, R>(private val serializer1: KSerializer<T1>, private val serializer2: KSerializer<T2>, private val
-    `_`: KSerializer<R>) : NodeWrapperSerializer<NodeSyncBailHook2<T1, T2, R>>({
+    internal class Serializer<T1, T2, R>(
+        private val serializer1: KSerializer<T1>,
+        private val serializer2: KSerializer<T2>,
+        private val `_`: KSerializer<R>,
+    ) : NodeWrapperSerializer<NodeSyncBailHook2<T1, T2, R>>({
         NodeSyncBailHook2(it, serializer1, serializer2)
     })
 }

--- a/jvm/core/src/main/kotlin/com/intuit/playerui/core/bridge/hooks/NodeSyncBailHook2.kt
+++ b/jvm/core/src/main/kotlin/com/intuit/playerui/core/bridge/hooks/NodeSyncBailHook2.kt
@@ -1,0 +1,38 @@
+package com.intuit.playerui.core.bridge.hooks
+
+import com.intuit.hooks.BailResult
+import com.intuit.hooks.HookContext
+import com.intuit.hooks.SyncBailHook
+import com.intuit.playerui.core.bridge.Node
+import com.intuit.playerui.core.bridge.serialization.serializers.NodeWrapperSerializer
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+
+@Serializable(with = NodeSyncBailHook2.Serializer::class)
+public class NodeSyncBailHook2<T1, T2, R>(
+    override val node: Node,
+    private val serializer1: KSerializer<T1>,
+    private val serializer2: KSerializer<T2>,
+) : SyncBailHook<(HookContext, T1, T2) -> BailResult<R>, R>(), NodeHook<R?> {
+
+    init { init(serializer1, serializer2) }
+
+    override fun call(context: HookContext, serializedArgs: Array<Any?>): R? {
+        require(serializedArgs.size == 2)
+        val (p1, p2) = serializedArgs
+        return call(
+            { f, t -> f(context, p1 as T1, p2 as T2) },
+        ) { Unit as R }
+    }
+
+    public fun tap(name: String, callback: (T1?, T2?) -> BailResult<R>): String? = super.tap(name) { _, p1, p2 -> callback(p1, p2) }
+
+    public inline fun tap(noinline callback: (T1?, T2?) -> BailResult<R>): String? = tap(callingStackTraceElement.toString(), callback)
+
+    public inline fun tap(noinline callback: (HookContext, T1?, T2?) -> BailResult<R>): String? = tap(callingStackTraceElement.toString(), callback)
+
+    internal class Serializer<T1, T2, R>(private val serializer1: KSerializer<T1>, private val serializer2: KSerializer<T2>, private val
+    `_`: KSerializer<R>) : NodeWrapperSerializer<NodeSyncBailHook2<T1, T2, R>>({
+        NodeSyncBailHook2(it, serializer1, serializer2)
+    })
+}

--- a/plugins/async-node/jvm/src/main/kotlin/com/intuit/playerui/plugins/asyncnode/AsyncNodePlugin.kt
+++ b/plugins/async-node/jvm/src/main/kotlin/com/intuit/playerui/plugins/asyncnode/AsyncNodePlugin.kt
@@ -1,9 +1,12 @@
 package com.intuit.playerui.plugins.asyncnode
 
 import com.intuit.hooks.BailResult
+import com.intuit.playerui.core.bridge.JSErrorException
 import com.intuit.playerui.core.bridge.Node
 import com.intuit.playerui.core.bridge.NodeWrapper
 import com.intuit.playerui.core.bridge.hooks.NodeAsyncParallelBailHook2
+import com.intuit.playerui.core.bridge.hooks.NodeSyncBailHook1
+import com.intuit.playerui.core.bridge.hooks.NodeSyncBailHook2
 import com.intuit.playerui.core.bridge.runtime.Runtime
 import com.intuit.playerui.core.bridge.runtime.ScriptContext
 import com.intuit.playerui.core.bridge.serialization.serializers.Function1Serializer
@@ -11,6 +14,7 @@ import com.intuit.playerui.core.bridge.serialization.serializers.GenericSerializ
 import com.intuit.playerui.core.bridge.serialization.serializers.NodeSerializableField
 import com.intuit.playerui.core.bridge.serialization.serializers.NodeSerializer
 import com.intuit.playerui.core.bridge.serialization.serializers.NodeWrapperSerializer
+import com.intuit.playerui.core.bridge.serialization.serializers.ThrowableSerializer
 import com.intuit.playerui.core.player.Player
 import com.intuit.playerui.core.player.PlayerException
 import com.intuit.playerui.core.plugins.JSScriptPluginWrapper
@@ -56,6 +60,16 @@ public class AsyncNodePlugin(private val asyncHandler: AsyncHandler? = null) : J
                     GenericSerializer(),
                 ),
             )
+
+        /** The hook after an error occurs in onAsyncNode */
+        public val onAsyncNodeError: NodeSyncBailHook2<PlayerException, Node, Any?> by
+            NodeSerializableField(
+                NodeSyncBailHook2.serializer(
+                    ThrowableSerializer() as KSerializer<PlayerException>,
+                NodeSerializer(),
+                    GenericSerializer(),
+            ),
+        )
 
         internal object Serializer : NodeWrapperSerializer<Hooks>(AsyncNodePlugin::Hooks)
     }

--- a/plugins/async-node/jvm/src/main/kotlin/com/intuit/playerui/plugins/asyncnode/AsyncNodePlugin.kt
+++ b/plugins/async-node/jvm/src/main/kotlin/com/intuit/playerui/plugins/asyncnode/AsyncNodePlugin.kt
@@ -1,11 +1,9 @@
 package com.intuit.playerui.plugins.asyncnode
 
 import com.intuit.hooks.BailResult
-import com.intuit.playerui.core.bridge.JSErrorException
 import com.intuit.playerui.core.bridge.Node
 import com.intuit.playerui.core.bridge.NodeWrapper
 import com.intuit.playerui.core.bridge.hooks.NodeAsyncParallelBailHook2
-import com.intuit.playerui.core.bridge.hooks.NodeSyncBailHook1
 import com.intuit.playerui.core.bridge.hooks.NodeSyncBailHook2
 import com.intuit.playerui.core.bridge.runtime.Runtime
 import com.intuit.playerui.core.bridge.runtime.ScriptContext
@@ -21,7 +19,6 @@ import com.intuit.playerui.core.plugins.JSScriptPluginWrapper
 import com.intuit.playerui.core.plugins.findPlugin
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.builtins.serializer
 
 // TODO: This typing is not great - need to fix once web plugin is updated as currently web also supports type Any
 public typealias asyncNodeUpdate = Any?
@@ -66,10 +63,10 @@ public class AsyncNodePlugin(private val asyncHandler: AsyncHandler? = null) : J
             NodeSerializableField(
                 NodeSyncBailHook2.serializer(
                     ThrowableSerializer() as KSerializer<PlayerException>,
-                NodeSerializer(),
+                    NodeSerializer(),
                     GenericSerializer(),
-            ),
-        )
+                ),
+            )
 
         internal object Serializer : NodeWrapperSerializer<Hooks>(AsyncNodePlugin::Hooks)
     }

--- a/plugins/async-node/jvm/src/test/kotlin/com/intuit/playerui/plugins/asyncnode/AsyncNodePluginTest.kt
+++ b/plugins/async-node/jvm/src/test/kotlin/com/intuit/playerui/plugins/asyncnode/AsyncNodePluginTest.kt
@@ -4,6 +4,8 @@ import com.intuit.hooks.BailResult
 import com.intuit.playerui.android.reference.assets.ReferenceAssetsPlugin
 import com.intuit.playerui.core.asset.Asset
 import com.intuit.playerui.core.bridge.Node
+import com.intuit.playerui.core.player.PlayerFlowStatus
+import com.intuit.playerui.core.player.state.PlayerFlowState
 import com.intuit.playerui.core.player.state.inProgressState
 import com.intuit.playerui.core.player.state.lastViewUpdate
 import com.intuit.playerui.utils.test.PlayerTest
@@ -13,8 +15,10 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.yield
+import org.amshove.kluent.internal.assertEquals
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
@@ -189,6 +193,72 @@ internal class AsyncNodePluginTest : PlayerTest() {
             Assertions.assertEquals("6", asset1?.get("id"))
             Assertions.assertEquals("text", asset1?.get("type"))
             Assertions.assertEquals("New", asset1?.get("value"))
+        }
+
+
+    @TestTemplate
+    fun `async node error bubbles up and fails the player state`() =
+        runBlockingTest {
+            plugin.hooks.onAsyncNode.tap("test") { _, node, callback ->
+                throw Exception("This is an error message from onAsyncNode")
+            }
+
+            val errorMessage = assertThrows<Exception> {
+                runBlockingTest {
+                    player.start(chatMessageContent).await()
+                }
+            }.message
+            assertEquals("This is an error message from onAsyncNode", errorMessage)
+        }
+
+    @TestTemplate
+    fun `async node error hook catches and gracefully handles the error`() =
+        runBlockingTest {
+            plugin.hooks.onAsyncNode.tap("test") { _, node, callback ->
+                throw Exception("This is an error message from onAsyncNode")
+            }
+
+            plugin.hooks.onAsyncNodeError.tap("test") { _, error, node ->
+                BailResult.Bail(mapOf(
+                    "type" to "value",
+                    "children" to listOf(
+                        mapOf(
+                            "path" to listOf("asset"),
+                            "value" to mapOf("type" to "asset",
+                                "value" to mapOf(
+                                    "type" to "text",
+                                    "value" to "Value",
+                                    "id" to "error-asset"
+                                )
+                            ),
+                        )
+                    )
+                ))
+            }
+
+            var count = 0
+            var update: Asset? = null
+            suspendCancellableCoroutine { cont ->
+                player.hooks.view.tap { v ->
+                    v?.hooks?.onUpdate?.tap { asset ->
+                        count++
+                        update = asset
+                        if (count == 2) cont.resume(true) {}
+                    }
+                }
+
+                player.start(chatMessageContent)
+            }
+
+            val values = (update as? Map<*, *>)?.get("values") as? List<*>
+            Assertions.assertNotNull(values)
+            Assertions.assertEquals(2, values?.size)
+
+            val asset0 = (values?.get(1) as? Map<*, *>)?.get("asset") as? Map<*, *>
+            Assertions.assertNotNull(asset0)
+            Assertions.assertEquals("text", asset0?.get("type"))
+            Assertions.assertEquals("Value", asset0?.get("value"))
+            Assertions.assertEquals("error-asset", asset0?.get("id"))
         }
 
     @TestTemplate

--- a/plugins/async-node/jvm/src/test/kotlin/com/intuit/playerui/plugins/asyncnode/AsyncNodePluginTest.kt
+++ b/plugins/async-node/jvm/src/test/kotlin/com/intuit/playerui/plugins/asyncnode/AsyncNodePluginTest.kt
@@ -4,8 +4,6 @@ import com.intuit.hooks.BailResult
 import com.intuit.playerui.android.reference.assets.ReferenceAssetsPlugin
 import com.intuit.playerui.core.asset.Asset
 import com.intuit.playerui.core.bridge.Node
-import com.intuit.playerui.core.player.PlayerFlowStatus
-import com.intuit.playerui.core.player.state.PlayerFlowState
 import com.intuit.playerui.core.player.state.inProgressState
 import com.intuit.playerui.core.player.state.lastViewUpdate
 import com.intuit.playerui.utils.test.PlayerTest
@@ -195,7 +193,6 @@ internal class AsyncNodePluginTest : PlayerTest() {
             Assertions.assertEquals("New", asset1?.get("value"))
         }
 
-
     @TestTemplate
     fun `async node error bubbles up and fails the player state`() =
         runBlockingTest {
@@ -219,21 +216,24 @@ internal class AsyncNodePluginTest : PlayerTest() {
             }
 
             plugin.hooks.onAsyncNodeError.tap("test") { _, error, node ->
-                BailResult.Bail(mapOf(
-                    "type" to "value",
-                    "children" to listOf(
-                        mapOf(
-                            "path" to listOf("asset"),
-                            "value" to mapOf("type" to "asset",
+                BailResult.Bail(
+                    mapOf(
+                        "type" to "value",
+                        "children" to listOf(
+                            mapOf(
+                                "path" to listOf("asset"),
                                 "value" to mapOf(
-                                    "type" to "text",
-                                    "value" to "Value",
-                                    "id" to "error-asset"
-                                )
+                                    "type" to "asset",
+                                    "value" to mapOf(
+                                        "type" to "text",
+                                        "value" to "Value",
+                                        "id" to "error-asset",
+                                    ),
+                                ),
                             ),
-                        )
-                    )
-                ))
+                        ),
+                    ),
+                )
             }
 
             var count = 0


### PR DESCRIPTION
- Update the `AsyncNodePlugin` to include a new hook `onAsyncNodeError`
  - The intent of this hook is to catch all errors in `onAsyncNode` hook and allow for a fallback node to be inserted in case of an error.
- Update the `AsyncNodePluginPlugin` to call the `onAsyncNodeError` hook when it fails to handle the async node.
- If the call to `onAsyncNodeError` does not return a new node or `null`, then the error is used to fail the current player flow.
  - This is different from the existing behaviour, where the error is left uncaught and just ends up in the browser's console.
  - Even if the error is handled, the error is logged to ensure it doesn't get lost.

##### TODO:
- [ ] Update documentation to add "Error Handling" section to usage of async node docs.
- [ ] Add hook definitions to the mobile wrappers.

### Change Type (required)
Indicate the type of change your pull request is:
- [X] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [X] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->