### PR TITLE
Fix transforms on assets with `applicability`

### DIFF
--- a/core/player/src/controllers/view/controller.ts
+++ b/core/player/src/controllers/view/controller.ts
@@ -9,7 +9,6 @@ import { ViewInstance } from "../../view";
 import type { Logger } from "../../logger";
 import type { FlowInstance, FlowController } from "../flow";
 import type { DataController } from "../data/controller";
-import { AssetTransformCorePlugin } from "./asset-transform";
 import type { TransformRegistry } from "./types";
 import type { BindingInstance } from "../../binding";
 
@@ -62,8 +61,6 @@ export class ViewController {
       },
       {},
     );
-
-    new AssetTransformCorePlugin(this.transformRegistry).apply(this);
 
     options.flowController.hooks.flow.tap(
       "viewController",

--- a/core/player/src/controllers/view/index.ts
+++ b/core/player/src/controllers/view/index.ts
@@ -1,4 +1,3 @@
-export * from "./asset-transform";
 export * from "./controller";
 export * from "./store";
 export * from "./types";

--- a/core/player/src/plugins/default-view-plugin.ts
+++ b/core/player/src/plugins/default-view-plugin.ts
@@ -1,8 +1,8 @@
-import { AssetTransformCorePlugin } from "../controllers";
 import type { Player, PlayerPlugin } from "../player";
 import {
   ApplicabilityPlugin,
   AssetPlugin,
+  AssetTransformCorePlugin,
   MultiNodePlugin,
   StringResolverPlugin,
   SwitchPlugin,

--- a/core/player/src/plugins/default-view-plugin.ts
+++ b/core/player/src/plugins/default-view-plugin.ts
@@ -23,7 +23,9 @@ export class DefaultViewPlugin implements PlayerPlugin {
         new AssetPlugin().apply(view);
         new SwitchPlugin(pluginOptions).apply(view);
         new ApplicabilityPlugin().apply(view);
-        new AssetTransformCorePlugin(viewController.transformRegistry).apply(view);
+        new AssetTransformCorePlugin(viewController.transformRegistry).apply(
+          view,
+        );
         new StringResolverPlugin().apply(view);
         const templatePlugin = new TemplatePlugin(pluginOptions);
         templatePlugin.apply(view);

--- a/core/player/src/plugins/default-view-plugin.ts
+++ b/core/player/src/plugins/default-view-plugin.ts
@@ -1,3 +1,4 @@
+import { AssetTransformCorePlugin } from "../controllers";
 import type { Player, PlayerPlugin } from "../player";
 import {
   ApplicabilityPlugin,
@@ -22,6 +23,7 @@ export class DefaultViewPlugin implements PlayerPlugin {
         new AssetPlugin().apply(view);
         new SwitchPlugin(pluginOptions).apply(view);
         new ApplicabilityPlugin().apply(view);
+        new AssetTransformCorePlugin(viewController.transformRegistry).apply(view);
         new StringResolverPlugin().apply(view);
         const templatePlugin = new TemplatePlugin(pluginOptions);
         templatePlugin.apply(view);

--- a/core/player/src/view/plugins/asset-transform.ts
+++ b/core/player/src/view/plugins/asset-transform.ts
@@ -20,7 +20,7 @@ function findUp(node: Node.Node, target: Node.Node): boolean {
  * A plugin to register custom transforms on certain asset types
  * This allows users to embed stateful data into transforms.
  */
-export class AssetTransformCorePlugin {
+export default class AssetTransformCorePlugin {
   public readonly stateStore: Map<Node.Node, LocalStateStore>;
   private readonly registry: TransformRegistry;
   private beforeResolveSymbol: symbol;

--- a/core/player/src/view/plugins/asset-transform.ts
+++ b/core/player/src/view/plugins/asset-transform.ts
@@ -1,7 +1,7 @@
-import type { Node, ViewInstance } from "../../view";
-import { NodeType } from "../../view";
-import { LocalStateStore } from "./store";
-import type { TransformRegistry } from "./types";
+import type { Node, ViewInstance } from "..";
+import { NodeType } from "..";
+import { LocalStateStore } from "../../controllers/view/store";
+import type { TransformRegistry } from "../../controllers/view/types";
 
 /** Traverse up the nodes until the target is found */
 function findUp(node: Node.Node, target: Node.Node): boolean {

--- a/core/player/src/view/plugins/index.ts
+++ b/core/player/src/view/plugins/index.ts
@@ -4,3 +4,4 @@ export { default as ApplicabilityPlugin } from "./applicability";
 export { default as SwitchPlugin } from "./switch";
 export { default as MultiNodePlugin } from "./multi-node";
 export { default as AssetPlugin } from "./asset";
+export * from "./asset-transform";

--- a/core/player/src/view/plugins/index.ts
+++ b/core/player/src/view/plugins/index.ts
@@ -4,4 +4,4 @@ export { default as ApplicabilityPlugin } from "./applicability";
 export { default as SwitchPlugin } from "./switch";
 export { default as MultiNodePlugin } from "./multi-node";
 export { default as AssetPlugin } from "./asset";
-export * from "./asset-transform";
+export { default as AssetTransformCorePlugin } from "./asset-transform";

--- a/plugins/asset-transform/core/src/__tests__/index.test.ts
+++ b/plugins/asset-transform/core/src/__tests__/index.test.ts
@@ -52,6 +52,7 @@ const basicFRFWithActionsAndExpressions = (asset = "action"): Flow<any> => ({
             type: asset,
             value: "{{foo.bar}}",
             example: ['{{foo.bar}} = "test"'],
+            applicability: true,
           },
         },
       ],


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->
Will close #667 

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->

# Release Notes

Move `AssetTransformCorePlugin` application after `applicability` and `switch` view plugins to ensure transforms properly apply to conditional assets.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.11.3--canary.668.23668</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.11.3--canary.668.23668
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
