### PR TITLE
fix iOS ManagedPlayerViewModel memory leak

### DIFF
--- a/ios/swiftui/Sources/ManagedPlayer/ManagedPlayerViewModel.swift
+++ b/ios/swiftui/Sources/ManagedPlayer/ManagedPlayerViewModel.swift
@@ -127,7 +127,7 @@ public class ManagedPlayerViewModel: ObservableObject, NativePlugin {
         switch result {
         case .success(let completed):
             self.prevResult = completed
-            Task { await self.next(completed) }
+            Task { [weak self] in await self?.next(completed) }
         case .failure(let error):
             self.loadingState = .failed(error)
         }


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

Fix ManagedPlayerViewModel memory leak by adding weak self

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->