### PR TITLE
Fix `ASYNC_ACTION` Expressions Being Fired Multiple Times

### DIFF
--- a/core/player/src/__tests__/flow.test.ts
+++ b/core/player/src/__tests__/flow.test.ts
@@ -4,6 +4,7 @@ import type { DataController } from "..";
 import { Player } from "..";
 import type { InProgressState } from "../types";
 import { waitFor } from "@testing-library/react";
+import { describe } from "node:test";
 
 test("transitions on action nodes", async () => {
   const player = new Player();
@@ -314,9 +315,10 @@ test("works with iffe flows", async () => {
 
 test("awaited async transitions", async () => {
   const player = new Player();
-
+  let counter = 0;
   player.hooks.expressionEvaluator.tap("test", (expEval) => {
     expEval.addExpressionFunction("testAsync", async (ctx, name) => {
+      counter += 1;
       return new Promise((resolve) => {
         setTimeout(() => {
           resolve(name);
@@ -377,6 +379,8 @@ test("awaited async transitions", async () => {
     },
     transitions: {},
   });
+
+  expect(counter).toEqual(1);
 });
 
 test("unawaited async transitions", async () => {
@@ -443,5 +447,90 @@ test("unawaited async transitions", async () => {
   await waitFor(() => {
     expect(mockFn1).toHaveBeenCalled();
     expect(mockFn2).not.toHaveBeenCalled();
+  });
+});
+
+describe("edge cases", () => {
+  test("async action nodes firing async expressions more than once after a regular action node", async () => {
+    const player = new Player();
+    let asyncCounter = 0;
+    let syncCounter = 0;
+    player.hooks.expressionEvaluator.tap("test", (expEval) => {
+      expEval.addExpressionFunction("testAsync", async (ctx, name) => {
+        asyncCounter += 1;
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            resolve(name);
+          }, 10);
+        });
+      });
+      expEval.addExpressionFunction("testSync", (ctx) => {
+        syncCounter += 1;
+        return "foo";
+      });
+    });
+
+    player.start({
+      id: "test-flow",
+      data: {
+        my: {
+          puppy: "Ginger",
+        },
+      },
+      navigation: {
+        BEGIN: "FLOW_1",
+        FLOW_1: {
+          startState: "ACTION_1",
+          ACTION_1: {
+            state_type: "ACTION",
+            exp: "{{something}} = testSync()",
+            transitions: {
+              "*": "ACTION_2",
+            },
+          },
+          ACTION_2: {
+            state_type: "ACTION",
+            exp: "{{something}} = testSync()",
+            transitions: {
+              "*": "ACTION_3",
+            },
+          },
+          ACTION_3: {
+            state_type: "ASYNC_ACTION",
+            exp: "{{my.puppy}} = await(testAsync('Daisy'))",
+            transitions: {
+              Daisy: "EXTERNAL_1",
+            },
+            await: true,
+          },
+          EXTERNAL_1: {
+            state_type: "EXTERNAL",
+            ref: "view_1",
+            param: {
+              best: "{{my.puppy}}",
+            },
+            transitions: {},
+          },
+        },
+      },
+    });
+
+    await vitest.waitFor(() =>
+      expect(player.getState().status).toBe("in-progress"),
+    );
+
+    let currentState: NamedState | undefined;
+
+    await waitFor(() => {
+      const state = player.getState();
+      currentState = (state as InProgressState).controllers.flow.current
+        ?.currentState;
+      expect(currentState?.name).toBe("EXTERNAL_1");
+    });
+
+    expect(currentState?.value.ref).toStrictEqual("view_1");
+
+    expect(asyncCounter).toEqual(1);
+    expect(syncCounter).toEqual(2);
   });
 });

--- a/core/player/src/__tests__/player.test.ts
+++ b/core/player/src/__tests__/player.test.ts
@@ -610,7 +610,7 @@ describe("failure cases", () => {
           startState: "ActionState",
           ActionState: {
             state_type: "ASYNC_ACTION",
-            exp: "{{something}} == await(testAsync('test'))",
+            exp: "await(testAsync('test'))",
             transitions: {
               test: "ViewState",
             },

--- a/core/player/src/__tests__/player.test.ts
+++ b/core/player/src/__tests__/player.test.ts
@@ -543,7 +543,7 @@ describe("failure cases", () => {
     );
   });
 
-  it("fails gracefully when states after an ACTION state have failures", async () => {
+  it("fails gracefully when states after an ACTION state have failures (sync)", async () => {
     const player = new Player();
 
     const payload = {
@@ -578,6 +578,56 @@ describe("failure cases", () => {
 
     await expect(response).rejects.toThrowError(
       "No view with id non-existing-view",
+    );
+  });
+
+  it("fails gracefully when states after an ACTION state have failures (async)", async () => {
+    const player = new Player();
+
+    player.hooks.expressionEvaluator.tap("test", (expEval) => {
+      expEval.addExpressionFunction("testAsync", async (ctx, name) => {
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            resolve(name);
+          }, 1);
+        });
+      });
+    });
+
+    const payload = {
+      id: "test",
+      views: [
+        {
+          id: "view",
+          type: "text",
+          value: "Some text",
+        },
+      ],
+      data: {},
+      navigation: {
+        BEGIN: "Flow",
+        Flow: {
+          startState: "ActionState",
+          ActionState: {
+            state_type: "ASYNC_ACTION",
+            exp: "{{something}} == await(testAsync('test'))",
+            transitions: {
+              test: "ViewState",
+            },
+            await: true,
+          },
+          ViewState: {
+            state_type: "VIEW",
+            ref: "non-existing-view-async",
+          },
+        },
+      },
+    };
+
+    const response = player.start(makeFlow(payload));
+
+    await expect(response).rejects.toThrowError(
+      "No view with id non-existing-view-async",
     );
   });
 

--- a/core/player/src/controllers/flow/controller.ts
+++ b/core/player/src/controllers/flow/controller.ts
@@ -4,9 +4,13 @@ import type { Logger } from "../../logger";
 import type { TransitionOptions } from "./flow";
 import { FlowInstance } from "./flow";
 
+export interface FlowControllerHooks {
+  flow: SyncHook<[FlowInstance], Record<string, any>>;
+}
+
 /** A manager for the navigation section of a Content blob */
 export class FlowController {
-  public readonly hooks = {
+  public readonly hooks: FlowControllerHooks = {
     flow: new SyncHook<[FlowInstance]>(),
   };
 
@@ -33,7 +37,10 @@ export class FlowController {
   }
 
   /** Navigate to another state in the state-machine */
-  public transition(stateTransition: string, options?: TransitionOptions) {
+  public transition(
+    stateTransition: string,
+    options?: TransitionOptions,
+  ): void {
     if (this.current === undefined) {
       throw new Error("Not currently in a flow. Cannot transition.");
     }

--- a/core/player/src/expressions/__tests__/evaluator.test.ts
+++ b/core/player/src/expressions/__tests__/evaluator.test.ts
@@ -470,6 +470,16 @@ describe("async evaluator", () => {
     expect(await result).toBe("truthy");
   });
 
+  test("Async functions are only called once", async () => {
+    const mockHandler = vitest.fn().mockReturnValue(Promise.resolve(true));
+    evaluator.addExpressionFunction("asyncTest", mockHandler);
+
+    const result = evaluator.evaluateAsync("await(asyncTest())");
+    expect(result).toBeInstanceOf(Promise);
+    expect(await result).toBe(true);
+    expect(mockHandler).toBeCalledTimes(1);
+  });
+
   test("logical operators with async values", async () => {
     evaluator.addExpressionFunction("asyncTrue", async () => {
       return Promise.resolve(true);

--- a/core/player/src/player.ts
+++ b/core/player/src/player.ts
@@ -348,33 +348,19 @@ export class Player {
         }
       });
 
-      // Tap for synchronous action states
-      flow.hooks.afterTransition.tap("player", (flowInstance) => {
-        const value = flowInstance.currentState?.value;
-        if (value && value.state_type === "ACTION") {
-          const { exp } = value;
-          const result = expressionEvaluator.evaluate(exp);
-          if (isPromiseLike(result)) {
-            this.logger.warn(
-              "Async expression used as return value in in non-async context, transitioning with '*' value",
-            );
-          }
-          flowController?.transition(String(result));
-        }
-
-        expressionEvaluator.reset();
-      });
-
-      // Tap for async action states
-      flow.hooks.afterTransition.tap("player", async (flowInstance) => {
+      // Tap for action states
+      flow.hooks.afterTransition.tap("player-action-states", (flowInstance) => {
         const value = flowInstance.currentState?.value;
         if (value && value.state_type === "ASYNC_ACTION") {
           const { exp } = value;
+          // defer async execution to next tick to allow transition to settle
           try {
-            let result = expressionEvaluator.evaluateAsync(exp);
+            const result = expressionEvaluator.evaluateAsync(exp);
             if (isPromiseLike(result)) {
               if (value.await) {
-                result = await result;
+                result
+                  .then((r) => flowController?.transition(String(r)))
+                  .catch(flowResultDeferred.reject);
               } else {
                 this.logger.warn(
                   "Unawaited promise used as return value in in non-async context, transitioning with '*' value",
@@ -389,6 +375,16 @@ export class Player {
           } catch (e) {
             flowResultDeferred.reject(e);
           }
+        } else if (value && value.state_type === "ACTION") {
+          // handle sync actions
+          const { exp } = value;
+          const result = expressionEvaluator.evaluate(exp);
+          if (isPromiseLike(result)) {
+            this.logger.warn(
+              "Async expression used as return value in in non-async context, transitioning with '*' value",
+            );
+          }
+          flowController?.transition(String(result));
         }
 
         expressionEvaluator.reset();


### PR DESCRIPTION
### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->
## Release Notes
Fix Issue with awaited `ASYNC_ACTION` state's expressions being fired multiple times if the Previous State was as `ACTION` state by deferring the awaited execution results rather than handling them in an async tap