### PR TITLE
update createAsyncTransform to allow for different node types

### DIFF
--- a/core/player/src/view/builder/index.ts
+++ b/core/player/src/view/builder/index.ts
@@ -39,11 +39,9 @@ export class Builder {
    * Creates a multiNode and associates the multiNode as the parent
    * of all the value nodes
    *
-   * @param values - the value, applicability or async nodes to put in the multinode
+   * @param values - the nodes to put in the multinode
    */
-  static multiNode(
-    ...values: (Node.Value | Node.Applicability | Node.Async)[]
-  ): Node.MultiNode {
+  static multiNode(...values: Node.Node[]): Node.MultiNode {
     const m: Node.MultiNode = {
       type: NodeType.MultiNode,
       override: true,

--- a/core/player/src/view/builder/index.ts
+++ b/core/player/src/view/builder/index.ts
@@ -39,9 +39,11 @@ export class Builder {
    * Creates a multiNode and associates the multiNode as the parent
    * of all the value nodes
    *
-   * @param values - the nodes to put in the multinode
+   * @param values - the value, applicability or async nodes to put in the multinode
    */
-  static multiNode(...values: Node.Node[]): Node.MultiNode {
+  static multiNode(
+    ...values: (Node.Value | Node.Applicability | Node.Async)[]
+  ): Node.MultiNode {
     const m: Node.MultiNode = {
       type: NodeType.MultiNode,
       override: true,

--- a/core/player/src/view/resolver/__tests__/index.test.ts
+++ b/core/player/src/view/resolver/__tests__/index.test.ts
@@ -58,7 +58,7 @@ describe("Async Node Resolution", () => {
     };
   });
 
-  it("should", () => {
+  it("should clear the cache for the async node and its parent when it is updated", () => {
     const beforeResolveFunction = vi.fn((node: Node.Node | null) => node);
 
     const resolver = new Resolver(simpleViewWithAsync, resolverOptions);
@@ -106,7 +106,7 @@ describe("Async Node Resolution", () => {
     );
   });
 
-  it("should also", () => {
+  it("should clear the cache for anything with a matching async node in its resolved list on update", () => {
     const beforeResolveFunction = vi.fn((node: Node.Node | null) => {
       // Add asyncNodesResolved to view to test tracking and invalidation of just the view.
       if (node?.type === NodeType.View) {

--- a/plugins/async-node/core/src/__tests__/createAsyncTransform.test.ts
+++ b/plugins/async-node/core/src/__tests__/createAsyncTransform.test.ts
@@ -1,18 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { createAsyncTransform } from "..";
 import { Builder, NodeType, Node } from "@player-ui/player";
-import {
-  extractNodeFromPath,
-  requiresAssetWrapper,
-  traverseAndReplace,
-  unwrapAsset,
-} from "../utils";
-
-vi.mock("../utils");
-
-beforeEach(() => {
-  vi.mocked(requiresAssetWrapper).mockReturnValue(true);
-});
 
 describe("createAsyncTransform", () => {
   const asset = Builder.asset({
@@ -142,7 +130,6 @@ describe("createAsyncTransform", () => {
 
   describe("getNestedAsset - different node types", () => {
     it("should add the async node to an existing multi node", () => {
-      vi.mocked(requiresAssetWrapper).mockReturnValue(false);
       const nodeIdFn = vi.fn();
       nodeIdFn.mockReturnValue("async-node");
 
@@ -266,7 +253,6 @@ describe("createAsyncTransform", () => {
     });
 
     it("should default to adding the node as-is", () => {
-      vi.mocked(requiresAssetWrapper).mockReturnValue(false);
       const nodeIdFn = vi.fn();
       nodeIdFn.mockReturnValue("async-node");
 
@@ -392,19 +378,7 @@ describe("createAsyncTransform", () => {
       expect(onValueReceivedFuncion).toBeDefined();
     });
 
-    it("should use traverseAndReplace as the onValueReceived callback", async () => {
-      const actualImplementation =
-        await vi.importActual<typeof import("../utils")>("../utils");
-
-      vi.mocked(traverseAndReplace).mockImplementation(
-        actualImplementation.traverseAndReplace,
-      );
-      vi.mocked(unwrapAsset).mockImplementation(
-        actualImplementation.unwrapAsset,
-      );
-      vi.mocked(extractNodeFromPath).mockImplementation(
-        actualImplementation.extractNodeFromPath,
-      );
+    it("should use traverseAndReplace as the onValueReceived callback", () => {
       const result = onValueReceivedFuncion?.(asset);
       expect(result).toStrictEqual({
         override: true,

--- a/plugins/async-node/core/src/createAsyncTransform.ts
+++ b/plugins/async-node/core/src/createAsyncTransform.ts
@@ -21,7 +21,14 @@ export type AsyncTransformOptions = {
   /** The asset type that will contain the async content. */
   wrapperAssetType: string;
   /** Function to get any nested asset that will need to be extracted and kept when creating the wrapper asset. */
-  getNestedAsset?: (node: Node.ViewOrAsset) => Node.Node | undefined;
+  getNestedAsset?: (
+    node: Node.ViewOrAsset,
+  ) =>
+    | Node.Asset
+    | Node.Value
+    | Node.Applicability
+    | Node.MultiNode
+    | undefined;
   /** Function to get the id for the async node being generated. Defaults to creating an id with the format of async-<ASSET.ID> */
   getAsyncNodeId?: (node: Node.ViewOrAsset) => string;
 };
@@ -79,7 +86,7 @@ export const createAsyncTransform = (
         const assetWrappedNode = Builder.assetWrapper(asset);
         multiNode = Builder.multiNode(assetWrappedNode, asyncNode);
       } else if (asset.type === NodeType.MultiNode) {
-        multiNode = Builder.multiNode(...asset.values, asyncNode);
+        multiNode = Builder.multiNode(...(asset.values as any[]), asyncNode);
       } else {
         multiNode = Builder.multiNode(asset, asyncNode);
       }

--- a/plugins/async-node/core/src/createAsyncTransform.ts
+++ b/plugins/async-node/core/src/createAsyncTransform.ts
@@ -4,7 +4,12 @@ import {
   Node,
   NodeType,
 } from "@player-ui/player";
-import { extractNodeFromPath, traverseAndReplace, unwrapAsset } from "./utils";
+import {
+  extractNodeFromPath,
+  requiresAssetWrapper,
+  traverseAndReplace,
+  unwrapAsset,
+} from "./utils";
 
 export type AsyncTransformOptions = {
   /** Whether or not to flatten the results into its container. Defaults to true */
@@ -69,10 +74,15 @@ export const createAsyncTransform = (
     const asyncNode = Builder.asyncNode(id, flatten, replaceFunction);
 
     let multiNode: Node.MultiNode | undefined;
-
     if (asset) {
-      const assetNode = Builder.assetWrapper(asset);
-      multiNode = Builder.multiNode(assetNode, asyncNode);
+      if (requiresAssetWrapper(asset)) {
+        const assetWrappedNode = Builder.assetWrapper(asset);
+        multiNode = Builder.multiNode(assetWrappedNode, asyncNode);
+      } else if (asset.type === NodeType.MultiNode) {
+        multiNode = Builder.multiNode(...asset.values, asyncNode);
+      } else {
+        multiNode = Builder.multiNode(asset, asyncNode);
+      }
     } else {
       multiNode = Builder.multiNode(asyncNode);
     }

--- a/plugins/async-node/core/src/createAsyncTransform.ts
+++ b/plugins/async-node/core/src/createAsyncTransform.ts
@@ -21,14 +21,7 @@ export type AsyncTransformOptions = {
   /** The asset type that will contain the async content. */
   wrapperAssetType: string;
   /** Function to get any nested asset that will need to be extracted and kept when creating the wrapper asset. */
-  getNestedAsset?: (
-    node: Node.ViewOrAsset,
-  ) =>
-    | Node.Asset
-    | Node.Value
-    | Node.Applicability
-    | Node.MultiNode
-    | undefined;
+  getNestedAsset?: (node: Node.ViewOrAsset) => Node.Node | undefined;
   /** Function to get the id for the async node being generated. Defaults to creating an id with the format of async-<ASSET.ID> */
   getAsyncNodeId?: (node: Node.ViewOrAsset) => string;
 };
@@ -88,7 +81,7 @@ export const createAsyncTransform = (
       } else if (asset.type === NodeType.MultiNode) {
         multiNode = Builder.multiNode(...(asset.values as any[]), asyncNode);
       } else {
-        multiNode = Builder.multiNode(asset, asyncNode);
+        multiNode = Builder.multiNode(asset as any, asyncNode);
       }
     } else {
       multiNode = Builder.multiNode(asyncNode);

--- a/plugins/async-node/core/src/utils/__tests__/requiresAssetWrapper.test.ts
+++ b/plugins/async-node/core/src/utils/__tests__/requiresAssetWrapper.test.ts
@@ -1,0 +1,63 @@
+import { NodeType, Node } from "@player-ui/player";
+import { describe, expect, it } from "vitest";
+import { requiresAssetWrapper } from "../requiresAssetWrapper";
+
+describe("requiresAssetWrapper", () => {
+  it("should return true for asset nodes", () => {
+    const node: Node.Asset = {
+      type: NodeType.Asset,
+      value: {
+        type: "text",
+        id: "id",
+      },
+    };
+
+    const result = requiresAssetWrapper(node);
+
+    expect(result).toBe(true);
+  });
+
+  it("should return true for applicability nodes containing asset nodes", () => {
+    const node: Node.Applicability = {
+      type: NodeType.Applicability,
+      expression: "",
+      value: {
+        type: NodeType.Asset,
+        value: {
+          type: "text",
+          id: "id",
+        },
+      },
+    };
+
+    const result = requiresAssetWrapper(node);
+
+    expect(result).toBe(true);
+  });
+
+  it("should return false for non-asset or non-applicability nodes", () => {
+    const node: Node.Value = {
+      type: NodeType.Value,
+      value: {},
+    };
+
+    const result = requiresAssetWrapper(node);
+
+    expect(result).toBe(false);
+  });
+
+  it("should return false for applicability nodes that do not contain an asset node", () => {
+    const node: Node.Applicability = {
+      type: NodeType.Applicability,
+      expression: "",
+      value: {
+        type: NodeType.Value,
+        value: {},
+      },
+    };
+
+    const result = requiresAssetWrapper(node);
+
+    expect(result).toBe(false);
+  });
+});

--- a/plugins/async-node/core/src/utils/index.ts
+++ b/plugins/async-node/core/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./extractNodeFromPath";
 export * from "./traverseAndReplace";
 export * from "./unwrapAsset";
+export * from "./requiresAssetWrapper";

--- a/plugins/async-node/core/src/utils/requiresAssetWrapper.ts
+++ b/plugins/async-node/core/src/utils/requiresAssetWrapper.ts
@@ -1,9 +1,7 @@
 import { NodeType } from "@player-ui/player";
 import type { Node } from "@player-ui/player";
 
-export const requiresAssetWrapper = (
-  node: Node.Node,
-): node is Node.Applicability | Node.Asset => {
+export const requiresAssetWrapper = (node: Node.Node): boolean => {
   if (node.type === NodeType.Asset) {
     return true;
   }

--- a/plugins/async-node/core/src/utils/requiresAssetWrapper.ts
+++ b/plugins/async-node/core/src/utils/requiresAssetWrapper.ts
@@ -1,0 +1,14 @@
+import { NodeType } from "@player-ui/player";
+import type { Node } from "@player-ui/player";
+
+export const requiresAssetWrapper = (node: Node.Node): boolean => {
+  if (node.type === NodeType.Asset) {
+    return true;
+  }
+
+  if (node.type !== NodeType.Applicability) {
+    return false;
+  }
+
+  return node.value.type === NodeType.Asset;
+};

--- a/plugins/async-node/core/src/utils/requiresAssetWrapper.ts
+++ b/plugins/async-node/core/src/utils/requiresAssetWrapper.ts
@@ -1,7 +1,9 @@
 import { NodeType } from "@player-ui/player";
 import type { Node } from "@player-ui/player";
 
-export const requiresAssetWrapper = (node: Node.Node): boolean => {
+export const requiresAssetWrapper = (
+  node: Node.Node,
+): node is Node.Applicability | Node.Asset => {
   if (node.type === NodeType.Asset) {
     return true;
   }


### PR DESCRIPTION
### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [X] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [X] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->
## Release Notes
- Update the `createAsyncTransform` util to consider different incoming node types coming from `getNestedAsset` option. Originally, this assumed that it would always be an `asset` node type and would asset-wrap the node, but to allow for some additional flexibility, the following rules are applied:
  - Asset nodes and Applicability nodes with a value that is an asset node get asset wrapped like before.
  - multi-nodes have their values spread into the initialized multi-node to keep the structure flat
  - everything else gets added to the initialized multi-node as-is.