### PR TITLE
add asyncNodePosition to createAsyncTransform options

### DIFF
--- a/docs/site/src/content/docs/plugins/multiplatform/async-node.mdx
+++ b/docs/site/src/content/docs/plugins/multiplatform/async-node.mdx
@@ -348,6 +348,7 @@ AndroidPlayer(asyncNodePlugin)
 - wrapperAssetType (Required) - The asset type that will contain the async content.
 - getNestedAsset (Optional) - Function to get any nested asset that will need to be extracted and kept when creating the wrapper asset. This is useful when combined with `flatten: true` to help chain async content with a single asset type.
 - getAsyncNodeId (Optional) - Function to get the id for the generated async node. By default it uses a format of `async-{asset.id}`
+- asyncNodePosition (Optional) - Where to place the async node relative to the asset from `getNestedAsset`. Defaults to `"last"`
 
 #### Usage
 

--- a/docs/site/src/content/docs/plugins/multiplatform/async-node.mdx
+++ b/docs/site/src/content/docs/plugins/multiplatform/async-node.mdx
@@ -348,7 +348,7 @@ AndroidPlayer(asyncNodePlugin)
 - wrapperAssetType (Required) - The asset type that will contain the async content.
 - getNestedAsset (Optional) - Function to get any nested asset that will need to be extracted and kept when creating the wrapper asset. This is useful when combined with `flatten: true` to help chain async content with a single asset type.
 - getAsyncNodeId (Optional) - Function to get the id for the generated async node. By default it uses a format of `async-{asset.id}`
-- asyncNodePosition (Optional) - Where to place the async node relative to the asset from `getNestedAsset`. Defaults to `"last"`
+- asyncNodePosition (Optional) - Where to place the async node relative to the asset from `getNestedAsset`. Defaults to `"append"`
 
 #### Usage
 

--- a/plugins/async-node/core/src/__tests__/createAsyncTransform.test.ts
+++ b/plugins/async-node/core/src/__tests__/createAsyncTransform.test.ts
@@ -319,7 +319,7 @@ describe("createAsyncTransform", () => {
   });
 
   describe("async node position", () => {
-    it("should place the async node before the inner asset node when the asyncNodePosition is 'first'", () => {
+    it("should place the async node before the inner asset node when the asyncNodePosition is 'prepend'", () => {
       const transform = createAsyncTransform({
         transformAssetType: "chat-message",
         wrapperAssetType: "collection",
@@ -329,7 +329,7 @@ describe("createAsyncTransform", () => {
           type: NodeType.Empty,
         }),
         getAsyncNodeId: () => "async-node",
-        asyncNodePosition: "first",
+        asyncNodePosition: "prepend",
       });
       const result = transform(asset, {} as any, {} as any);
 
@@ -371,9 +371,9 @@ describe("createAsyncTransform", () => {
       });
     });
 
-    const options = ["last", undefined] as const;
+    const options = ["append", undefined] as const;
     it.each(options)(
-      "should place the async node after the inner asset node when the asyncNodePosition is 'last' or undefined",
+      "should place the async node after the inner asset node when the asyncNodePosition is 'append' or undefined",
       (position) => {
         const transform = createAsyncTransform({
           transformAssetType: "chat-message",

--- a/plugins/async-node/core/src/__tests__/createAsyncTransform.test.ts
+++ b/plugins/async-node/core/src/__tests__/createAsyncTransform.test.ts
@@ -318,6 +318,116 @@ describe("createAsyncTransform", () => {
     });
   });
 
+  describe("async node position", () => {
+    it("should place the async node before the inner asset node when the asyncNodePosition is 'first'", () => {
+      const transform = createAsyncTransform({
+        transformAssetType: "chat-message",
+        wrapperAssetType: "collection",
+        flatten: false,
+        path: ["array"],
+        getNestedAsset: () => ({
+          type: NodeType.Empty,
+        }),
+        getAsyncNodeId: () => "async-node",
+        asyncNodePosition: "first",
+      });
+      const result = transform(asset, {} as any, {} as any);
+
+      expect(result).toStrictEqual({
+        type: NodeType.Asset,
+        children: [
+          {
+            path: ["array"],
+            value: {
+              type: NodeType.MultiNode,
+              override: true,
+              parent: expect.anything(),
+              values: [
+                {
+                  parent: expect.anything(),
+                  type: NodeType.Async,
+                  flatten: false,
+                  onValueReceived: undefined,
+                  id: "async-node",
+                  value: {
+                    type: NodeType.Value,
+                    value: {
+                      id: "async-node",
+                    },
+                  },
+                },
+                {
+                  parent: expect.anything(),
+                  type: NodeType.Empty,
+                },
+              ],
+            },
+          },
+        ],
+        value: {
+          id: "collection-async-node",
+          type: "collection",
+        },
+      });
+    });
+
+    const options = ["last", undefined] as const;
+    it.each(options)(
+      "should place the async node after the inner asset node when the asyncNodePosition is 'last' or undefined",
+      (position) => {
+        const transform = createAsyncTransform({
+          transformAssetType: "chat-message",
+          wrapperAssetType: "collection",
+          flatten: false,
+          path: ["array"],
+          getNestedAsset: () => ({
+            type: NodeType.Empty,
+          }),
+          getAsyncNodeId: () => "async-node",
+          asyncNodePosition: position,
+        });
+        const result = transform(asset, {} as any, {} as any);
+
+        expect(result).toStrictEqual({
+          type: NodeType.Asset,
+          children: [
+            {
+              path: ["array"],
+              value: {
+                type: NodeType.MultiNode,
+                override: true,
+                parent: expect.anything(),
+                values: [
+                  {
+                    parent: expect.anything(),
+                    type: NodeType.Empty,
+                  },
+                  {
+                    parent: expect.anything(),
+                    type: NodeType.Async,
+                    flatten: false,
+                    onValueReceived: undefined,
+                    id: "async-node",
+                    value: {
+                      type: NodeType.Value,
+                      value: {
+                        id: "async-node",
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+          value: {
+            id: "collection-async-node",
+            type: "collection",
+          },
+        });
+      },
+    );
+  });
+
   describe("onValueReceived callback setup", () => {
     let transformedAsset: Node.Node;
     let onValueReceivedFuncion: ((node: Node.Node) => Node.Node) | undefined;

--- a/plugins/async-node/core/src/createAsyncTransform.ts
+++ b/plugins/async-node/core/src/createAsyncTransform.ts
@@ -76,7 +76,7 @@ export const createAsyncTransform = (
     const replaceFunction = flatten ? replacer : undefined;
     const asyncNode = Builder.asyncNode(id, flatten, replaceFunction);
 
-    let values: Node.Node[] = [asyncNode];
+    const values: Node.Node[] = [asyncNode];
     if (asset) {
       const otherValues = [];
       if (requiresAssetWrapper(asset)) {
@@ -87,10 +87,11 @@ export const createAsyncTransform = (
         otherValues.push(asset);
       }
 
-      values =
-        asyncNodePosition === "prepend"
-          ? [...values, ...otherValues]
-          : [...otherValues, ...values];
+      if (asyncNodePosition === "prepend") {
+        values.unshift(...otherValues);
+      } else {
+        values.push(...otherValues);
+      }
     }
 
     const multiNode = Builder.multiNode(...(values as any[]));

--- a/plugins/async-node/core/src/createAsyncTransform.ts
+++ b/plugins/async-node/core/src/createAsyncTransform.ts
@@ -87,7 +87,7 @@ export const createAsyncTransform = (
         otherValues.push(asset);
       }
 
-      if (asyncNodePosition === "prepend") {
+      if (asyncNodePosition === "append") {
         values.unshift(...otherValues);
       } else {
         values.push(...otherValues);

--- a/plugins/async-node/core/src/createAsyncTransform.ts
+++ b/plugins/async-node/core/src/createAsyncTransform.ts
@@ -24,8 +24,8 @@ export type AsyncTransformOptions = {
   getNestedAsset?: (node: Node.ViewOrAsset) => Node.Node | undefined;
   /** Function to get the id for the async node being generated. Defaults to creating an id with the format of async-<ASSET.ID> */
   getAsyncNodeId?: (node: Node.ViewOrAsset) => string;
-  /** Where to place the async node relative to the asset from `getNestedAsset`. Defaults to "last" */
-  asyncNodePosition?: "first" | "last";
+  /** Where to place the async node relative to the asset from `getNestedAsset`. Defaults to "append" */
+  asyncNodePosition?: "append" | "prepend";
 };
 
 const defaultGetNodeId = (node: Node.ViewOrAsset): string => {
@@ -49,7 +49,7 @@ export const createAsyncTransform = (
     getAsyncNodeId = defaultGetNodeId,
     path = ["values"],
     flatten = true,
-    asyncNodePosition = "last",
+    asyncNodePosition = "append",
   } = options;
 
   const replaceNode = (node: Node.Node): Node.Node => {
@@ -88,7 +88,7 @@ export const createAsyncTransform = (
       }
 
       values =
-        asyncNodePosition === "first"
+        asyncNodePosition === "prepend"
           ? [...values, ...otherValues]
           : [...otherValues, ...values];
     }


### PR DESCRIPTION
### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [X] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [X] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->

## Release Notes
- Added `asyncNodePosition` as an option to `createAsyncTransform`. This lets user choose if the generated async node goes to the top or bottom of the generated multi-node.