### PR TITLE
replace parallel hook with series hook in async node

### DIFF
--- a/plugins/async-node/core/src/__tests__/index.test.ts
+++ b/plugins/async-node/core/src/__tests__/index.test.ts
@@ -1520,6 +1520,71 @@ describe("view", () => {
     });
   });
 
+  test("should not start async node handling if process has already started", async () => {
+    const plugin = new AsyncNodePlugin({
+      plugins: [new AsyncNodePluginPlugin()],
+    });
+
+    const doNothingTap = vi.fn();
+    doNothingTap.mockReturnValue(undefined);
+    const asyncTapFn = vi.fn();
+    let deferredResolve = (_?: any) => {};
+    asyncTapFn.mockReturnValue(
+      new Promise((res) => {
+        deferredResolve = () => {
+          res({
+            asset: {
+              type: "text",
+              id: "async-text",
+              value: "text",
+            },
+          });
+        };
+      }),
+    );
+
+    plugin.hooks.onAsyncNode.tap("test", doNothingTap);
+    plugin.hooks.onAsyncNode.tap("test", asyncTapFn);
+
+    const player = new Player({ plugins: [plugin] });
+    player.start(simpleAsyncContent);
+
+    await vi.waitFor(() => {
+      expect(asyncTapFn).toHaveBeenCalledOnce();
+      expect(doNothingTap).toHaveBeenCalledOnce();
+    });
+
+    const playerState = player.getState();
+    expect(playerState.status).toBe("in-progress");
+    // force an update while ignoring the cache.
+    const firstRender = (playerState as InProgressState).controllers.view
+      .currentView?.lastUpdate;
+
+    // Should not be called again.
+    expect(firstRender).toStrictEqual({
+      type: "view",
+      id: "my-view",
+    });
+
+    deferredResolve();
+
+    vi.waitFor(() => {
+      const currentView = (playerState as InProgressState).controllers.view
+        .currentView?.lastUpdate;
+      expect(currentView).toStrictEqual({
+        type: "view",
+        id: "my-view",
+        values: {
+          asset: {
+            type: "text",
+            id: "async-text",
+            value: "text",
+          },
+        },
+      });
+    });
+  });
+
   // For tests dealing with the startup and cleanup of promises for async nodes.
   describe("Promise Management", () => {
     test("should not start async node handling if process has already started", async () => {

--- a/plugins/async-node/core/src/index.ts
+++ b/plugins/async-node/core/src/index.ts
@@ -11,7 +11,7 @@ import type {
   Resolver,
   Resolve,
 } from "@player-ui/player";
-import { AsyncParallelBailHook, SyncBailHook } from "tapable-ts";
+import { AsyncSeriesBailHook, SyncBailHook } from "tapable-ts";
 import queueMicrotask from "queue-microtask";
 
 export * from "./types";
@@ -38,8 +38,6 @@ export interface AsyncNodePluginOptions {
 export interface AsyncNodeViewPlugin extends ViewPlugin {
   /** Use this to tap into the async node plugin hooks */
   applyPlugin: (asyncNodePlugin: AsyncNodePlugin) => void;
-
-  asyncNode: AsyncParallelBailHook<[Node.Async, (result: any) => void], any>;
 }
 export type AsyncHandler = (
   node: Node.Async,
@@ -55,7 +53,7 @@ export type AsyncContent = {
 /** Hook declaration for the AsyncNodePlugin */
 export type AsyncNodeHooks = {
   /** Async hook to get content for an async node */
-  onAsyncNode: AsyncParallelBailHook<[Node.Async, (result: any) => void], any>;
+  onAsyncNode: AsyncSeriesBailHook<[Node.Async, (result: any) => void], any>;
   /** Sync hook to manage errors coming from the onAsyncNode hook. Return a fallback node or null to render a fallback. The first argument of passed in the call is the error thrown. */
   onAsyncNodeError: SyncBailHook<[Error, Node.Async], any>;
 };
@@ -92,7 +90,7 @@ export class AsyncNodePlugin implements PlayerPlugin {
   }
 
   public readonly hooks: AsyncNodeHooks = {
-    onAsyncNode: new AsyncParallelBailHook(),
+    onAsyncNode: new AsyncSeriesBailHook(),
     onAsyncNodeError: new SyncBailHook(),
   };
 
@@ -116,10 +114,6 @@ export class AsyncNodePlugin implements PlayerPlugin {
 }
 
 export class AsyncNodePluginPlugin implements AsyncNodeViewPlugin {
-  public asyncNode: AsyncParallelBailHook<
-    [Node.Async, (result: any) => void],
-    any
-  > = new AsyncParallelBailHook();
   private basePlugin: AsyncNodePlugin | undefined;
 
   name = "AsyncNode";


### PR DESCRIPTION
### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [X] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [X] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->

## Release Notes
- make the `onAsyncNode` hook of `AsyncNodePlugin` an `AsyncSeriesBailHook` to allow taps to return `undefined` in order to skip resolving the node.
- Remove `asyncNode` hook from `AsyncNodePluginPlugin` because it never gets called or tapped.