### PR TITLE
allow for arrays of expressions in reference action asset dsl

### DIFF
--- a/plugins/reference-assets/components/src/index.test.tsx
+++ b/plugins/reference-assets/components/src/index.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { describe, test, expect } from "vitest";
-import { render, binding as b } from "@player-tools/dsl";
+import { render, binding as b, expression as e } from "@player-tools/dsl";
 import { Text, Action, Info, Collection, Input, Choice, ChatMessage } from ".";
 
 describe("JSON serialization", () => {
@@ -321,6 +321,88 @@ describe("JSON serialization", () => {
       ).toStrictEqual({
         id: "1",
         type: "chat-message",
+      });
+    });
+  });
+
+  describe("action", () => {
+    test("action allows for an array of expressions", async () => {
+      expect(
+        (
+          await render(
+            <Action
+              id="action"
+              exp={[
+                e`${b`local.testValue`} = 1`,
+                e`${b`local.otherValue`} = 2`,
+              ]}
+            >
+              <Action.Label>
+                <Text id="text">Test</Text>
+              </Action.Label>
+            </Action>,
+          )
+        ).jsonValue,
+      ).toStrictEqual({
+        id: "action",
+        type: "action",
+        exp: ["{{local.testValue}} = 1", "{{local.otherValue}} = 2"],
+        label: {
+          asset: {
+            id: "text",
+            type: "text",
+            value: "Test",
+          },
+        },
+      });
+    });
+
+    test("action allows for a single expression", async () => {
+      expect(
+        (
+          await render(
+            <Action id="action" exp={e`${b`local.testValue`} = 1`}>
+              <Action.Label>
+                <Text id="text">Test</Text>
+              </Action.Label>
+            </Action>,
+          )
+        ).jsonValue,
+      ).toStrictEqual({
+        id: "action",
+        type: "action",
+        exp: "{{local.testValue}} = 1",
+        label: {
+          asset: {
+            id: "text",
+            type: "text",
+            value: "Test",
+          },
+        },
+      });
+    });
+
+    test("action allows for an undefined expression", async () => {
+      expect(
+        (
+          await render(
+            <Action id="action">
+              <Action.Label>
+                <Text id="text">Test</Text>
+              </Action.Label>
+            </Action>,
+          )
+        ).jsonValue,
+      ).toStrictEqual({
+        id: "action",
+        type: "action",
+        label: {
+          asset: {
+            id: "text",
+            type: "text",
+            value: "Test",
+          },
+        },
       });
     });
   });

--- a/plugins/reference-assets/components/src/index.tsx
+++ b/plugins/reference-assets/components/src/index.tsx
@@ -18,6 +18,7 @@ import {
   toJsonProperties,
   ObjectWithIndexTracking,
   GeneratedIDProperty,
+  toJsonElement,
 } from "@player-tools/dsl";
 import type { Asset as AssetType } from "@player-ui/player";
 import type {
@@ -102,14 +103,18 @@ Collection.Label = LabelSlot;
 export const Action = (
   props: Omit<AssetPropsWithChildren<ActionAsset>, "exp"> & {
     /** An optional expression to execute before transitioning */
-    exp?: ExpressionTemplateInstance;
+    exp?: ExpressionTemplateInstance | Array<ExpressionTemplateInstance>;
   },
 ) => {
   const { exp, children, ...rest } = props;
 
   return (
     <Asset type="action" {...rest}>
-      <property name="exp">{exp?.toValue()}</property>
+      <property name="exp">
+        {Array.isArray(exp)
+          ? toJsonElement(exp.map((e) => e.toValue()))
+          : exp?.toValue()}
+      </property>
       {children}
     </Asset>
   );


### PR DESCRIPTION
- Extend type on `Action` dsl component props to allow for `exp` to be an array of expressions.
  - This is already supported on the `action` asset type itself and works with how the `Node.ResolveOptions` `evaluate` function works.
- Added tests to support the above.

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [X] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [X] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->

## Release Notes
- Extend type on `Action` dsl component props to allow for `exp` to be an array of expressions.