### PR TITLE
Added a note while setting up the repo for first time

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,7 @@ iOS Development requires a bit more set-up.
     ```bash
     bazel run //ios:xcodeproj
     ```
-    **Note:** Ensure you are connected to **Intuit Guest** wifi or not on **Intuit VPN** to successfully download external dependencies during project generation.
+    **Note:** Ensure you are connected to wifi or not on **Intuit VPN** to successfully download external dependencies during project generation.
    
 1. Open the `.xcodeproj`. If Xcode is your default app for xcodeprojs, you can use this:
     ```


### PR DESCRIPTION
## Summary
Added network connectivity requirement to iOS README for Xcode project generation.

## Problem
During Xcode project generation via `bazel run //ios:xcodeproj`, developers may encounter connection errors when downloading external Swift package dependencies (e.g., EyesXCUI from Applitools Artifactory). This results in build failures with SSL/connection reset errors.

## Solution
Added a note in the iOS README.md to inform developers that they must be connected to **Intuit Guest** wifi network before running the Xcode project generation command to successfully download external dependencies.

## Changes
- Updated `ios/README.md` with network requirement note in the "Xcode Project generation" section



### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->