### PR TITLE
export soloader from hermes

### DIFF
--- a/jvm/hermes/BUILD
+++ b/jvm/hermes/BUILD
@@ -7,13 +7,13 @@ load(":defs.bzl", "merge_jni_into_android_library")
 
 main_exports = [
     "//jvm/core",
+    artifact("com.facebook.soloader:soloader"),
 ]
 
 main_deps = main_exports + [
     "//plugins/console-logger/jvm",
     "//plugins/set-time-out/jvm",
     artifact("com.facebook.fbjni:fbjni-java-only"),
-    artifact("com.facebook.soloader:soloader"),
 ]
 
 test_deps = [


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->
Because `SoLoader` configuration is required for Hermes, we should export it from our artifact to make it easier to consume.

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [x] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->

# Release Notes

Export `com.facebook.soloader:soloader` from `hermes` artifacts
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.14.1--canary.733.28263</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.14.1--canary.733.28263
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
