### PR TITLE
Add docs for consuming Swift package

### DIFF
--- a/docs/site/src/components/PodAndPackage.astro
+++ b/docs/site/src/components/PodAndPackage.astro
@@ -1,0 +1,43 @@
+---
+// Custom component that makes it easier to change the usage docs for all the plugins.
+// This component adds docs for how to leverage a PlayerUI plugin via CocoaPods and
+// Swift Package Manager.
+
+import {Code} from "@astrojs/starlight/components";
+
+const product = Astro.props.product;
+
+// For CocoaPods
+const podSpec = `pod 'PlayerUI/${product}'`;
+const podImport = `import PlayerUI`;
+
+// For Swift Package Manager
+const spmTarget = `
+.target(
+    name: "MyApp",
+    dependencies: [
+        .product(name: "PlayerUI${product}", package: "playerui-swift-package"),
+    ]
+)`;
+const spmImport = `import PlayerUI${product}`;
+---
+
+<h3>CocoaPods</h3>
+
+<p>Add the subspec to your <code>Podfile</code>.</p>
+
+<Code code={podSpec} lang="ruby" />
+
+<p>In your Swift file, import the pod. Only one import is needed for all PlayerUI pods.</p>
+
+<Code code={podImport} lang="swift" />
+
+<h3>Swift Package Manager</h3>
+
+<p>Add the product to the appropriate target's dependencies in your <code>Package.swift</code>.</p>
+
+<Code code={spmTarget} lang="swift" />
+
+<p>In your Swift file, import the sub-package. A different import is needed for each PlayerUI sub-package.</p>
+
+<Code code={spmImport} lang="swift" />

--- a/docs/site/src/content/docs/getting-started.mdx
+++ b/docs/site/src/content/docs/getting-started.mdx
@@ -4,6 +4,7 @@ title: "Getting Started"
 
 import PlatformTabs from "../../components/PlatformTabs.astro";
 import { PackageManagers } from "starlight-package-managers";
+import { Aside } from "@astrojs/starlight/components";
 
 Getting started with Player is simple.
 
@@ -21,6 +22,8 @@ You can do this by installing the React Player and Reference Assets Packages
   </Fragment>
   <Fragment slot='ios'>
 
+### CocoaPods
+
 In your `Podfile` you'll need to add `PlayerUI` as a dependency and the `ReferenceAssets` plugin to use the base set of assets.
 
 ```ruby
@@ -31,6 +34,30 @@ target 'MyApp' do
   pod 'PlayerUI'
   pod 'PlayerUI/ReferenceAssets' # For example only
 end
+```
+
+### Swift Package Manager
+
+In your `Package.swift` you'll need to add `PlayerUI` as a dependency and the `ReferenceAssets` plugin to use the base set of assets.
+
+<Aside title="Different SPM Repo">The SPM package is maintained in a separate auto-generated repo. You must use that git URL, not the git URL for the main Player repo.</Aside>
+
+```swift
+let package = Package(
+    name: "MyApp",
+    dependencies: [
+        .package(url: "https://github.com/player-ui/playerui-swift-package.git", from: "0.6.0"),
+    ],
+    targets: [
+        .target(
+            name: "MyApp",
+            dependencies: [
+                .product(name: "PlayerUI", package: "playerui-swift-package"),
+                .product(name: "PlayerUIReferenceAssets", package: "playerui-swift-package"),
+            ]
+        ),
+    ]
+)
 ```
 
   </Fragment>

--- a/docs/site/src/content/docs/plugins/core/common-expressions.mdx
+++ b/docs/site/src/content/docs/plugins/core/common-expressions.mdx
@@ -4,6 +4,7 @@ title: Common Expressions
 
 import PlatformTabs from "../../../../components/PlatformTabs.astro";
 import { PackageManagers } from 'starlight-package-managers'
+import PodAndPackage from "../../../../components/PodAndPackage.astro";
 
 This plugin exposes some basic expressions into Player content.
 
@@ -36,15 +37,7 @@ This will allow any included expressions or custom expressions to be used in the
 
 <Fragment slot='ios'>
 
-### CocoaPods
-
-Add the subspec to your `Podfile`
-
-```ruby
-
-pod 'PlayerUI/CommonExpressionsPlugin'
-
-```
+<PodAndPackage product="CommonExpressionsPlugin" />
 
 ### Swift Usage
 

--- a/docs/site/src/content/docs/plugins/core/common-types.mdx
+++ b/docs/site/src/content/docs/plugins/core/common-types.mdx
@@ -3,6 +3,7 @@ title: Common Types
 ---
 
 import PlatformTabs from "../../../../components/PlatformTabs.astro";
+import PodAndPackage from "../../../../components/PodAndPackage.astro";
 import { PackageManagers } from 'starlight-package-managers'
 
 This plugin exposes some basic `DataTypes`, `validations`, and `formats` into Player content.
@@ -36,15 +37,7 @@ This will allow any `DataTypes`, `formats`, `validations` and custom data types 
 
 <Fragment slot='ios'>
 
-### CocoaPods
-
-Add the subspec to your `Podfile`
-
-```ruby
-
-pod 'PlayerUI/CommonTypesPlugin'
-
-```
+<PodAndPackage product="CommonTypesPlugin" />
 
 ### Swift Usage
 

--- a/docs/site/src/content/docs/plugins/core/computed-properties.mdx
+++ b/docs/site/src/content/docs/plugins/core/computed-properties.mdx
@@ -3,6 +3,7 @@ title: Computed Properties
 ---
 
 import PlatformTabs from "../../../../components/PlatformTabs.astro";
+import PodAndPackage from "../../../../components/PodAndPackage.astro";
 
 This plugin allows users to specify a path in the data-model (binding) as a computed property in the schema.
 Anytime this binding is read from, the given expression will be evaluated and returned instead of the it being read from the actual model. Writes to the binding will be prevented, and an error will be thrown.
@@ -27,13 +28,7 @@ const player = new Player({
 
   <Fragment slot='ios'>
 
-### CocoaPods
-
-Add the subspec to your `Podfile`
-
-```ruby
-pod 'PlayerUI/ComputedPropertiesPlugin'
-```
+<PodAndPackage product="ComputedPropertiesPlugin" />
 
 ### Swift Usage
 

--- a/docs/site/src/content/docs/plugins/core/expression.mdx
+++ b/docs/site/src/content/docs/plugins/core/expression.mdx
@@ -3,6 +3,7 @@ title: Expression
 ---
 
 import PlatformTabs from "../../../../components/PlatformTabs.astro";
+import PodAndPackage from "../../../../components/PodAndPackage.astro";
 
 This plugin assists with exposing custom expressions to Player content.
 
@@ -52,13 +53,7 @@ Any calls to `myCustomFunction()` within the flow will utilize the newly registe
   </Fragment>
   <Fragment slot='ios'>
 
-### CocoaPods
-
-Add the subspec to your `Podfile`
-
-```ruby
-pod 'PlayerUI/ExpressionPlugin'
-```
+<PodAndPackage product="ExpressionPlugin" />
 
 ### Swift Usage
 

--- a/docs/site/src/content/docs/plugins/core/stage-revert-data.mdx
+++ b/docs/site/src/content/docs/plugins/core/stage-revert-data.mdx
@@ -4,6 +4,7 @@ platform: core
 ---
 
 import PlatformTabs from "../../../../components/PlatformTabs.astro";
+import PodAndPackage from "../../../../components/PodAndPackage.astro";
 
 This plugin enables users to temporarily stage data changes before committing to the actual data model
 
@@ -46,13 +47,7 @@ const player = new Player({
   </Fragment>
   <Fragment slot='ios'>
 
-### CocoaPods
-
-Add the subspec to your `Podfile`
-
-```ruby
-pod 'PlayerUI/StageRevertDataPlugin'
-```
+<PodAndPackage product="StageRevertDataPlugin" />
 
 ### Swift Usage
 

--- a/docs/site/src/content/docs/plugins/core/types-provider.mdx
+++ b/docs/site/src/content/docs/plugins/core/types-provider.mdx
@@ -3,6 +3,7 @@ title: Types Provider
 ---
 
 import PlatformTabs from "../../../../components/PlatformTabs.astro";
+import PodAndPackage from "../../../../components/PodAndPackage.astro";
 
 Similar to the [Expression Plugin](/plugins/core/expression), this plugin adds support for easily exposing new `DataTypes`, `formats`, and `validations` to Player's content.
 
@@ -75,13 +76,7 @@ Given a data-type reference to `CustomType` in the content, your new validation 
 
 The swift `TypesProviderPlugin` enables adding custom data types, formatters and validation purely through swift code. While in general, the recommendation would be to share a single JavaScript implementation to multiple platforms, some use cases may need a native integration.
 
-### CocoaPods
-
-Add the subspec to your `Podfile`
-
-```ruby
-pod 'PlayerUI/TypesProviderPlugin'
-```
+<PodAndPackage product="TypesProviderPlugin" />
 
 ### Swift Usage
 

--- a/docs/site/src/content/docs/plugins/iOS/external-action-view-modifier.mdx
+++ b/docs/site/src/content/docs/plugins/iOS/external-action-view-modifier.mdx
@@ -3,15 +3,11 @@ title: External Action View Modifier
 platform: ios
 ---
 
+import PodAndPackage from "../../../../components/PodAndPackage.astro";
+
 This plugin is used to handle EXTERNAL states, allowing you to asynchronously tell Player when, and what to transition with once you have finished processing the external state request.
 
-### CocoaPods
-
-Add the subspec to your `Podfile`
-
-```ruby
-pod 'PlayerUI/ExternalActionViewModifierPlugin'
-```
+<PodAndPackage product="ExternalActionViewModifierPlugin" />
 
 ### Swift Usage
 

--- a/docs/site/src/content/docs/plugins/iOS/swiftui-pending-transaction.mdx
+++ b/docs/site/src/content/docs/plugins/iOS/swiftui-pending-transaction.mdx
@@ -3,15 +3,11 @@ title: SwiftUIPendingTransactionPlugin
 platform: ios
 ---
 
+import PodAndPackage from "../../../../components/PodAndPackage.astro";
+
 The `SwiftUIPendingTransactionPlugin` allows you to register pending transactions (callbacks) in the userInfo on the decoder. Users can decide when to register, commit and clear transactions based on the use case. Anytime there is a scenario where we want a native transaction to happen while a view update is taking place, we can make use of this plugin. Below is an example used in the sample app where we can see this take place:
 
-### CocoaPods
-
-Add the subspec to your `Podfile`
-
-```ruby
-pod 'PlayerUI/SwiftUIPendingTransactionPlugin'
-```
+<PodAndPackage product="SwiftUIPendingTransactionPlugin" />
 
 ## **The Issue:**
 

--- a/docs/site/src/content/docs/plugins/iOS/transition.mdx
+++ b/docs/site/src/content/docs/plugins/iOS/transition.mdx
@@ -2,15 +2,11 @@
 title: Transition Plugin
 ---
 
+import PodAndPackage from "../../../../components/PodAndPackage.astro";
+
 The `TransitionPlugin` allows for specifying transitions for when Player loads a flow, and for transition between views in the same flow.
 
-### CocoaPods
-
-Add the subspec to your `Podfile`
-
-```ruby
-pod 'PlayerUI/TransitionPlugin'
-```
+<PodAndPackage product="TransitionPlugin" />
 
 ### Swift Usage
 

--- a/docs/site/src/content/docs/plugins/multiplatform/async-node.mdx
+++ b/docs/site/src/content/docs/plugins/multiplatform/async-node.mdx
@@ -3,6 +3,7 @@ title: AsyncNode Plugin
 ---
 
 import PlatformTabs from "../../../../components/PlatformTabs.astro";
+import PodAndPackage from "../../../../components/PodAndPackage.astro";
 
 The AsyncNode Plugin is used to enable streaming additional content into a flow that has already been loaded and rendered.  
 A common use case for this plugin is conversational UI, as the users input more dialogue, new content must be streamed into Player in order to keep the UI up to date.
@@ -182,13 +183,7 @@ asyncNodePlugin.hooks.onAsyncNodeError.tap("handleAsyncError", (error, node) => 
 });
 ```
 
-### CocoaPods
-
-Add the subspec to your `Podfile`
-
-```ruby
-pod 'PlayerUI/AsyncNodePlugin'
-```
+<PodAndPackage product="AsyncNodePlugin" />
 
 ### Swift Usage
 

--- a/docs/site/src/content/docs/plugins/multiplatform/beacon.mdx
+++ b/docs/site/src/content/docs/plugins/multiplatform/beacon.mdx
@@ -3,6 +3,7 @@ title: Beacon Plugin
 ---
 
 import PlatformTabs from "../../../../components/PlatformTabs.astro";
+import PodAndPackage from "../../../../components/PodAndPackage.astro";
 
 The beacon plugin enables users to send and/or collect beaconing information from assets in a normalized API. It exposes a common API for publishing beacons from an asset library, and will automatically attach itself to the current view, enabling additional meta-data to be added to each event.
 
@@ -93,13 +94,7 @@ This will add additional React Context to the running player for the producers f
   </Fragment>
   <Fragment slot='ios'>
 
-### CocoaPods
-
-Add the subspec to your `Podfile`
-
-```ruby
-pod 'PlayerUI/BeaconPlugin'
-```
+<PodAndPackage product="BeaconPlugin" />
 
 ### Swift Usage
 

--- a/docs/site/src/content/docs/plugins/multiplatform/check-path.mdx
+++ b/docs/site/src/content/docs/plugins/multiplatform/check-path.mdx
@@ -3,6 +3,7 @@ title: Check Path Plugin
 ---
 
 import PlatformTabs from "../../../../components/PlatformTabs.astro";
+import PodAndPackage from "../../../../components/PodAndPackage.astro";
 import { PackageManagers } from 'starlight-package-managers'
 
 The Check Path Plugin enables users to query segments of the view tree for contextual rendering or behavior.
@@ -62,13 +63,7 @@ This will automatically create the underlying _core_ version of the `CheckPathPl
 
 <Fragment slot='ios'>
 
-### CocoaPods
-
-Add the subspec to your `Podfile`
-
-```ruby
-pod 'PlayerUI/SwiftUICheckPathPlugin'
-```
+<PodAndPackage product="SwiftUICheckPathPlugin" />
 
 ### Swift Usage
 

--- a/docs/site/src/content/docs/plugins/multiplatform/console-logger.mdx
+++ b/docs/site/src/content/docs/plugins/multiplatform/console-logger.mdx
@@ -3,6 +3,7 @@ title: Console Logger
 ---
 
 import PlatformTabs from "../../../../components/PlatformTabs.astro";
+import PodAndPackage from "../../../../components/PodAndPackage.astro";
 
 A plugin to easily enable logs to be written to the JS console. Extremely helpful for local Player development and debugging.
 
@@ -33,13 +34,7 @@ consoleLogger.setSeverity("warn");
   </Fragment>
   <Fragment slot='ios'>
 
-### CocoaPods
-
-Add the subspec to your `Podfile`
-
-```ruby
-pod 'PlayerUI/PrintLoggerPlugin'
-```
+<PodAndPackage product="PrintLoggerPlugin" />
 
 ### Swift Usage
 

--- a/docs/site/src/content/docs/plugins/multiplatform/external-action.mdx
+++ b/docs/site/src/content/docs/plugins/multiplatform/external-action.mdx
@@ -3,6 +3,7 @@ title: External Action
 ---
 
 import PlatformTabs from "../../../../components/PlatformTabs.astro";
+import PodAndPackage from "../../../../components/PodAndPackage.astro";
 import { PackageManagers } from 'starlight-package-managers'
 
 The External Action Plugin is an easy way to handle External states from the navigation of a Player flow.
@@ -44,13 +45,7 @@ This will transition any `EXTERNAL` state in Player's navigation, with a `ref` p
   </Fragment>
   <Fragment slot='ios'>
 
-### CocoaPods
-
-Add the subspec to your `Podfile`
-
-```ruby
-pod 'PlayerUI/ExternalActionPlugin'
-```
+<PodAndPackage product="ExternalActionPlugin" />
 
 ### Swift Usage
 

--- a/docs/site/src/content/docs/plugins/multiplatform/metrics.mdx
+++ b/docs/site/src/content/docs/plugins/multiplatform/metrics.mdx
@@ -3,6 +3,7 @@ title: Metrics
 ---
 
 import PlatformTabs from "../../../../components/PlatformTabs.astro";
+import PodAndPackage from "../../../../components/PodAndPackage.astro";
 import Image from "../../../../components/Image.astro";
 import metricsTiming from "../../../../assets/metrics-timing.png";
 
@@ -70,13 +71,7 @@ const player = new ReactPlayer({
 
 The `ios` version of the Metrics Plugin will track initial render time for each view in a flow. Due to current SwiftUI limitations, update time can't be tracked yet. It can be used in conjunction with a core plugin that utilizes the events, through `findPlugin`, or standalone.
 
-### CocoaPods
-
-Add the subspec to your `Podfile`
-
-```ruby
-pod 'PlayerUI/MetricsPlugin'
-```
+<PodAndPackage product="MetricsPlugin" />
 
 ### Swift Usage
 

--- a/docs/site/src/content/docs/plugins/multiplatform/partial-match-fingerprint.mdx
+++ b/docs/site/src/content/docs/plugins/multiplatform/partial-match-fingerprint.mdx
@@ -3,6 +3,7 @@ title: Partial Match
 ---
 
 import PlatformTabs from "../../../../components/PlatformTabs.astro";
+import PodAndPackage from "../../../../components/PodAndPackage.astro";
 
 This plugin enables users to map matches of assets to any arbitrary value in a partial-match-registry.
 For each asset in a resolved view, the matches will be computed.
@@ -44,13 +45,7 @@ const value = matchPlugin.get("asset-id"); // 'ABC'
 
 This plugin is used by `BaseAssetRegistry` to handle matching resolved asset nodes with their native implementation, to decode for rendering. It is unlikely to be needed to be used directly in iOS use cases.
 
-### CocoaPods
-
-Add the subspec to your `Podfile`
-
-```ruby
-pod 'PlayerUI'
-```
+<PodAndPackage product="PlayerUI" />
 
 ### Swift Usage
 

--- a/docs/site/src/content/docs/plugins/multiplatform/pub-sub.mdx
+++ b/docs/site/src/content/docs/plugins/multiplatform/pub-sub.mdx
@@ -3,6 +3,7 @@ title: PubSub
 ---
 
 import PlatformTabs from "../../../../components/PlatformTabs.astro";
+import PodAndPackage from "../../../../components/PodAndPackage.astro";
 
 The PubSub plugin adds a publish/subscribe interface between the host app and Player's content.
 
@@ -39,13 +40,7 @@ pubsub.unsubscribe(token);
 
 If your content uses the `@[ publish() ]@` expression for actions, you can subscribe to these events by using the `PubSubPlugin`.
 
-### CocoaPods
-
-Add the subspec to your `Podfile`
-
-```ruby
-pod 'PlayerUI/PubSubPlugin'
-```
+<PodAndPackage product="PubSubPlugin" />
 
 ### Swift Usage
 


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

> [!NOTE]
> ✨AI-abetted: Updates aided by Augment with VS Code.

Solves https://github.com/player-ui/player/issues/495.

1. We now release as both a Swift Package and a CocoaPod. However, we only had docs for how users could consume the CocoaPod. This PR adds docs for how to consume the Swift Package.

2. Previously, we were repeating basically exactly the same wording for the CocoaPods docs of every plugin. These docs now live in a `PodAndPackage` astro component that allows us to quickly and easily update docs across all plugins.


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
- [x] `N/A`


### Does your PR have any documentation updates?
- [x] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->