### PR TITLE
Lowercase URLs for docs preview

### DIFF
--- a/docs/site/astro.config.mjs
+++ b/docs/site/astro.config.mjs
@@ -145,7 +145,7 @@ export default defineConfig({
             },
             {
               label: "iOS Plugins",
-              autogenerate: { directory: "plugins/iOS" },
+              autogenerate: { directory: "plugins/ios" },
             },
             {
               label: "Language Plugins",

--- a/scripts/docs/get-changed-docs.js
+++ b/scripts/docs/get-changed-docs.js
@@ -47,7 +47,8 @@ export function getChangedDocsPages(baseBranch = "origin/main") {
           .replace("site/", "")
           .replace(".mdx", "")
           .replace(".md", "")
-          .replace(/\/?index$/, ""); // Remove "/index" or "index" suffix for landing pages
+          .replace(/\/?index$/, "") // Remove "/index" or "index" suffix for landing pages
+          .toLowerCase(); // Docs Preview URLs are case sensitive and need to be lower case
 
         return {
           name: pageName,


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

Resolves https://github.com/player-ui/player/issues/740.

Links belonging to folders with upper case letters throw a 404 in the Docs Preview. The links apparently need to be lower case to work. Update the URL generation script to lower case the links. 

Also, change the `iOS` folder name to `ios` to be consistent with the other folder names and avoid this issue in the first place.

### Instances of this issue.
1. https://github.com/player-ui/player/pull/739#issuecomment-3463348838. The `plugins/iOS` links aren't working, but changing the link to `plugins/ios` works.
2. https://github.com/player-ui/player/pull/742. The `content/Test/test` link doesn't work, but `content/test/test` does work.

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
- [x] `N/A`


### Does your PR have any documentation updates?
- [x] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->