### PR TITLE
iOS ManagedPlayer only call unload in loading state

### DIFF
--- a/ios/swiftui/Sources/ManagedPlayer/ManagedPlayer.swift
+++ b/ios/swiftui/Sources/ManagedPlayer/ManagedPlayer.swift
@@ -179,7 +179,14 @@ internal struct ManagedPlayer14<Loading: View, Fallback: View>: View {
                     /// to prevent alternative between loaded and loading state when flows reach multiple non VIEW states after another causing flickering of the loading spinner, change the opacity to show either the loading view or the player view
                     ZStack {
                         // use isViewLoaded to determine when the loader is shown instead of checking for .loading case
-                        loading().onAppear { context.unload() }.opacity(isViewLoaded ? 0 : 1)
+                        loading().onAppear {
+                            guard case .loading = viewModel.loadingState else {
+                                return
+                            }
+                            
+                            // only call unload if were in loading state
+                            context.unload()
+                        }.opacity(isViewLoaded ? 0 : 1)
 
                         if case .loaded(let flow) = viewModel.loadingState {
                             makePlayerView(flow: flow).opacity(isViewLoaded ? 1 : 0)


### PR DESCRIPTION
Only call context.unload if we are in a loading state not when its in loaded state

previous change https://github.com/player-ui/player/pull/570/files to make smoother transitions between non view states required us to handle loading and loaded states together so that the loading view could be smoother 

Missed an edge case where the context.unload() may get called if were in a loaded state causing flow to be re-rendered

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

# Release Notes
#### iOS Managed Player fix for SwiftuiPlayer's context unload being called in loaded state
- Fix: Only call context.unload if we are in a loading state not when its in loaded state
