### PR TITLE
fix circle checkout to not use blobless

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,8 +252,7 @@ jobs:
   android_test:
     executor: android
     steps:
-      - checkout:
-          method: full
+      - checkout
 
       - attach_workspace:
           at: ~/player


### PR DESCRIPTION
### Change Type (required)

fix circle checkout to not use blobless

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`