### PR TITLE
Set timeout of publish stage to 40m

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,10 +79,12 @@ commands:
       - run: |
           echo -e $GPG_KEY | gpg --import --batch
           echo -e "pinentry-mode loopback\npassphrase $DEPLOY_MAVEN_GPG_PASSPHRASE" > ~/.gnupg/gpg.conf
-      - run: |
-          source ~/.bashrc
-          bundle install
-          npx auto shipit --only-graduate-with-release-label
+      - run: 
+          command: |
+            source ~/.bashrc
+            bundle install
+            npx auto shipit --only-graduate-with-release-label
+          no_output_timeout: 40m
 
 jobs:
   setup:


### PR DESCRIPTION
Set timeout to 40m. This is now required because of removing the `-vv` arg from auto which silences the script output during the publish stage which was causing cirlcle to preemptively kill the job assuming nothing was happening. 

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->
