### PR TITLE
Make AnyType Sendable with Reflection support

### DIFF
--- a/ios/test-utils-core/Sources/ui-test/AssetCollection.swift
+++ b/ios/test-utils-core/Sources/ui-test/AssetCollection.swift
@@ -50,7 +50,7 @@ public struct AssetCollection: View {
                         NavigationLink(flow.name) {
                             AssetFlowView(flow: flow.flow, plugins: plugins, result: result)
                                 .padding(padding)
-                                .navigationTitle(Text(flow.name))
+                                .navigationBarTitle(Text(flow.name))
                         }
                         .accessibility(identifier: "\(section.title) \(flow.name)")
                     }
@@ -61,7 +61,7 @@ public struct AssetCollection: View {
             }
         }
         .accessibility(identifier: "AssetCollection")
-        .navigationTitle(Text("Flows"))
+        .navigationBarTitle(Text("Flows"))
     }
 }
 

--- a/ios/test-utils-core/Sources/utilities/AssetTestHelper.swift
+++ b/ios/test-utils-core/Sources/utilities/AssetTestHelper.swift
@@ -17,7 +17,7 @@ extension JSContext {
         guard objectForKeyedSubscript("MakeFlow").isUndefined else { return }
         guard
             let url = bundleUrl,
-            let contents = try? String(contentsOf: url, encoding: .utf8)
+            let contents = try? String(contentsOf: url)
         else { return }
         evaluateScript(contents)
     }


### PR DESCRIPTION
# Make AnyType Sendable (Breaking Change)

## Overview

This PR makes the `AnyType` enum conform to the `Sendable` protocol by removing all `Any`-based APIs and using only recursive `AnyType` values. This enables safe usage across Swift concurrency boundaries but introduces breaking changes for code that relied on `Any` interoperability.

## Motivation

With Swift 6's strict concurrency checking, `AnyType` needed to be `Sendable` to be used safely in concurrent contexts. The previous implementation used `[String: Any]` and `[Any]` in the `anyDictionary` and `anyArray` cases, which are not `Sendable` because `Any` cannot guarantee thread-safety.

## Changes

### 1. Sendable Conformance via Recursive Types

Changed:

```swift
// Before
case anyDictionary(data: [String: Any])
case anyArray(data: [Any])

// After  
case anyDictionary(data: [String: AnyType])
case anyArray(data: [AnyType])
```

This recursive approach eliminates `Any` types completely, making `AnyType` fully `Sendable`.

### 2. Removed Backward Compatibility APIs

**Removed the following APIs that depended on `Any`:**

- `init(anyDictionary: [String: Any])` - Convert from `[String: Any]`
- `init(anyArray: [Any])` - Convert from `[Any]`
- `init(from: Any)` - Convert any `Any` value
- `asAnyDictionary: [String: Any]?` - Convert to legacy dictionary
- `asAnyArray: [Any]?` - Convert to legacy array  
- `asAny: Any` - Convert back to `Any`

### 3. Added Sendable-Safe Convenience API

Added a type-safe value extraction method that doesn't rely on `Any`:

```swift
public func `as`<T>(_ type: T.Type) -> T?
```

This enables clean value extraction without pattern matching:

```swift
let title: String? = anyType["title"]?.as(String.self)
```

**Implementation:** Directly pattern matches on `AnyType` cases and casts the underlying values, maintaining full `Sendable` conformance.

### 4. Simplified Encoding/Decoding

- **Encoder:** Now directly encodes recursive `AnyType` values without converting through `Any`
- **Decoder:** Simplified to only handle direct JSON decoding (mixed-type collections require `AnyTypeDecodingContext`)
- **CustomEncodable:** Simplified unused `init?(intValue:)` to return `nil`

### 5. Updated Documentation

All comments now accurately reflect the current `Sendable`-safe implementation without references to removed `Any`-based APIs.

## Test Coverage

- **Removed:** 495 lines of tests for backward compatibility APIs
- **Kept:** 34 core tests (encoding, decoding, hash, equality, Sendable conformance)
- **Added:** 5 new tests for the `as<T>(_:)` convenience API
- **Total:** 39 tests, all passing

## Breaking Changes

**This is a breaking change.** Code that used the following APIs will need to be updated:

### Removed APIs

```swift
//  No longer available
let anyType = AnyType(anyDictionary: dict)
let anyType = AnyType(anyArray: array)
let anyType = AnyType(from: someValue)
let dict = anyType.asAnyDictionary
let array = anyType.asAnyArray
let value = anyType.asAny
```

### Migration Guide

**Before (removed):**
```swift
let dict: [String: Any] = ["title": "Hello"]
let anyType = AnyType(anyDictionary: dict)
if let converted = anyType.asAnyDictionary {
    let title = converted["title"] as? String
}
```

**After (use AnyType directly):**
```swift
let anyType = AnyType.anyDictionary(data: [
    "title": .string(data: "Hello")
])
let title: String? = anyType["title"]?.as(String.self)
```

## Examples

### Sendable Usage

```swift
actor DataManager {
    var state: AnyType = .unknownData
    
    func updateState(_ newState: AnyType) async {
        self.state = newState //  Now safe!
    }
}
```

### Value Extraction

```swift
// Clean, functional style
let title: String? = payload["title"]?.as(String.self)
let count: Double? = payload["count"]?.as(Double.self)

// Nested access
let name: String? = payload["user"]?["name"]?.as(String.self)
```

### Creating AnyType Values

```swift
let data = AnyType.anyDictionary(data: [
    "title": .string(data: "Hello"),
    "count": .number(data: 42),
    "active": .bool(data: true)
])
```

## Change Type

**major** - Breaking changes to public API

## Release Notes

### Breaking Changes

The `AnyType` enum now conforms to `Sendable` protocol, but this required removing all APIs that depended on the `Any` type:

**Removed APIs:**
- `init(anyDictionary:)`, `init(anyArray:)`, `init(from:)` 
- `asAnyDictionary`, `asAnyArray`, `asAny` properties

**Migration:** Use `AnyType` cases directly instead of converting from/to `Any`:

```swift
// Old (removed)
let anyType = AnyType(anyDictionary: ["key": "value"])
let dict = anyType.asAnyDictionary

// New (Sendable-safe)  
let anyType = AnyType.anyDictionary(data: ["key": .string(data: "value")])
let value: String? = anyType["key"]?.as(String.self)
```

### New Features

Added `as<T>(_:)` convenience method for type-safe value extraction:

```swift
let title: String? = anyType["title"]?.as(String.self)
let count: Double? = anyType["count"]?.as(Double.self)
```

This provides ergonomic access without requiring `Any` types or verbose pattern matching.
