### PR TITLE
`ExternalActionPlugin` & `ExternalActionViewModifierPlugin` use array of match-handler pairs

### DIFF
--- a/core/partial-match-registry/src/__tests__/matcher.test.ts
+++ b/core/partial-match-registry/src/__tests__/matcher.test.ts
@@ -7,3 +7,27 @@ test("works on basic objects", () => {
   expect(matcher({ foo: "bar" })).toBe(true);
   expect(matcher({ foo: "bar", bar: "baz" })).toBe(true);
 });
+
+test("handles null values correctly", () => {
+  // Test matching on null value
+  const matcherWithNull = createObjectMatcher({ foo: null });
+  expect(matcherWithNull({ foo: null })).toBe(true);
+  expect(matcherWithNull({ foo: "bar" })).toBe(false);
+  expect(matcherWithNull({})).toBe(false);
+
+  // Test matching on combination of null and non-null values
+  const matcherMixed = createObjectMatcher({ foo: null, bar: "baz" });
+  expect(matcherMixed({ foo: null, bar: "baz" })).toBe(true);
+  expect(matcherMixed({ foo: null, bar: "other" })).toBe(false);
+  expect(matcherMixed({ foo: "something", bar: "baz" })).toBe(false);
+});
+
+test("handles undefined values correctly", () => {
+  // Test matching on undefined value
+  // Note: dlv treats missing properties the same as undefined, so { foo: undefined } matches {}
+  const matcherWithUndefined = createObjectMatcher({ foo: undefined });
+  expect(matcherWithUndefined({ foo: undefined })).toBe(true);
+  expect(matcherWithUndefined({})).toBe(true); // Missing property is treated as undefined
+  expect(matcherWithUndefined({ foo: "bar" })).toBe(false);
+  expect(matcherWithUndefined({ foo: null })).toBe(false);
+});

--- a/core/partial-match-registry/src/deep-partial-matcher.ts
+++ b/core/partial-match-registry/src/deep-partial-matcher.ts
@@ -16,7 +16,13 @@ function traverseObj(
     const val: any = object[key];
     const nestedPath = [...path, key];
 
-    if (typeof val === "object") {
+    /* Explicitly avoid traversing null values.
+    JavaScript's typeof null === "object" would otherwise cause the function to traverse null as an object
+    and throw an error. 
+    
+    Ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#typeof_null
+    */
+    if (typeof val === "object" && val !== null) {
       traverseObj(val, nestedPath, pairs);
     } else {
       pairs.set(nestedPath, val);

--- a/ios/demo/Sources/App.swift
+++ b/ios/demo/Sources/App.swift
@@ -56,15 +56,16 @@ struct MainView: View {
         BeaconPlugin<DefaultBeacon> { print(String(describing: $0)) },
         SwiftUIPendingTransactionPlugin<PendingTransactionPhases>()
     ] + [
-        try? ExternalActionPlugin(handlers: [
+        // swiftlint:disable:next force_try
+        try! ExternalActionPlugin(handlers: [
             ExternalActionHandler(
-                match: ["ref":"test-1"],
+                match: ["ref": "test-1"],
                 handler: { _, _, _ in
                     print("MainView External State triggered")
                 }
             )
         ])
-    ].compactMap { $0 }
+    ]
 
 
     var body: some View {

--- a/ios/demo/Sources/App.swift
+++ b/ios/demo/Sources/App.swift
@@ -44,9 +44,14 @@ struct MainView: View {
         CommonTypesPlugin(),
         ExpressionPlugin(),
         CommonExpressionsPlugin(),
-        ExternalActionPlugin(handler: { _, _, _ in
-            print("external state")
-        }),
+        ExternalActionPlugin(handlers: [
+            ExternalStateHandler(
+                match: ["ref":"test-1"],
+                handler: { _, _, _ in
+                    print("MainView External State triggered")
+                }
+            )
+        ]),
         MetricsPlugin { timing, render, flow in
             print(timing as Any)
             print(render as Any)

--- a/ios/demo/Sources/App.swift
+++ b/ios/demo/Sources/App.swift
@@ -44,14 +44,6 @@ struct MainView: View {
         CommonTypesPlugin(),
         ExpressionPlugin(),
         CommonExpressionsPlugin(),
-        ExternalActionPlugin(handlers: [
-            ExternalStateHandler(
-                match: ["ref":"test-1"],
-                handler: { _, _, _ in
-                    print("MainView External State triggered")
-                }
-            )
-        ]),
         MetricsPlugin { timing, render, flow in
             print(timing as Any)
             print(render as Any)
@@ -63,7 +55,18 @@ struct MainView: View {
         TransitionPlugin(popTransition: .pop),
         BeaconPlugin<DefaultBeacon> { print(String(describing: $0)) },
         SwiftUIPendingTransactionPlugin<PendingTransactionPhases>()
-    ]
+    ] + [
+        try? ExternalActionPlugin(handlers: [
+            ExternalActionHandler(
+                match: ["ref":"test-1"],
+                handler: { _, _, _ in
+                    print("MainView External State triggered")
+                }
+            )
+        ])
+    ].compactMap { $0 }
+
+
     var body: some View {
         SegmentControlView(
             plugins: plugins,

--- a/ios/demo/Sources/App.swift
+++ b/ios/demo/Sources/App.swift
@@ -38,35 +38,44 @@ struct MainView: View {
         }
     }
 
-    let plugins: [NativePlugin] = [
-        PrintLoggerPlugin(level: .trace),
-        ReferenceAssetsPlugin(),
-        CommonTypesPlugin(),
-        ExpressionPlugin(),
-        CommonExpressionsPlugin(),
-        MetricsPlugin { timing, render, flow in
-            print(timing as Any)
-            print(render as Any)
-            print(flow as Any)
-        },
-        RequestTimePlugin { 5 },
-        PubSubPlugin([]),
-        TypesProviderPlugin(types: [], validators: [], formats: []),
-        TransitionPlugin(popTransition: .pop),
-        BeaconPlugin<DefaultBeacon> { print(String(describing: $0)) },
-        SwiftUIPendingTransactionPlugin<PendingTransactionPhases>()
-    ] + [
-        // swiftlint:disable:next force_try
-        try! ExternalActionPlugin(handlers: [
-            ExternalActionHandler(
-                match: ["ref": "test-1"],
-                handler: { _, _, _ in
-                    print("MainView External State triggered")
-                }
-            )
-        ])
-    ]
+    private var plugins: [NativePlugin] {
+        [
+            PrintLoggerPlugin(level: .trace),
+            ReferenceAssetsPlugin(),
+            CommonTypesPlugin(),
+            ExpressionPlugin(),
+            CommonExpressionsPlugin(),
+            MetricsPlugin { timing, render, flow in
+                print(timing as Any)
+                print(render as Any)
+                print(flow as Any)
+            },
+            RequestTimePlugin { 5 },
+            PubSubPlugin([]),
+            TypesProviderPlugin(types: [], validators: [], formats: []),
+            TransitionPlugin(popTransition: .pop),
+            BeaconPlugin<DefaultBeacon> { print(String(describing: $0)) },
+            SwiftUIPendingTransactionPlugin<PendingTransactionPhases>()
+        ] + throwingPlugins
+    }
 
+    private var throwingPlugins: [NativePlugin] {
+        var plugins: [NativePlugin] = []
+        do {
+            let plugin = try ExternalActionPlugin(handlers: [
+                ExternalActionHandler(
+                    match: ["ref": "test-1"],
+                    handler: { _, _, _ in
+                        print("MainView External State triggered")
+                    }
+                )
+            ])
+            plugins.append(plugin)
+        } catch {
+            fatalError("Failed to create ExternalActionPlugin: \(error)")
+        }
+        return plugins
+    }
 
     var body: some View {
         SegmentControlView(

--- a/ios/demo/Sources/FlowManagerView.swift
+++ b/ios/demo/Sources/FlowManagerView.swift
@@ -35,15 +35,22 @@ public struct FlowManagerView: View {
                             MetricsPlugin { (render, _, flow) in
                                 print("Render: \(render?.duration ?? 0 )ms | Request \(flow?.flow.requestTime ?? 0)ms")
                             },
-                            ExternalActionViewModifierPlugin<ExternalStateSheetModifier> { (state, _, transition) in
-
-                                return AnyView(
-                                    Text("External State")
-                                        .onDisappear {
-                                            transition("Next")
-                                        }
+                            ExternalActionViewModifierPlugin<ExternalStateSheetModifier>(handlers: [
+                                ExternalStateViewModifierHandler(
+                                    match: ["ref":"test-1"],
+                                    handler: { (state, _, transition) in
+                                        return AnyView(
+                                            Text("External State")
+                                                .onAppear {
+                                                    print("Managed Player External State triggered")
+                                                }
+                                                .onDisappear {
+                                                    transition("Next")
+                                                }
+                                        )
+                                    }
                                 )
-                            }
+                            ])
                         ],
                         flowManager: ConstantFlowManager(flowSequence),
                         onComplete: { _ in

--- a/ios/demo/Sources/FlowManagerView.swift
+++ b/ios/demo/Sources/FlowManagerView.swift
@@ -72,10 +72,11 @@ public struct FlowManagerView: View {
         }.navigationBarTitle(Text(navTitle))
     }
 
-    private let externalActionPlugin = try? ExternalActionViewModifierPlugin<ExternalActionSheetModifier>(handlers: [
+    // swiftlint:disable:next force_try
+    private let externalActionPlugin = try! ExternalActionViewModifierPlugin<ExternalActionSheetModifier>(handlers: [
         .init(
             match: ["ref": "test-1"],
-            handler: { (state, _, transition) in
+            handler: { _, _, transition in
                 return AnyView(
                     Text("External State")
                         .onAppear {

--- a/ios/demo/Sources/FlowManagerView.swift
+++ b/ios/demo/Sources/FlowManagerView.swift
@@ -30,12 +30,7 @@ public struct FlowManagerView: View {
             } else {
                 VStack {
                     ManagedPlayer(
-                        plugins: [
-                            ReferenceAssetsPlugin(),
-                            MetricsPlugin { (render, _, flow) in
-                                print("Render: \(render?.duration ?? 0 )ms | Request \(flow?.flow.requestTime ?? 0)ms")
-                            }
-                        ] + [externalActionPlugin].compactMap { $0 },
+                        plugins: plugins,
                         flowManager: ConstantFlowManager(flowSequence),
                         onComplete: { _ in
                             complete = true
@@ -72,21 +67,38 @@ public struct FlowManagerView: View {
         }.navigationBarTitle(Text(navTitle))
     }
 
-    // swiftlint:disable:next force_try
-    private let externalActionPlugin = try! ExternalActionViewModifierPlugin<ExternalActionSheetModifier>(handlers: [
-        .init(
-            match: ["ref": "test-1"],
-            handler: { _, _, transition in
-                return AnyView(
-                    Text("External State")
-                        .onAppear {
-                            print("Managed Player External State triggered")
-                        }
-                        .onDisappear {
-                            transition("Next")
-                        }
-                )
+    private var plugins: [NativePlugin] {
+        [
+            ReferenceAssetsPlugin(),
+            MetricsPlugin { (render, _, flow) in
+                print("Render: \(render?.duration ?? 0 )ms | Request \(flow?.flow.requestTime ?? 0)ms")
             }
-        )
-    ])
+        ] + throwingPlugins
+    }
+
+    private var throwingPlugins: [NativePlugin] {
+        var plugins: [NativePlugin] = []
+        do {
+            let externalActionPlugin = try ExternalActionViewModifierPlugin<ExternalActionSheetModifier>(handlers: [
+                .init(
+                    match: ["ref": "test-1"],
+                    handler: { _, _, transition in
+                        return AnyView(
+                            Text("External State")
+                                .onAppear {
+                                    print("Managed Player External State triggered")
+                                }
+                                .onDisappear {
+                                    transition("Next")
+                                }
+                        )
+                    }
+                )
+            ])
+            plugins.append(externalActionPlugin)
+        } catch {
+            fatalError("Failed to create ExternalActionPlugin: \(error)")
+        }
+        return plugins
+    }
 }

--- a/ios/demo/Sources/FlowManagerView.swift
+++ b/ios/demo/Sources/FlowManagerView.swift
@@ -37,7 +37,7 @@ public struct FlowManagerView: View {
                             },
                             ExternalActionViewModifierPlugin<ExternalStateSheetModifier>(handlers: [
                                 ExternalStateViewModifierHandler(
-                                    match: ["ref":"test-1"],
+                                    match: ["ref": "test-1"],
                                     handler: { (state, _, transition) in
                                         return AnyView(
                                             Text("External State")

--- a/ios/demo/Sources/FlowManagerView.swift
+++ b/ios/demo/Sources/FlowManagerView.swift
@@ -34,24 +34,8 @@ public struct FlowManagerView: View {
                             ReferenceAssetsPlugin(),
                             MetricsPlugin { (render, _, flow) in
                                 print("Render: \(render?.duration ?? 0 )ms | Request \(flow?.flow.requestTime ?? 0)ms")
-                            },
-                            ExternalActionViewModifierPlugin<ExternalStateSheetModifier>(handlers: [
-                                ExternalStateViewModifierHandler(
-                                    match: ["ref": "test-1"],
-                                    handler: { (state, _, transition) in
-                                        return AnyView(
-                                            Text("External State")
-                                                .onAppear {
-                                                    print("Managed Player External State triggered")
-                                                }
-                                                .onDisappear {
-                                                    transition("Next")
-                                                }
-                                        )
-                                    }
-                                )
-                            ])
-                        ],
+                            }
+                        ] + [externalActionPlugin].compactMap { $0 },
                         flowManager: ConstantFlowManager(flowSequence),
                         onComplete: { _ in
                             complete = true
@@ -87,4 +71,21 @@ public struct FlowManagerView: View {
             }
         }.navigationBarTitle(Text(navTitle))
     }
+
+    private let externalActionPlugin = try? ExternalActionViewModifierPlugin<ExternalActionSheetModifier>(handlers: [
+        .init(
+            match: ["ref": "test-1"],
+            handler: { (state, _, transition) in
+                return AnyView(
+                    Text("External State")
+                        .onAppear {
+                            print("Managed Player External State triggered")
+                        }
+                        .onDisappear {
+                            transition("Next")
+                        }
+                )
+            }
+        )
+    ])
 }

--- a/ios/demo/Sources/PluginsAndPlayerCollection.swift
+++ b/ios/demo/Sources/PluginsAndPlayerCollection.swift
@@ -91,44 +91,13 @@ public struct PluginsAndPlayerCollection: View {
     }
 
     var pluginFlows: some View {
-        let pubsubPlugin = PubSubPlugin([("some-event", { (eventName, eventData) in
-            $alertPresented.wrappedValue = true
-
-            switch eventData {
-            case .string(data: let string):
-                $beaconAndPubsubInfo.wrappedValue += "Published: `\(eventName)` with message: `\(string)` \n"
-            default: break
-            }
-        })])
-
-        let beaconPlugin =  BeaconPlugin<DefaultBeacon> { beaconStruct in
-            $alertPresented.wrappedValue = true
-            let encoder = JSONEncoder()
-            if let data = try? encoder.encode(beaconStruct), let jsonString = String(data: data, encoding: .utf8) {
-                $beaconAndPubsubInfo.wrappedValue += "Beacon: \(jsonString) \n"
-            }
-        }
-
-        // swiftlint:disable:next force_try
-        let externalActionPlugin = try! ExternalActionPlugin(handlers: [
-            ExternalActionHandler(
-                match: ["ref": "test-1"],
-                handler: { _, options, transition in
-                    print("PluginsAndPlayerCollection External State triggered")
-                    let transitionValue = options.data.get(binding: "transitionValue") as? String
-                    options.expression.evaluate("{{foo}} = 'bar'")
-                    transition(transitionValue ?? "Next")
-                }
-            )
-        ])
-
-        return ForEach(sections, id: \.title) { section in
+        ForEach(sections, id: \.title) { section in
             Section {
                 ForEach(section.flows, id: \.name) { flow in
                     NavigationLink(flow.name) {
                         AssetFlowView(
                             flow: flow.flow,
-                            plugins: (plugins + [externalActionPlugin, beaconPlugin, pubsubPlugin]).compactMap { $0 },
+                            plugins: plugins + throwingPlugins + [beaconPlugin, pubsubPlugin],
                             completion: completion(result:)
                         )
                         .padding(padding)
@@ -171,7 +140,7 @@ public struct PluginsAndPlayerCollection: View {
                 )
         }
     }
-    
+
     func completion(result: Result<CompletedState, PlayerError>) {
         $alertPresented.wrappedValue = true
         switch result {
@@ -185,5 +154,48 @@ public struct PluginsAndPlayerCollection: View {
 
             completionMessage = "\(errorState.error)"
         }
+    }
+
+    var pubsubPlugin: PubSubPlugin {
+        .init([("some-event", { (eventName, eventData) in
+            $alertPresented.wrappedValue = true
+
+            switch eventData {
+            case .string(data: let string):
+                $beaconAndPubsubInfo.wrappedValue += "Published: `\(eventName)` with message: `\(string)` \n"
+            default: break
+            }
+        })])
+    }
+
+    var beaconPlugin : BeaconPlugin<DefaultBeacon> {
+        .init { beaconStruct in
+            $alertPresented.wrappedValue = true
+            let encoder = JSONEncoder()
+            if let data = try? encoder.encode(beaconStruct), let jsonString = String(data: data, encoding: .utf8) {
+                $beaconAndPubsubInfo.wrappedValue += "Beacon: \(jsonString) \n"
+            }
+        }
+    }
+
+    var throwingPlugins: [NativePlugin] {
+        var plugins: [NativePlugin] = []
+        do {
+            let externalActionPlugin = try ExternalActionPlugin(handlers: [
+                ExternalActionHandler(
+                    match: ["ref": "test-1"],
+                    handler: { _, options, transition in
+                        print("PluginsAndPlayerCollection External State triggered")
+                        let transitionValue = options.data.get(binding: "transitionValue") as? String
+                        options.expression.evaluate("{{foo}} = 'bar'")
+                        transition(transitionValue ?? "Next")
+                    }
+                )
+            ])
+            plugins.append(externalActionPlugin)
+        } catch {
+            fatalError("Failed to create ExternalActionPlugin: \(error)")
+        }
+        return plugins
     }
 }

--- a/ios/demo/Sources/PluginsAndPlayerCollection.swift
+++ b/ios/demo/Sources/PluginsAndPlayerCollection.swift
@@ -109,10 +109,11 @@ public struct PluginsAndPlayerCollection: View {
             }
         }
 
-        let externalActionPlugin = try? ExternalActionPlugin(handlers: [
+        // swiftlint:disable:next force_try
+        let externalActionPlugin = try! ExternalActionPlugin(handlers: [
             ExternalActionHandler(
                 match: ["ref": "test-1"],
-                handler: { state, options, transition in
+                handler: { _, options, transition in
                     print("PluginsAndPlayerCollection External State triggered")
                     let transitionValue = options.data.get(binding: "transitionValue") as? String
                     options.expression.evaluate("{{foo}} = 'bar'")

--- a/ios/demo/Sources/PluginsAndPlayerCollection.swift
+++ b/ios/demo/Sources/PluginsAndPlayerCollection.swift
@@ -26,9 +26,9 @@ public struct PluginsAndPlayerCollection: View {
     /**
      Initializes and loads flows
      - parameters:
-     - plugins: Plugins to add to Player instance that is created
-     - sections: The `[FlowSection]` to display
-     - padding: Padding around the AssetFlowView
+        - plugins: Plugins to add to Player instance that is created
+        - sections: The `[FlowSection]` to display
+        - padding: Padding around the AssetFlowView
      */
     public init(
         plugins: [NativePlugin],

--- a/ios/demo/Sources/PluginsAndPlayerCollection.swift
+++ b/ios/demo/Sources/PluginsAndPlayerCollection.swift
@@ -26,9 +26,9 @@ public struct PluginsAndPlayerCollection: View {
     /**
      Initializes and loads flows
      - parameters:
-        - plugins: Plugins to add to Player instance that is created
-        - sections: The `[FlowSection]` to display
-        - padding: Padding around the AssetFlowView
+     - plugins: Plugins to add to Player instance that is created
+     - sections: The `[FlowSection]` to display
+     - padding: Padding around the AssetFlowView
      */
     public init(
         plugins: [NativePlugin],
@@ -59,7 +59,7 @@ public struct PluginsAndPlayerCollection: View {
                     )
                     .padding(padding)
                 }.accessibility(identifier: "Reuse already loaded flow")
-                
+
                 NavigationLink("Simple Flows") {
                     FlowManagerView(flowSequence: [.firstFlow, .secondFlow], navTitle: "Simple Flows")
                         .padding(padding)
@@ -109,8 +109,8 @@ public struct PluginsAndPlayerCollection: View {
             }
         }
 
-        let externalActionPlugin = ExternalActionPlugin(handlers: [
-            ExternalStateHandler(
+        let externalActionPlugin = try? ExternalActionPlugin(handlers: [
+            ExternalActionHandler(
                 match: ["ref": "test-1"],
                 handler: { state, options, transition in
                     print("PluginsAndPlayerCollection External State triggered")
@@ -125,19 +125,23 @@ public struct PluginsAndPlayerCollection: View {
             Section {
                 ForEach(section.flows, id: \.name) { flow in
                     NavigationLink(flow.name) {
-                        AssetFlowView(flow: flow.flow, plugins: plugins + [externalActionPlugin, beaconPlugin, pubsubPlugin], completion: completion(result:))
-                            .padding(padding)
-                            .navigationBarTitle(Text(flow.name))
-                            .modifier(
-                                AlertViewModifier(
-                                    alertPresented: $alertPresented,
-                                    pubsubEventName: $beaconAndPubsubInfo,
-                                    completionMessage: $completionMessage)
-                            )
-                            .onDisappear {
-                                // clear tracked beacons and pub sub info
-                                $beaconAndPubsubInfo.wrappedValue = ""
-                            }
+                        AssetFlowView(
+                            flow: flow.flow,
+                            plugins: (plugins + [externalActionPlugin, beaconPlugin, pubsubPlugin]).compactMap { $0 },
+                            completion: completion(result:)
+                        )
+                        .padding(padding)
+                        .navigationBarTitle(Text(flow.name))
+                        .modifier(
+                            AlertViewModifier(
+                                alertPresented: $alertPresented,
+                                pubsubEventName: $beaconAndPubsubInfo,
+                                completionMessage: $completionMessage)
+                        )
+                        .onDisappear {
+                            // clear tracked beacons and pub sub info
+                            $beaconAndPubsubInfo.wrappedValue = ""
+                        }
                     }
                     .accessibility(identifier: "\(section.title) \(flow.name)")
                 }
@@ -166,7 +170,7 @@ public struct PluginsAndPlayerCollection: View {
                 )
         }
     }
-
+    
     func completion(result: Result<CompletedState, PlayerError>) {
         $alertPresented.wrappedValue = true
         switch result {

--- a/ios/demo/Sources/PluginsAndPlayerCollection.swift
+++ b/ios/demo/Sources/PluginsAndPlayerCollection.swift
@@ -109,12 +109,17 @@ public struct PluginsAndPlayerCollection: View {
             }
         }
 
-        let externalActionPlugin =  ExternalActionPlugin(handler: { state, options, transition in
-            guard state.ref == "test-1" else { return transition("Prev") }
-            let transitionValue = options.data.get(binding: "transitionValue") as? String
-            options.expression.evaluate("{{foo}} = 'bar'")
-            transition(transitionValue ?? "Next")
-        })
+        let externalActionPlugin = ExternalActionPlugin(handlers: [
+            ExternalStateHandler(
+                match: ["ref": "test-1"],
+                handler: { state, options, transition in
+                    print("PluginsAndPlayerCollection External State triggered")
+                    let transitionValue = options.data.get(binding: "transitionValue") as? String
+                    options.expression.evaluate("{{foo}} = 'bar'")
+                    transition(transitionValue ?? "Next")
+                }
+            )
+        ])
 
         return ForEach(sections, id: \.title) { section in
             Section {

--- a/plugins/external-action/core/src/__tests__/index.test.ts
+++ b/plugins/external-action/core/src/__tests__/index.test.ts
@@ -533,10 +533,14 @@ describe("Type Safety", () => {
 
     // Warnings should have been logged for handlers with invalid matches (2 warnings)
     expect(warnSpy).toHaveBeenCalledTimes(2);
-    expect(warnSpy).toHaveBeenCalledWith(
+    // First warning for empty object match
+    expect(warnSpy).toHaveBeenNthCalledWith(
+      1,
       "An external action match is missing the 'ref' property. This handler will be ignored. Match: {}",
     );
-    expect(warnSpy).toHaveBeenCalledWith(
+    // Second warning for match without ref
+    expect(warnSpy).toHaveBeenNthCalledWith(
+      2,
       'An external action match is missing the \'ref\' property. This handler will be ignored. Match: {"testProperty":"testValue"}',
     );
 

--- a/plugins/external-action/core/src/__tests__/index.test.ts
+++ b/plugins/external-action/core/src/__tests__/index.test.ts
@@ -493,22 +493,31 @@ describe("Type Safety", () => {
       plugins: [
         new ExternalActionPlugin([
           // Invalid match - empty object (TypeScript error suppressed for testing)
-          // @ts-expect-error - testing runtime behavior with invalid match
-          [{}, () => {
-            invalidHandler1Called();
-            return "Next";
-          }],
+          [
+            // @ts-expect-error - testing runtime behavior with invalid match
+            {},
+            () => {
+              invalidHandler1Called();
+              return "Next";
+            },
+          ],
           // Invalid match - missing ref (TypeScript error suppressed for testing)
-          // @ts-expect-error - testing runtime behavior with invalid match
-          [{ testProperty: "testValue" }, () => {
-            invalidHandler2Called();
-            return "Next";
-          }],
+          [
+            // @ts-expect-error - testing runtime behavior with invalid match
+            { testProperty: "testValue" },
+            () => {
+              invalidHandler2Called();
+              return "Next";
+            },
+          ],
           // Valid match - has ref
-          [{ ref: "test-1" }, () => {
-            validHandlerCalled();
-            return "Next";
-          }],
+          [
+            { ref: "test-1" },
+            () => {
+              validHandlerCalled();
+              return "Next";
+            },
+          ],
         ]),
       ],
       logger: {
@@ -525,19 +534,19 @@ describe("Type Safety", () => {
     // Warnings should have been logged for handlers with invalid matches (2 warnings)
     expect(warnSpy).toHaveBeenCalledTimes(2);
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("An external action match is missing the 'ref' property")
+      "An external action match is missing the 'ref' property. This handler will be ignored. Match: {}",
     );
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("This handler will be ignored")
+      'An external action match is missing the \'ref\' property. This handler will be ignored. Match: {"testProperty":"testValue"}',
     );
 
     // The handlers with invalid matches should NOT have been called
     expect(invalidHandler1Called).not.toHaveBeenCalled();
     expect(invalidHandler2Called).not.toHaveBeenCalled();
-    
+
     // The valid handler should have been called
     expect(validHandlerCalled).toHaveBeenCalledTimes(1);
-    
+
     // Flow should complete successfully using the valid handler
     expect(completed.endState.outcome).toBe("FWD");
   });

--- a/plugins/external-action/core/src/__tests__/index.test.ts
+++ b/plugins/external-action/core/src/__tests__/index.test.ts
@@ -481,3 +481,64 @@ describe("edge cases", () => {
     await started;
   });
 });
+
+describe("Type Safety", () => {
+  test("handlers with invalid matches (no ref) should not be triggered at runtime", async () => {
+    const invalidHandler1Called = vitest.fn();
+    const invalidHandler2Called = vitest.fn();
+    const validHandlerCalled = vitest.fn();
+    const warnSpy = vitest.fn();
+
+    const player = new Player({
+      plugins: [
+        new ExternalActionPlugin([
+          // Invalid match - empty object (TypeScript error suppressed for testing)
+          // @ts-expect-error - testing runtime behavior with invalid match
+          [{}, () => {
+            invalidHandler1Called();
+            return "Next";
+          }],
+          // Invalid match - missing ref (TypeScript error suppressed for testing)
+          // @ts-expect-error - testing runtime behavior with invalid match
+          [{ testProperty: "testValue" }, () => {
+            invalidHandler2Called();
+            return "Next";
+          }],
+          // Valid match - has ref
+          [{ ref: "test-1" }, () => {
+            validHandlerCalled();
+            return "Next";
+          }],
+        ]),
+      ],
+      logger: {
+        trace: vitest.fn(),
+        debug: vitest.fn(),
+        info: vitest.fn(),
+        warn: warnSpy,
+        error: vitest.fn(),
+      },
+    });
+
+    const completed = await player.start(externalFlow as Flow);
+
+    // Warnings should have been logged for handlers with invalid matches (2 warnings)
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("An external action match is missing the 'ref' property")
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("This handler will be ignored")
+    );
+
+    // The handlers with invalid matches should NOT have been called
+    expect(invalidHandler1Called).not.toHaveBeenCalled();
+    expect(invalidHandler2Called).not.toHaveBeenCalled();
+    
+    // The valid handler should have been called
+    expect(validHandlerCalled).toHaveBeenCalledTimes(1);
+    
+    // Flow should complete successfully using the valid handler
+    expect(completed.endState.outcome).toBe("FWD");
+  });
+});

--- a/plugins/external-action/core/src/index.ts
+++ b/plugins/external-action/core/src/index.ts
@@ -161,6 +161,8 @@ export class ExternalActionPlugin implements PlayerPlugin {
    */
   private registerHandlers(player: Player): void {
     for (const [state, handler] of this.handlers) {
+      // Runtime check for 'ref' property is necessary despite TypeScript constraint because
+      // the Swift bridge allows improperly formatted objects to bypass TypeScript validation.
       // We log this here and not in the constructor because the Logger is not yet available in the constructor.
       if (!state.ref) {
         player.logger.warn(`An external action match is missing the 'ref' property. This handler will be ignored. Match: ${JSON.stringify(state)}`);

--- a/plugins/external-action/core/src/index.ts
+++ b/plugins/external-action/core/src/index.ts
@@ -14,8 +14,11 @@ export type ExternalStateHandler = (
   options: InProgressState["controllers"],
 ) => string | undefined | Promise<string | undefined>;
 
-type ExternalActionMatch = Partial<NavigationFlowExternalState> &
-  Pick<NavigationFlowExternalState, "ref">;
+// Require "ref" property while making all others optional
+// The explicit { ref: string } overrides any index signature leniency
+type ExternalActionMatch = {
+  ref: string;
+} & Partial<NavigationFlowExternalState>;
 
 /**
  * A plugin to handle external action states
@@ -69,7 +72,7 @@ export class ExternalActionPlugin implements PlayerPlugin {
 
   apply(player: Player): void {
     const isFirstInstance = this.createRegistry(player);
-    this.registerHandlers();
+    this.registerHandlers(player);
 
     // Only the first instance should tap the hooks to avoid redundant taps
     if (!isFirstInstance) {
@@ -156,8 +159,13 @@ export class ExternalActionPlugin implements PlayerPlugin {
    * If a handler with the same specificity already exists, it will be replaced
    * and a debug log will be emitted (accessible via player.logger.debug).
    */
-  private registerHandlers(): void {
+  private registerHandlers(player: Player): void {
     for (const [state, handler] of this.handlers) {
+      // We log this here and not in the constructor because the Logger is not yet available in the constructor.
+      if (!state.ref) {
+        player.logger.warn(`An external action match is missing the 'ref' property. This handler will be ignored. Match: ${JSON.stringify(state)}`);
+        continue;
+      }
       // Registry will handle keeping only the last handler for each state
       this.registry?.set(state, handler);
     }

--- a/plugins/external-action/core/src/index.ts
+++ b/plugins/external-action/core/src/index.ts
@@ -9,13 +9,11 @@ import type {
 import { Registry } from "@player-ui/partial-match-registry";
 import { ExternalActionPluginSymbol } from "./symbols.js";
 
-export type ExternalStateHandler = (
+export type ExternalActionHandler = (
   state: NavigationFlowExternalState,
   options: InProgressState["controllers"],
 ) => string | undefined | Promise<string | undefined>;
 
-// Require "ref" property while making all others optional
-// The explicit { ref: string } overrides any index signature leniency
 type ExternalActionMatch = {
   ref: string;
 } & Partial<NavigationFlowExternalState>;
@@ -38,12 +36,12 @@ export class ExternalActionPlugin implements PlayerPlugin {
    * The shared registry that maps external states to handlers.
    * All plugin instances use the same registry.
    */
-  private registry?: Registry<ExternalStateHandler>;
+  private registry?: Registry<ExternalActionHandler>;
 
   /**
    * The handlers for this plugin instance.
    */
-  private readonly handlers: Map<ExternalActionMatch, ExternalStateHandler>;
+  private readonly handlers: Map<ExternalActionMatch, ExternalActionHandler>;
 
   /**
    * Creates a new ExternalActionPlugin
@@ -65,7 +63,7 @@ export class ExternalActionPlugin implements PlayerPlugin {
    */
   constructor(
     // This array of tuples is an established player pattern. Internally we use a Map.
-    handlers: [ExternalActionMatch, ExternalStateHandler][],
+    handlers: [ExternalActionMatch, ExternalActionHandler][],
   ) {
     this.handlers = new Map(handlers);
   }
@@ -146,7 +144,7 @@ export class ExternalActionPlugin implements PlayerPlugin {
     }
 
     // We are the first plugin instance, create the registry
-    this.registry = new Registry<ExternalStateHandler>(
+    this.registry = new Registry<ExternalActionHandler>(
       undefined,
       player.logger,
     );
@@ -165,7 +163,9 @@ export class ExternalActionPlugin implements PlayerPlugin {
       // the Swift bridge allows improperly formatted objects to bypass TypeScript validation.
       // We log this here and not in the constructor because the Logger is not yet available in the constructor.
       if (!state.ref) {
-        player.logger.warn(`An external action match is missing the 'ref' property. This handler will be ignored. Match: ${JSON.stringify(state)}`);
+        player.logger.warn(
+          `An external action match is missing the 'ref' property. This handler will be ignored. Match: ${JSON.stringify(state)}`,
+        );
         continue;
       }
       // Registry will handle keeping only the last handler for each state

--- a/plugins/external-action/ios/Sources/ExternalActionPlugin.swift
+++ b/plugins/external-action/ios/Sources/ExternalActionPlugin.swift
@@ -10,32 +10,45 @@ import JavaScriptCore
 
 import PlayerUI
 
-/**
- This plugin is for registering a handler for EXTERNAL states
- */
-public class ExternalActionPlugin: JSBasePlugin, NativePlugin {
+public struct ExternalStateHandler {
+    public typealias Match = [String: Any]
+
     /**
      The handler function to run when an external state is transitioned to
      - parameters:
         - state: The state object that represents the external state
         - options: An object containing the dataModel instance and evaluate function
-        - transition: A completion handler that takes a string to transition with
+        - transition: A completion handler that takes a string to transition with.
+            This completion handler lets the user transition at an appropriate time.
      */
-    public typealias ExternalStateHandler = (NavigationFlowExternalState, PlayerControllers, @escaping (String) -> Void) throws -> Void
+    public typealias Handler = (NavigationFlowExternalState, PlayerControllers, @escaping (String) -> Void) throws -> Void
 
-    private var handler: ExternalStateHandler?
+    public let match: Match
+    public let handler: Handler
+
+    public init(match: Match, handler: @escaping Handler) {
+        self.match = match
+        self.handler = handler
+    }
+}
+
+/**
+ This plugin is for registering a handler for EXTERNAL states
+ */
+public class ExternalActionPlugin: JSBasePlugin, NativePlugin {
+    private var handlers: [ExternalStateHandler]
 
     /**
      Construct a plugin to handle external states
      - parameters:
-        - handler: the function to call when an external state is transitioned to
+        - handlers: array of handlers with matchers and handler functions
      */
-    public convenience init(handler: @escaping ExternalStateHandler) {
-        self.init(
+    public init(handlers: [ExternalStateHandler]) {
+        self.handlers = handlers
+        super.init(
             fileName: "ExternalActionPlugin.native",
             pluginName: "ExternalActionPlugin.ExternalActionPlugin"
         )
-        self.handler = handler
     }
 
     /**
@@ -44,13 +57,16 @@ public class ExternalActionPlugin: JSBasePlugin, NativePlugin {
      - returns: An array of arguments to construct the plugin
      */
     override public func getArguments() -> [Any] {
+        guard let context = context else { return [] }
+
+        let jsHandlers = handlers.map { matchedHandler in
             let callback: @convention(block) (JSValue, JSValue) -> JSValue? = { [weak self] (state, options) in
                 guard
                     let context = self?.context,
                     let controllers = PlayerControllers(from: options),
                     let promise = JSUtilities.createPromise(context: context, handler: { (resolve, reject) in
                         do {
-                            try self?.handler?(NavigationFlowExternalState(state), controllers) { transition in
+                            try matchedHandler.handler(NavigationFlowExternalState(state), controllers) { transition in
                                 resolve(transition)
                             }
                         } catch {
@@ -60,9 +76,14 @@ public class ExternalActionPlugin: JSBasePlugin, NativePlugin {
                 else { return nil }
                 return promise
             }
-            let jsCallback = JSValue(object: callback, in: context) as Any
-            return [jsCallback]
+
+            let jsMatch = JSValue(object: matchedHandler.match, in: context)
+            let jsCallback = JSValue(object: callback, in: context)
+            return [jsMatch, jsCallback]
         }
+        
+        return [jsHandlers]
+    }
 
     override open func getUrlForFile(fileName: String) -> URL? {
         ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)

--- a/plugins/external-action/ios/Sources/ExternalActionPlugin.swift
+++ b/plugins/external-action/ios/Sources/ExternalActionPlugin.swift
@@ -11,7 +11,7 @@ import JavaScriptCore
 import PlayerUI
 
 public enum ExternalActionPluginError: LocalizedError {
-    case matchMissingRef(match: [String: Any])
+    case matchMissingRef(match: [String: Any?])
 
     public var errorDescription: String? {
         switch self {
@@ -22,7 +22,9 @@ public enum ExternalActionPluginError: LocalizedError {
 }
 
 public struct ExternalActionHandler {
-    public typealias Match = [String: Any]
+    /// Map of properties to match against external states.
+    /// Must include "ref" key.
+    public typealias Match = [String: Any?]
 
     /**
      The handler function to run when an external state is transitioned to

--- a/plugins/external-action/ios/Sources/ExternalActionPlugin.swift
+++ b/plugins/external-action/ios/Sources/ExternalActionPlugin.swift
@@ -11,7 +11,7 @@ import JavaScriptCore
 import PlayerUI
 
 public enum ExternalActionPluginError: LocalizedError {
-    case matchMissingRef(match: [String: Any?])
+    case matchMissingRef(match: [String: Any])
 
     public var errorDescription: String? {
         switch self {
@@ -24,7 +24,7 @@ public enum ExternalActionPluginError: LocalizedError {
 public struct ExternalActionHandler {
     /// Map of properties to match against external states.
     /// Must include "ref" key.
-    public typealias Match = [String: Any?]
+    public typealias Match = [String: Any]
 
     /**
      The handler function to run when an external state is transitioned to

--- a/plugins/external-action/ios/Sources/ExternalActionPlugin.swift
+++ b/plugins/external-action/ios/Sources/ExternalActionPlugin.swift
@@ -10,7 +10,18 @@ import JavaScriptCore
 
 import PlayerUI
 
-public struct ExternalStateHandler {
+public enum ExternalActionPluginError: LocalizedError {
+    case matchMissingRef(match: [String: Any])
+
+    public var errorDescription: String? {
+        switch self {
+        case .matchMissingRef(let match):
+            return "The key/match (\(match)) must contain a 'ref' key."
+        }
+    }
+}
+
+public struct ExternalActionHandler {
     public typealias Match = [String: Any]
 
     /**
@@ -21,7 +32,11 @@ public struct ExternalStateHandler {
         - transition: A completion handler that takes a string to transition with.
             This completion handler lets the user transition at an appropriate time.
      */
-    public typealias Handler = (NavigationFlowExternalState, PlayerControllers, @escaping (String) -> Void) throws -> Void
+    public typealias Handler = (
+        NavigationFlowExternalState,
+        PlayerControllers,
+        @escaping (String) -> Void
+    ) throws -> Void
 
     public let match: Match
     public let handler: Handler
@@ -36,14 +51,20 @@ public struct ExternalStateHandler {
  This plugin is for registering a handler for EXTERNAL states
  */
 public class ExternalActionPlugin: JSBasePlugin, NativePlugin {
-    private var handlers: [ExternalStateHandler]
+    private var handlers: [ExternalActionHandler]
 
     /**
-     Construct a plugin to handle external states
+     Construct a plugin to handle external states. Every match/key must include a `ref`.
      - parameters:
-        - handlers: array of handlers with matchers and handler functions
+        - handlers: array of handlers with matchers and handler functions.
      */
-    public init(handlers: [ExternalStateHandler]) {
+    public init(handlers: [ExternalActionHandler]) throws {
+        try handlers.forEach { handler in
+            let match = handler.match
+            if match["ref"] == nil {
+                throw ExternalActionPluginError.matchMissingRef(match: match)
+            }
+        }
         self.handlers = handlers
         super.init(
             fileName: "ExternalActionPlugin.native",
@@ -52,8 +73,9 @@ public class ExternalActionPlugin: JSBasePlugin, NativePlugin {
     }
 
     /**
-     Retrieves the arguments for constructing this plugin, this is necessary because the arguments need to be supplied after
-     construction of the swift object, once the context has been provided
+     Retrieves the arguments for constructing this plugin.
+     This is necessary because the arguments need to be supplied after construction of the swift object,
+     once the context has been provided.
      - returns: An array of arguments to construct the plugin
      */
     override public func getArguments() -> [Any] {
@@ -81,7 +103,7 @@ public class ExternalActionPlugin: JSBasePlugin, NativePlugin {
             let jsCallback = JSValue(object: callback, in: context)
             return [jsMatch, jsCallback]
         }
-        
+
         return [jsHandlers]
     }
 

--- a/plugins/external-action/ios/Tests/ExternalActionPluginTests.swift
+++ b/plugins/external-action/ios/Tests/ExternalActionPluginTests.swift
@@ -50,15 +50,20 @@ class ExternalActionPluginTests: XCTestCase {
 
         let handlerExpectation = XCTestExpectation(description: "handler called")
         let completionExpectation = XCTestExpectation(description: "flow completed")
-        let plugin = ExternalActionPlugin { (state, _, handler) in
-            XCTAssertEqual(state.transitions, ["Next": "END_FWD", "Prev": "END_BCK"])
-            XCTAssertEqual(state.ref, "test-1")
-            // Test out subscript fetching additional properties
-            let extra: String? = state.extraProperty
-            XCTAssertEqual(extra, "extraValue")
-            handlerExpectation.fulfill()
-            handler("Next")
-        }
+        let plugin = ExternalActionPlugin(handlers: [
+            ExternalStateHandler(
+                match: ["ref": "test-1"],
+                handler: { (state, _, handler) in
+                    XCTAssertEqual(state.transitions, ["Next": "END_FWD", "Prev": "END_BCK"])
+                    XCTAssertEqual(state.ref, "test-1")
+                    // Test out subscript fetching additional properties
+                    let extra: String? = state.extraProperty
+                    XCTAssertEqual(extra, "extraValue")
+                    handlerExpectation.fulfill()
+                    handler("Next")
+                }
+            )
+        ])
         let player = HeadlessPlayerImpl(plugins: [plugin])
 
         player.start(flow: json) { (result) in
@@ -109,10 +114,15 @@ class ExternalActionPluginTests: XCTestCase {
 
         let handlerExpectation = XCTestExpectation(description: "handler called")
         let completionExpectation = XCTestExpectation(description: "flow completed")
-        let plugin = ExternalActionPlugin { (_, _, _) in
-            handlerExpectation.fulfill()
-            throw PlayerError.jsConversionFailure
-        }
+        let plugin = ExternalActionPlugin(handlers: [
+            ExternalStateHandler(
+                match: ["ref": "test-1"],
+                handler: { (_, _, _) in
+                    handlerExpectation.fulfill()
+                    throw PlayerError.jsConversionFailure
+                }
+            )
+        ])
         let player = HeadlessPlayerImpl(plugins: [plugin])
 
         player.start(flow: json) { (result) in
@@ -171,17 +181,22 @@ class ExternalActionPluginTests: XCTestCase {
 
         let handlerExpectation = XCTestExpectation(description: "handler called")
         let completionExpectation = XCTestExpectation(description: "flow completed")
-        let plugin = ExternalActionPlugin { (state, _, handler) in
-            XCTAssertEqual(state.transitions, ["Next": "END_FWD", "Prev": "END_BCK"])
-            XCTAssertEqual(state.ref, "test-1")
-            if let param: [String: Any] = state.param {
-                XCTAssertEqual(param["name"] as? String, "ctg/pmec")
-            } else {
-                XCTFail("param was not a dictionary")
-            }
-            handlerExpectation.fulfill()
-            handler("Next")
-        }
+        let plugin = ExternalActionPlugin(handlers: [
+            ExternalStateHandler(
+                match: ["ref": "test-1"],
+                handler: { (state, _, handler) in
+                    XCTAssertEqual(state.transitions, ["Next": "END_FWD", "Prev": "END_BCK"])
+                    XCTAssertEqual(state.ref, "test-1")
+                    if let param: [String: Any] = state.param {
+                        XCTAssertEqual(param["name"] as? String, "ctg/pmec")
+                    } else {
+                        XCTFail("param was not a dictionary")
+                    }
+                    handlerExpectation.fulfill()
+                    handler("Next")
+                }
+            )
+        ])
         let player = HeadlessPlayerImpl(plugins: [plugin])
 
         player.start(flow: json) { (result) in
@@ -232,12 +247,17 @@ class ExternalActionPluginTests: XCTestCase {
 
         let handlerExpectation = XCTestExpectation(description: "handler called")
         let completionExpectation = XCTestExpectation(description: "flow completed")
-        let plugin = ExternalActionPlugin { (_, _, handler) in
-            DispatchQueue.global().asyncAfter(deadline: .now() + 1) {
-                handlerExpectation.fulfill()
-                handler("Next")
-            }
-        }
+        let plugin = ExternalActionPlugin(handlers: [
+            ExternalStateHandler(
+                match: ["ref": "test-1"],
+                handler: { (_, _, handler) in
+                    DispatchQueue.global().asyncAfter(deadline: .now() + 1) {
+                        handlerExpectation.fulfill()
+                        handler("Next")
+                    }
+                }
+            )
+        ])
         let player = HeadlessPlayerImpl(plugins: [plugin])
 
         player.start(flow: json) { (result) in
@@ -288,19 +308,24 @@ class ExternalActionPluginTests: XCTestCase {
 
         let handlerExpectation = XCTestExpectation(description: "handler called")
         let completionExpectation = XCTestExpectation(description: "flow completed")
-        let plugin = ExternalActionPlugin { (_, options, handler) in
-            XCTAssertEqual(options.data.get(binding: "transitionValue") as? String, "Next")
+        let plugin = ExternalActionPlugin(handlers: [
+            ExternalStateHandler(
+                match: ["ref": "test-1"],
+                handler: { (_, options, handler) in
+                    XCTAssertEqual(options.data.get(binding: "transitionValue") as? String, "Next")
 
-            // Test expression evaluation
+                    // Test expression evaluation
 
-            options.expression.evaluate("{{transitionValue}} = 'Prev'")
-            XCTAssertEqual(options.data.get(binding: "transitionValue") as? String, "Prev")
+                    options.expression.evaluate("{{transitionValue}} = 'Prev'")
+                    XCTAssertEqual(options.data.get(binding: "transitionValue") as? String, "Prev")
 
-            options.expression.evaluate(["{{transitionValue}} = 'Previous'", "{{transitionValue}} = 'Next'"])
-            XCTAssertEqual(options.data.get(binding: "transitionValue") as? String, "Next")
-            handlerExpectation.fulfill()
-            handler("Next")
-        }
+                    options.expression.evaluate(["{{transitionValue}} = 'Previous'", "{{transitionValue}} = 'Next'"])
+                    XCTAssertEqual(options.data.get(binding: "transitionValue") as? String, "Next")
+                    handlerExpectation.fulfill()
+                    handler("Next")
+                }
+            )
+        ])
         let player = HeadlessPlayerImpl(plugins: [plugin])
 
         player.start(flow: json) { (result) in
@@ -314,5 +339,77 @@ class ExternalActionPluginTests: XCTestCase {
         }
 
         wait(for: [handlerExpectation, completionExpectation], timeout: 1)
+    }
+    
+    func testExternalStateHandlingWithSpecificity() {
+        let json = """
+        {
+          "id": "test-flow",
+          "data": {
+            "transitionValue": "Next"
+          },
+          "navigation": {
+            "BEGIN": "FLOW_1",
+            "FLOW_1": {
+              "startState": "EXT_1",
+              "EXT_1": {
+                "state_type": "EXTERNAL",
+                "ref": "test-1",
+                "transitions": {
+                  "Next": "END_FWD",
+                  "Prev": "END_BCK"
+                },
+                "extraProperty": "extraValue"
+              },
+              "END_FWD": {
+                "state_type": "END",
+                "outcome": "FWD"
+              },
+              "END_BCK": {
+                "state_type": "END",
+                "outcome": "BCK"
+              }
+            }
+          }
+        }
+        """
+
+        let lessSpecificExpectation = XCTestExpectation(description: "less specific handler should not be called")
+        lessSpecificExpectation.isInverted = true
+        let moreSpecificExpectation = XCTestExpectation(description: "more specific handler called")
+        let completionExpectation = XCTestExpectation(description: "flow completed")
+        
+        let plugin = ExternalActionPlugin(handlers: [
+            // Less specific - only matches ref
+            ExternalStateHandler(
+                match: ["ref": "test-1"],
+                handler: { (_, _, handler) in
+                    lessSpecificExpectation.fulfill()
+                    handler("Prev")
+                }
+            ),
+            // More specific - matches ref and extraProperty
+            ExternalStateHandler(
+                match: ["ref": "test-1", "extraProperty": "extraValue"],
+                handler: { (_, _, handler) in
+                    moreSpecificExpectation.fulfill()
+                    handler("Next")
+                }
+            )
+        ])
+        let player = HeadlessPlayerImpl(plugins: [plugin])
+
+        player.start(flow: json) { (result) in
+            switch result {
+            case .success(let state):
+                // More specific handler should have been called, returning "Next" -> outcome "FWD"
+                XCTAssertEqual(state.endState?.outcome, "FWD")
+                completionExpectation.fulfill()
+            case .failure:
+                XCTFail("flow failed")
+            }
+        }
+
+        wait(for: [moreSpecificExpectation, lessSpecificExpectation, completionExpectation], timeout: 1)
     }
 }

--- a/plugins/external-action/ios/Tests/ExternalActionPluginTests.swift
+++ b/plugins/external-action/ios/Tests/ExternalActionPluginTests.swift
@@ -13,9 +13,10 @@ import JavaScriptCore
 @testable import PlayerUITestUtilitiesCore
 @testable import PlayerUIExternalActionPlugin
 
-// swiftlint:disable type_body_length
+// swiftlint:disable type_body_length force_try
 class ExternalActionPluginTests: XCTestCase {
-    func testExternalStateHandling() {
+    // swiftlint:disable:next function_body_length
+    func testExternalActionHandling() {
         let json = """
         {
           "id": "test-flow",
@@ -50,8 +51,8 @@ class ExternalActionPluginTests: XCTestCase {
 
         let handlerExpectation = XCTestExpectation(description: "handler called")
         let completionExpectation = XCTestExpectation(description: "flow completed")
-        let plugin = ExternalActionPlugin(handlers: [
-            ExternalStateHandler(
+        let plugin = try! ExternalActionPlugin(handlers: [
+            ExternalActionHandler(
                 match: ["ref": "test-1"],
                 handler: { (state, _, handler) in
                     XCTAssertEqual(state.transitions, ["Next": "END_FWD", "Prev": "END_BCK"])
@@ -79,7 +80,8 @@ class ExternalActionPluginTests: XCTestCase {
         wait(for: [handlerExpectation, completionExpectation], timeout: 1)
     }
 
-    func testExternalStateHandlingThrowsError() {
+    // swiftlint:disable:next function_body_length
+    func testExternalActionHandlingThrowsError() {
         let json = """
         {
           "id": "test-flow",
@@ -114,8 +116,8 @@ class ExternalActionPluginTests: XCTestCase {
 
         let handlerExpectation = XCTestExpectation(description: "handler called")
         let completionExpectation = XCTestExpectation(description: "flow completed")
-        let plugin = ExternalActionPlugin(handlers: [
-            ExternalStateHandler(
+        let plugin = try! ExternalActionPlugin(handlers: [
+            ExternalActionHandler(
                 match: ["ref": "test-1"],
                 handler: { (_, _, _) in
                     handlerExpectation.fulfill()
@@ -138,7 +140,8 @@ class ExternalActionPluginTests: XCTestCase {
     }
 
     // swiftlint:disable function_body_length
-    func testExternalStateHandlingComplexState() {
+    // swiftlint:disable:next function_body_length
+    func testExternalActionHandlingComplexState() {
         let json = """
         {
           "id": "test-flow",
@@ -181,8 +184,8 @@ class ExternalActionPluginTests: XCTestCase {
 
         let handlerExpectation = XCTestExpectation(description: "handler called")
         let completionExpectation = XCTestExpectation(description: "flow completed")
-        let plugin = ExternalActionPlugin(handlers: [
-            ExternalStateHandler(
+        let plugin = try! ExternalActionPlugin(handlers: [
+            ExternalActionHandler(
                 match: ["ref": "test-1"],
                 handler: { (state, _, handler) in
                     XCTAssertEqual(state.transitions, ["Next": "END_FWD", "Prev": "END_BCK"])
@@ -212,7 +215,7 @@ class ExternalActionPluginTests: XCTestCase {
         wait(for: [handlerExpectation, completionExpectation], timeout: 2)
     }
 
-    func testExternalStateHandlingWithDelay() {
+    func testExternalActionHandlingWithDelay() {
         let json = """
         {
           "id": "test-flow",
@@ -247,8 +250,8 @@ class ExternalActionPluginTests: XCTestCase {
 
         let handlerExpectation = XCTestExpectation(description: "handler called")
         let completionExpectation = XCTestExpectation(description: "flow completed")
-        let plugin = ExternalActionPlugin(handlers: [
-            ExternalStateHandler(
+        let plugin = try! ExternalActionPlugin(handlers: [
+            ExternalActionHandler(
                 match: ["ref": "test-1"],
                 handler: { (_, _, handler) in
                     DispatchQueue.global().asyncAfter(deadline: .now() + 1) {
@@ -273,7 +276,7 @@ class ExternalActionPluginTests: XCTestCase {
         wait(for: [handlerExpectation, completionExpectation], timeout: 5)
     }
 
-    func testExternalStateHandlingOptions() {
+    func testExternalActionHandlingOptions() {
         let json = """
         {
           "id": "test-flow",
@@ -308,8 +311,8 @@ class ExternalActionPluginTests: XCTestCase {
 
         let handlerExpectation = XCTestExpectation(description: "handler called")
         let completionExpectation = XCTestExpectation(description: "flow completed")
-        let plugin = ExternalActionPlugin(handlers: [
-            ExternalStateHandler(
+        let plugin = try! ExternalActionPlugin(handlers: [
+            ExternalActionHandler(
                 match: ["ref": "test-1"],
                 handler: { (_, options, handler) in
                     XCTAssertEqual(options.data.get(binding: "transitionValue") as? String, "Next")
@@ -340,8 +343,9 @@ class ExternalActionPluginTests: XCTestCase {
 
         wait(for: [handlerExpectation, completionExpectation], timeout: 1)
     }
-    
-    func testExternalStateHandlingWithSpecificity() {
+
+    // swiftlint:disable:next function_body_length
+    func testExternalActionHandlingWithSpecificity() {
         let json = """
         {
           "id": "test-flow",
@@ -378,10 +382,10 @@ class ExternalActionPluginTests: XCTestCase {
         lessSpecificExpectation.isInverted = true
         let moreSpecificExpectation = XCTestExpectation(description: "more specific handler called")
         let completionExpectation = XCTestExpectation(description: "flow completed")
-        
-        let plugin = ExternalActionPlugin(handlers: [
+
+        let plugin = try! ExternalActionPlugin(handlers: [
             // Less specific - only matches ref
-            ExternalStateHandler(
+            ExternalActionHandler(
                 match: ["ref": "test-1"],
                 handler: { (_, _, handler) in
                     lessSpecificExpectation.fulfill()
@@ -389,7 +393,7 @@ class ExternalActionPluginTests: XCTestCase {
                 }
             ),
             // More specific - matches ref and extraProperty
-            ExternalStateHandler(
+            ExternalActionHandler(
                 match: ["ref": "test-1", "extraProperty": "extraValue"],
                 handler: { (_, _, handler) in
                     moreSpecificExpectation.fulfill()
@@ -411,5 +415,29 @@ class ExternalActionPluginTests: XCTestCase {
         }
 
         wait(for: [moreSpecificExpectation, lessSpecificExpectation, completionExpectation], timeout: 1)
+    }
+
+    func testInitThrowsErrorWhenHandlerMissingRef() {
+        // Test that initializer throws when a handler match is missing the 'ref' key
+        XCTAssertThrowsError(try ExternalActionPlugin(handlers: [
+            ExternalActionHandler(
+                match: ["extraProperty": "value"],
+                handler: { (_, _, handler) in
+                    handler("Next")
+                }
+            )
+        ])) { error in
+            guard let pluginError = error as? ExternalActionPluginError else {
+                XCTFail("Expected ExternalActionPluginError but got \(type(of: error))")
+                return
+            }
+
+            if case .matchMissingRef(let match) = pluginError {
+                XCTAssertNil(match["ref"])
+                XCTAssertEqual(match["extraProperty"] as? String, "value")
+            } else {
+                XCTFail("Expected matchMissingRef error")
+            }
+        }
     }
 }

--- a/plugins/external-action/jvm/src/main/kotlin/com/intuit/playerui/plugins/externalAction/ExternalActionPlugin.kt
+++ b/plugins/external-action/jvm/src/main/kotlin/com/intuit/playerui/plugins/externalAction/ExternalActionPlugin.kt
@@ -8,27 +8,53 @@ import com.intuit.playerui.core.bridge.runtime.add
 import com.intuit.playerui.core.flow.state.NavigationFlowExternalState
 import com.intuit.playerui.core.flow.state.NavigationFlowState
 import com.intuit.playerui.core.player.Player
+import com.intuit.playerui.core.player.PlayerException
 import com.intuit.playerui.core.player.state.ControllerState
 import com.intuit.playerui.core.plugins.JSScriptPluginWrapper
 import com.intuit.playerui.core.plugins.PlayerPlugin
 import com.intuit.playerui.core.plugins.findPlugin
 import com.intuit.playerui.plugins.settimeout.SetTimeoutPlugin
 
-/** Function definition of an external action handler */
-public fun interface ExternalActionHandler {
-    public fun onExternalState(
-        state: NavigationFlowExternalState,
-        options: ControllerState,
-        transition: (String) -> Unit,
-    )
+public data class ExternalActionHandler(
+    val match: Map<String, Any>,
+    val handler: Handler,
+) {
+    /**
+     * Function definition of an external action handler
+     * @param state The NavigationFlowExternalState that was transitioned to
+     * @param options The ControllerState providing access to data and expression evaluation
+     * @param transition Callback to transition to the next state
+     */
+    public fun interface Handler {
+        public fun onExternalAction(
+            state: NavigationFlowExternalState,
+            options: ControllerState,
+            transition: (String) -> Unit,
+        )
+    }
+
+    init {
+        require(match.containsKey("ref")) {
+            "The match map must contain a 'ref' key. Got: $match"
+        }
+    }
 }
 
-/** Core plugin wrapper providing external action support for the JVM Player */
+/**
+ * Core plugin wrapper providing external action support for the JVM Player.
+ *
+ * This plugin uses a registry-based approach to match external states to handler functions.
+ * Multiple handlers can be registered, and handlers are matched using partial object matching
+ * with specificity ordering (more specific matches take precedence).
+ *
+ * @param handlers List of handler configurations with matchers and handler functions.
+ */
 public class ExternalActionPlugin(
-    private var handler: ExternalActionHandler? = null,
+    vararg handlers: ExternalActionHandler,
 ) : JSScriptPluginWrapper(PLUGIN_NAME, sourcePath = BUNDLED_SOURCE_PATH),
     PlayerPlugin {
     private lateinit var player: Player
+    private val handlers: List<ExternalActionHandler> = handlers.toList()
 
     override fun apply(player: Player) {
         this.player = player
@@ -37,21 +63,26 @@ public class ExternalActionPlugin(
     override fun apply(runtime: Runtime<*>) {
         SetTimeoutPlugin().apply(runtime)
         runtime.load(ScriptContext(script, BUNDLED_SOURCE_PATH))
-        runtime.add("externalActionHandler") externalActionHandler@{ state: Node, options: Node ->
-            val state = state.deserialize(NavigationFlowState.serializer())
-                as? NavigationFlowExternalState ?: return@externalActionHandler null
-            val options = options.deserialize(ControllerState.serializer())
 
-            return@externalActionHandler runtime.Promise<Any> { resolve, _ ->
-                handler?.onExternalState(state, options, resolve)
+        // Build array of [match, handler] tuples for JavaScript
+        val jsHandlers = handlers.map { handlerConfig ->
+            // Register handler callback
+            val callback: (Node, Node) -> Any? = callback@{ state, options ->
+                val externalState = state.deserialize(NavigationFlowState.serializer())
+                    as? NavigationFlowExternalState ?: throw PlayerException("ExternalActionPlugin Could not deserialize $state")
+                val controllerState = options.deserialize(ControllerState.serializer())
+
+                runtime.Promise<Any> { resolve, _ ->
+                    handlerConfig.handler.onExternalAction(externalState, controllerState, resolve)
+                }
             }
-        }
-        instance = runtime.buildInstance("""(new $name(externalActionHandler))""")
-    }
 
-    /** Register handler for external action navigation nodes */
-    public fun onExternalAction(handler: ExternalActionHandler) {
-        this.handler = handler
+            // Return [match, callback] tuple
+            listOf(handlerConfig.match, callback)
+        }
+
+        runtime.add("externalActionHandlers", jsHandlers)
+        instance = runtime.buildInstance("(new $name(externalActionHandlers))")
     }
 
     private companion object {
@@ -62,8 +93,3 @@ public class ExternalActionPlugin(
 
 /** Convenience getter to find the first [ExternalActionPlugin] registered to the [Player] */
 public val Player.externalActionPlugin: ExternalActionPlugin? get() = findPlugin()
-
-/** Convenience method for registering an external action handler without a reference to the [ExternalActionPlugin] */
-public fun Player.onExternalAction(handler: ExternalActionHandler) {
-    externalActionPlugin?.onExternalAction(handler)
-}

--- a/plugins/external-action/jvm/src/test/kotlin/com/intuit/playerui/plugins/externalAction/ExternalActionPluginTest.kt
+++ b/plugins/external-action/jvm/src/test/kotlin/com/intuit/playerui/plugins/externalAction/ExternalActionPluginTest.kt
@@ -1,20 +1,19 @@
 package com.intuit.playerui.plugins.externalAction
 
 import com.intuit.playerui.core.expressions.evaluate
+import com.intuit.playerui.core.player.state.ControllerState
 import com.intuit.playerui.utils.test.PlayerTest
 import com.intuit.playerui.utils.test.runBlockingTest
+import com.intuit.playerui.utils.test.setupPlayer
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.TestTemplate
 import org.junit.jupiter.api.assertThrows
 
 internal class ExternalActionPluginTest : PlayerTest() {
-    override val plugins = listOf(ExternalActionPlugin())
-
-    private val plugin get() = player.externalActionPlugin!!
-
     private val jsonFlow =
         """
 {
@@ -49,26 +48,38 @@ internal class ExternalActionPluginTest : PlayerTest() {
         """
 
     @TestTemplate
-    fun testExternalStateHandling() = runBlockingTest {
-        plugin.onExternalAction { state, _, transition ->
-            assertEquals(state.transitions, mapOf("Next" to "END_FWD", "Prev" to "END_BCK"))
-            assertEquals(state.ref, "test-1")
+    fun testExternalActionHandling() = runBlockingTest {
+        val plugin = ExternalActionPlugin(
+            ExternalActionHandler(
+                match = mapOf("ref" to "test-1"),
+                handler = { state, _, transition ->
+                    assertEquals(state.transitions, mapOf("Next" to "END_FWD", "Prev" to "END_BCK"))
+                    assertEquals(state.ref, "test-1")
 
-            val extra = state["extraProperty"]
-            assertEquals(extra, "extraValue")
-            transition("Next")
-        }
+                    val extra = state["extraProperty"]
+                    assertEquals(extra, "extraValue")
+                    transition("Next")
+                },
+            ),
+        )
 
+        setupPlayer(plugin)
         val result = player.start(jsonFlow).await()
         assertEquals(result.endState.outcome, "FWD")
     }
 
     @TestTemplate
-    fun testExternalStateHandlingThrows() = runBlockingTest {
-        plugin.onExternalAction { state, _, transition ->
-            throw Exception("Bad Code")
-        }
+    fun testExternalActionHandlingThrows() = runBlockingTest {
+        val plugin = ExternalActionPlugin(
+            ExternalActionHandler(
+                match = mapOf("ref" to "test-1"),
+                handler = { _, _, _ ->
+                    throw Exception("Bad Code")
+                },
+            ),
+        )
 
+        setupPlayer(plugin)
         assertEquals(
             "Bad Code",
             assertThrows<Exception> {
@@ -80,33 +91,117 @@ internal class ExternalActionPluginTest : PlayerTest() {
     }
 
     @TestTemplate
-    fun testExternalStateHandlingWithDelay() = runBlockingTest {
-        player.onExternalAction { _, _, transition ->
-            launch {
-                delay(2000)
-                transition("Next")
-            }
-        }
+    fun testExternalActionHandlingWithDelay() = runBlockingTest {
+        val plugin = ExternalActionPlugin(
+            ExternalActionHandler(
+                match = mapOf("ref" to "test-1"),
+                handler = { _, _, transition ->
+                    launch {
+                        delay(2000)
+                        transition("Next")
+                    }
+                },
+            ),
+        )
 
+        setupPlayer(plugin)
         val result = player.start(jsonFlow).await()
         assertEquals(result.endState.outcome, "FWD")
     }
 
     @TestTemplate
-    fun testExternalStateHandlingOptions() = runBlockingTest {
-        player.onExternalAction { _, options, transition ->
-            assertEquals(options.data.get("transitionValue"), "Next")
+    fun testExternalActionHandlingOptions() = runBlockingTest {
+        var callbackOptions: ControllerState? = null
 
-            // Test expression evaluation
-            options.expression.evaluate("{{transitionValue}} = 'Prev'")
-            assertEquals(options.data.get("transitionValue"), "Prev")
+        val plugin = ExternalActionPlugin(
+            ExternalActionHandler(
+                match = mapOf("ref" to "test-1"),
+                handler = { _, options, transition ->
+                    callbackOptions = options
+                    transition("Prev")
+                },
+            ),
+        )
 
-            options.expression.evaluate(listOf("{{transitionValue}} = 'Previous'", "{{transitionValue}} = 'Next'"))
-            assertEquals(options.data.get("transitionValue"), "Next")
-            transition("Prev")
-        }
-
+        setupPlayer(plugin)
         val result = player.start(jsonFlow).await()
         assertEquals(result.endState.outcome, "BCK")
+
+        assertEquals(callbackOptions!!.data.get("transitionValue"), "Next")
+        callbackOptions!!.expression.evaluate("{{transitionValue}} = 'Prev'")
+        assertEquals(callbackOptions!!.data.get("transitionValue"), "Prev")
+        callbackOptions!!.expression.evaluate(listOf("{{transitionValue}} = 'Previous'", "{{transitionValue}} = 'Next'"))
+        assertEquals(callbackOptions!!.data.get("transitionValue"), "Next")
+    }
+
+    @TestTemplate
+    fun testExternalActionHandlingWithSpecificity() = runBlockingTest {
+        var lessSpecificCalled = false
+        var moreSpecificCalled = false
+
+        val plugin = ExternalActionPlugin(
+            // Less specific - only matches ref
+            ExternalActionHandler(
+                match = mapOf("ref" to "test-1"),
+                handler = { _, _, transition ->
+                    lessSpecificCalled = true
+                    transition("Prev")
+                },
+            ),
+            // More specific - matches ref and extraProperty
+            ExternalActionHandler(
+                match = mapOf("ref" to "test-1", "extraProperty" to "extraValue"),
+                handler = { _, _, transition ->
+                    moreSpecificCalled = true
+                    transition("Next")
+                },
+            ),
+        )
+
+        setupPlayer(plugin)
+        val result = player.start(jsonFlow).await()
+
+        // More specific handler should have been called
+        assertTrue(moreSpecificCalled, "More specific handler should have been called")
+        assertTrue(!lessSpecificCalled, "Less specific handler should not have been called")
+        assertEquals(result.endState.outcome, "FWD")
+    }
+
+    @TestTemplate
+    fun testMultiplePluginsLastOneWins() = runBlockingTest {
+        val plugin1 = ExternalActionPlugin(
+            ExternalActionHandler(
+                match = mapOf("ref" to "test-1"),
+                handler = { _, _, transition ->
+                    transition("Next")
+                },
+            ),
+        )
+
+        val plugin2 = ExternalActionPlugin(
+            ExternalActionHandler(
+                match = mapOf("ref" to "test-1"),
+                handler = { _, _, transition ->
+                    transition("Prev")
+                },
+            ),
+        )
+
+        setupPlayer(plugin1, plugin2)
+        val result = player.start(jsonFlow).await()
+
+        // Last handler registered wins (Prev)
+        assertEquals(result.endState.outcome, "BCK")
+    }
+
+    @TestTemplate
+    fun testHandlerConfigRequiresRef() {
+        val exception = assertThrows<IllegalArgumentException> {
+            ExternalActionHandler(
+                match = mapOf("extraProperty" to "value"),
+                handler = ExternalActionHandler.Handler { _, _, transition -> transition("Next") },
+            )
+        }
+        assertTrue(exception.message?.contains("must contain a 'ref' key") == true)
     }
 }

--- a/plugins/external-action/swiftui/Sources/ExternalActionViewModifierPlugin.swift
+++ b/plugins/external-action/swiftui/Sources/ExternalActionViewModifierPlugin.swift
@@ -8,7 +8,7 @@ import PlayerUIExternalActionPlugin
 public struct ExternalActionViewModifierHandler {
     /// Map of properties to match against external states.
     /// Must include "ref" key.
-    public typealias Match = [String: Any?]
+    public typealias Match = [String: Any]
 
     /**
      The handler function to run when an external state is transitioned to

--- a/plugins/external-action/swiftui/Sources/ExternalActionViewModifierPlugin.swift
+++ b/plugins/external-action/swiftui/Sources/ExternalActionViewModifierPlugin.swift
@@ -5,7 +5,7 @@ import PlayerUI
 import PlayerUISwiftUI
 import PlayerUIExternalActionPlugin
 
-public struct ExternalStateViewModifierHandler {
+public struct ExternalActionViewModifierHandler {
     public typealias Match = [String: Any]
     
     /**
@@ -16,7 +16,11 @@ public struct ExternalStateViewModifierHandler {
         - transition: A completion handler that takes a string to transition with
      - returns: A view to show as content by the ViewModifier
      */
-    public typealias Handler = (NavigationFlowExternalState, PlayerControllers, @escaping (String) -> Void) throws -> AnyView
+    public typealias Handler = (
+        NavigationFlowExternalState,
+        PlayerControllers,
+        @escaping (String) -> Void
+    ) throws -> AnyView
     
     public let match: Match
     public let handler: Handler
@@ -28,27 +32,38 @@ public struct ExternalStateViewModifierHandler {
 }
 
 /**
- A variation on `ExternalActionPlugin` for `SwiftUIPlayer` that applies a ViewModifier to SwiftUIPlayer content when in an external state
+ A variation on `ExternalActionPlugin` for `SwiftUIPlayer` that applies a ViewModifier to
+ SwiftUIPlayer content when in an external state
  */
-open class ExternalActionViewModifierPlugin<ModifierType: ExternalStateViewModifier>: JSBasePlugin, NativePlugin, ObservableObject {
+open class ExternalActionViewModifierPlugin<ModifierType: ExternalActionViewModifier>:
+    JSBasePlugin, NativePlugin, ObservableObject {
 
     /// Whether or not Player is currently in an EXTERNAL state
-    @Published public var isExternalState = false
+    @Published public var isExternalAction = false
     /// The content the plugin has determined to show during the current EXTERNAL state
     @Published public var content: AnyView?
     /// The current state if player is in an EXTERNAL state
     @Published public var state: NavigationFlowExternalState?
 
-    private var handlers: [ExternalStateViewModifierHandler]
+    private var handlers: [ExternalActionViewModifierHandler]
 
     /**
      Construct a plugin to handle external states
      - parameters:
         - handlers: array of handlers with matchers and handler functions
      */
-    public init(handlers: [ExternalStateViewModifierHandler]) {
+    public init(handlers: [ExternalActionViewModifierHandler]) throws {
+        try handlers.forEach { handler in
+            let match = handler.match
+            if match["ref"] == nil {
+                throw ExternalActionPluginError.matchMissingRef(match: match)
+            }
+        }
         self.handlers = handlers
-        super.init(fileName: "ExternalActionPlugin.native", pluginName: "ExternalActionPlugin.ExternalActionPlugin")
+        super.init(
+            fileName: "ExternalActionPlugin.native",
+            pluginName: "ExternalActionPlugin.ExternalActionPlugin"
+        )
     }
 
     open func apply<P>(player: P) where P: HeadlessPlayer {
@@ -66,7 +81,7 @@ open class ExternalActionViewModifierPlugin<ModifierType: ExternalStateViewModif
                         old?.value?.stateType == "EXTERNAL",
                         newState.value?.stateType != "EXTERNAL"
                     else { return }
-                    self?.isExternalState = false
+                    self?.isExternalAction = false
                     self?.state = nil
                 }
             }
@@ -74,13 +89,14 @@ open class ExternalActionViewModifierPlugin<ModifierType: ExternalStateViewModif
     }
 
     /**
-     Retrieves the arguments for constructing this plugin, this is necessary because the arguments need to be supplied after
-     construction of the swift object, once the context has been provided
+     Retrieves the arguments for constructing this plugin.
+     This is necessary because the arguments need to be supplied after construction of the swift object,
+     once the context has been provided.
      - returns: An array of arguments to construct the plugin
      */
     override open func getArguments() -> [Any] {
         guard let context = context else { return [] }
-        
+
         // Convert handlers to array of tuples [match, callback]
         let jsHandlers = handlers.map { handler in
             let callback: @convention(block) (JSValue, JSValue) -> JSValue? = { [weak self] (state, options) in
@@ -88,14 +104,14 @@ open class ExternalActionViewModifierPlugin<ModifierType: ExternalStateViewModif
                     let context = self?.context,
                     let controllers = PlayerControllers(from: options),
                     let promise = JSUtilities.createPromise(context: context, handler: { (resolve, reject) in
-                        self?.isExternalState = true
+                        self?.isExternalAction = true
                         let state = NavigationFlowExternalState(state)
                         self?.state = state
                         do {
                             self?.content = try handler.handler(state, controllers) { transition in
                                 resolve(transition)
                                 withAnimation {
-                                    self?.isExternalState = false
+                                    self?.isExternalAction = false
                                     self?.state = nil
                                 }
                                 self?.content = nil
@@ -107,12 +123,12 @@ open class ExternalActionViewModifierPlugin<ModifierType: ExternalStateViewModif
                 else { return nil }
                 return promise
             }
-            
+
             let jsMatch = JSValue(object: handler.match, in: context)
             let jsCallback = JSValue(object: callback, in: context)
             return [jsMatch, jsCallback]
         }
-        
+
         return [jsHandlers]
     }
 
@@ -128,12 +144,12 @@ open class ExternalActionViewModifierPlugin<ModifierType: ExternalStateViewModif
  ViewModifier type specifically for the `ExternalActionViewModifierPlugin` to provide observable properties
  to present content in an external action
  */
-public protocol ExternalStateViewModifier: ViewModifier {
+public protocol ExternalActionViewModifier: ViewModifier {
     /// An observable reference to the presenting plugin, to know when we are in an external state
     var plugin: ExternalActionViewModifierPlugin<Self> { get }
 
     /**
-     Creates a new `ExternalStateViewModifier` with the plugin that is presenting it
+     Creates a new `ExternalActionViewModifier` with the plugin that is presenting it
      - parameters:
         - plugin: The plugin presenting this view modifier
      */
@@ -143,7 +159,7 @@ public protocol ExternalStateViewModifier: ViewModifier {
 /**
  A ViewModifier for the `ExternalActionViewModifierPlugin` that presents the external state with the `.sheet` modifier
  */
-public struct ExternalStateSheetModifier: ExternalStateViewModifier {
+public struct ExternalActionSheetModifier: ExternalActionViewModifier {
     @ObservedObject public var plugin: ExternalActionViewModifierPlugin<Self>
     /**
      Constructs this ViewModifier
@@ -155,7 +171,7 @@ public struct ExternalStateSheetModifier: ExternalStateViewModifier {
     }
     @ViewBuilder
     public func body(content: Content) -> some View {
-        content.inspectableSheet(isPresented: $plugin.isExternalState, content: {
+        content.inspectableSheet(isPresented: $plugin.isExternalAction, content: {
             plugin.content
         })
     }

--- a/plugins/external-action/swiftui/Sources/ExternalActionViewModifierPlugin.swift
+++ b/plugins/external-action/swiftui/Sources/ExternalActionViewModifierPlugin.swift
@@ -117,6 +117,10 @@ open class ExternalActionViewModifierPlugin<ModifierType: ExternalActionViewModi
                                 self?.content = nil
                             }
                         } catch {
+                            // Reset state when handler throws
+                            self?.isExternalAction = false
+                            self?.state = nil
+                            self?.content = nil
                             reject(JSValue(newErrorFromMessage: error.playerDescription, in: context) as Any)
                         }
                     })

--- a/plugins/external-action/swiftui/Sources/ExternalActionViewModifierPlugin.swift
+++ b/plugins/external-action/swiftui/Sources/ExternalActionViewModifierPlugin.swift
@@ -106,7 +106,7 @@ open class ExternalActionViewModifierPlugin<ModifierType: ExternalActionViewModi
                     let context = self?.context,
                     let controllers = PlayerControllers(from: options),
                     let promise = JSUtilities.createPromise(context: context, handler: { (resolve, reject) in
-                        Task { @MainActor in
+                        let updateUI: () -> Void = {
                             self?.isExternalAction = true
                             let state = NavigationFlowExternalState(state)
                             self?.state = state
@@ -126,6 +126,12 @@ open class ExternalActionViewModifierPlugin<ModifierType: ExternalActionViewModi
                                 self?.content = nil
                                 reject(JSValue(newErrorFromMessage: error.playerDescription, in: context) as Any)
                             }
+                        }
+
+                        if Thread.isMainThread {
+                            updateUI()
+                        } else {
+                            DispatchQueue.main.sync(execute: updateUI)
                         }
                     })
                 else { return nil }

--- a/plugins/external-action/swiftui/Sources/ExternalActionViewModifierPlugin.swift
+++ b/plugins/external-action/swiftui/Sources/ExternalActionViewModifierPlugin.swift
@@ -113,17 +113,20 @@ open class ExternalActionViewModifierPlugin<ModifierType: ExternalActionViewModi
                             do {
                                 self?.content = try handler.handler(state, controllers) { transition in
                                     resolve(transition)
-                                    withAnimation {
-                                        self?.isExternalAction = false
-                                        self?.state = nil
+                                    let resetWithAnimation: () -> Void = {
+                                        withAnimation {
+                                            self?.resetState()
+                                        }
                                     }
-                                    self?.content = nil
+                                    if Thread.isMainThread {
+                                        resetWithAnimation()
+                                    } else {
+                                        DispatchQueue.main.sync { resetWithAnimation() }
+                                    }
                                 }
                             } catch {
                                 // Reset state when handler throws
-                                self?.isExternalAction = false
-                                self?.state = nil
-                                self?.content = nil
+                                self?.resetState()
                                 reject(JSValue(newErrorFromMessage: error.playerDescription, in: context) as Any)
                             }
                         }
@@ -144,6 +147,12 @@ open class ExternalActionViewModifierPlugin<ModifierType: ExternalActionViewModi
         }
 
         return [jsHandlers]
+    }
+
+    private func resetState() {
+        isExternalAction = false
+        state = nil
+        content = nil
     }
 
     override open func getUrlForFile(fileName: String) -> URL? {

--- a/plugins/external-action/swiftui/Sources/ExternalActionViewModifierPlugin.swift
+++ b/plugins/external-action/swiftui/Sources/ExternalActionViewModifierPlugin.swift
@@ -5,6 +5,28 @@ import PlayerUI
 import PlayerUISwiftUI
 import PlayerUIExternalActionPlugin
 
+public struct ExternalStateViewModifierHandler {
+    public typealias Match = [String: Any]
+    
+    /**
+     The handler function to run when an external state is transitioned to
+     - parameters:
+        - state: The state object that represents the external state
+        - options: An object containing the dataModel instance and evaluate function
+        - transition: A completion handler that takes a string to transition with
+     - returns: A view to show as content by the ViewModifier
+     */
+    public typealias Handler = (NavigationFlowExternalState, PlayerControllers, @escaping (String) -> Void) throws -> AnyView
+    
+    public let match: Match
+    public let handler: Handler
+    
+    public init(match: Match, handler: @escaping Handler) {
+        self.match = match
+        self.handler = handler
+    }
+}
+
 /**
  A variation on `ExternalActionPlugin` for `SwiftUIPlayer` that applies a ViewModifier to SwiftUIPlayer content when in an external state
  */
@@ -17,26 +39,16 @@ open class ExternalActionViewModifierPlugin<ModifierType: ExternalStateViewModif
     /// The current state if player is in an EXTERNAL state
     @Published public var state: NavigationFlowExternalState?
 
-    /**
-     The handler function to run when an external state is transitioned to
-     - parameters:
-        - state: The state object that represents the external state
-        - options: An object containing the dataModel instance and evaluate function
-        - transition: A completion handler that takes a string to transition with
-     - returns: A view to show as content by the ViewModifier
-     */
-    public typealias ExternalStateViewModifierHandler = (NavigationFlowExternalState, PlayerControllers, @escaping (String) -> Void) throws -> AnyView
-
-    private var handler: ExternalStateViewModifierHandler?
+    private var handlers: [ExternalStateViewModifierHandler]
 
     /**
      Construct a plugin to handle external states
      - parameters:
-        - handler: the function to call when an external state is transitioned to
+        - handlers: array of handlers with matchers and handler functions
      */
-    public convenience init(handler: @escaping ExternalStateViewModifierHandler) {
-        self.init(fileName: "ExternalActionPlugin.native", pluginName: "ExternalActionPlugin.ExternalActionPlugin")
-        self.handler = handler
+    public init(handlers: [ExternalStateViewModifierHandler]) {
+        self.handlers = handlers
+        super.init(fileName: "ExternalActionPlugin.native", pluginName: "ExternalActionPlugin.ExternalActionPlugin")
     }
 
     open func apply<P>(player: P) where P: HeadlessPlayer {
@@ -67,32 +79,41 @@ open class ExternalActionViewModifierPlugin<ModifierType: ExternalStateViewModif
      - returns: An array of arguments to construct the plugin
      */
     override open func getArguments() -> [Any] {
-        let callback: @convention(block) (JSValue, JSValue) -> JSValue? = { [weak self] (state, options) in
-            guard
-                let context = self?.context,
-                let controllers = PlayerControllers(from: options),
-                let promise = JSUtilities.createPromise(context: context, handler: { (resolve, reject) in
-                    self?.isExternalState = true
-                    let state = NavigationFlowExternalState(state)
-                    self?.state = state
-                    do {
-                        self?.content = try self?.handler?(state, controllers) { transition in
-                            resolve(transition)
-                            withAnimation {
-                                self?.isExternalState = false
-                                self?.state = nil
+        guard let context = context else { return [] }
+        
+        // Convert handlers to array of tuples [match, callback]
+        let jsHandlers = handlers.map { handler in
+            let callback: @convention(block) (JSValue, JSValue) -> JSValue? = { [weak self] (state, options) in
+                guard
+                    let context = self?.context,
+                    let controllers = PlayerControllers(from: options),
+                    let promise = JSUtilities.createPromise(context: context, handler: { (resolve, reject) in
+                        self?.isExternalState = true
+                        let state = NavigationFlowExternalState(state)
+                        self?.state = state
+                        do {
+                            self?.content = try handler.handler(state, controllers) { transition in
+                                resolve(transition)
+                                withAnimation {
+                                    self?.isExternalState = false
+                                    self?.state = nil
+                                }
+                                self?.content = nil
                             }
-                            self?.content = nil
+                        } catch {
+                            reject(JSValue(newErrorFromMessage: error.playerDescription, in: context) as Any)
                         }
-                    } catch {
-                        reject(JSValue(newErrorFromMessage: error.playerDescription, in: context) as Any)
-                    }
-                })
-            else { return nil }
-            return promise
+                    })
+                else { return nil }
+                return promise
+            }
+            
+            let jsMatch = JSValue(object: handler.match, in: context)
+            let jsCallback = JSValue(object: callback, in: context)
+            return [jsMatch, jsCallback]
         }
-        let jsCallback = JSValue(object: callback, in: context) as Any
-        return [jsCallback]
+        
+        return [jsHandlers]
     }
 
     override open func getUrlForFile(fileName: String) -> URL? {

--- a/plugins/external-action/swiftui/Sources/ExternalActionViewModifierPlugin.swift
+++ b/plugins/external-action/swiftui/Sources/ExternalActionViewModifierPlugin.swift
@@ -6,7 +6,9 @@ import PlayerUISwiftUI
 import PlayerUIExternalActionPlugin
 
 public struct ExternalActionViewModifierHandler {
-    public typealias Match = [String: Any]
+    /// Map of properties to match against external states.
+    /// Must include "ref" key.
+    public typealias Match = [String: Any?]
 
     /**
      The handler function to run when an external state is transitioned to

--- a/plugins/external-action/swiftui/Sources/ExternalActionViewModifierPlugin.swift
+++ b/plugins/external-action/swiftui/Sources/ExternalActionViewModifierPlugin.swift
@@ -111,13 +111,11 @@ open class ExternalActionViewModifierPlugin<ModifierType: ExternalActionViewModi
                             do {
                                 self?.content = try handler.handler(state, controllers) { transition in
                                     resolve(transition)
-                                    Task { @MainActor in
-                                        withAnimation {
-                                            self?.isExternalAction = false
-                                            self?.state = nil
-                                        }
-                                        self?.content = nil
+                                    withAnimation {
+                                        self?.isExternalAction = false
+                                        self?.state = nil
                                     }
+                                    self?.content = nil
                                 }
                             } catch {
                                 // Reset state when handler throws

--- a/plugins/external-action/swiftui/Sources/ExternalActionViewModifierPlugin.swift
+++ b/plugins/external-action/swiftui/Sources/ExternalActionViewModifierPlugin.swift
@@ -7,7 +7,7 @@ import PlayerUIExternalActionPlugin
 
 public struct ExternalActionViewModifierHandler {
     public typealias Match = [String: Any]
-    
+
     /**
      The handler function to run when an external state is transitioned to
      - parameters:
@@ -21,10 +21,10 @@ public struct ExternalActionViewModifierHandler {
         PlayerControllers,
         @escaping (String) -> Void
     ) throws -> AnyView
-    
+
     public let match: Match
     public let handler: Handler
-    
+
     public init(match: Match, handler: @escaping Handler) {
         self.match = match
         self.handler = handler
@@ -104,24 +104,28 @@ open class ExternalActionViewModifierPlugin<ModifierType: ExternalActionViewModi
                     let context = self?.context,
                     let controllers = PlayerControllers(from: options),
                     let promise = JSUtilities.createPromise(context: context, handler: { (resolve, reject) in
-                        self?.isExternalAction = true
-                        let state = NavigationFlowExternalState(state)
-                        self?.state = state
-                        do {
-                            self?.content = try handler.handler(state, controllers) { transition in
-                                resolve(transition)
-                                withAnimation {
-                                    self?.isExternalAction = false
-                                    self?.state = nil
+                        Task { @MainActor in
+                            self?.isExternalAction = true
+                            let state = NavigationFlowExternalState(state)
+                            self?.state = state
+                            do {
+                                self?.content = try handler.handler(state, controllers) { transition in
+                                    resolve(transition)
+                                    Task { @MainActor in
+                                        withAnimation {
+                                            self?.isExternalAction = false
+                                            self?.state = nil
+                                        }
+                                        self?.content = nil
+                                    }
                                 }
+                            } catch {
+                                // Reset state when handler throws
+                                self?.isExternalAction = false
+                                self?.state = nil
                                 self?.content = nil
+                                reject(JSValue(newErrorFromMessage: error.playerDescription, in: context) as Any)
                             }
-                        } catch {
-                            // Reset state when handler throws
-                            self?.isExternalAction = false
-                            self?.state = nil
-                            self?.content = nil
-                            reject(JSValue(newErrorFromMessage: error.playerDescription, in: context) as Any)
                         }
                     })
                 else { return nil }
@@ -183,9 +187,14 @@ public struct ExternalActionSheetModifier: ExternalActionViewModifier {
 
 // MARK: ViewInspector
 extension View {
-    func inspectableSheet<Sheet>(isPresented: Binding<Bool>, onDismiss: (() -> Void)? = nil, @ViewBuilder content: @escaping () -> Sheet
+    func inspectableSheet<Sheet>(
+        isPresented: Binding<Bool>,
+        onDismiss: (() -> Void)? = nil,
+        @ViewBuilder content: @escaping () -> Sheet
     ) -> some View where Sheet: View {
-        return self.modifier(InspectableSheet(isPresented: isPresented, onDismiss: onDismiss, popupBuilder: content))
+        return self.modifier(
+            InspectableSheet(isPresented: isPresented, onDismiss: onDismiss, popupBuilder: content)
+        )
     }
 }
 

--- a/plugins/external-action/swiftui/ViewInspector/ExternalActionViewModifierPluginTests.swift
+++ b/plugins/external-action/swiftui/ViewInspector/ExternalActionViewModifierPluginTests.swift
@@ -17,12 +17,13 @@ import ViewInspector
 @testable import PlayerUIReferenceAssets
 @testable import PlayerUIExternalActionViewModifierPlugin
 
+// swiftlint:disable type_body_length force_try
 class ExternalActionViewModifierPluginTests: XCTestCase {
     override func setUp() {
         XCUIApplication().terminate()
     }
-    // swiftlint:disable function_body_length
-    func testExternalStateHandling() throws {
+    // swiftlint:disable:next function_body_length
+    func testExternalActionHandling() throws {
         let json = """
         {
           "id": "test-flow",
@@ -58,8 +59,8 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
         let handlerExpectation = XCTestExpectation(description: "handler called")
         let completionExpectation = XCTestExpectation(description: "flow completed")
         let renderExpectation = XCTestExpectation(description: "external view rendered")
-        let plugin = ExternalActionViewModifierPlugin<ExternalStateSheetModifier>(handlers: [
-            ExternalStateViewModifierHandler(
+        let plugin = try! ExternalActionViewModifierPlugin<ExternalActionSheetModifier>(handlers: [
+            ExternalActionViewModifierHandler(
                 match: ["ref": "test-1"],
                 handler: { (state, _, transition) in
                     XCTAssertEqual(state.transitions, ["Next": "END_FWD", "Prev": "END_BCK"])
@@ -83,21 +84,26 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
 
         let context = SwiftUIPlayer.Context()
 
-        let player = SwiftUIPlayer(flow: json, plugins: [ReferenceAssetsPlugin(), plugin], result: Binding(get: {nil}, set: { (result) in
-            switch result {
-            case .success:
-                completionExpectation.fulfill()
-            default:
-                break
-            }
-        }), context: context, unloadOnDisappear: false)
+        let player = SwiftUIPlayer(
+            flow: json,
+            plugins: [ReferenceAssetsPlugin(), plugin],
+            result: Binding(get: {nil}, set: { (result) in
+                switch result {
+                case .success:
+                    completionExpectation.fulfill()
+                default:
+                    break
+                }
+            }), context: context, unloadOnDisappear: false
+        )
 
         ViewHosting.host(view: player)
 
         wait(for: [renderExpectation, handlerExpectation], timeout: 10)
 
         XCTAssertNotNil(plugin.state)
-        let content = try player.inspect().vStack().first?.anyView().anyView().modifier(ExternalStateSheetModifier.self).viewModifierContent()
+        let content = try player.inspect().vStack().first?.anyView().anyView()
+            .modifier(ExternalActionSheetModifier.self).viewModifierContent()
         try content?.sheet().anyView().text().callOnDisappear()
 
         wait(for: [completionExpectation], timeout: 10)
@@ -106,8 +112,8 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
         ViewHosting.expel()
     }
 
-    // swiftlint:disable function_body_length
-    func testExternalStateHandlingForcedTransition() throws {
+    // swiftlint:disable:next function_body_length
+    func testExternalActionHandlingForcedTransition() throws {
         let json = """
         {
           "id": "test-flow",
@@ -157,8 +163,8 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
         let handlerExpectation = XCTestExpectation(description: "handler called")
         let completionExpectation = XCTestExpectation(description: "flow completed")
         let renderExpectation = XCTestExpectation(description: "external view rendered")
-        let plugin = ExternalActionViewModifierPlugin<ExternalStateSheetModifier>(handlers: [
-            ExternalStateViewModifierHandler(
+        let plugin = try! ExternalActionViewModifierPlugin<ExternalActionSheetModifier>(handlers: [
+            ExternalActionViewModifierHandler(
                 match: ["ref": "test-1"],
                 handler: { (state, _, transition) in
                     XCTAssertEqual(state.transitions, ["Next": "VIEW_1", "Prev": "END_BCK"])
@@ -183,7 +189,7 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
                 self.expectation = expectation
             }
 
-            func apply<P>(player: P) where P : HeadlessPlayer {
+            func apply<P>(player: P) where P: HeadlessPlayer {
                 player.hooks?.flowController.tap({ flowController in
                     flowController.hooks.flow.tap { flow in
                         flow.hooks.afterTransition.tap { [weak self] newFlow in
@@ -200,7 +206,14 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
 
         let context = SwiftUIPlayer.Context()
 
-        let player = SwiftUIPlayer(flow: json, plugins: [ReferenceAssetsPlugin(), plugin, HasTransitionedPlugin(expected: "VIEW", expectation: viewTransition)], result: Binding(get: {nil}, set: { (result) in
+        let player = SwiftUIPlayer(
+            flow: json,
+            plugins: [
+                ReferenceAssetsPlugin(),
+                plugin,
+                HasTransitionedPlugin(expected: "VIEW", expectation: viewTransition)
+            ],
+            result: Binding(get: {nil}, set: { (result) in
             switch result {
             case .success:
                 completionExpectation.fulfill()
@@ -214,7 +227,8 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
         wait(for: [renderExpectation, handlerExpectation], timeout: 10)
 
         XCTAssertNotNil(plugin.state)
-        let content = try player.inspect().vStack().first?.anyView().anyView().modifier(ExternalStateSheetModifier.self).viewModifierContent()
+        let content = try player.inspect().vStack().first?.anyView().anyView()
+            .modifier(ExternalActionSheetModifier.self).viewModifierContent()
         let value = try content?.sheet().anyView().text().string()
         XCTAssertEqual(value, "External State")
         try (player.state as? InProgressState)?.controllers?.flow.transition(with: "Next")
@@ -224,7 +238,7 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
         XCTAssertNotNil(state)
         XCTAssertEqual(state?.controllers?.flow.current?.currentState?.value?.stateType, "VIEW")
         XCTAssertNil(plugin.state)
-        XCTAssertFalse(plugin.isExternalState)
+        XCTAssertFalse(plugin.isExternalAction)
         do {
             try state?.controllers?.flow.transition(with: "Next")
         } catch {
@@ -235,7 +249,7 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
         ViewHosting.expel()
     }
 
-    func skiptestExternalStateHandlingThrowsError() throws {
+    func skiptestExternalActionHandlingThrowsError() throws {
         let json = """
         {
           "id": "test-flow",
@@ -270,8 +284,8 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
 
         let handlerExpectation = XCTestExpectation(description: "handler called")
         let completionExpectation = XCTestExpectation(description: "flow completed")
-        let plugin = ExternalActionViewModifierPlugin<ExternalStateSheetModifier>(handlers: [
-            ExternalStateViewModifierHandler(
+        let plugin = try! ExternalActionViewModifierPlugin<ExternalActionSheetModifier>(handlers: [
+            ExternalActionViewModifierHandler(
                 match: ["ref": "test-1"],
                 handler: { (_, _, _) in
                     handlerExpectation.fulfill()
@@ -282,15 +296,19 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
 
         let context = SwiftUIPlayer.Context()
 
-        let player = SwiftUIPlayer(flow: json, plugins: [ReferenceAssetsPlugin(), plugin], result: Binding(get: {nil}, set: { (result) in
-            guard result != nil else { return }
-            switch result {
-            case .success:
-                XCTFail("Should have failed")
-            default:
-                completionExpectation.fulfill()
-            }
-        }), context: context, unloadOnDisappear: false)
+        let player = SwiftUIPlayer(
+            flow: json,
+            plugins: [ReferenceAssetsPlugin(), plugin],
+            result: Binding(get: {nil}, set: { (result) in
+                guard result != nil else { return }
+                switch result {
+                case .success:
+                    XCTFail("Should have failed")
+                default:
+                    completionExpectation.fulfill()
+                }
+            }), context: context, unloadOnDisappear: false
+        )
 
         ViewHosting.host(view: player)
 
@@ -298,9 +316,9 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
 
         ViewHosting.expel()
     }
-    
-    // swiftlint:disable function_body_length
-    func testExternalStateHandlingWithSpecificity() throws {
+
+    // swiftlint:disable:next function_body_length
+    func testExternalActionHandlingWithSpecificity() throws {
         let json = """
         {
           "id": "test-flow",
@@ -338,10 +356,10 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
         let moreSpecificExpectation = XCTestExpectation(description: "more specific handler called")
         let completionExpectation = XCTestExpectation(description: "flow completed")
         let renderExpectation = XCTestExpectation(description: "external view rendered")
-        
-        let plugin = ExternalActionViewModifierPlugin<ExternalStateSheetModifier>(handlers: [
+
+        let plugin = try! ExternalActionViewModifierPlugin<ExternalActionSheetModifier>(handlers: [
             // Less specific - only matches ref
-            ExternalStateViewModifierHandler(
+            ExternalActionViewModifierHandler(
                 match: ["ref": "test-1"],
                 handler: { (_, _, transition) in
                     lessSpecificExpectation.fulfill()
@@ -354,7 +372,7 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
                 }
             ),
             // More specific - matches ref and extraProperty
-            ExternalStateViewModifierHandler(
+            ExternalActionViewModifierHandler(
                 match: ["ref": "test-1", "extraProperty": "extraValue"],
                 handler: { (_, _, transition) in
                     moreSpecificExpectation.fulfill()
@@ -373,29 +391,58 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
 
         let context = SwiftUIPlayer.Context()
 
-        let player = SwiftUIPlayer(flow: json, plugins: [ReferenceAssetsPlugin(), plugin], result: Binding(get: {nil}, set: { (result) in
-            switch result {
-            case .success(let completed):
-                // More specific handler should have been called, returning "Next" -> outcome "FWD"
-                XCTAssertEqual(completed.endState?.outcome, "FWD")
-                completionExpectation.fulfill()
-            default:
-                break
-            }
-        }), context: context, unloadOnDisappear: false)
+        let player = SwiftUIPlayer(
+            flow: json,
+            plugins: [ReferenceAssetsPlugin(), plugin],
+            result: Binding(get: {nil}, set: { (result) in
+                switch result {
+                case .success(let completed):
+                    // More specific handler should have been called, returning "Next" -> outcome "FWD"
+                    XCTAssertEqual(completed.endState?.outcome, "FWD")
+                    completionExpectation.fulfill()
+                default:
+                    break
+                }
+            }), context: context, unloadOnDisappear: false
+        )
 
         ViewHosting.host(view: player)
 
         wait(for: [renderExpectation, moreSpecificExpectation], timeout: 10)
 
         XCTAssertNotNil(plugin.state)
-        let content = try player.inspect().vStack().first?.anyView().anyView().modifier(ExternalStateSheetModifier.self).viewModifierContent()
+        let content = try player.inspect().vStack().first?.anyView().anyView()
+            .modifier(ExternalActionSheetModifier.self).viewModifierContent()
         try content?.sheet().anyView().text().callOnDisappear()
 
         wait(for: [lessSpecificExpectation, completionExpectation], timeout: 10)
         XCTAssertNil(plugin.state)
 
         ViewHosting.expel()
+    }
+
+    func testInitThrowsErrorWhenHandlerMissingRef() {
+        // Test that initializer throws when a handler match is missing the 'ref' key
+        XCTAssertThrowsError(try ExternalActionViewModifierPlugin<ExternalActionSheetModifier>(handlers: [
+            ExternalActionViewModifierHandler(
+                match: ["extraProperty": "value"],
+                handler: { _, _, _ in
+                    return AnyView(Text("Should not be called"))
+                }
+            )
+        ])) { error in
+            guard let pluginError = error as? ExternalActionPluginError else {
+                XCTFail("Expected ExternalActionPluginError but got \(type(of: error))")
+                return
+            }
+
+            if case .matchMissingRef(let match) = pluginError {
+                XCTAssertNil(match["ref"])
+                XCTAssertEqual(match["extraProperty"] as? String, "value")
+            } else {
+                XCTFail("Expected matchMissingRef error")
+            }
+        }
     }
 }
 

--- a/plugins/external-action/swiftui/ViewInspector/ExternalActionViewModifierPluginTests.swift
+++ b/plugins/external-action/swiftui/ViewInspector/ExternalActionViewModifierPluginTests.swift
@@ -15,6 +15,7 @@ import ViewInspector
 @testable import PlayerUIInternalTestUtilities
 @testable import PlayerUISwiftUI
 @testable import PlayerUIReferenceAssets
+@testable import PlayerUIExternalActionPlugin
 @testable import PlayerUIExternalActionViewModifierPlugin
 
 // swiftlint:disable type_body_length force_try
@@ -60,7 +61,7 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
         let completionExpectation = XCTestExpectation(description: "flow completed")
         let renderExpectation = XCTestExpectation(description: "external view rendered")
         let plugin = try! ExternalActionViewModifierPlugin<ExternalActionSheetModifier>(handlers: [
-            ExternalActionViewModifierHandler(
+            .init(
                 match: ["ref": "test-1"],
                 handler: { (state, _, transition) in
                     XCTAssertEqual(state.transitions, ["Next": "END_FWD", "Prev": "END_BCK"])
@@ -164,7 +165,7 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
         let completionExpectation = XCTestExpectation(description: "flow completed")
         let renderExpectation = XCTestExpectation(description: "external view rendered")
         let plugin = try! ExternalActionViewModifierPlugin<ExternalActionSheetModifier>(handlers: [
-            ExternalActionViewModifierHandler(
+            .init(
                 match: ["ref": "test-1"],
                 handler: { (state, _, transition) in
                     XCTAssertEqual(state.transitions, ["Next": "VIEW_1", "Prev": "END_BCK"])
@@ -249,7 +250,7 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
         ViewHosting.expel()
     }
 
-    func skiptestExternalActionHandlingThrowsError() throws {
+    func testExternalActionHandlingThrowsError() throws {
         let json = """
         {
           "id": "test-flow",
@@ -285,7 +286,7 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
         let handlerExpectation = XCTestExpectation(description: "handler called")
         let completionExpectation = XCTestExpectation(description: "flow completed")
         let plugin = try! ExternalActionViewModifierPlugin<ExternalActionSheetModifier>(handlers: [
-            ExternalActionViewModifierHandler(
+            .init(
                 match: ["ref": "test-1"],
                 handler: { (_, _, _) in
                     handlerExpectation.fulfill()
@@ -359,7 +360,7 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
 
         let plugin = try! ExternalActionViewModifierPlugin<ExternalActionSheetModifier>(handlers: [
             // Less specific - only matches ref
-            ExternalActionViewModifierHandler(
+            .init(
                 match: ["ref": "test-1"],
                 handler: { (_, _, transition) in
                     lessSpecificExpectation.fulfill()
@@ -372,7 +373,7 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
                 }
             ),
             // More specific - matches ref and extraProperty
-            ExternalActionViewModifierHandler(
+            .init(
                 match: ["ref": "test-1", "extraProperty": "extraValue"],
                 handler: { (_, _, transition) in
                     moreSpecificExpectation.fulfill()
@@ -424,7 +425,7 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
     func testInitThrowsErrorWhenHandlerMissingRef() {
         // Test that initializer throws when a handler match is missing the 'ref' key
         XCTAssertThrowsError(try ExternalActionViewModifierPlugin<ExternalActionSheetModifier>(handlers: [
-            ExternalActionViewModifierHandler(
+            .init(
                 match: ["extraProperty": "value"],
                 handler: { _, _, _ in
                     return AnyView(Text("Should not be called"))

--- a/plugins/external-action/swiftui/ViewInspector/ExternalActionViewModifierPluginTests.swift
+++ b/plugins/external-action/swiftui/ViewInspector/ExternalActionViewModifierPluginTests.swift
@@ -58,23 +58,28 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
         let handlerExpectation = XCTestExpectation(description: "handler called")
         let completionExpectation = XCTestExpectation(description: "flow completed")
         let renderExpectation = XCTestExpectation(description: "external view rendered")
-        let plugin = ExternalActionViewModifierPlugin<ExternalStateSheetModifier> { (state, _, transition) in
-            XCTAssertEqual(state.transitions, ["Next": "END_FWD", "Prev": "END_BCK"])
-            XCTAssertEqual(state.ref, "test-1")
-            // Test out subscript fetching additional properties
-            let extra: String? = state.extraProperty
-            XCTAssertEqual(extra, "extraValue")
-            handlerExpectation.fulfill()
-            return AnyView(
-                Text("External State")
-                    .onDisappear {
-                        transition("Next")
-                    }
-                    .onAppear {
-                        renderExpectation.fulfill()
-                    }
+        let plugin = ExternalActionViewModifierPlugin<ExternalStateSheetModifier>(handlers: [
+            ExternalStateViewModifierHandler(
+                match: ["ref": "test-1"],
+                handler: { (state, _, transition) in
+                    XCTAssertEqual(state.transitions, ["Next": "END_FWD", "Prev": "END_BCK"])
+                    XCTAssertEqual(state.ref, "test-1")
+                    // Test out subscript fetching additional properties
+                    let extra: String? = state.extraProperty
+                    XCTAssertEqual(extra, "extraValue")
+                    handlerExpectation.fulfill()
+                    return AnyView(
+                        Text("External State")
+                            .onDisappear {
+                                transition("Next")
+                            }
+                            .onAppear {
+                                renderExpectation.fulfill()
+                            }
+                    )
+                }
             )
-        }
+        ])
 
         let context = SwiftUIPlayer.Context()
 
@@ -152,15 +157,20 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
         let handlerExpectation = XCTestExpectation(description: "handler called")
         let completionExpectation = XCTestExpectation(description: "flow completed")
         let renderExpectation = XCTestExpectation(description: "external view rendered")
-        let plugin = ExternalActionViewModifierPlugin<ExternalStateSheetModifier> { (state, _, transition) in
-            XCTAssertEqual(state.transitions, ["Next": "VIEW_1", "Prev": "END_BCK"])
-            XCTAssertEqual(state.ref, "test-1")
-            // Test out subscript fetching additional properties
-            let extra: String? = state.extraProperty
-            XCTAssertEqual(extra, "extraValue")
-            handlerExpectation.fulfill()
-            return AnyView(Text("External State").onAppear { renderExpectation.fulfill() })
-        }
+        let plugin = ExternalActionViewModifierPlugin<ExternalStateSheetModifier>(handlers: [
+            ExternalStateViewModifierHandler(
+                match: ["ref": "test-1"],
+                handler: { (state, _, transition) in
+                    XCTAssertEqual(state.transitions, ["Next": "VIEW_1", "Prev": "END_BCK"])
+                    XCTAssertEqual(state.ref, "test-1")
+                    // Test out subscript fetching additional properties
+                    let extra: String? = state.extraProperty
+                    XCTAssertEqual(extra, "extraValue")
+                    handlerExpectation.fulfill()
+                    return AnyView(Text("External State").onAppear { renderExpectation.fulfill() })
+                }
+            )
+        ])
         class HasTransitionedPlugin: NativePlugin {
             var pluginName: String = "HasTransitioned"
 
@@ -260,10 +270,15 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
 
         let handlerExpectation = XCTestExpectation(description: "handler called")
         let completionExpectation = XCTestExpectation(description: "flow completed")
-        let plugin = ExternalActionViewModifierPlugin<ExternalStateSheetModifier> { (_, _, _) in
-            handlerExpectation.fulfill()
-            throw PlayerError.jsConversionFailure
-        }
+        let plugin = ExternalActionViewModifierPlugin<ExternalStateSheetModifier>(handlers: [
+            ExternalStateViewModifierHandler(
+                match: ["ref": "test-1"],
+                handler: { (_, _, _) in
+                    handlerExpectation.fulfill()
+                    throw PlayerError.jsConversionFailure
+                }
+            )
+        ])
 
         let context = SwiftUIPlayer.Context()
 
@@ -280,6 +295,105 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
         ViewHosting.host(view: player)
 
         wait(for: [handlerExpectation, completionExpectation], timeout: 10)
+
+        ViewHosting.expel()
+    }
+    
+    // swiftlint:disable function_body_length
+    func testExternalStateHandlingWithSpecificity() throws {
+        let json = """
+        {
+          "id": "test-flow",
+          "data": {
+            "transitionValue": "Next"
+          },
+          "navigation": {
+            "BEGIN": "FLOW_1",
+            "FLOW_1": {
+              "startState": "EXT_1",
+              "EXT_1": {
+                "state_type": "EXTERNAL",
+                "ref": "test-1",
+                "transitions": {
+                  "Next": "END_FWD",
+                  "Prev": "END_BCK"
+                },
+                "extraProperty": "extraValue"
+              },
+              "END_FWD": {
+                "state_type": "END",
+                "outcome": "FWD"
+              },
+              "END_BCK": {
+                "state_type": "END",
+                "outcome": "BCK"
+              }
+            }
+          }
+        }
+        """
+
+        let lessSpecificExpectation = XCTestExpectation(description: "less specific handler should not be called")
+        lessSpecificExpectation.isInverted = true
+        let moreSpecificExpectation = XCTestExpectation(description: "more specific handler called")
+        let completionExpectation = XCTestExpectation(description: "flow completed")
+        let renderExpectation = XCTestExpectation(description: "external view rendered")
+        
+        let plugin = ExternalActionViewModifierPlugin<ExternalStateSheetModifier>(handlers: [
+            // Less specific - only matches ref
+            ExternalStateViewModifierHandler(
+                match: ["ref": "test-1"],
+                handler: { (_, _, transition) in
+                    lessSpecificExpectation.fulfill()
+                    return AnyView(
+                        Text("Less Specific")
+                            .onDisappear {
+                                transition("Prev")
+                            }
+                    )
+                }
+            ),
+            // More specific - matches ref and extraProperty
+            ExternalStateViewModifierHandler(
+                match: ["ref": "test-1", "extraProperty": "extraValue"],
+                handler: { (_, _, transition) in
+                    moreSpecificExpectation.fulfill()
+                    return AnyView(
+                        Text("More Specific")
+                            .onDisappear {
+                                transition("Next")
+                            }
+                            .onAppear {
+                                renderExpectation.fulfill()
+                            }
+                    )
+                }
+            )
+        ])
+
+        let context = SwiftUIPlayer.Context()
+
+        let player = SwiftUIPlayer(flow: json, plugins: [ReferenceAssetsPlugin(), plugin], result: Binding(get: {nil}, set: { (result) in
+            switch result {
+            case .success(let completed):
+                // More specific handler should have been called, returning "Next" -> outcome "FWD"
+                XCTAssertEqual(completed.endState?.outcome, "FWD")
+                completionExpectation.fulfill()
+            default:
+                break
+            }
+        }), context: context, unloadOnDisappear: false)
+
+        ViewHosting.host(view: player)
+
+        wait(for: [renderExpectation, moreSpecificExpectation], timeout: 10)
+
+        XCTAssertNotNil(plugin.state)
+        let content = try player.inspect().vStack().first?.anyView().anyView().modifier(ExternalStateSheetModifier.self).viewModifierContent()
+        try content?.sheet().anyView().text().callOnDisappear()
+
+        wait(for: [lessSpecificExpectation, completionExpectation], timeout: 10)
+        XCTAssertNil(plugin.state)
 
         ViewHosting.expel()
     }


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

## What
This is the ios/swiftui part of https://github.com/player-ui/player/pull/817. This does not include a docs update. I plan to update the multi-platform docs in a separate PR once the APIs are solidified.

This PR changes the `ExternalActionPlugin` & `ExternalActionViewModifierPlugin` to accept an array of match-handler pairs. These pairs are passed through to the core.

### `ExternalActionPlugin` Before / After
```swift
// Before: Single handler - requires manual routing logic
let plugin = ExternalActionPlugin { state, options, transition in
    // Must manually check which action to handle
    guard state.ref == "custom-action" else {
        return transition("default")
    }
    transition("next")
}

// After: Array of keyed handlers - automatic routing with specificity matching
let plugin = ExternalActionPlugin(handlers: [
    ExternalStateHandler(
        match: ["ref": "custom-action"],
        handler: { state, options, transition in
            transition("next")
        }
    ),
    ExternalStateHandler(
        match: ["ref": "other-action"],
        handler: { state, options, transition in
            transition("prev")
        }
    )
])
```

### `ExternalActionViewModifierPlugin` Before / After

(For those unfamiliar, this version of the plugin allows the user to also provide the External Action view through the same API.)

```swift
// Before: Single handler - requires manual routing logic
let plugin = ExternalActionViewModifierPlugin<ExternalStateSheetModifier> { state, options, transition in
    // Must manually check which action to handle
    guard state.ref == "custom-action" else {
        return AnyView(Text("Unknown Action"))
    } 
    return AnyView(
        CustomActionView(onComplete: { transition("next") })
    )
}

// After: Array of keyed handlers - automatic routing with specificity matching
let plugin = ExternalActionViewModifierPlugin<ExternalStateSheetModifier>(handlers: [
    ExternalStateViewModifierHandler(
        match: ["ref": "custom-action"],
        handler: { state, options, transition in
            AnyView(CustomActionView(onComplete: { transition("next") }))
        }
    ),
    ExternalStateViewModifierHandler(
        match: ["ref": "other-action"],
        handler: { state, options, transition in
            AnyView(OtherActionView(onComplete: { transition("prev") }))
        }
    )
])
```

Additionally:
1. We were randomly using ExternalAction vs ExternalState. Everything is now aligned to use ExternalAction.
1. I realized that the Swift `JavaScriptCore` bypasses TypeScripty safety. It was allowing `[:]` as a valid match. Valid matches should require at least `["ref" : something]`. I added a check in the core layer to throw out match-handler pairs without a `ref` in them.

## Why

**Deterministic Overrides**: Users want predictable behaviour when multiple plugins or handlers are registered. Registerying handlers by `match` ensures that:

* More specific matchers always take precedence (e.g., { ref: "x", type: "y" } beats { ref: "x" })
* Later registrations replace earlier ones with the same specificity
* Behaviour is consistent regardless of registration order

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
- [x] `N/A` (part of 1.0)


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->