### PR TITLE
JVM supports deterministic override API for `ExternalActionPlugin`

### DIFF
--- a/plugins/external-action/jvm/src/main/kotlin/com/intuit/playerui/plugins/externalAction/ExternalActionPlugin.kt
+++ b/plugins/external-action/jvm/src/main/kotlin/com/intuit/playerui/plugins/externalAction/ExternalActionPlugin.kt
@@ -8,27 +8,53 @@ import com.intuit.playerui.core.bridge.runtime.add
 import com.intuit.playerui.core.flow.state.NavigationFlowExternalState
 import com.intuit.playerui.core.flow.state.NavigationFlowState
 import com.intuit.playerui.core.player.Player
+import com.intuit.playerui.core.player.PlayerException
 import com.intuit.playerui.core.player.state.ControllerState
 import com.intuit.playerui.core.plugins.JSScriptPluginWrapper
 import com.intuit.playerui.core.plugins.PlayerPlugin
 import com.intuit.playerui.core.plugins.findPlugin
 import com.intuit.playerui.plugins.settimeout.SetTimeoutPlugin
 
-/** Function definition of an external action handler */
-public fun interface ExternalActionHandler {
-    public fun onExternalState(
-        state: NavigationFlowExternalState,
-        options: ControllerState,
-        transition: (String) -> Unit,
-    )
+public data class ExternalActionHandler(
+    val match: Map<String, Any>,
+    val handler: Handler,
+) {
+    /**
+     * Function definition of an external action handler
+     * @param state The NavigationFlowExternalState that was transitioned to
+     * @param options The ControllerState providing access to data and expression evaluation
+     * @param transition Callback to transition to the next state
+     */
+    public fun interface Handler {
+        public fun onExternalAction(
+            state: NavigationFlowExternalState,
+            options: ControllerState,
+            transition: (String) -> Unit,
+        )
+    }
+
+    init {
+        require(match.containsKey("ref")) {
+            "The match map must contain a 'ref' key. Got: $match"
+        }
+    }
 }
 
-/** Core plugin wrapper providing external action support for the JVM Player */
+/**
+ * Core plugin wrapper providing external action support for the JVM Player.
+ *
+ * This plugin uses a registry-based approach to match external states to handler functions.
+ * Multiple handlers can be registered, and handlers are matched using partial object matching
+ * with specificity ordering (more specific matches take precedence).
+ *
+ * @param handlers List of handler configurations with matchers and handler functions.
+ */
 public class ExternalActionPlugin(
-    private var handler: ExternalActionHandler? = null,
+    vararg handlers: ExternalActionHandler,
 ) : JSScriptPluginWrapper(PLUGIN_NAME, sourcePath = BUNDLED_SOURCE_PATH),
     PlayerPlugin {
     private lateinit var player: Player
+    private val handlers: List<ExternalActionHandler> = handlers.toList()
 
     override fun apply(player: Player) {
         this.player = player
@@ -37,21 +63,26 @@ public class ExternalActionPlugin(
     override fun apply(runtime: Runtime<*>) {
         SetTimeoutPlugin().apply(runtime)
         runtime.load(ScriptContext(script, BUNDLED_SOURCE_PATH))
-        runtime.add("externalActionHandler") externalActionHandler@{ state: Node, options: Node ->
-            val state = state.deserialize(NavigationFlowState.serializer())
-                as? NavigationFlowExternalState ?: return@externalActionHandler null
-            val options = options.deserialize(ControllerState.serializer())
 
-            return@externalActionHandler runtime.Promise<Any> { resolve, _ ->
-                handler?.onExternalState(state, options, resolve)
+        // Build array of [match, handler] tuples for JavaScript
+        val jsHandlers = handlers.map { handlerConfig ->
+            // Register handler callback
+            val callback: (Node, Node) -> Any? = callback@{ state, options ->
+                val externalState = state.deserialize(NavigationFlowState.serializer())
+                    as? NavigationFlowExternalState ?: throw PlayerException("ExternalActionPlugin Could not deserialize $state")
+                val controllerState = options.deserialize(ControllerState.serializer())
+
+                runtime.Promise<Any> { resolve, _ ->
+                    handlerConfig.handler.onExternalAction(externalState, controllerState, resolve)
+                }
             }
-        }
-        instance = runtime.buildInstance("""(new $name(externalActionHandler))""")
-    }
 
-    /** Register handler for external action navigation nodes */
-    public fun onExternalAction(handler: ExternalActionHandler) {
-        this.handler = handler
+            // Return [match, callback] tuple
+            listOf(handlerConfig.match, callback)
+        }
+
+        runtime.add("externalActionHandlers", jsHandlers)
+        instance = runtime.buildInstance("(new $name(externalActionHandlers))")
     }
 
     private companion object {
@@ -62,8 +93,3 @@ public class ExternalActionPlugin(
 
 /** Convenience getter to find the first [ExternalActionPlugin] registered to the [Player] */
 public val Player.externalActionPlugin: ExternalActionPlugin? get() = findPlugin()
-
-/** Convenience method for registering an external action handler without a reference to the [ExternalActionPlugin] */
-public fun Player.onExternalAction(handler: ExternalActionHandler) {
-    externalActionPlugin?.onExternalAction(handler)
-}

--- a/plugins/external-action/jvm/src/test/kotlin/com/intuit/playerui/plugins/externalAction/ExternalActionPluginTest.kt
+++ b/plugins/external-action/jvm/src/test/kotlin/com/intuit/playerui/plugins/externalAction/ExternalActionPluginTest.kt
@@ -1,20 +1,19 @@
 package com.intuit.playerui.plugins.externalAction
 
 import com.intuit.playerui.core.expressions.evaluate
+import com.intuit.playerui.core.player.state.ControllerState
 import com.intuit.playerui.utils.test.PlayerTest
 import com.intuit.playerui.utils.test.runBlockingTest
+import com.intuit.playerui.utils.test.setupPlayer
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.TestTemplate
 import org.junit.jupiter.api.assertThrows
 
 internal class ExternalActionPluginTest : PlayerTest() {
-    override val plugins = listOf(ExternalActionPlugin())
-
-    private val plugin get() = player.externalActionPlugin!!
-
     private val jsonFlow =
         """
 {
@@ -49,26 +48,38 @@ internal class ExternalActionPluginTest : PlayerTest() {
         """
 
     @TestTemplate
-    fun testExternalStateHandling() = runBlockingTest {
-        plugin.onExternalAction { state, _, transition ->
-            assertEquals(state.transitions, mapOf("Next" to "END_FWD", "Prev" to "END_BCK"))
-            assertEquals(state.ref, "test-1")
+    fun testExternalActionHandling() = runBlockingTest {
+        val plugin = ExternalActionPlugin(
+            ExternalActionHandler(
+                match = mapOf("ref" to "test-1"),
+                handler = { state, _, transition ->
+                    assertEquals(state.transitions, mapOf("Next" to "END_FWD", "Prev" to "END_BCK"))
+                    assertEquals(state.ref, "test-1")
 
-            val extra = state["extraProperty"]
-            assertEquals(extra, "extraValue")
-            transition("Next")
-        }
+                    val extra = state["extraProperty"]
+                    assertEquals(extra, "extraValue")
+                    transition("Next")
+                },
+            ),
+        )
 
+        setupPlayer(plugin)
         val result = player.start(jsonFlow).await()
         assertEquals(result.endState.outcome, "FWD")
     }
 
     @TestTemplate
-    fun testExternalStateHandlingThrows() = runBlockingTest {
-        plugin.onExternalAction { state, _, transition ->
-            throw Exception("Bad Code")
-        }
+    fun testExternalActionHandlingThrows() = runBlockingTest {
+        val plugin = ExternalActionPlugin(
+            ExternalActionHandler(
+                match = mapOf("ref" to "test-1"),
+                handler = { _, _, _ ->
+                    throw Exception("Bad Code")
+                },
+            ),
+        )
 
+        setupPlayer(plugin)
         assertEquals(
             "Bad Code",
             assertThrows<Exception> {
@@ -80,33 +91,117 @@ internal class ExternalActionPluginTest : PlayerTest() {
     }
 
     @TestTemplate
-    fun testExternalStateHandlingWithDelay() = runBlockingTest {
-        player.onExternalAction { _, _, transition ->
-            launch {
-                delay(2000)
-                transition("Next")
-            }
-        }
+    fun testExternalActionHandlingWithDelay() = runBlockingTest {
+        val plugin = ExternalActionPlugin(
+            ExternalActionHandler(
+                match = mapOf("ref" to "test-1"),
+                handler = { _, _, transition ->
+                    launch {
+                        delay(2000)
+                        transition("Next")
+                    }
+                },
+            ),
+        )
 
+        setupPlayer(plugin)
         val result = player.start(jsonFlow).await()
         assertEquals(result.endState.outcome, "FWD")
     }
 
     @TestTemplate
-    fun testExternalStateHandlingOptions() = runBlockingTest {
-        player.onExternalAction { _, options, transition ->
-            assertEquals(options.data.get("transitionValue"), "Next")
+    fun testExternalActionHandlingOptions() = runBlockingTest {
+        var callbackOptions: ControllerState? = null
 
-            // Test expression evaluation
-            options.expression.evaluate("{{transitionValue}} = 'Prev'")
-            assertEquals(options.data.get("transitionValue"), "Prev")
+        val plugin = ExternalActionPlugin(
+            ExternalActionHandler(
+                match = mapOf("ref" to "test-1"),
+                handler = { _, options, transition ->
+                    callbackOptions = options
+                    transition("Prev")
+                },
+            ),
+        )
 
-            options.expression.evaluate(listOf("{{transitionValue}} = 'Previous'", "{{transitionValue}} = 'Next'"))
-            assertEquals(options.data.get("transitionValue"), "Next")
-            transition("Prev")
-        }
-
+        setupPlayer(plugin)
         val result = player.start(jsonFlow).await()
         assertEquals(result.endState.outcome, "BCK")
+
+        assertEquals(callbackOptions!!.data.get("transitionValue"), "Next")
+        callbackOptions!!.expression.evaluate("{{transitionValue}} = 'Prev'")
+        assertEquals(callbackOptions!!.data.get("transitionValue"), "Prev")
+        callbackOptions!!.expression.evaluate(listOf("{{transitionValue}} = 'Previous'", "{{transitionValue}} = 'Next'"))
+        assertEquals(callbackOptions!!.data.get("transitionValue"), "Next")
+    }
+
+    @TestTemplate
+    fun testExternalActionHandlingWithSpecificity() = runBlockingTest {
+        var lessSpecificCalled = false
+        var moreSpecificCalled = false
+
+        val plugin = ExternalActionPlugin(
+            // Less specific - only matches ref
+            ExternalActionHandler(
+                match = mapOf("ref" to "test-1"),
+                handler = { _, _, transition ->
+                    lessSpecificCalled = true
+                    transition("Prev")
+                },
+            ),
+            // More specific - matches ref and extraProperty
+            ExternalActionHandler(
+                match = mapOf("ref" to "test-1", "extraProperty" to "extraValue"),
+                handler = { _, _, transition ->
+                    moreSpecificCalled = true
+                    transition("Next")
+                },
+            ),
+        )
+
+        setupPlayer(plugin)
+        val result = player.start(jsonFlow).await()
+
+        // More specific handler should have been called
+        assertTrue(moreSpecificCalled, "More specific handler should have been called")
+        assertTrue(!lessSpecificCalled, "Less specific handler should not have been called")
+        assertEquals(result.endState.outcome, "FWD")
+    }
+
+    @TestTemplate
+    fun testMultiplePluginsLastOneWins() = runBlockingTest {
+        val plugin1 = ExternalActionPlugin(
+            ExternalActionHandler(
+                match = mapOf("ref" to "test-1"),
+                handler = { _, _, transition ->
+                    transition("Next")
+                },
+            ),
+        )
+
+        val plugin2 = ExternalActionPlugin(
+            ExternalActionHandler(
+                match = mapOf("ref" to "test-1"),
+                handler = { _, _, transition ->
+                    transition("Prev")
+                },
+            ),
+        )
+
+        setupPlayer(plugin1, plugin2)
+        val result = player.start(jsonFlow).await()
+
+        // Last handler registered wins (Prev)
+        assertEquals(result.endState.outcome, "BCK")
+    }
+
+    @TestTemplate
+    fun testHandlerConfigRequiresRef() {
+        val exception = assertThrows<IllegalArgumentException> {
+            ExternalActionHandler(
+                match = mapOf("extraProperty" to "value"),
+                handler = ExternalActionHandler.Handler { _, _, transition -> transition("Next") },
+            )
+        }
+        assertTrue(exception.message?.contains("must contain a 'ref' key") == true)
     }
 }


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

## What
This is the JVM part of https://github.com/player-ui/player/pull/817. This does not include a docs update. I plan to update the multi-platform docs in a separate PR once the APIs are solidified.

This PR changes the `ExternalActionPlugin` to accept an array of match-handler pairs. These pairs are passed through to the core.

**Before:**
```kotlin
// Single handler approach - one handler per plugin
val plugin = ExternalActionPlugin()
// Register handler dynamically
player.onExternalAction { state, options, transition ->
    when (state.ref) {
        "action-1" -> {
            // Handle action 1
            transition("Next")
        }
        "action-2" -> {
            // Handle action 2
            transition("Other")
        }
    }
}
```

**After:**
```kotlin
// Array-based approach - multiple handlers with specificity
val plugin = ExternalActionPlugin(
    listOf(
        // Less specific - matches any state with ref: "action"
        ExternalActionHandler(
            match = mapOf("ref" to "action"),
            handler = { state, options, transition ->
                // Default handler
                transition("default")
            }
        ),
        // More specific - matches state with both ref and type
        ExternalActionHandler(
            match = mapOf("ref" to "action", "type" to "special"),
            handler = { state, options, transition ->
                // This handler takes precedence when type: "special"
                transition("special")
            }
        )
    )
)
val player = setupPlayer(plugin)
```

## Why

**Deterministic Overrides**: Users want predictable behaviour when multiple plugins or handlers are registered. Registering handlers by `match` ensures that:

* More specific matchers always take precedence (e.g., { ref: "x", type: "y" } beats { ref: "x" })
* Later registrations replace earlier ones with the same specificity
* Behaviour is consistent regardless of registration order

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
- [x] `N/A` (part of 1.0)


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any necessary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->