### PR TITLE
Align Post Initialization Plugin Registration API

### DIFF
--- a/android/player/src/main/kotlin/com/intuit/playerui/android/AndroidPlayer.kt
+++ b/android/player/src/main/kotlin/com/intuit/playerui/android/AndroidPlayer.kt
@@ -306,8 +306,6 @@ public class AndroidPlayer private constructor(
         player.registerPlugin(plugin)
         if (plugin is AndroidPlayerPlugin) {
             plugin.apply(this)
-        } else {
-            player.registerPlugin(plugin)
         }
     }
 

--- a/android/player/src/main/kotlin/com/intuit/playerui/android/AndroidPlayer.kt
+++ b/android/player/src/main/kotlin/com/intuit/playerui/android/AndroidPlayer.kt
@@ -48,7 +48,7 @@ public typealias AndroidPlayerConfig = AndroidPlayer.Config
  */
 public class AndroidPlayer private constructor(
     public val player: HeadlessPlayer,
-    override val plugins: List<Plugin> = player.plugins,
+    plugins: List<Plugin> = player.plugins,
 ) : Player() {
     /** Convenience constructor to provide vararg style [plugins] parameter */
     public constructor(
@@ -89,6 +89,9 @@ public class AndroidPlayer private constructor(
         player,
         (plugins.toList() + player.plugins).distinct(),
     )
+
+    private val _plugins: MutableList<Plugin> = plugins.toMutableList()
+    override val plugins: List<Plugin> get() = _plugins
 
     override val logger: TapableLogger by player::logger
 
@@ -297,6 +300,16 @@ public class AndroidPlayer private constructor(
         clearCaches()
         player.release()
         hooks.release.call()
+    }
+
+    /** Register and apply a [Plugin] to this player after instantiation. */
+    public fun registerPlugin(plugin: Plugin) {
+        _plugins.add(plugin)
+        if (plugin is AndroidPlayerPlugin) {
+            plugin.apply(this)
+        } else {
+            player.registerPlugin(plugin)
+        }
     }
 
     // TODO: Do we even need context as a param anymore?

--- a/android/player/src/main/kotlin/com/intuit/playerui/android/AndroidPlayer.kt
+++ b/android/player/src/main/kotlin/com/intuit/playerui/android/AndroidPlayer.kt
@@ -90,7 +90,7 @@ public class AndroidPlayer private constructor(
         (plugins.toList() + player.plugins).distinct(),
     )
 
-    override val plugins: List<Plugin> by player::plugins
+    override val plugins: List<Plugin> get() = player.plugins
 
     override val logger: TapableLogger by player::logger
 
@@ -302,8 +302,8 @@ public class AndroidPlayer private constructor(
     }
 
     /** Register and apply a [Plugin] to this player after instantiation. */
-    public fun registerPlugin(plugin: Plugin) {
-        plugins.add(plugin)
+    override fun registerPlugin(plugin: Plugin) {
+        player.registerPlugin(plugin)
         if (plugin is AndroidPlayerPlugin) {
             plugin.apply(this)
         } else {

--- a/android/player/src/main/kotlin/com/intuit/playerui/android/AndroidPlayer.kt
+++ b/android/player/src/main/kotlin/com/intuit/playerui/android/AndroidPlayer.kt
@@ -90,8 +90,7 @@ public class AndroidPlayer private constructor(
         (plugins.toList() + player.plugins).distinct(),
     )
 
-    private val _plugins: MutableList<Plugin> = plugins.toMutableList()
-    override val plugins: List<Plugin> get() = _plugins
+    override val plugins: List<Plugin> by player::plugins
 
     override val logger: TapableLogger by player::logger
 
@@ -304,7 +303,7 @@ public class AndroidPlayer private constructor(
 
     /** Register and apply a [Plugin] to this player after instantiation. */
     public fun registerPlugin(plugin: Plugin) {
-        _plugins.add(plugin)
+        plugins.add(plugin)
         if (plugin is AndroidPlayerPlugin) {
             plugin.apply(this)
         } else {

--- a/android/player/src/test/kotlin/com/intuit/playerui/android/AndroidPlayerTest.kt
+++ b/android/player/src/test/kotlin/com/intuit/playerui/android/AndroidPlayerTest.kt
@@ -1,0 +1,59 @@
+package com.intuit.playerui.android
+
+import com.intuit.playerui.android.utils.CoroutineTestDispatcherExtension
+import com.intuit.playerui.core.player.Player
+import com.intuit.playerui.core.plugins.PlayerPlugin
+import com.intuit.playerui.core.plugins.findPlugin
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(CoroutineTestDispatcherExtension::class)
+internal class AndroidPlayerTest {
+    @Test
+    fun `registerPlugin applies AndroidPlayerPlugin`() {
+        var applied = false
+        val plugin = object : AndroidPlayerPlugin {
+            override fun apply(androidPlayer: AndroidPlayer) {
+                applied = true
+            }
+        }
+
+        val androidPlayer = AndroidPlayer()
+        androidPlayer.registerPlugin(plugin)
+
+        assertTrue(applied)
+        assertTrue(androidPlayer.plugins.contains(plugin))
+    }
+
+    @Test
+    fun `registerPlugin delegates non-Android plugin to HeadlessPlayer`() {
+        var applied = false
+        val plugin = object : PlayerPlugin {
+            override fun apply(player: Player) {
+                applied = true
+            }
+        }
+
+        val androidPlayer = AndroidPlayer()
+        androidPlayer.registerPlugin(plugin)
+
+        assertTrue(applied)
+        assertTrue(androidPlayer.plugins.contains(plugin))
+        assertTrue(androidPlayer.player.plugins.contains(plugin))
+    }
+
+    @Test
+    fun `findPlugin returns plugin registered after instantiation`() {
+        class TrackingPlugin : AndroidPlayerPlugin {
+            override fun apply(androidPlayer: AndroidPlayer) {}
+        }
+
+        val androidPlayer = AndroidPlayer()
+        val plugin = TrackingPlugin()
+        androidPlayer.registerPlugin(plugin)
+
+        assertNotNull(androidPlayer.findPlugin<TrackingPlugin>())
+    }
+}

--- a/ios/core/Sources/Player/HeadlessPlayer.swift
+++ b/ios/core/Sources/Player/HeadlessPlayer.swift
@@ -225,6 +225,17 @@ public extension HeadlessPlayer {
         jsPlayerReference?.invokeMethod("registerPlugin", withArguments: [plugin.pluginRef as Any])
     }
 
+    /// Registers a NativePlugin with player after instantiation
+    /// For JSBasePlugin instances, delegates to the typed overload; for other NativePlugins, calls apply directly
+    /// - Parameter plugin: The plugin to register
+    func registerPlugin(_ plugin: NativePlugin) {
+        if let jsPlugin = plugin as? JSBasePlugin {
+            registerPlugin(jsPlugin)
+        } else {
+            plugin.apply(player: self)
+        }
+    }
+
     /**
      Starts Player for the given flow
      - parameters:

--- a/ios/core/Tests/HeadlessPlayerTests.swift
+++ b/ios/core/Tests/HeadlessPlayerTests.swift
@@ -184,6 +184,21 @@ class HeadlessPlayerTests: XCTestCase {
         XCTAssertNotNil(plugin.context)
     }
 
+    func testRegisterNativePlugin() {
+        var applied = false
+        class NativeOnlyPlugin: NativePlugin {
+            var onApply: () -> Void
+            init(onApply: @escaping () -> Void) { self.onApply = onApply }
+            var pluginName: String { "native-only-plugin" }
+            func apply<P: HeadlessPlayer>(player: P) { onApply() }
+        }
+        let player = HeadlessPlayerImpl(plugins: [])
+        player.start(flow: FlowData.COUNTER) { _ in }
+        let plugin = NativeOnlyPlugin(onApply: { applied = true })
+        player.registerPlugin(plugin)
+        XCTAssertTrue(applied)
+    }
+
     func testEmptyFlowObject() {
         let player = HeadlessPlayerImpl(plugins: [])
         player.start(flow: "{}") { (result) in

--- a/jvm/core/src/main/kotlin/com/intuit/playerui/core/player/HeadlessPlayer.kt
+++ b/jvm/core/src/main/kotlin/com/intuit/playerui/core/player/HeadlessPlayer.kt
@@ -74,7 +74,8 @@ public class HeadlessPlayer @ExperimentalPlayerApi @JvmOverloads public construc
 
     private val player: Node
 
-    override var plugins: List<Plugin> = plugins; private set
+    override var plugins: List<Plugin> = plugins
+        private set
 
     override val node: Node by ::player
 
@@ -200,17 +201,15 @@ public class HeadlessPlayer @ExperimentalPlayerApi @JvmOverloads public construc
     }
 
     /** Register and apply a [Plugin] to this player after instantiation. */
-    public fun registerPlugin(plugin: Plugin) {
+    override fun registerPlugin(plugin: Plugin) {
         plugins = plugins + plugin
-        when (plugin) {
-            is RuntimePlugin -> {
-                plugin.apply(runtime)
-                if (plugin is JSPluginWrapper) {
-                    registerPlugin.invoke(plugin.instance)
-                }
+        if (plugin is RuntimePlugin) {
+            plugin.apply(runtime)
+            if (plugin is JSPluginWrapper) {
+                registerPlugin.invoke(plugin.instance)
             }
-            is PlayerPlugin -> plugin.apply(this)
         }
+        if (plugin is PlayerPlugin) plugin.apply(this)
     }
 
     internal companion object {

--- a/jvm/core/src/main/kotlin/com/intuit/playerui/core/player/HeadlessPlayer.kt
+++ b/jvm/core/src/main/kotlin/com/intuit/playerui/core/player/HeadlessPlayer.kt
@@ -1,6 +1,7 @@
 package com.intuit.playerui.core.player
 
 import com.intuit.playerui.core.bridge.Completable
+import com.intuit.playerui.core.bridge.Invokable
 import com.intuit.playerui.core.bridge.Node
 import com.intuit.playerui.core.bridge.NodeWrapper
 import com.intuit.playerui.core.bridge.Promise
@@ -13,6 +14,7 @@ import com.intuit.playerui.core.bridge.runtime.add
 import com.intuit.playerui.core.bridge.runtime.runtimeContainers
 import com.intuit.playerui.core.bridge.runtime.runtimeFactory
 import com.intuit.playerui.core.bridge.serialization.serializers.NodeSerializableField
+import com.intuit.playerui.core.bridge.serialization.serializers.NodeSerializableFunction
 import com.intuit.playerui.core.constants.ConstantsController
 import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
 import com.intuit.playerui.core.logger.TapableLogger
@@ -72,8 +74,7 @@ public class HeadlessPlayer @ExperimentalPlayerApi @JvmOverloads public construc
 
     private val player: Node
 
-    private val _plugins: MutableList<Plugin> = plugins.toMutableList()
-    override val plugins: List<Plugin> get() = _plugins
+    override var plugins: List<Plugin> = plugins; private set
 
     override val node: Node by ::player
 
@@ -174,6 +175,8 @@ public class HeadlessPlayer @ExperimentalPlayerApi @JvmOverloads public construc
             .onEach { it.apply(this) }
     }
 
+    private val registerPlugin: Invokable<Unit> by NodeSerializableFunction()
+
     override fun start(flow: String): Completable<CompletedState> = try {
         start(runtime.execute("($flow)") as Node)
     } catch (exception: Exception) {
@@ -198,12 +201,12 @@ public class HeadlessPlayer @ExperimentalPlayerApi @JvmOverloads public construc
 
     /** Register and apply a [Plugin] to this player after instantiation. */
     public fun registerPlugin(plugin: Plugin) {
-        _plugins.add(plugin)
+        plugins = plugins + plugin
         when (plugin) {
             is RuntimePlugin -> {
                 plugin.apply(runtime)
                 if (plugin is JSPluginWrapper) {
-                    player.getInvokable<Unit>("registerPlugin")!!.invoke(plugin.instance)
+                    registerPlugin.invoke(plugin.instance)
                 }
             }
             is PlayerPlugin -> plugin.apply(this)

--- a/jvm/core/src/main/kotlin/com/intuit/playerui/core/player/HeadlessPlayer.kt
+++ b/jvm/core/src/main/kotlin/com/intuit/playerui/core/player/HeadlessPlayer.kt
@@ -50,7 +50,7 @@ import java.net.URL
  */
 @Suppress("ktlint:standard:annotation") // To prevent class from being double indented
 public class HeadlessPlayer @ExperimentalPlayerApi @JvmOverloads public constructor(
-    override val plugins: List<Plugin>,
+    plugins: List<Plugin>,
     explicitRuntime: Runtime<*>? = null,
     private val source: URL = bundledSource,
     config: PlayerRuntimeConfig = PlayerRuntimeConfig(),
@@ -71,6 +71,9 @@ public class HeadlessPlayer @ExperimentalPlayerApi @JvmOverloads public construc
     ) : this(plugins.toList(), explicitRuntime, config = explicitRuntime.config)
 
     private val player: Node
+
+    private val _plugins: MutableList<Plugin> = plugins.toMutableList()
+    override val plugins: List<Plugin> get() = _plugins
 
     override val node: Node by ::player
 
@@ -190,6 +193,20 @@ public class HeadlessPlayer @ExperimentalPlayerApi @JvmOverloads public construc
         if (!runtime.isReleased()) {
             hooks.state.call(HashMap(), arrayOf(ReleasedState))
             runtime.release()
+        }
+    }
+
+    /** Register and apply a [Plugin] to this player after instantiation. */
+    public fun registerPlugin(plugin: Plugin) {
+        _plugins.add(plugin)
+        when (plugin) {
+            is RuntimePlugin -> {
+                plugin.apply(runtime)
+                if (plugin is JSPluginWrapper) {
+                    player.getInvokable<Unit>("registerPlugin")!!.invoke(plugin.instance)
+                }
+            }
+            is PlayerPlugin -> plugin.apply(this)
         }
     }
 

--- a/jvm/core/src/main/kotlin/com/intuit/playerui/core/player/Player.kt
+++ b/jvm/core/src/main/kotlin/com/intuit/playerui/core/player/Player.kt
@@ -18,6 +18,7 @@ import com.intuit.playerui.core.player.state.CompletedState
 import com.intuit.playerui.core.player.state.PlayerFlowState
 import com.intuit.playerui.core.player.state.ReleasedState
 import com.intuit.playerui.core.plugins.Pluggable
+import com.intuit.playerui.core.plugins.Plugin
 import com.intuit.playerui.core.validation.ValidationController
 import com.intuit.playerui.core.view.View
 import com.intuit.playerui.core.view.ViewController
@@ -122,6 +123,11 @@ public abstract class Player : Pluggable {
      * method has no effect.
      */
     public abstract fun release()
+
+    /**
+     * Registers a Plugin on a running Player instance
+     */
+    public abstract fun registerPlugin(plugin: Plugin)
 
     /**
      * Utility method to allow consumers to start a flow from a

--- a/jvm/core/src/test/kotlin/com/intuit/playerui/core/player/HeadlessPlayerTest.kt
+++ b/jvm/core/src/test/kotlin/com/intuit/playerui/core/player/HeadlessPlayerTest.kt
@@ -27,7 +27,9 @@ import com.intuit.playerui.core.player.state.dataModel
 import com.intuit.playerui.core.player.state.errorState
 import com.intuit.playerui.core.player.state.inProgressState
 import com.intuit.playerui.core.player.state.lastViewUpdate
+import com.intuit.playerui.core.plugins.PlayerPlugin
 import com.intuit.playerui.core.plugins.Plugin
+import com.intuit.playerui.core.plugins.findPlugin
 import com.intuit.playerui.core.validation.getWarningsAndErrors
 import com.intuit.playerui.plugins.assets.ReferenceAssetsPlugin
 import com.intuit.playerui.plugins.beacon.BeaconPlugin
@@ -627,5 +629,37 @@ internal class HeadlessPlayerTest :
         logger.warn.invoke("Beacon plugin warn logged") shouldBe null
         logger.error.invoke("Beacon plugin error logged") shouldBe null
         logger.info.invoke("Beacon plugin info logged") shouldBe null
+    }
+
+    @TestTemplate
+    fun `registerPlugin applies PlayerPlugin`() {
+        var applied = false
+        val plugin = object : PlayerPlugin {
+            override fun apply(player: Player) {
+                applied = true
+            }
+        }
+        (player as HeadlessPlayer).registerPlugin(plugin)
+        assertTrue(applied)
+        assertTrue(player.plugins.contains(plugin))
+    }
+
+    @TestTemplate
+    fun `registerPlugin adds plugin to plugins list`() {
+        val sizeBefore = player.plugins.size
+        val plugin = object : PlayerPlugin {
+            override fun apply(player: Player) {}
+        }
+        (player as HeadlessPlayer).registerPlugin(plugin)
+        assertEquals(sizeBefore + 1, player.plugins.size)
+    }
+
+    @TestTemplate
+    fun `registerPlugin applies JSScriptPluginWrapper via BeaconPlugin`() {
+        val sizeBefore = player.plugins.size
+        val beaconPlugin2 = BeaconPlugin()
+        (player as HeadlessPlayer).registerPlugin(beaconPlugin2)
+        assertEquals(sizeBefore + 1, player.plugins.size)
+        assertNotNull(player.findPlugin<BeaconPlugin>())
     }
 }

--- a/jvm/core/src/test/kotlin/com/intuit/playerui/core/player/HeadlessPlayerTest.kt
+++ b/jvm/core/src/test/kotlin/com/intuit/playerui/core/player/HeadlessPlayerTest.kt
@@ -639,7 +639,7 @@ internal class HeadlessPlayerTest :
                 applied = true
             }
         }
-        (player as HeadlessPlayer).registerPlugin(plugin)
+        player.registerPlugin(plugin)
         assertTrue(applied)
         assertTrue(player.plugins.contains(plugin))
     }
@@ -650,7 +650,7 @@ internal class HeadlessPlayerTest :
         val plugin = object : PlayerPlugin {
             override fun apply(player: Player) {}
         }
-        (player as HeadlessPlayer).registerPlugin(plugin)
+        player.registerPlugin(plugin)
         assertEquals(sizeBefore + 1, player.plugins.size)
     }
 
@@ -658,7 +658,7 @@ internal class HeadlessPlayerTest :
     fun `registerPlugin applies JSScriptPluginWrapper via BeaconPlugin`() {
         val sizeBefore = player.plugins.size
         val beaconPlugin2 = BeaconPlugin()
-        (player as HeadlessPlayer).registerPlugin(beaconPlugin2)
+        player.registerPlugin(beaconPlugin2)
         assertEquals(sizeBefore + 1, player.plugins.size)
         assertNotNull(player.findPlugin<BeaconPlugin>())
     }

--- a/react/player/src/__tests__/player.test.tsx
+++ b/react/player/src/__tests__/player.test.tsx
@@ -94,4 +94,69 @@ describe("ReactPlayer", () => {
       </Suspense>,
     );
   }
+
+  describe("registerPlugin", () => {
+    it("should call apply on the underlying core player for a plugin with only apply", () => {
+      let applyCalled = false;
+      const corePlugin: ReactPlayerPlugin = {
+        name: "core-only-plugin",
+        apply: () => {
+          applyCalled = true;
+        },
+      };
+
+      const rp = new ReactPlayer({ plugins: [] });
+      rp.registerPlugin(corePlugin);
+
+      expect(applyCalled).toBe(true);
+      expect(rp.options.plugins).toContain(corePlugin);
+    });
+
+    it("should call both apply and applyReact for a plugin with both", () => {
+      let applyCalled = false;
+      let applyReactCalled = false;
+      const dualPlugin: ReactPlayerPlugin = {
+        name: "dual-plugin",
+        apply: () => {
+          applyCalled = true;
+        },
+        applyReact: () => {
+          applyReactCalled = true;
+        },
+      };
+
+      const rp = new ReactPlayer({ plugins: [] });
+      rp.registerPlugin(dualPlugin);
+
+      expect(applyCalled).toBe(true);
+      expect(applyReactCalled).toBe(true);
+    });
+
+    it("should call applyReact for a plugin with only applyReact", () => {
+      let applyReactCalled = false;
+      const reactPlugin: ReactPlayerPlugin = {
+        name: "react-only-plugin",
+        applyReact: () => {
+          applyReactCalled = true;
+        },
+      };
+
+      const rp = new ReactPlayer({ plugins: [] });
+      rp.registerPlugin(reactPlugin);
+
+      expect(applyReactCalled).toBe(true);
+      expect(rp.options.plugins).toContain(reactPlugin);
+    });
+
+    it("should initialize plugins array if undefined", () => {
+      const plugin: ReactPlayerPlugin = {
+        name: "test-plugin",
+      };
+
+      const rp = new ReactPlayer({});
+      rp.registerPlugin(plugin);
+
+      expect(rp.options.plugins).toContain(plugin);
+    });
+  });
 });

--- a/react/player/src/player.tsx
+++ b/react/player/src/player.tsx
@@ -153,13 +153,13 @@ export class ReactPlayer {
   }
 
   /** Register and apply [Plugin] if one with the same symbol is not already registered. */
-  public registerPlugin(plugin: ReactPlayerPlugin): void {
+  public registerPlugin(plugin: ReactPlayerPlugin | PlayerPlugin): void {
     if (plugin.apply) {
       this.player.registerPlugin(plugin as PlayerPlugin);
     }
 
-    if (plugin.applyReact) {
-      plugin.applyReact(this);
+    if ((plugin as ReactPlayerPlugin).applyReact) {
+      (plugin as ReactPlayerPlugin).applyReact?.(this);
     }
 
     if (!this.options.plugins) {

--- a/react/player/src/player.tsx
+++ b/react/player/src/player.tsx
@@ -154,10 +154,19 @@ export class ReactPlayer {
 
   /** Register and apply [Plugin] if one with the same symbol is not already registered. */
   public registerPlugin(plugin: ReactPlayerPlugin): void {
-    if (!plugin.applyReact) return;
+    if (plugin.apply) {
+      this.player.registerPlugin(plugin as PlayerPlugin);
+    }
 
-    plugin.applyReact(this);
-    this.options.plugins?.push(plugin);
+    if (plugin.applyReact) {
+      plugin.applyReact(this);
+    }
+
+    if (!this.options.plugins) {
+      this.options.plugins = [];
+    }
+
+    this.options.plugins.push(plugin);
   }
 
   /**


### PR DESCRIPTION
Closes #790 

All platforms now support registering plugins with a player after it has been instantiated.

## JVM (HeadlessPlayer)
Added registerPlugin(plugin: Plugin) that appends to the plugins list and applies the plugin appropriately (RuntimePlugin, JSPluginWrapper, or PlayerPlugin).

## Android (AndroidPlayer)
- Added registerPlugin(plugin: Plugin) that delegates to the underlying HeadlessPlayer for standard plugins, or stores and applies AndroidPlayerPlugin instances directly.

## iOS (HeadlessPlayer / HeadlessPlayerImpl)
- Added registerPlugin(_ plugin: NativePlugin) as a protocol requirement with a default implementation. Concrete implementations (e.g. HeadlessPlayerImpl) track registered plugins in a mutable plugins list.

## React (ReactPlayer)
- Updated registerPlugin to accept both ReactPlayerPlugin and PlayerPlugin, calling apply on the core player and applyReact on the React player as appropriate.

TODO:

- [ ] Update Migration Guide

### Change Type (required)
Indicate the type of change your pull request is:

- [x] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs