### PR TITLE
Fix the memory leak for large payloads

### DIFF
--- a/ios/core/Sources/Types/Assets/BaseAssetRegistry.swift
+++ b/ios/core/Sources/Types/Assets/BaseAssetRegistry.swift
@@ -203,14 +203,6 @@ extension AnyTypeDecodingContext {
 }
 
 extension JSValue {
-    var jsonDisplayString: String {
-        do {
-            return try String(data: jsonData(pretty: true), encoding: .utf8) ?? "notuf8"
-        } catch {
-            return error.localizedDescription
-        }
-    }
-
     /// Returns the contents of this value encoded into UTF-8 string data. Throws DecodingError.malformedData
     /// if this value can't be transformed.
     func jsonData(pretty: Bool = false) throws -> Data {
@@ -291,8 +283,13 @@ extension JSONDecoder {
         setRootJS(value)
         defer { setRootJS(nil) }
 
-        logger?.t("Decoding: \(value.jsonDisplayString)")
-        return try decode(T.self, from: value.jsonData())
+        let data = try value.jsonData()
+        // Log a truncated preview to aid debugging without re-serializing the full tree.
+        let truncated = data.count > 500
+        if let preview = String(data: data.prefix(500), encoding: .utf8) {
+            logger?.t("Decoding (\(data.count) bytes): \(preview)\(truncated ? "..." : "")")
+        }
+        return try decode(T.self, from: data)
     }
 
     func setDecodeAssetFunction<Asset>(_ function: @escaping DecodeAssetFunction<Asset>) {

--- a/ios/core/Tests/utilities/JSUtilitiesTests.swift
+++ b/ios/core/Tests/utilities/JSUtilitiesTests.swift
@@ -10,6 +10,7 @@ import Foundation
 import JavaScriptCore
 import XCTest
 @testable import PlayerUI
+import PlayerUILogger
 
 class JSUtilitiesTests: XCTestCase {
     func testPolyfill() {

--- a/ios/core/Tests/utilities/JSUtilitiesTests.swift
+++ b/ios/core/Tests/utilities/JSUtilitiesTests.swift
@@ -67,47 +67,6 @@ class JSUtilitiesTests: XCTestCase {
         wait(for: [catchExpect], timeout: 1)
     }
 
-    func testJsonStringPretty() {
-        let context = JSContext()!
-
-        let obj = context.evaluateScript("({a: 1})")
-
-        let objWithNaN = context.evaluateScript("({a: NaN})")
-
-        let objWithFunction = context.evaluateScript("({a: () => {}})")
-
-        let array = context.evaluateScript("(['a', 'b'])")
-
-        let str = context.evaluateScript("('a')")
-
-        XCTAssertEqual(obj?.jsonDisplayString, """
-        {
-          "a": 1
-        }
-        """)
-
-        XCTAssertEqual(objWithNaN?.jsonDisplayString, """
-        {
-          "a": null
-        }
-        """)
-
-        XCTAssertEqual(objWithFunction?.jsonDisplayString, """
-        {
-          "a": {}
-        }
-        """)
-
-        XCTAssertEqual(array?.jsonDisplayString, """
-        [
-          "a",
-          "b"
-        ]
-        """)
-
-        XCTAssertEqual(str?.jsonDisplayString, "\"a\"")
-    }
-
     func testJsonData() throws {
         let context = JSContext()!
 
@@ -138,5 +97,64 @@ class JSUtilitiesTests: XCTestCase {
         """.data(using: .utf8))
 
         XCTAssertEqual(try str?.jsonData(), "\"a\"".data(using: .utf8))
+    }
+
+    func testDecodeLogsTruncatedPreviewForSmallPayload() throws {
+        let context = JSContext()!
+        let value = context.evaluateScript("({id: 'test', type: 'text'})")!
+
+        let logger = TapableLogger()
+        logger.logLevel = .trace
+
+        var loggedMessage: String?
+        logger.hooks.trace.tap(name: "test") { messages in
+            loggedMessage = messages.compactMap { $0 as? String }.joined()
+        }
+
+        let decoder = JSONDecoder()
+        decoder.setLogger(logger)
+
+        struct SimpleAsset: Decodable {
+            let id: String
+            let type: String
+        }
+
+        let decoded = try decoder.decode(SimpleAsset.self, from: value)
+        XCTAssertEqual(decoded.id, "test")
+
+        let message = try XCTUnwrap(loggedMessage)
+        XCTAssertTrue(message.contains("bytes)"), "Log should include byte count")
+        XCTAssertFalse(message.hasSuffix("..."), "Small payload should not be truncated")
+    }
+
+    func testDecodeLogsTruncatedPreviewForLargePayload() throws {
+        let context = JSContext()!
+        // Generate a JSON object larger than 500 bytes
+        let script = "({id: 'test', type: 'text', value: '\(String(repeating: "x", count: 600))'})"
+        let value = context.evaluateScript(script)!
+
+        let logger = TapableLogger()
+        logger.logLevel = .trace
+
+        var loggedMessage: String?
+        logger.hooks.trace.tap(name: "test") { messages in
+            loggedMessage = messages.compactMap { $0 as? String }.joined()
+        }
+
+        let decoder = JSONDecoder()
+        decoder.setLogger(logger)
+
+        struct SimpleAsset: Decodable {
+            let id: String
+            let type: String
+            let value: String
+        }
+
+        let decoded = try decoder.decode(SimpleAsset.self, from: value)
+        XCTAssertEqual(decoded.id, "test")
+
+        let message = try XCTUnwrap(loggedMessage)
+        XCTAssertTrue(message.contains("bytes)"), "Log should include byte count")
+        XCTAssertTrue(message.hasSuffix("..."), "Large payload should be truncated with ellipsis")
     }
 }


### PR DESCRIPTION
1. Serialize once and reuse — the previous approach called jsonDisplayString (which pretty-prints the entire tree) before jsonData(), doubling peak memory for large payloads.
2. Log a truncated preview for first 500 data

<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->
refer to: https://jira.cloud.intuit.com/browse/PLAYA-10213

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [x] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->