### PR TITLE
fix: create ErrorState with error.message is undefined

### DIFF
--- a/ios/core/Sources/Types/Core/CompletedState.swift
+++ b/ios/core/Sources/Types/Core/CompletedState.swift
@@ -238,10 +238,19 @@ public class ErrorState: BaseFlowState, PlayerFlowExecutionData {
     - returns: A ErrorState object if the JSValue was one
     */
     public static func createInstance(from value: JSValue?) -> ErrorState? {
-        guard
-            let flow = value?.objectForKeyedSubscript("flow"),
-            let message = value?.objectForKeyedSubscript("error")?.objectForKeyedSubscript("message")?.toString()
-        else { return nil }
+        guard let flow = value?.objectForKeyedSubscript("flow") else { return nil }
+
+        let message: String
+        if let errorValue = value?.objectForKeyedSubscript("error"), !errorValue.isUndefined, !errorValue.isNull {
+            if let msgValue = errorValue.objectForKeyedSubscript("message"), !msgValue.isUndefined, !msgValue.isNull {
+                message = msgValue.toString()
+            } else {
+                message = errorValue.toString()
+            }
+        } else {
+            message = "Unknown error"
+        }
+
         return ErrorState(flow: Flow.createInstance(value: flow), error: message)
     }
 

--- a/ios/core/Sources/Types/Core/CompletedState.swift
+++ b/ios/core/Sources/Types/Core/CompletedState.swift
@@ -241,8 +241,8 @@ public class ErrorState: BaseFlowState, PlayerFlowExecutionData {
         guard let flow = value?.objectForKeyedSubscript("flow") else { return nil }
 
         let message: String
-        if let errorValue = value?.objectForKeyedSubscript("error"), !errorValue.isUndefined, !errorValue.isNull {
-            if let msgValue = errorValue.objectForKeyedSubscript("message"), !msgValue.isUndefined, !msgValue.isNull {
+        if let errorValue = value?.objectForKeyedSubscript("error"), !errorValue.isUndefined {
+            if let msgValue = errorValue.objectForKeyedSubscript("message"), !msgValue.isUndefined {
                 message = msgValue.toString()
             } else {
                 message = errorValue.toString()


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->
Falls back to error.toString() if message is undefined/null, and uses "Unknown error" if no error object exists at all.

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->