### PR TITLE
Add ios-review skill with iOS code conventions

### DIFF
--- a/.claude/skills/ios-review/SKILL.md
+++ b/.claude/skills/ios-review/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: ios-review
+description: Review Swift/iOS code against team conventions. Use when the user asks to review Swift code, runs /ios-review, or when writing or editing Swift files in this repo. Enforces standards that linters cannot catch.
+context: fork
+---
+
+## Current diff (when reviewing a PR)
+- Diff: !`git diff HEAD~1 2>/dev/null || echo "No diff available"`
+
+# iOS Code Review — Team Conventions
+
+Review the code (or the diff above if present) against the rules below. Apply **General Rules** always. Apply **UI Rules** only if the changes include SwiftUI views (files containing `View`, `body`, `@ViewBuilder`, or SwiftUI imports).
+
+For each violation, report:
+- **Rule**: which rule was broken
+- **Location**: file + line number
+- **Suggestion**: concrete fix
+
+If no violations are found, say so clearly.
+
+---
+
+## General Rules
+
+### 1. Function length ≤ 50 lines
+Functions should be 50 lines or fewer. If a function exceeds this, suggest extracting logical chunks into named helpers.
+
+**Why:** Long functions are harder to read, test, and maintain. Shorter functions with clear names make the call site self-documenting.
+
+### 2. Avoid nested conditionals
+Nested conditionals (`if`, `guard`, `switch`, `for`, `while`, `repeat`) are a bad pattern in iOS code. Prefer:
+- `guard`/`else` to exit early instead of nesting
+- Extracting conditions into well-named boolean variables or functions
+- AI-assisted rewrites when nesting is deep
+
+Flag any conditional nested inside another conditional.
+
+**Why:** Deep nesting hides the happy path, increases cognitive load, and makes it easy to miss edge cases. Early exits keep logic linear and readable.
+
+### 3. Use async/await instead of callbacks
+All async code should use Swift's `async/await`. Callbacks (completion handlers, closures passed as the last argument to async operations) are the old pattern and should not appear in new code.
+
+**Why:** Callbacks invert control flow and make error handling inconsistent. `async/await` reads top-to-bottom, composes cleanly with `try`, and eliminates callback pyramids.
+
+### 4. Clear logic path — name functions after intent, not implementation
+Function names should describe *what* the function achieves (its intention), not *how* it works technically. For example, a function that registers a hook to make an interaction fail should be called `failInteraction()`, not `registerFailureHook()`.
+
+Also: add comments on functions you can't rename (e.g. protocol requirements, library callbacks) explaining their intent.
+
+**Why:** Implementation details change; intent rarely does. Names tied to mechanics rot as the code evolves and obscure the purpose at the call site.
+
+### 5. Public methods before private methods
+`public` and `open` methods should appear near the top of a type, just below `init`.
+
+Correct order within a type:
+1. `init`
+2. `public`/`open` methods
+3. `internal` methods
+4. `private` methods
+
+**Why:** Public APIs are hard to change post-release. Placing them at the top makes the contract immediately visible to reviewers without scrolling past implementation details.
+
+### 6. Doc comments on all public/open declarations
+Every `public` or `open` function, property, type, and initializer must have a doc comment (`///`). This includes anything a consumer of the library will interact with directly.
+
+**Why:** Doc comments are the contract between the library and its callers. They surface in Xcode "Quick help" and are the first place a consumer looks before reading source.
+
+### 7. Use shorthand `guard/if let foo` (not `guard/if let foo = foo`)
+Modern Swift (5.7+) supports shorthand optional binding. Prefer:
+```swift
+guard let foo else { return }   // ✅
+if let bar { ... }              // ✅
+```
+Over:
+```swift
+guard let foo = foo else { return }  // ❌ verbose
+if let bar = bar { ... }             // ❌ verbose
+```
+
+**Why:** The redundant `= foo` is noise. Shorthand is idiomatic Swift 5.7+ and reduces visual clutter.
+
+### 8. No force-unwrap (`!`) in production code
+Force-unwrap crashes the app if the value is nil. Use `guard let`, `if let`, or `??` with an appropriate default instead. The only acceptable use of `!` is in test code (where crashes surface bugs immediately).
+
+**Why:** Force-unwrap turns a recoverable nil into an unrecoverable crash. Production code should handle unexpected nils gracefully rather than terminating.
+
+### 9. Boolean variables should start with `is` (preferred), `has`, `should`, `can`, or similar
+Boolean variables and properties should read as a yes/no question. E.g. `isEnabled`, `hasLoaded`, `shouldRetry`. Avoid names like `enabled`, `loaded`, `retry`.
+
+**Why:** Boolean names that read as questions make conditionals (`if isEnabled`) self-explanatory. Noun/verb names (`if enabled`, `if retry`) are ambiguous and harder to parse at a glance.
+
+### 10. Use `private extension String` for string constants (not bare string literals or `enum`)
+Define file-scoped string constants as a `private extension String` at the bottom of the file:
+```swift
+// ✅ Prefer
+private extension String {
+    static let submitTitle = "Submit"
+}
+// Usage — shorthand works wherever String is accepted
+button.setTitle(.submitTitle)
+```
+Exception: use an `enum` (not `String` extension) for **closed, finite sets** where the compiler should enforce exhaustiveness — e.g. state type discriminators (`VIEW`, `ACTION`, `EXTERNAL`). Those are better modeled as enums so the compiler catches missing cases.
+
+**Why:** The `private extension String` pattern enables the clean `.foo` shorthand at every call site without polluting the global namespace. Enums are reserved for cases where exhaustiveness matters — mixing the two degrades the compiler's ability to catch missing cases.
+
+### 11. Avoid abbreviations that obscure intent
+Variable and parameter names should be clear to a reader unfamiliar with the codebase. Avoid:
+- Programming jargon new contributors may not know (e.g. `noop`)
+- Acronyms that collide with common abbreviations (e.g. `CI` → "Continuous Integration")
+- Single-letter or heavily truncated names outside of trivial loop indices
+
+Prefer descriptive middle-ground names: `placeholderBeacon` over `noopBeacon`, `error` over `e`.
+
+**Why:** Abbreviations that seem obvious to the author are often opaque to reviewers and future maintainers. Colliding acronyms introduce a second source of confusion on top of the original ambiguity.
+
+### 12. Always use `[weak self]` in closures
+Any closure that captures `self` must use `[weak self]`, regardless of whether a retain cycle is obvious. This includes completion handlers, notification callbacks, and any escaping closure.
+
+**Why:** Retain cycles through closures are easy to introduce and hard to spot in review. Requiring `[weak self]` universally eliminates the need to reason about object lifetimes on a case-by-case basis.
+
+### 13. Always capture `[weak self]` explicitly inside `Task` closures
+`Task { }` creates its own capture scope and does **not** inherit `[weak self]` from an enclosing closure. Always re-declare it:
+```swift
+// ❌ Wrong — self is strongly captured inside the Task
+doSomething { [weak self] in
+    Task {
+        self?.handle()  // self is strong here despite outer [weak self]
+    }
+}
+
+// ✅ Correct
+doSomething { [weak self] in
+    Task { [weak self] in
+        self?.handle()
+    }
+}
+```
+
+**Why:** Forgetting `[weak self]` inside a `Task` creates a retain cycle even when the enclosing closure correctly uses `[weak self]`. The two capture lists are independent.
+
+---
+
+## UI Rules
+
+> Only apply these rules if the diff includes SwiftUI view code.
+
+### 15. Avoid if/else branching on SwiftUI Views
+In SwiftUI, views inside `if/else` branches have different structural identities even if they look identical. Instead of branching on views, branch on *properties* (color, size, text, etc.):
+```swift
+// ❌ Avoid
+if isHighlighted {
+    Text("Hello").foregroundColor(.red)
+} else {
+    Text("Hello").foregroundColor(.black)
+}
+
+// ✅ Prefer
+Text("Hello").foregroundColor(isHighlighted ? .red : .black)
+```
+
+Use `@ViewBuilder` when you genuinely need to return different view types from a branch.
+
+**Why:** Branching on views causes animation glitches, performance regressions, and unexpected state resets because SwiftUI treats each branch as a distinct view identity.
+
+Reference: [Demystify SwiftUI — WWDC21](https://developer.apple.com/videos/play/wwdc2021/10022/)
+
+### 16. Use generics (`<T: View>`) instead of `AnyView`
+`AnyView` erases type information and reduces performance. Prefer generics:
+```swift
+// ❌ Avoid
+func wrap(_ view: AnyView) -> some View { ... }
+
+// ✅ Prefer
+func wrap<Content: View>(_ view: Content) -> some View { ... }
+```
+
+**Why:** Generics preserve type information and let the compiler optimize the view hierarchy.

--- a/.claude/skills/ios-review/SKILL.md
+++ b/.claude/skills/ios-review/SKILL.md
@@ -33,12 +33,7 @@ The team rules below are **additions or overrides** to those guides. Do not re-r
 
 ## General Rules
 
-### 1. Function length ≤ 50 lines
-Functions should generally be 50 lines or fewer. If a function exceeds this, suggest extracting logical chunks into named helpers.
-
-**Why:** Long functions are harder to read, test, and maintain. Shorter functions with clear names make the call site self-documenting.
-
-### 2. Avoid 2+ depth nested conditionals
+### 1. Avoid 2+ depth nested conditionals
 Nested conditionals (`if`, `guard`, `switch`, `for`, `while`, `repeat`) at a depth greater than 2 (more than one conditional inside another) are a bad pattern. Prefer:
 - `guard`/`else` to exit early instead of nesting
 - Extracting conditions into well-named boolean variables or functions
@@ -48,19 +43,19 @@ Flag any conditional nested inside another at a depth greater than 2, OR with un
 
 **Why:** Deep nesting hides the happy path, increases cognitive load, and makes it easy to miss edge cases. Early exits keep logic linear and readable.
 
-### 3. Use async/await instead of callbacks
+### 2. Use async/await instead of callbacks
 All async code should use Swift's `async/await`. Callbacks (completion handlers, closures passed as the last argument to async operations) are the old pattern and should not appear in new code.
 
 **Why:** Callbacks invert control flow and make error handling inconsistent. `async/await` reads top-to-bottom, composes cleanly with `try`, and eliminates callback pyramids.
 
-### 4. Name functions after intent, not implementation
+### 3. Name functions after intent, not implementation
 Function names should describe *what* the function achieves, not *how* it works. For example, a function that registers a hook to make an interaction fail should be called `failInteraction()`, not `registerFailureHook()`.
 
 Also: add comments on functions you cannot rename (e.g. protocol requirements, library callbacks) explaining their intent.
 
 **Why:** Implementation details change; intent rarely does. Names tied to mechanics rot as the code evolves and obscure the purpose at the call site.
 
-### 5. Public methods before private methods
+### 4. Public methods before private methods
 `public` and `open` methods should appear near the top of a type, just below `init`.
 
 Correct order within a type:
@@ -71,28 +66,14 @@ Correct order within a type:
 
 **Why:** Public APIs are hard to change post-release. Placing them at the top makes the contract immediately visible to reviewers without scrolling past implementation details.
 
-### 6. Use shorthand `guard/if let foo` (not `guard/if let foo = foo`)
-Modern Swift (5.7+) supports shorthand optional binding. Prefer:
-```swift
-guard let foo else { return }   // ✅
-if let bar { ... }              // ✅
-```
-Over:
-```swift
-guard let foo = foo else { return }  // ❌ verbose
-if let bar = bar { ... }             // ❌ verbose
-```
-
-**Why:** The redundant `= foo` is noise. Shorthand is idiomatic Swift 5.7+ and reduces visual clutter.
-
-### 7. No force-unwrap (`!`) in production code — stricter than Google guide
+### 6. No force-unwrap (`!`) in production code — stricter than Google guide
 Force-unwrap is **forbidden** in production code. Use `guard let`, `if let`, or `??` with an appropriate default. The only acceptable use of `!` is in test code (where crashes surface bugs immediately).
 
 This is stricter than the Google Swift Style Guide, which allows force-unwrap with a safety comment. We do not permit that escape hatch in production.
 
 **Why:** Force-unwrap turns a recoverable nil into an unrecoverable crash. Production code should handle unexpected nils gracefully rather than terminating.
 
-### 8. Use `private extension String` for string constants (not bare literals or `enum`)
+### 7. Use `private extension String` for string constants (not bare literals or `enum`)
 Define file-scoped string constants as a `private extension String` at the bottom of the file:
 ```swift
 // ✅ Prefer
@@ -106,12 +87,12 @@ Exception: use an `enum` (not `String` extension) for **closed, finite sets** wh
 
 **Why:** The `private extension String` pattern enables the clean `.foo` shorthand at every call site without polluting the global namespace. Enums are reserved for cases where exhaustiveness matters.
 
-### 9. Always use `[weak self]` in closures
+### 8. Always use `[weak self]` in closures
 Any closure that captures `self` must use `[weak self]`, regardless of whether a retain cycle is obvious. This includes completion handlers, notification callbacks, and any escaping closure.
 
 **Why:** Retain cycles through closures are easy to introduce and hard to spot in review. Requiring `[weak self]` universally eliminates the need to reason about object lifetimes on a case-by-case basis.
 
-### 10. Always capture `[weak self]` explicitly inside `Task` closures
+### 9. Always capture `[weak self]` explicitly inside `Task` closures
 `Task { }` creates its own capture scope and does **not** inherit `[weak self]` from an enclosing closure. Always re-declare it:
 ```swift
 // ❌ Wrong — self is strongly captured inside the Task
@@ -137,7 +118,7 @@ doSomething { [weak self] in
 
 > Only apply these rules if the diff includes SwiftUI view code.
 
-### 11. Avoid if/else branching on SwiftUI Views
+### 10. Avoid if/else branching on SwiftUI Views
 In SwiftUI, views inside `if/else` branches have different structural identities even if they look identical. Instead of branching on views, branch on *properties* (color, size, text, etc.):
 ```swift
 // ❌ Avoid
@@ -157,7 +138,7 @@ Use `@ViewBuilder` when you genuinely need to return different view types from a
 
 Reference: [Demystify SwiftUI — WWDC21](https://developer.apple.com/videos/play/wwdc2021/10022/)
 
-### 12. Use generics (`<Content: View>`) instead of `AnyView`
+### 11. Use generics (`<Content: View>`) instead of `AnyView`
 `AnyView` erases type information and reduces performance. Prefer generics:
 ```swift
 // ❌ Avoid

--- a/.claude/skills/ios-review/SKILL.md
+++ b/.claude/skills/ios-review/SKILL.md
@@ -20,20 +20,31 @@ If no violations are found, say so clearly.
 
 ---
 
+## Authoritative Style Guides
+
+Apply these guides in full during every review:
+
+1. **[Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/)** — naming, documentation, Boolean assertions, protocol suffixes, factory method prefixes, mutating/nonmutating pairs, parameter ordering.
+2. **[Google Swift Style Guide](https://google.github.io/swift/)** — formatting, brace style, import ordering, enum layout, trailing closures, trailing commas, `///` documentation format.
+
+The team rules below are **additions or overrides** to those guides. Do not re-report violations already covered by the guides unless a rule here applies a stricter standard.
+
+---
+
 ## General Rules
 
 ### 1. Function length ≤ 50 lines
-Functions should be 50 lines or fewer. If a function exceeds this, suggest extracting logical chunks into named helpers.
+Functions should generally be 50 lines or fewer. If a function exceeds this, suggest extracting logical chunks into named helpers.
 
 **Why:** Long functions are harder to read, test, and maintain. Shorter functions with clear names make the call site self-documenting.
 
-### 2. Avoid nested conditionals
-Nested conditionals (`if`, `guard`, `switch`, `for`, `while`, `repeat`) are a bad pattern in iOS code. Prefer:
+### 2. Avoid 2+ depth nested conditionals
+Nested conditionals (`if`, `guard`, `switch`, `for`, `while`, `repeat`) at a depth greater than 2 (more than one conditional inside another) are a bad pattern. Prefer:
 - `guard`/`else` to exit early instead of nesting
 - Extracting conditions into well-named boolean variables or functions
 - AI-assisted rewrites when nesting is deep
 
-Flag any conditional nested inside another conditional.
+Flag any conditional nested inside another at a depth greater than 2, OR with unnecessary nesting that could be chained.
 
 **Why:** Deep nesting hides the happy path, increases cognitive load, and makes it easy to miss edge cases. Early exits keep logic linear and readable.
 
@@ -42,10 +53,10 @@ All async code should use Swift's `async/await`. Callbacks (completion handlers,
 
 **Why:** Callbacks invert control flow and make error handling inconsistent. `async/await` reads top-to-bottom, composes cleanly with `try`, and eliminates callback pyramids.
 
-### 4. Clear logic path — name functions after intent, not implementation
-Function names should describe *what* the function achieves (its intention), not *how* it works technically. For example, a function that registers a hook to make an interaction fail should be called `failInteraction()`, not `registerFailureHook()`.
+### 4. Name functions after intent, not implementation
+Function names should describe *what* the function achieves, not *how* it works. For example, a function that registers a hook to make an interaction fail should be called `failInteraction()`, not `registerFailureHook()`.
 
-Also: add comments on functions you can't rename (e.g. protocol requirements, library callbacks) explaining their intent.
+Also: add comments on functions you cannot rename (e.g. protocol requirements, library callbacks) explaining their intent.
 
 **Why:** Implementation details change; intent rarely does. Names tied to mechanics rot as the code evolves and obscure the purpose at the call site.
 
@@ -60,12 +71,7 @@ Correct order within a type:
 
 **Why:** Public APIs are hard to change post-release. Placing them at the top makes the contract immediately visible to reviewers without scrolling past implementation details.
 
-### 6. Doc comments on all public/open declarations
-Every `public` or `open` function, property, type, and initializer must have a doc comment (`///`). This includes anything a consumer of the library will interact with directly.
-
-**Why:** Doc comments are the contract between the library and its callers. They surface in Xcode "Quick help" and are the first place a consumer looks before reading source.
-
-### 7. Use shorthand `guard/if let foo` (not `guard/if let foo = foo`)
+### 6. Use shorthand `guard/if let foo` (not `guard/if let foo = foo`)
 Modern Swift (5.7+) supports shorthand optional binding. Prefer:
 ```swift
 guard let foo else { return }   // ✅
@@ -79,17 +85,14 @@ if let bar = bar { ... }             // ❌ verbose
 
 **Why:** The redundant `= foo` is noise. Shorthand is idiomatic Swift 5.7+ and reduces visual clutter.
 
-### 8. No force-unwrap (`!`) in production code
-Force-unwrap crashes the app if the value is nil. Use `guard let`, `if let`, or `??` with an appropriate default instead. The only acceptable use of `!` is in test code (where crashes surface bugs immediately).
+### 7. No force-unwrap (`!`) in production code — stricter than Google guide
+Force-unwrap is **forbidden** in production code. Use `guard let`, `if let`, or `??` with an appropriate default. The only acceptable use of `!` is in test code (where crashes surface bugs immediately).
+
+This is stricter than the Google Swift Style Guide, which allows force-unwrap with a safety comment. We do not permit that escape hatch in production.
 
 **Why:** Force-unwrap turns a recoverable nil into an unrecoverable crash. Production code should handle unexpected nils gracefully rather than terminating.
 
-### 9. Boolean variables should start with `is` (preferred), `has`, `should`, `can`, or similar
-Boolean variables and properties should read as a yes/no question. E.g. `isEnabled`, `hasLoaded`, `shouldRetry`. Avoid names like `enabled`, `loaded`, `retry`.
-
-**Why:** Boolean names that read as questions make conditionals (`if isEnabled`) self-explanatory. Noun/verb names (`if enabled`, `if retry`) are ambiguous and harder to parse at a glance.
-
-### 10. Use `private extension String` for string constants (not bare string literals or `enum`)
+### 8. Use `private extension String` for string constants (not bare literals or `enum`)
 Define file-scoped string constants as a `private extension String` at the bottom of the file:
 ```swift
 // ✅ Prefer
@@ -99,26 +102,16 @@ private extension String {
 // Usage — shorthand works wherever String is accepted
 button.setTitle(.submitTitle)
 ```
-Exception: use an `enum` (not `String` extension) for **closed, finite sets** where the compiler should enforce exhaustiveness — e.g. state type discriminators (`VIEW`, `ACTION`, `EXTERNAL`). Those are better modeled as enums so the compiler catches missing cases.
+Exception: use an `enum` (not `String` extension) for **closed, finite sets** where the compiler should enforce exhaustiveness — e.g. state type discriminators (`VIEW`, `ACTION`, `EXTERNAL`).
 
-**Why:** The `private extension String` pattern enables the clean `.foo` shorthand at every call site without polluting the global namespace. Enums are reserved for cases where exhaustiveness matters — mixing the two degrades the compiler's ability to catch missing cases.
+**Why:** The `private extension String` pattern enables the clean `.foo` shorthand at every call site without polluting the global namespace. Enums are reserved for cases where exhaustiveness matters.
 
-### 11. Avoid abbreviations that obscure intent
-Variable and parameter names should be clear to a reader unfamiliar with the codebase. Avoid:
-- Programming jargon new contributors may not know (e.g. `noop`)
-- Acronyms that collide with common abbreviations (e.g. `CI` → "Continuous Integration")
-- Single-letter or heavily truncated names outside of trivial loop indices
-
-Prefer descriptive middle-ground names: `placeholderBeacon` over `noopBeacon`, `error` over `e`.
-
-**Why:** Abbreviations that seem obvious to the author are often opaque to reviewers and future maintainers. Colliding acronyms introduce a second source of confusion on top of the original ambiguity.
-
-### 12. Always use `[weak self]` in closures
+### 9. Always use `[weak self]` in closures
 Any closure that captures `self` must use `[weak self]`, regardless of whether a retain cycle is obvious. This includes completion handlers, notification callbacks, and any escaping closure.
 
 **Why:** Retain cycles through closures are easy to introduce and hard to spot in review. Requiring `[weak self]` universally eliminates the need to reason about object lifetimes on a case-by-case basis.
 
-### 13. Always capture `[weak self]` explicitly inside `Task` closures
+### 10. Always capture `[weak self]` explicitly inside `Task` closures
 `Task { }` creates its own capture scope and does **not** inherit `[weak self]` from an enclosing closure. Always re-declare it:
 ```swift
 // ❌ Wrong — self is strongly captured inside the Task
@@ -144,7 +137,7 @@ doSomething { [weak self] in
 
 > Only apply these rules if the diff includes SwiftUI view code.
 
-### 15. Avoid if/else branching on SwiftUI Views
+### 11. Avoid if/else branching on SwiftUI Views
 In SwiftUI, views inside `if/else` branches have different structural identities even if they look identical. Instead of branching on views, branch on *properties* (color, size, text, etc.):
 ```swift
 // ❌ Avoid
@@ -164,7 +157,7 @@ Use `@ViewBuilder` when you genuinely need to return different view types from a
 
 Reference: [Demystify SwiftUI — WWDC21](https://developer.apple.com/videos/play/wwdc2021/10022/)
 
-### 16. Use generics (`<T: View>`) instead of `AnyView`
+### 12. Use generics (`<Content: View>`) instead of `AnyView`
 `AnyView` erases type information and reduces performance. Prefer generics:
 ```swift
 // ❌ Avoid

--- a/.claude/skills/ios-review/SKILL.md
+++ b/.claude/skills/ios-review/SKILL.md
@@ -5,7 +5,7 @@ context: fork
 ---
 
 ## Current diff (when reviewing a PR)
-- Diff: !`git diff $(git log --oneline --decorate --simplify-by-decoration HEAD | awk 'NR>1{for(i=3;i<=NF;i++) if($i ~ /^origin\// || ($i !~ /HEAD/ && $i !~ /tag:/)) {gsub(/[,)]/,"",$i); print $i; exit}}')...HEAD 2>/dev/null || echo "No diff available"`
+Get the diff between this branch and its parent branch (NOT always main). If this has no parent branch, stop.
 
 # iOS Code Review — Team Conventions
 

--- a/.claude/skills/ios-review/SKILL.md
+++ b/.claude/skills/ios-review/SKILL.md
@@ -5,7 +5,7 @@ context: fork
 ---
 
 ## Current diff (when reviewing a PR)
-- Diff: !`git diff HEAD~1 2>/dev/null || echo "No diff available"`
+- Diff: !`git diff $(git log --oneline --decorate --simplify-by-decoration HEAD | awk 'NR>1{for(i=3;i<=NF;i++) if($i ~ /^origin\// || ($i !~ /HEAD/ && $i !~ /tag:/)) {gsub(/[,)]/,"",$i); print $i; exit}}')...HEAD 2>/dev/null || echo "No diff available"`
 
 # iOS Code Review — Team Conventions
 
@@ -66,33 +66,19 @@ Correct order within a type:
 
 **Why:** Public APIs are hard to change post-release. Placing them at the top makes the contract immediately visible to reviewers without scrolling past implementation details.
 
-### 6. No force-unwrap (`!`) in production code — stricter than Google guide
+### 5. No force-unwrap (`!`) in production code — stricter than Google guide
 Force-unwrap is **forbidden** in production code. Use `guard let`, `if let`, or `??` with an appropriate default. The only acceptable use of `!` is in test code (where crashes surface bugs immediately).
 
 This is stricter than the Google Swift Style Guide, which allows force-unwrap with a safety comment. We do not permit that escape hatch in production.
 
 **Why:** Force-unwrap turns a recoverable nil into an unrecoverable crash. Production code should handle unexpected nils gracefully rather than terminating.
 
-### 7. Use `private extension String` for string constants (not bare literals or `enum`)
-Define file-scoped string constants as a `private extension String` at the bottom of the file:
-```swift
-// ✅ Prefer
-private extension String {
-    static let submitTitle = "Submit"
-}
-// Usage — shorthand works wherever String is accepted
-button.setTitle(.submitTitle)
-```
-Exception: use an `enum` (not `String` extension) for **closed, finite sets** where the compiler should enforce exhaustiveness — e.g. state type discriminators (`VIEW`, `ACTION`, `EXTERNAL`).
-
-**Why:** The `private extension String` pattern enables the clean `.foo` shorthand at every call site without polluting the global namespace. Enums are reserved for cases where exhaustiveness matters.
-
-### 8. Always use `[weak self]` in closures
+### 6. Always use `[weak self]` in closures
 Any closure that captures `self` must use `[weak self]`, regardless of whether a retain cycle is obvious. This includes completion handlers, notification callbacks, and any escaping closure.
 
 **Why:** Retain cycles through closures are easy to introduce and hard to spot in review. Requiring `[weak self]` universally eliminates the need to reason about object lifetimes on a case-by-case basis.
 
-### 9. Always capture `[weak self]` explicitly inside `Task` closures
+### 7. Always capture `[weak self]` explicitly inside `Task` closures
 `Task { }` creates its own capture scope and does **not** inherit `[weak self]` from an enclosing closure. Always re-declare it:
 ```swift
 // ❌ Wrong — self is strongly captured inside the Task
@@ -118,7 +104,7 @@ doSomething { [weak self] in
 
 > Only apply these rules if the diff includes SwiftUI view code.
 
-### 10. Avoid if/else branching on SwiftUI Views
+### 8. Avoid if/else branching on SwiftUI Views
 In SwiftUI, views inside `if/else` branches have different structural identities even if they look identical. Instead of branching on views, branch on *properties* (color, size, text, etc.):
 ```swift
 // ❌ Avoid
@@ -138,7 +124,7 @@ Use `@ViewBuilder` when you genuinely need to return different view types from a
 
 Reference: [Demystify SwiftUI — WWDC21](https://developer.apple.com/videos/play/wwdc2021/10022/)
 
-### 11. Use generics (`<Content: View>`) instead of `AnyView`
+### 9. Use generics (`<Content: View>`) instead of `AnyView`
 `AnyView` erases type information and reduces performance. Prefer generics:
 ```swift
 // ❌ Avoid

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,13 +1,20 @@
 disabled_rules:
     - unused_optional_binding
     - unused_setter_value
+
 type_name:
     excluded:
+        # T is a universally understood generic placeholder
         - T
+
 line_length:
+    # TODO: Change this to the Google Swift Style Guide 100-char limit when we update our swiftlint config
     warning: 160
     ignores_comments: true
+
+# Longer functions should be split into named helpers. Long functions are harder to read, test, and maintain.
 function_body_length: 50
+
 identifier_name:
     excluded:
         - id
@@ -17,6 +24,27 @@ identifier_name:
         - drop_down
         - radio_button
         - search_input
+
 included:
     - ios
     - plugins
+
+opt_in_rules:
+    # Enforces Swift 5.7+ shorthand `guard let foo` over verbose `guard let foo = foo` to reduce visual clutter
+    - shorthand_optional_binding
+    # We should never force unwrap in production code because it will crash the app
+    - force_unwrapping
+    # We should avoid more than 2 levels of nested conditionals because it makes the code harder to read and understand
+    - nesting
+
+# TODO: Add severity overrides for "error" when we update our swiftlint config
+# Severity overrides — all set to error so lint fails on violations
+# shorthand_optional_binding:
+#     severity: error
+# force_unwrapping:
+#     severity: error
+# nesting:
+#     severity: error
+# # Don't add unnecessary parentheses to control statements
+# control_statement:
+#     severity: error

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -4364,7 +4364,7 @@
     "@@swiftlint+//bazel:extensions.bzl%extra_rules": {
       "general": {
         "bzlTransitiveDigest": "bQaIwIVfdP8t32ZvwG0ZM8y3N7Q6hhlgHsz7avAKFFs=",
-        "usagesDigest": "r5RqdZFXmQSIDGQviPfbXUMN4/brzsjh67xrejS2vME=",
+        "usagesDigest": "jGC0K54Ctu94xi3kzH4//qjUi+OsxCLDYZYr+8Gvw9E=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -4379,21 +4379,13 @@
     },
     "@@swiftlint+//bazel:repos.bzl%swiftlint_repos_bzlmod": {
       "general": {
-        "bzlTransitiveDigest": "N66OI5+AnM49F2ZlarqZsJ2XOTTPrklddss6v2ge5Cg=",
-        "usagesDigest": "Z6oXN1UqQYgd6Zkoj9qknKMWmgfX5f3DTk5sPsd7mpA=",
+        "bzlTransitiveDigest": "ybtEcu8rTdsEUtWwFQ8KM7Hu15+gEIpAicMLP7zs8KE=",
+        "usagesDigest": "tZS+6cNJAy71LmcQ2aqmNv08uAzm2wt/GnF/v1J6ZLk=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
-          "SwiftSyntax": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
-            "attributes": {
-              "sha256": "cf23f9e5a560da4232f9e60e151a979da3a0fe7214d8f884fe1d95843db83695",
-              "strip_prefix": "swift-syntax-604.0.0-prerelease-2026-01-20",
-              "url": "https://github.com/swiftlang/swift-syntax/archive/refs/tags/604.0.0-prerelease-2026-01-20.tar.gz"
-            }
-          },
-          "SwiftyTextTable": {
+          "swiftlint_com_github_scottrhoyt_swifty_text_table": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "sha256": "b77d403db9f33686caeb2a12986997fb02a0819e029e669c6b9554617c4fd6ae",
@@ -4402,7 +4394,7 @@
               "url": "https://github.com/scottrhoyt/SwiftyTextTable/archive/refs/tags/0.9.0.tar.gz"
             }
           },
-          "CollectionConcurrencyKit": {
+          "com_github_johnsundell_collectionconcurrencykit": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "sha256": "9083fe6f8b4f820bfb5ef5c555b31953116f158ec113e94c6406686e78da34aa",
@@ -4411,21 +4403,13 @@
               "url": "https://github.com/JohnSundell/CollectionConcurrencyKit/archive/refs/tags/0.2.0.tar.gz"
             }
           },
-          "CryptoSwift": {
+          "com_github_krzyzanowskim_cryptoswift": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
-              "sha256": "81b1ba186e2edcff47bcc2a3b6a242df083ba2f64bfb42209f79090cb8d7f889",
+              "sha256": "69b23102ff453990d03aff4d3fabd172d0667b2b3ed95730021d60a0f8d50d14",
               "build_file": "@@swiftlint+//bazel:CryptoSwift.BUILD",
-              "strip_prefix": "CryptoSwift-1.9.0",
-              "url": "https://github.com/krzyzanowskim/CryptoSwift/archive/refs/tags/1.9.0.tar.gz"
-            }
-          },
-          "FilenameMatcher": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
-            "attributes": {
-              "sha256": "c0a6041be02ddd12f1cdde089f84dfa70e33e384cc476a786542a536d8401c6e",
-              "strip_prefix": "swift-filename-matcher-2.0.1",
-              "url": "https://github.com/ileitch/swift-filename-matcher/archive/refs/tags/2.0.1.tar.gz"
+              "strip_prefix": "CryptoSwift-1.8.4",
+              "url": "https://github.com/krzyzanowskim/CryptoSwift/archive/refs/tags/1.8.4.tar.gz"
             }
           }
         },


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->
We're getting more ios contribution since AI has become more popular. Now that we have more PRs, we ios reviewers end up putting a lot of duplicate comments across PRs. To reduce churn in human-led reviews, this PR introduces a new Claude skill `ios-review` to handle common issues. This skill is also intended to be human-readable documentation of our design standards.

This also adds some more `swiftlint` rules but does not enforce them yet because that would add a lot of reformatting to this PR. Instead, we will revise our swiftlint config fully and reformat as part of this issue: https://github.com/player-ui/player/issues/849.

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
- [x] `N/A`


### Does your PR have any documentation updates?
- [x] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->