### PR TITLE
Refactor stateType from String to NavigationFlowStateType enum

### DIFF
--- a/ios/core/Sources/Types/Core/NavigationFlowStateType.swift
+++ b/ios/core/Sources/Types/Core/NavigationFlowStateType.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// All possible enumerations of navigation flow states.
+///
+/// Maps to the `state_type` field in the JSON flow definition (e.g. `"state_type": "VIEW"`).
+/// Mirrors `NavigationFlowStateType` on the JVM/Android side.
+public enum NavigationFlowStateType: Equatable {
+    /// A state representing a renderable view (`"VIEW"`)
+    case view
+    /// An action state that executes an expression to determine the next transition (`"ACTION"`)
+    case action
+    /// An asynchronous variant of an action state (`"ASYNC_ACTION"`)
+    case asyncAction
+    /// A sub-flow state that delegates to another flow (`"FLOW"`)
+    case flow
+    /// An external state managed by the host application (`"EXTERNAL"`)
+    case external
+    /// A terminal state indicating the flow has completed (`"END"`)
+    case end
+    /// A state type not recognized by this version of the SDK.
+    /// Preserves the original `state_type` string for forward-compatibility
+    /// if new state types are added on the JS side.
+    case unknown(String)
+
+    /// Creates a `NavigationFlowStateType` from the raw `state_type` string in the flow JSON.
+    /// Unrecognized values are captured as `.unknown(rawValue)` rather than discarded.
+    public init(_ rawValue: String) {
+        switch rawValue {
+        case "VIEW": self = .view
+        case "ACTION": self = .action
+        case "ASYNC_ACTION": self = .asyncAction
+        case "FLOW": self = .flow
+        case "EXTERNAL": self = .external
+        case "END": self = .end
+        default:
+            assertionFailure("Unrecognized state_type: \(rawValue)")
+            self = .unknown(rawValue)
+        }
+    }
+
+    /// The raw `state_type` string as it appears in the flow JSON.
+    public var rawValue: String {
+        switch self {
+        case .view: return "VIEW"
+        case .action: return "ACTION"
+        case .asyncAction: return "ASYNC_ACTION"
+        case .flow: return "FLOW"
+        case .external: return "EXTERNAL"
+        case .end: return "END"
+        case .unknown(let value): return value
+        }
+    }
+}

--- a/ios/core/Sources/Types/Core/NavigationFlowStateType.swift
+++ b/ios/core/Sources/Types/Core/NavigationFlowStateType.swift
@@ -33,7 +33,6 @@ public enum NavigationFlowStateType: Equatable {
         case "EXTERNAL": self = .external
         case "END": self = .end
         default:
-            assertionFailure("Unrecognized state_type: \(rawValue)")
             self = .unknown(rawValue)
         }
     }

--- a/ios/core/Sources/Types/Core/NavigationStates.swift
+++ b/ios/core/Sources/Types/Core/NavigationStates.swift
@@ -6,7 +6,7 @@ open class NavigationBaseState: CreatedFromJSValue, JSValueProviding {
     public typealias T = NavigationBaseState
 
     /// A property to determine the type of state this is
-    public let stateType: String
+    public let stateType: NavigationFlowStateType
 
     internal let rawValue: JSValue
 
@@ -16,19 +16,19 @@ open class NavigationBaseState: CreatedFromJSValue, JSValueProviding {
     public static func createInstance(value: JSValue) -> NavigationBaseState {
         let base = NavigationBaseState(value)
         switch base.stateType {
-        case "VIEW": return NavigationFlowViewState(value)
-        case "ACTION": return NavigationFlowActionState(value)
-        case "ASYNC_ACTION": return NavigationFlowAsyncActionState(value)
-        case "FLOW": return NavigationFlowFlowState(value)
-        case "EXTERNAL": return NavigationFlowExternalState(value)
-        case "END": return NavigationFlowEndState(value)
+        case .view: return NavigationFlowViewState(value)
+        case .action: return NavigationFlowActionState(value)
+        case .asyncAction: return NavigationFlowAsyncActionState(value)
+        case .flow: return NavigationFlowFlowState(value)
+        case .external: return NavigationFlowExternalState(value)
+        case .end: return NavigationFlowEndState(value)
         default: return base
         }
     }
 
     public init(_ value: JSValue) {
         rawValue = value
-        stateType = value.objectForKeyedSubscript("state_type").toString()
+        stateType = NavigationFlowStateType(value.objectForKeyedSubscript("state_type").toString())
     }
 }
 

--- a/ios/core/Tests/NavigationFlowStateTypeTests.swift
+++ b/ios/core/Tests/NavigationFlowStateTypeTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import XCTest
+@testable import PlayerUI
+
+class NavigationFlowStateTypeTests: XCTestCase {
+
+    func testKnownStateTypes() {
+        let cases: [(String, NavigationFlowStateType)] = [
+            ("VIEW", .view),
+            ("ACTION", .action),
+            ("ASYNC_ACTION", .asyncAction),
+            ("FLOW", .flow),
+            ("EXTERNAL", .external),
+            ("END", .end),
+        ]
+
+        for (raw, expected) in cases {
+            let stateType = NavigationFlowStateType(raw)
+            XCTAssertEqual(stateType, expected)
+            XCTAssertEqual(stateType.rawValue, raw)
+        }
+    }
+
+    func testUnknownStateType() {
+        let stateType = NavigationFlowStateType("SOME_NEW_TYPE")
+        XCTAssertEqual(stateType, .unknown("SOME_NEW_TYPE"))
+        XCTAssertEqual(stateType.rawValue, "SOME_NEW_TYPE")
+    }
+}

--- a/plugins/external-action/swiftui/Sources/ExternalActionViewModifierPlugin.swift
+++ b/plugins/external-action/swiftui/Sources/ExternalActionViewModifierPlugin.swift
@@ -53,8 +53,8 @@ open class ExternalActionViewModifierPlugin<ModifierType: ExternalStateViewModif
             flowController.hooks.flow.tap { flow in
                 flow.hooks.transition.tap {[weak self] old, newState in
                     guard
-                        old?.value?.stateType == "EXTERNAL",
-                        newState.value?.stateType != "EXTERNAL"
+                        old?.value?.stateType == .external,
+                        newState.value?.stateType != .external
                     else { return }
                     self?.isExternalState = false
                     self?.state = nil

--- a/plugins/external-action/swiftui/ViewInspector/ExternalActionViewModifierPluginTests.swift
+++ b/plugins/external-action/swiftui/ViewInspector/ExternalActionViewModifierPluginTests.swift
@@ -164,11 +164,11 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
         class HasTransitionedPlugin: NativePlugin {
             var pluginName: String = "HasTransitioned"
 
-            var expected: String
+            var expected: NavigationFlowStateType
 
             var expectation: XCTestExpectation
 
-            init(expected: String, expectation: XCTestExpectation) {
+            init(expected: NavigationFlowStateType, expectation: XCTestExpectation) {
                 self.expected = expected
                 self.expectation = expectation
             }
@@ -190,7 +190,7 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
 
         let context = SwiftUIPlayer.Context()
 
-        let player = SwiftUIPlayer(flow: json, plugins: [ReferenceAssetsPlugin(), plugin, HasTransitionedPlugin(expected: "VIEW", expectation: viewTransition)], result: Binding(get: {nil}, set: { (result) in
+        let player = SwiftUIPlayer(flow: json, plugins: [ReferenceAssetsPlugin(), plugin, HasTransitionedPlugin(expected: .view, expectation: viewTransition)], result: Binding(get: {nil}, set: { (result) in
             switch result {
             case .success:
                 completionExpectation.fulfill()
@@ -212,7 +212,7 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
         wait(for: [viewTransition], timeout: 10)
         let state = player.state as? InProgressState
         XCTAssertNotNil(state)
-        XCTAssertEqual(state?.controllers?.flow.current?.currentState?.value?.stateType, "VIEW")
+        XCTAssertEqual(state?.controllers?.flow.current?.currentState?.value?.stateType, .view)
         XCTAssertNil(plugin.state)
         XCTAssertFalse(plugin.isExternalState)
         do {


### PR DESCRIPTION
- Add `NavigationFlowStateType` enum in its own file (`NavigationFlowStateType.swift`), matching the JVM project structure (`NavigationFlowStateType.kt`).
- Use an `unknown(String)` case with associated value for forward-compatibility: unrecognized state types from JS are preserved rather than discarded, with an assertionFailure in debug builds to catch contract mismatches early.
- added unit tests

<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [x] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->