### PR TITLE
guard against async released exceptions when retrieving state

### DIFF
--- a/jvm/core/src/main/kotlin/com/intuit/playerui/core/player/HeadlessPlayer.kt
+++ b/jvm/core/src/main/kotlin/com/intuit/playerui/core/player/HeadlessPlayer.kt
@@ -3,6 +3,7 @@ package com.intuit.playerui.core.player
 import com.intuit.playerui.core.bridge.Completable
 import com.intuit.playerui.core.bridge.Node
 import com.intuit.playerui.core.bridge.NodeWrapper
+import com.intuit.playerui.core.bridge.PlayerRuntimeReleasedException
 import com.intuit.playerui.core.bridge.Promise
 import com.intuit.playerui.core.bridge.getInvokable
 import com.intuit.playerui.core.bridge.runtime.PlayerRuntimeConfig
@@ -86,7 +87,12 @@ public class HeadlessPlayer @ExperimentalPlayerApi @JvmOverloads public construc
     override val state: PlayerFlowState get() = if (player.isReleased()) {
         ReleasedState
     } else {
-        player.getInvokable<Node>("getState")!!().deserialize(PlayerFlowState.serializer())
+        try {
+            player.getInvokable<Node>("getState")!!().deserialize(PlayerFlowState.serializer())
+        } catch (exception: PlayerRuntimeReleasedException) {
+            // If the runtime is released async
+            ReleasedState
+        }
     }
 
     public val runtime: Runtime<*> = explicitRuntime ?: runtimeFactory.create {

--- a/jvm/hermes/src/main/jni/BUILD
+++ b/jvm/hermes/src/main/jni/BUILD
@@ -35,7 +35,7 @@ cc_library(
     copts = CMAKE_BUILD_TYPE_COPTS + select({
         # TODO: Using React Natives JSI doesn't contain microtask - come back to this if we build it ourselves
         ":should_include_jni": [
-            "-DJSI_MICROTASK"
+            "-DJSI_MICROTASK",
         ],
         "//conditions:default": [],
     }),
@@ -45,9 +45,12 @@ cc_library(
         # Android build
         "//conditions:default": [
             "-Wl,-z,max-page-size=16384",
-            "-lunwind"
+            "-lunwind",
         ],
     }),
+    tags = [
+        "manual",
+    ],
     visibility = ["//visibility:public"],
     deps = select({
         # Host build


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

We can guard against released exceptions during state retrieval since we can just return `ReleasedState`. We might need a better solve for other APIs, since invoking them has the potential to crash user applications if not handled by the consumers, but that's a tougher problem.

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->

# Release Notes

Guard against released exceptions when retrieving state since we can turn that into a `ReleasedState`.