### PR TITLE
Automatically lint swift files in CI/CD, format on pre-commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,9 +164,7 @@ jobs:
               $(bazel query "kind(ios_unit_test, //ios/...)") \
               $(bazel query "kind(ios_unit_test, //plugins/...)") \
               $(bazel query "kind(ios_ui_test, //ios/...)") \
-              $(bazel query "kind(ios_ui_test, //plugins/...)") \
-              $(bazel query "attr(name, '.*SwiftLint', //ios/...)") \
-              $(bazel query "attr(name, '.*SwiftLint', //plugins/...)")
+              $(bazel query "kind(ios_ui_test, //plugins/...)")
       - run:
           name: Tests
           command: |
@@ -181,18 +179,11 @@ jobs:
               $(bazel query "kind(ios_ui_test, //ios/...)") \
               $(bazel query "kind(ios_ui_test, //plugins/...)")
       - run:
-          name: Lint
-          command: |
-            bazel test \
-              --config=ci-mac \
-              $(bazel query "attr(name, '.*SwiftLint', //ios/...)") \
-              $(bazel query "attr(name, '.*SwiftLint', //plugins/...)")
-
-      - run:
-          name: SwiftFormat
+          name: Swift Lint and Format
           command: |
             mint bootstrap
-            just swift-format-lint
+            mint run swiftlint lint --strict
+            mint run swiftformat ios plugins --lint
 
       - run:
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
       - run:
           name: Homebrew Dependencies
           command: |
-            HOMEBREW_NO_AUTO_UPDATE=1 brew install bazelisk lcov
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install bazelisk lcov mint
 
       - macos/preboot-simulator:
           version: "26.4"
@@ -187,6 +187,12 @@ jobs:
               --config=ci-mac \
               $(bazel query "attr(name, '.*SwiftLint', //ios/...)") \
               $(bazel query "attr(name, '.*SwiftLint', //plugins/...)")
+
+      - run:
+          name: SwiftFormat
+          command: |
+            mint bootstrap
+            just swift-format-lint
 
       - run:
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
       - run:
           name: Homebrew Dependencies
           command: |
-            HOMEBREW_NO_AUTO_UPDATE=1 brew install bazelisk lcov mint
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install bazelisk lcov
 
       - macos/preboot-simulator:
           version: "26.4"
@@ -179,13 +179,6 @@ jobs:
               $(bazel query "kind(ios_ui_test, //ios/...)") \
               $(bazel query "kind(ios_ui_test, //plugins/...)")
       - run:
-          name: Swift Lint and Format
-          command: |
-            mint bootstrap
-            mint run swiftlint lint --strict
-            mint run swiftformat ios plugins --lint
-
-      - run:
           when: always
           command: |
             RESULTS_DIR=_test_results
@@ -209,6 +202,25 @@ jobs:
 
       - store_test_results:
           path: _test_results
+
+  # We run this stage in parallel with build-ios-trunk so it doesn't slow down the build
+  lint_ios:
+    executor: ios
+    steps:
+      - attach_workspace:
+          at: ~/player
+
+      - run:
+          name: Homebrew Dependencies
+          command: |
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install mint
+
+      - run:
+          name: Swift Lint and Format
+          command: |
+            mint bootstrap
+            mint run swiftlint lint --strict
+            mint run swiftformat ios plugins --lint
 
   test:
     executor: base
@@ -443,6 +455,26 @@ workflows:
             - build-fork
             - bazelrc_fork
 
+      - lint_ios:
+          name: lint-ios-trunk
+          filters:
+            branches:
+              ignore:
+                - /pull\/.*/
+          requires:
+            - bazelrc
+            - build-trunk
+
+      - lint_ios:
+          name: lint-ios-fork
+          filters:
+            branches:
+              only:
+                - /pull\/.*/
+          requires:
+            - build-fork
+            - bazelrc_fork
+
       - maybe_release:
           filters:
             branches:
@@ -453,6 +485,7 @@ workflows:
           requires:
             - test-trunk
             - build-ios-trunk
+            - lint-ios-trunk
             - android-test-trunk
 
       - test:
@@ -577,6 +610,10 @@ workflows:
           requires:
             - build
 
+      - lint_ios:
+          requires:
+            - build
+
       - android_test:
           context:
             - Build
@@ -611,6 +648,7 @@ workflows:
             - test
             - bundle-analyze
             - build_and_test_ios
+            - lint_ios
             - build_docs
 
   full_release:
@@ -630,6 +668,10 @@ workflows:
             - setup
 
       - build_and_test_ios:
+          requires:
+            - bazelrc
+
+      - lint_ios:
           requires:
             - bazelrc
 
@@ -666,4 +708,5 @@ workflows:
             - test
             - bundle_analyze
             - build_and_test_ios
+            - lint_ios
             - build_docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,9 +162,7 @@ jobs:
             bazel build \
               --config=ci-mac \
               $(bazel query "kind('ios_unit_test|ios_ui_test', //ios/...)") \
-              $(bazel query "kind('ios_unit_test|ios_ui_test', //plugins/...)") \
-              $(bazel query "attr(name, '.*SwiftLint', //ios/...)") \
-              $(bazel query "attr(name, '.*SwiftLint', //plugins/...)")
+              $(bazel query "kind('ios_unit_test|ios_ui_test', //plugins/...)")
       - run:
           name: Tests
           command: |
@@ -176,14 +174,6 @@ jobs:
               --test_timeout=1800 \
               $(bazel query "kind('ios_unit_test|ios_ui_test', //ios/...)") \
               $(bazel query "kind('ios_unit_test|ios_ui_test', //plugins/...)")
-      - run:
-          name: Lint
-          command: |
-            bazel test \
-              --config=ci-mac \
-              $(bazel query "attr(name, '.*SwiftLint', //ios/...)") \
-              $(bazel query "attr(name, '.*SwiftLint', //plugins/...)")
-
       - run:
           when: always
           command: |
@@ -208,6 +198,25 @@ jobs:
 
       - store_test_results:
           path: _test_results
+
+  # We run this stage in parallel with build-ios-trunk so it doesn't slow down the build
+  lint_ios:
+    executor: ios
+    steps:
+      - attach_workspace:
+          at: ~/player
+
+      - run:
+          name: Homebrew Dependencies
+          command: |
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install mint
+
+      - run:
+          name: Swift Lint and Format
+          command: |
+            mint bootstrap
+            mint run swiftlint lint --strict
+            mint run swiftformat ios plugins --lint
 
   test:
     executor: base
@@ -469,6 +478,26 @@ workflows:
             - build-fork
             - bazelrc_fork
 
+      - lint_ios:
+          name: lint-ios-trunk
+          filters:
+            branches:
+              ignore:
+                - /pull\/.*/
+          requires:
+            - bazelrc
+            - build-trunk
+
+      - lint_ios:
+          name: lint-ios-fork
+          filters:
+            branches:
+              only:
+                - /pull\/.*/
+          requires:
+            - build-fork
+            - bazelrc_fork
+
       - maybe_release:
           filters:
             branches:
@@ -479,6 +508,7 @@ workflows:
           requires:
             - test-trunk
             - build-ios-trunk
+            - lint-ios-trunk
             - android-test-trunk
 
       - test:
@@ -606,6 +636,10 @@ workflows:
             - build
             - test
 
+      - lint_ios:
+          requires:
+            - build
+
       - android_test:
           context:
             - Build
@@ -647,6 +681,7 @@ workflows:
             - test
             - bundle-analyze
             - build_and_test_ios
+            - lint_ios
             - build_docs
 
   full_release:
@@ -666,6 +701,10 @@ workflows:
             - setup
 
       - build_and_test_ios:
+          requires:
+            - bazelrc
+
+      - lint_ios:
           requires:
             - bazelrc
 
@@ -702,4 +741,5 @@ workflows:
             - test
             - bundle_analyze
             - build_and_test_ios
+            - lint_ios
             - build_docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -462,6 +462,7 @@ workflows:
           requires:
             - bazelrc
             - build-trunk
+            - lint-ios-trunk
 
       - build_and_test_ios:
           name: build-ios-fork
@@ -472,6 +473,7 @@ workflows:
           requires:
             - build-fork
             - bazelrc_fork
+            - lint-ios-fork
 
       - lint_ios:
           name: lint-ios-trunk
@@ -501,7 +503,6 @@ workflows:
           requires:
             - test-trunk
             - build-ios-trunk
-            - lint-ios-trunk
             - android-test-trunk
 
       - test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,7 +209,7 @@ jobs:
       - run:
           name: Homebrew Dependencies
           command: |
-            HOMEBREW_NO_AUTO_UPDATE=1 brew install mint
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install mint@0.18.0
 
       - run:
           name: Swift Lint and Format
@@ -486,7 +486,6 @@ workflows:
                 - /pull\/.*/
           requires:
             - bazelrc
-            - build-trunk
 
       - lint_ios:
           name: lint-ios-fork
@@ -495,7 +494,6 @@ workflows:
               only:
                 - /pull\/.*/
           requires:
-            - build-fork
             - bazelrc_fork
 
       - maybe_release:
@@ -638,7 +636,7 @@ workflows:
 
       - lint_ios:
           requires:
-            - build
+            - bazelrc
 
       - android_test:
           context:
@@ -681,7 +679,6 @@ workflows:
             - test
             - bundle-analyze
             - build_and_test_ios
-            - lint_ios
             - build_docs
 
   full_release:
@@ -741,5 +738,4 @@ workflows:
             - test
             - bundle_analyze
             - build_and_test_ios
-            - lint_ios
             - build_docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,18 +207,11 @@ jobs:
           at: ~/player
 
       - run:
-          name: Homebrew Dependencies
-          # mint has no versions in homebrew, so pin the homebrew version with it
-          # This is mint 0.18.0
-          command: |
-            HOMEBREW_NO_AUTO_UPDATE=1 brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f682012776a07b711896a7294bf262534f0dfc98/Formula/m/mint.rb
-
-      - run:
           name: Swift Lint and Format
           command: |
-            mint bootstrap
-            mint run swiftlint lint --strict
-            mint run swiftformat ios plugins --lint
+            swift run --package-path xcode mint bootstrap
+            swift run --package-path xcode mint run swiftlint lint --strict ios plugins
+            swift run --package-path xcode mint run swiftformat ios plugins --lint
 
   test:
     executor: base

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,9 +209,8 @@ jobs:
       - run:
           name: Swift Lint and Format
           command: |
-            swift run --package-path xcode mint bootstrap
-            swift run --package-path xcode mint run swiftlint lint --strict ios plugins
-            swift run --package-path xcode mint run swiftformat ios plugins --lint
+            swift run --package-path xcode swiftlint lint --strict ios plugins
+            swift run --package-path xcode swiftformat ios plugins --lint
 
   test:
     executor: base

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,8 +208,10 @@ jobs:
 
       - run:
           name: Homebrew Dependencies
+          # mint has no versions in homebrew, so pin the homebrew version with it
+          # This is mint 0.18.0
           command: |
-            HOMEBREW_NO_AUTO_UPDATE=1 brew install mint@0.18.0
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f682012776a07b711896a7294bf262534f0dfc98/Formula/m/mint.rb
 
       - run:
           name: Swift Lint and Format

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -462,7 +462,6 @@ workflows:
           requires:
             - bazelrc
             - build-trunk
-            - lint-ios-trunk
 
       - build_and_test_ios:
           name: build-ios-fork
@@ -473,7 +472,6 @@ workflows:
           requires:
             - build-fork
             - bazelrc_fork
-            - lint-ios-fork
 
       - lint_ios:
           name: lint-ios-trunk

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn lint-staged
+pnpm lint-staged

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -6,4 +6,8 @@ module.exports = {
   '*.md': (filenames) => {
     return [`prettier --write ${filenames.join(' ')}`];
   },
+  '*.swift': (filenames) => {
+    const files = filenames.join(' ');
+    return [`mint run swiftformat ${files}`];
+  },
 };

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -6,4 +6,8 @@ module.exports = {
   '*.md': (filenames) => {
     return [`prettier --write ${filenames.join(' ')}`];
   },
+  '*.swift': (filenames) => {
+    const files = filenames.join(' ');
+    return [`mint run swiftformat ${files}`, `mint run swiftlint --fix`];
+  },
 };

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -8,6 +8,6 @@ module.exports = {
   },
   '*.swift': (filenames) => {
     const files = filenames.join(' ');
-    return [`mint run swiftformat ${files}`];
+    return [`mint run swiftformat ${files}`, `mint run swiftlint --fix`];
   },
 };

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -8,6 +8,9 @@ module.exports = {
   },
   '*.swift': (filenames) => {
     const files = filenames.join(' ');
-    return [`mint run swiftformat ${files}`, `mint run swiftlint --fix ${files}`];
+    return [
+      `swift run --package-path xcode mint run swiftformat ${files}`,
+      `swift run --package-path xcode mint run swiftlint --fix ${files}`,
+    ];
   },
 };

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -9,8 +9,8 @@ module.exports = {
   '*.swift': (filenames) => {
     const files = filenames.join(' ');
     return [
-      `swift run --package-path xcode mint run swiftformat ${files}`,
-      `swift run --package-path xcode mint run swiftlint --fix ${files}`,
+      `swift run --package-path xcode swiftformat ${files}`,
+      `swift run --package-path xcode swiftlint --fix ${files}`,
     ];
   },
 };

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -8,6 +8,6 @@ module.exports = {
   },
   '*.swift': (filenames) => {
     const files = filenames.join(' ');
-    return [`mint run swiftformat ${files}`, `mint run swiftlint --fix`];
+    return [`mint run swiftformat ${files}`, `mint run swiftlint --fix ${files}`];
   },
 };

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,28 @@
+--swiftversion 5.5
+--exclude .build,.swiftpm,xcode/.build,bazel-*
+--indent 4
+--allman false
+--max-width 100
+
+# Opt-in rules
+--enable blockComments
+--enable isEmpty
+--enable noGuardInTests
+--enable organizeDeclarations
+--enable preferSwiftStringAPI
+--enable propertyTypes
+--enable singlePropertyPerLine
+--enable sortSwitchCases
+--enable testSuiteAccessControl
+--enable unusedPrivateDeclarations
+--enable validateTestCases
+--enable wrapMultilineConditionalAssignment
+--enable wrapMultilineFunctionChains
+
+--disable wrapMultilineStatementBraces
+
+# Order for organizeDeclarations
+--organizationmode type
+--mark-categories false
+--type-order beforeMarks, staticProperty, instanceProperty, instancePropertyWithBody, swiftUIPropertyWrapper, swiftUIProperty, overriddenProperty, staticPropertyWithBody, classPropertyWithBody, computedProperty, instanceLifecycle, instanceMethod, overriddenMethod, swiftUIMethod, classMethod, staticMethod, nestedType
+

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,3 +1,28 @@
 --swiftversion 5.5
---indent 4
 --exclude .build,.swiftpm,xcode/.build,bazel-*
+--indent 4
+--allman false
+--max-width 100
+
+# Opt-in rules
+--enable blockComments
+--enable isEmpty
+--enable noGuardInTests
+--enable organizeDeclarations
+--enable preferSwiftStringAPI
+--enable propertyTypes
+--enable singlePropertyPerLine
+--enable sortSwitchCases
+--enable testSuiteAccessControl
+--enable unusedPrivateDeclarations
+--enable validateTestCases
+--enable wrapMultilineConditionalAssignment
+--enable wrapMultilineFunctionChains
+
+--disable wrapMultilineStatementBraces
+
+# Order for organizeDeclarations
+--organizationmode type
+--mark-categories false
+--type-order beforeMarks, staticProperty, instanceProperty, instancePropertyWithBody, swiftUIPropertyWrapper, swiftUIProperty, overriddenProperty, staticPropertyWithBody, classPropertyWithBody, computedProperty, instanceLifecycle, instanceMethod, overriddenMethod, swiftUIMethod, classMethod, staticMethod, nestedType
+

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,3 @@
+--swiftversion 5.5
+--indent 4
+--exclude .build,.swiftpm,xcode/.build,bazel-*

--- a/.swiftformat
+++ b/.swiftformat
@@ -8,7 +8,6 @@
 --enable blockComments
 --enable isEmpty
 --enable noGuardInTests
---enable organizeDeclarations
 --enable propertyTypes
 --enable singlePropertyPerLine
 --enable sortSwitchCases

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,4 +1,4 @@
---swiftversion 5.5
+--swiftversion 5.9
 --exclude .build,.swiftpm,xcode/.build,bazel-*
 --indent 4
 --allman false

--- a/.swiftformat
+++ b/.swiftformat
@@ -9,7 +9,6 @@
 --enable isEmpty
 --enable noGuardInTests
 --enable organizeDeclarations
---enable preferSwiftStringAPI
 --enable propertyTypes
 --enable singlePropertyPerLine
 --enable sortSwitchCases

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,11 +3,25 @@ disabled_rules:
     - unused_setter_value
     # SwiftFormat owns trailing comma style via its trailingCommas rule
     - trailing_comma
+    # disable:next comments between doc comment params and a declaration trigger false positives
+    - orphaned_doc_comment
 
 type_name:
     excluded:
         # T is a universally understood generic placeholder
         - T
+
+identifier_name:
+    excluded:
+        # id is a universally understood identifier in iOS/SwiftUI
+        - id
+        # Snake_case names are generated from JSON schema and must match the wire format exactly
+        - radio_button
+        - drop_down
+        - check_box
+        - text_input
+        - search_input
+        - file_input
 
 # Longer functions should be split into named helpers. Long functions are harder to read, test, and maintain.
 function_body_length:
@@ -16,6 +30,42 @@ function_body_length:
 included:
     - ios
     - plugins
+
+excluded:
+    # Generated mock data — intentionally excluded from all lint rules
+    - ios/demo/Sources/MockFlows.swift
+    # Demo-only file — file length acceptable for a demo
+    - ios/demo/Sources/String+Extensions.swift
+    # Test folders. SwiftLint is pretty strict about test files unnecessarily, so we exclude them.
+    # SwiftFormat still covers these.
+    - ios/core/Tests
+    - ios/logger/Tests
+    - ios/swiftui/Tests
+    - ios/swiftui/ViewInspector
+    - ios/test-utils-core/Tests
+    - ios/test-utils/Tests
+    - ios/test-utils/ViewInspector
+    - plugins/async-node/ios/Tests
+    - plugins/async-node/ios/ViewInspector
+    - plugins/beacon/ios/Tests
+    - plugins/beacon/swiftui/ViewInspector
+    - plugins/check-path/ios/Tests
+    - plugins/check-path/swiftui/ViewInspector
+    - plugins/common-expressions/ios/Tests
+    - plugins/common-types/ios/Tests
+    - plugins/computed-properties/ios/Tests
+    - plugins/console-logger/ios/Tests
+    - plugins/expression/ios/Tests
+    - plugins/external-action/ios/Tests
+    - plugins/external-action/swiftui/ViewInspector
+    - plugins/metrics/swiftui/ViewInspector
+    - plugins/pending-transaction/swiftui/ViewInspector
+    - plugins/pubsub/ios/Tests
+    - plugins/reference-assets/swiftui/UITests
+    - plugins/reference-assets/swiftui/ViewInspector
+    - plugins/stage-revert-data/ios/Tests
+    - plugins/transition/swiftui/ViewInspector
+    - plugins/types-provider/ios/Tests
 
 opt_in_rules:
     # Enforces Swift 5.7+ shorthand `guard let foo` over verbose `guard let foo = foo` to reduce visual clutter
@@ -29,8 +79,6 @@ opt_in_rules:
 shorthand_optional_binding:
     severity: error
 force_unwrapping:
-    severity: error
-nesting:
     severity: error
 # Don't add unnecessary parentheses to control statements
 control_statement:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,29 +1,17 @@
 disabled_rules:
     - unused_optional_binding
     - unused_setter_value
+    # SwiftFormat owns trailing comma style via its trailingCommas rule
+    - trailing_comma
 
 type_name:
     excluded:
         # T is a universally understood generic placeholder
         - T
 
-line_length:
-    # TODO: Change this to the Google Swift Style Guide 100-char limit when we update our swiftlint config
-    warning: 160
-    ignores_comments: true
-
 # Longer functions should be split into named helpers. Long functions are harder to read, test, and maintain.
-function_body_length: 50
-
-identifier_name:
-    excluded:
-        - id
-        - file_input
-        - text_input
-        - check_box
-        - drop_down
-        - radio_button
-        - search_input
+function_body_length:
+    error: 50
 
 included:
     - ios
@@ -37,14 +25,13 @@ opt_in_rules:
     # We should avoid more than 2 levels of nested conditionals because it makes the code harder to read and understand
     - nesting
 
-# TODO: Add severity overrides for "error" when we update our swiftlint config
 # Severity overrides — all set to error so lint fails on violations
-# shorthand_optional_binding:
-#     severity: error
-# force_unwrapping:
-#     severity: error
-# nesting:
-#     severity: error
-# # Don't add unnecessary parentheses to control statements
-# control_statement:
-#     severity: error
+shorthand_optional_binding:
+    severity: error
+force_unwrapping:
+    severity: error
+nesting:
+    severity: error
+# Don't add unnecessary parentheses to control statements
+control_statement:
+    severity: error

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,33 +1,71 @@
 disabled_rules:
     - unused_optional_binding
     - unused_setter_value
+    # SwiftFormat owns trailing comma style via its trailingCommas rule
+    - trailing_comma
+    # disable:next comments between doc comment params and a declaration trigger false positives
+    - orphaned_doc_comment
 
 type_name:
     excluded:
         # T is a universally understood generic placeholder
         - T
 
-line_length:
-    # TODO: Change this to the Google Swift Style Guide 100-char limit when we update our swiftlint config
-    warning: 160
-    ignores_comments: true
-
-# Longer functions should be split into named helpers. Long functions are harder to read, test, and maintain.
-function_body_length: 50
-
 identifier_name:
     excluded:
+        # id is a universally understood identifier in iOS/SwiftUI
         - id
-        - file_input
-        - text_input
-        - check_box
-        - drop_down
+        # Snake_case names are generated from JSON schema and must match the wire format exactly
         - radio_button
+        - drop_down
+        - check_box
+        - text_input
         - search_input
+        - file_input
+
+# Longer functions should be split into named helpers. Long functions are harder to read, test, and maintain.
+function_body_length:
+    error: 50
 
 included:
     - ios
     - plugins
+
+excluded:
+    # Generated mock data — intentionally excluded from all lint rules
+    - ios/demo/Sources/MockFlows.swift
+    # Demo-only file — file length acceptable for a demo
+    - ios/demo/Sources/String+Extensions.swift
+    # Test folders. SwiftLint is pretty strict about test files unnecessarily, so we exclude them.
+    # SwiftFormat still covers these.
+    - ios/core/Tests
+    - ios/logger/Tests
+    - ios/swiftui/Tests
+    - ios/swiftui/ViewInspector
+    - ios/test-utils-core/Tests
+    - ios/test-utils/Tests
+    - ios/test-utils/ViewInspector
+    - plugins/async-node/ios/Tests
+    - plugins/async-node/ios/ViewInspector
+    - plugins/beacon/ios/Tests
+    - plugins/beacon/swiftui/ViewInspector
+    - plugins/check-path/ios/Tests
+    - plugins/check-path/swiftui/ViewInspector
+    - plugins/common-expressions/ios/Tests
+    - plugins/common-types/ios/Tests
+    - plugins/computed-properties/ios/Tests
+    - plugins/console-logger/ios/Tests
+    - plugins/expression/ios/Tests
+    - plugins/external-action/ios/Tests
+    - plugins/external-action/swiftui/ViewInspector
+    - plugins/metrics/swiftui/ViewInspector
+    - plugins/pending-transaction/swiftui/ViewInspector
+    - plugins/pubsub/ios/Tests
+    - plugins/reference-assets/swiftui/UITests
+    - plugins/reference-assets/swiftui/ViewInspector
+    - plugins/stage-revert-data/ios/Tests
+    - plugins/transition/swiftui/ViewInspector
+    - plugins/types-provider/ios/Tests
 
 opt_in_rules:
     # Enforces Swift 5.7+ shorthand `guard let foo` over verbose `guard let foo = foo` to reduce visual clutter
@@ -37,14 +75,11 @@ opt_in_rules:
     # We should avoid more than 2 levels of nested conditionals because it makes the code harder to read and understand
     - nesting
 
-# TODO: Add severity overrides for "error" when we update our swiftlint config
 # Severity overrides — all set to error so lint fails on violations
-# shorthand_optional_binding:
-#     severity: error
-# force_unwrapping:
-#     severity: error
-# nesting:
-#     severity: error
-# # Don't add unnecessary parentheses to control statements
-# control_statement:
-#     severity: error
+shorthand_optional_binding:
+    severity: error
+force_unwrapping:
+    severity: error
+# Don't add unnecessary parentheses to control statements
+control_statement:
+    severity: error

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -58,6 +58,8 @@ excluded:
     - plugins/expression/ios/Tests
     - plugins/external-action/ios/Tests
     - plugins/external-action/swiftui/ViewInspector
+    - plugins/external-state/ios/Tests
+    - plugins/external-state/swiftui/ViewInspector
     - plugins/metrics/swiftui/ViewInspector
     - plugins/pending-transaction/swiftui/ViewInspector
     - plugins/pubsub/ios/Tests

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -38,36 +38,12 @@ excluded:
     - ios/demo/Sources/String+Extensions.swift
     # Test folders. SwiftLint is pretty strict about test files unnecessarily, so we exclude them.
     # SwiftFormat still covers these.
-    - ios/core/Tests
-    - ios/logger/Tests
-    - ios/swiftui/Tests
-    - ios/swiftui/ViewInspector
-    - ios/test-utils-core/Tests
-    - ios/test-utils/Tests
-    - ios/test-utils/ViewInspector
-    - plugins/async-node/ios/Tests
-    - plugins/async-node/ios/ViewInspector
-    - plugins/beacon/ios/Tests
-    - plugins/beacon/swiftui/ViewInspector
-    - plugins/check-path/ios/Tests
-    - plugins/check-path/swiftui/ViewInspector
-    - plugins/common-expressions/ios/Tests
-    - plugins/common-types/ios/Tests
-    - plugins/computed-properties/ios/Tests
-    - plugins/console-logger/ios/Tests
-    - plugins/expression/ios/Tests
-    - plugins/external-action/ios/Tests
-    - plugins/external-action/swiftui/ViewInspector
-    - plugins/external-state/ios/Tests
-    - plugins/external-state/swiftui/ViewInspector
-    - plugins/metrics/swiftui/ViewInspector
-    - plugins/pending-transaction/swiftui/ViewInspector
-    - plugins/pubsub/ios/Tests
-    - plugins/reference-assets/swiftui/UITests
-    - plugins/reference-assets/swiftui/ViewInspector
-    - plugins/stage-revert-data/ios/Tests
-    - plugins/transition/swiftui/ViewInspector
-    - plugins/types-provider/ios/Tests
+    - ios/*/Tests
+    - ios/*/ViewInspector
+    - ios/*/UITests
+    - plugins/*/Tests
+    - plugins/*/UITests
+    - plugins/*/ViewInspector
 
 opt_in_rules:
     # Enforces Swift 5.7+ shorthand `guard let foo` over verbose `guard let foo = foo` to reduce visual clutter

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,10 +175,11 @@ iOS Development requires a bit more set-up.
 
    This installs the pinned versions of SwiftFormat and SwiftLint used by the project. Both are needed by the pre-commit hook to auto-fix formatting.
 
-   | Command               | Description                      |
-   | --------------------- | -------------------------------- |
-   | `just swift-format`   | Auto-format Swift files in-place |
-   | `just swift-lint-fix` | Auto-fix fixable lint errors     |
+   | Command                      | Description                                  |
+   | ---------------------------- | -------------------------------------------- |
+   | `just format-ios`            | Auto-fix all lint and format errors in-place |
+   | `just swift-lint-ios`        | Check lint (strict, no modifications)        |
+   | `just swift-format-lint-ios` | Check formatting (no modifications)          |
 
 ### To Run
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,6 @@ iOS Development requires a bit more set-up.
    - If you instead have `/usr/local` or something similar, you have the Intel chip homebrew.
      You need Apple Silicon homebrew. This will let you run the project without Rosetta. Follow the next step.
 1. If you need to replace Intel homebrew, do the following. Keep in mind that this will remove everything you have installed through homebrew. E.g. existing installations of VSCode, xcodes, rsync, etc.
-
    1. Delete all your formulas and casks. This is to ensure no conflicts with the new homebrew. If you don’t feel comfortable deleting everything, delete at least bazelisk.
 
       ````bash
@@ -158,6 +157,24 @@ iOS Development requires a bit more set-up.
 1. `brew install rsync`. This fixes a bunch of permission denied issues.
    1. Close and re-open the terminal.
    1. Run `which rsync` to make sure you’re using the homebrew one. If it’s not the homebrew rsync, something is wrong and needs to be fixed.
+
+1. Install git hooks:
+
+   ```bash
+   pnpm run prepare
+   ```
+
+   These hooks include auto-formatting and will run for all staged files pre-commit.
+
+1. Install [Mint](https://github.com/yonaskolb/Mint) and bootstrap SwiftFormat tooling:
+
+   ```bash
+   brew install mint
+   mint bootstrap
+   ```
+
+   This installs the pinned version of SwiftFormat used by the project. This is needed by the pre-commit hook to auto-fix formatting.
+   Run `just swift-format` to auto-format Swift files, or `just swift-format-lint` to check without modifying.
 
 ### To Run
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,6 @@ iOS Development requires a bit more set-up.
    - If you instead have `/usr/local` or something similar, you have the Intel chip homebrew.
      You need Apple Silicon homebrew. This will let you run the project without Rosetta. Follow the next step.
 1. If you need to replace Intel homebrew, do the following. Keep in mind that this will remove everything you have installed through homebrew. E.g. existing installations of VSCode, xcodes, rsync, etc.
-
    1. Delete all your formulas and casks. This is to ensure no conflicts with the new homebrew. If you don’t feel comfortable deleting everything, delete at least bazelisk.
 
       ````bash
@@ -158,6 +157,29 @@ iOS Development requires a bit more set-up.
 1. `brew install rsync`. This fixes a bunch of permission denied issues.
    1. Close and re-open the terminal.
    1. Run `which rsync` to make sure you’re using the homebrew one. If it’s not the homebrew rsync, something is wrong and needs to be fixed.
+
+1. Install git hooks:
+
+   ```bash
+   pnpm run prepare
+   ```
+
+   These hooks include auto-formatting and will run for all staged files pre-commit.
+
+1. Install [Mint](https://github.com/yonaskolb/Mint) and bootstrap Swift tooling:
+
+   ```bash
+   brew install mint
+   mint bootstrap
+   ```
+
+   This installs the pinned versions of SwiftFormat and SwiftLint used by the project. Both are needed by the pre-commit hook to auto-fix formatting.
+
+   | Command                      | Description                                  |
+   | ---------------------------- | -------------------------------------------- |
+   | `just format-ios`            | Auto-fix all lint and format errors in-place |
+   | `just swift-lint-ios`        | Check lint (strict, no modifications)        |
+   | `just swift-format-lint-ios` | Check formatting (no modifications)          |
 
 ### To Run
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,15 +166,19 @@ iOS Development requires a bit more set-up.
 
    These hooks include auto-formatting and will run for all staged files pre-commit.
 
-1. Install [Mint](https://github.com/yonaskolb/Mint) and bootstrap SwiftFormat tooling:
+1. Install [Mint](https://github.com/yonaskolb/Mint) and bootstrap Swift tooling:
 
    ```bash
    brew install mint
    mint bootstrap
    ```
 
-   This installs the pinned version of SwiftFormat used by the project. This is needed by the pre-commit hook to auto-fix formatting.
-   Run `just swift-format` to auto-format Swift files, or `just swift-format-lint` to check without modifying.
+   This installs the pinned versions of SwiftFormat and SwiftLint used by the project. Both are needed by the pre-commit hook to auto-fix formatting.
+
+   | Command               | Description                      |
+   | --------------------- | -------------------------------- |
+   | `just swift-format`   | Auto-format Swift files in-place |
+   | `just swift-lint-fix` | Auto-fix fixable lint errors     |
 
 ### To Run
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,13 +166,7 @@ iOS Development requires a bit more set-up.
 
    These hooks include auto-formatting and will run for all staged files pre-commit.
 
-1. Bootstrap Swift tooling:
-
-   ```bash
-   swift run --package-path xcode mint bootstrap
-   ```
-
-   [Mint](https://github.com/yonaskolb/Mint) is pinned via SPM in `xcode/Package.swift`, so no separate install is needed. `mint bootstrap` installs the pinned versions of SwiftFormat and SwiftLint (see the `Mintfile`) used by the project. Both are needed by the pre-commit hook to auto-fix formatting.
+1. Our linters, ([SwiftLint](https://github.com/realm/SwiftLint) and [SwiftFormat](https://github.com/nicklockwood/SwiftFormat)), are pinned via SPM in `xcode/Package.swift` and run with `swift run --package-path xcode`, so no separate install is needed. Use the `just` commands below.
 
    | Command                      | Description                                  |
    | ---------------------------- | -------------------------------------------- |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,14 +166,13 @@ iOS Development requires a bit more set-up.
 
    These hooks include auto-formatting and will run for all staged files pre-commit.
 
-1. Install [Mint](https://github.com/yonaskolb/Mint) and bootstrap Swift tooling:
+1. Bootstrap Swift tooling:
 
    ```bash
-   brew install mint
-   mint bootstrap
+   swift run --package-path xcode mint bootstrap
    ```
 
-   This installs the pinned versions of SwiftFormat and SwiftLint used by the project. Both are needed by the pre-commit hook to auto-fix formatting.
+   [Mint](https://github.com/yonaskolb/Mint) is pinned via SPM in `xcode/Package.swift`, so no separate install is needed. `mint bootstrap` installs the pinned versions of SwiftFormat and SwiftLint (see the `Mintfile`) used by the project. Both are needed by the pre-commit hook to auto-fix formatting.
 
    | Command                      | Description                                  |
    | ---------------------------- | -------------------------------------------- |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,6 +161,7 @@ iOS Development requires a bit more set-up.
 1. Install git hooks:
 
    ```bash
+   pnpm i
    pnpm run prepare
    ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,7 +162,6 @@ iOS Development requires a bit more set-up.
 
    ```bash
    pnpm i
-   pnpm run prepare
    ```
 
    These hooks include auto-formatting and will run for all staged files pre-commit.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -64,8 +64,9 @@ swift_deps.from_package(
 use_repo(
     swift_deps,
     "swift_package",
-    "swiftpkg_mint",
     "swiftpkg_swift_hooks",
+    "swiftpkg_swiftformat",
+    "swiftpkg_swiftlint",
     "swiftpkg_viewinspector",
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -64,8 +64,8 @@ swift_deps.from_package(
 use_repo(
     swift_deps,
     "swift_package",
+    "swiftpkg_mint",
     "swiftpkg_swift_hooks",
-    "swiftpkg_swiftlint",
     "swiftpkg_viewinspector",
 )
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -350,7 +350,7 @@
         "recordedInputs": [
           "REPO_MAPPING:aspect_rules_ts+,aspect_rules_ts aspect_rules_ts+",
           "REPO_MAPPING:aspect_rules_ts+,bazel_tools bazel_tools",
-          "FILE:@@//package.json 1a1fc0f6219010184b43f2c5107dd38b51c447d8087ad23f9f492ec8fa1d74db"
+          "FILE:@@//package.json e6ac289e3a49423c7783f1ed235e5cd88606c7c24f1c02d8725e26b259af99a9"
         ],
         "generatedRepoSpecs": {
           "npm_typescript": {
@@ -1386,6 +1386,73 @@
           "explicitRootModuleDirectDevDeps": [],
           "useAllRepos": "NO",
           "reproducible": false
+        }
+      }
+    },
+    "@@swiftlint+//bazel:extensions.bzl%extra_rules": {
+      "general": {
+        "bzlTransitiveDigest": "bQaIwIVfdP8t32ZvwG0ZM8y3N7Q6hhlgHsz7avAKFFs=",
+        "usagesDigest": "ObdUK4AVHbUsn2En6qO9lAjwbTu1cc4968qI20zsRfI=",
+        "recordedInputs": [],
+        "generatedRepoSpecs": {
+          "swiftlint_extra_rules": {
+            "repoRuleId": "@@swiftlint+//bazel:deps.bzl%extra_swift_sources",
+            "attributes": {}
+          }
+        }
+      }
+    },
+    "@@swiftlint+//bazel:repos.bzl%swiftlint_repos_bzlmod": {
+      "general": {
+        "bzlTransitiveDigest": "s0OfPc+YZJ5vKUNKhwQWh4xKB4PER5sWeDKA3frych8=",
+        "usagesDigest": "++Ol3ruKD4ys9BRQdvlodpellaCRE/qeLEL074LesPQ=",
+        "recordedInputs": [
+          "REPO_MAPPING:swiftlint+,bazel_tools bazel_tools"
+        ],
+        "generatedRepoSpecs": {
+          "SwiftSyntax": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "39b3c675e5f21c40ef7e74f2b94c20df22c609ef282b9c16ce15937e390ed6ac",
+              "strip_prefix": "swift-syntax-604.0.0-prerelease-2026-04-21",
+              "url": "https://github.com/swiftlang/swift-syntax/archive/refs/tags/604.0.0-prerelease-2026-04-21.tar.gz"
+            }
+          },
+          "SwiftyTextTable": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b77d403db9f33686caeb2a12986997fb02a0819e029e669c6b9554617c4fd6ae",
+              "build_file": "@@swiftlint+//bazel:SwiftyTextTable.BUILD",
+              "strip_prefix": "SwiftyTextTable-0.9.0",
+              "url": "https://github.com/scottrhoyt/SwiftyTextTable/archive/refs/tags/0.9.0.tar.gz"
+            }
+          },
+          "CollectionConcurrencyKit": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9083fe6f8b4f820bfb5ef5c555b31953116f158ec113e94c6406686e78da34aa",
+              "build_file": "@@swiftlint+//bazel:CollectionConcurrencyKit.BUILD",
+              "strip_prefix": "CollectionConcurrencyKit-0.2.0",
+              "url": "https://github.com/JohnSundell/CollectionConcurrencyKit/archive/refs/tags/0.2.0.tar.gz"
+            }
+          },
+          "CryptoSwift": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "81b1ba186e2edcff47bcc2a3b6a242df083ba2f64bfb42209f79090cb8d7f889",
+              "build_file": "@@swiftlint+//bazel:CryptoSwift.BUILD",
+              "strip_prefix": "CryptoSwift-1.9.0",
+              "url": "https://github.com/krzyzanowskim/CryptoSwift/archive/refs/tags/1.9.0.tar.gz"
+            }
+          },
+          "FilenameMatcher": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c0a6041be02ddd12f1cdde089f84dfa70e33e384cc476a786542a536d8401c6e",
+              "strip_prefix": "swift-filename-matcher-2.0.1",
+              "url": "https://github.com/ileitch/swift-filename-matcher/archive/refs/tags/2.0.1.tar.gz"
+            }
+          }
         }
       }
     },

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -343,6 +343,82 @@
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
+    "@@aspect_rules_js+//npm:extensions.bzl%pnpm": {
+      "general": {
+        "bzlTransitiveDigest": "oHJXQd5fCITYmy6OxDEqB61DyWGKezoh0maKxuRw1Go=",
+        "usagesDigest": "kbjSw2REjlSC0HtTZDf2p+l/dmiMt3NHLoiWEXYAoQI=",
+        "recordedInputs": [
+          "REPO_MAPPING:aspect_bazel_lib+,bazel_lib bazel_lib+",
+          "REPO_MAPPING:aspect_bazel_lib+,bazel_skylib bazel_skylib+",
+          "REPO_MAPPING:aspect_bazel_lib+,bazel_tools bazel_tools",
+          "REPO_MAPPING:aspect_bazel_lib+,tar.bzl tar.bzl+",
+          "REPO_MAPPING:aspect_rules_js+,aspect_bazel_lib aspect_bazel_lib+",
+          "REPO_MAPPING:aspect_rules_js+,aspect_rules_js aspect_rules_js+",
+          "REPO_MAPPING:aspect_rules_js+,bazel_features bazel_features+",
+          "REPO_MAPPING:aspect_rules_js+,bazel_skylib bazel_skylib+",
+          "REPO_MAPPING:aspect_rules_js+,bazel_tools bazel_tools",
+          "REPO_MAPPING:bazel_features+,bazel_features_globals bazel_features++version_extension+bazel_features_globals",
+          "REPO_MAPPING:bazel_features+,bazel_features_version bazel_features++version_extension+bazel_features_version",
+          "REPO_MAPPING:bazel_lib+,bazel_skylib bazel_skylib+",
+          "REPO_MAPPING:bazel_lib+,bazel_tools bazel_tools",
+          "REPO_MAPPING:tar.bzl+,aspect_bazel_lib aspect_bazel_lib+",
+          "REPO_MAPPING:tar.bzl+,bazel_skylib bazel_skylib+",
+          "REPO_MAPPING:tar.bzl+,tar.bzl tar.bzl+"
+        ],
+        "generatedRepoSpecs": {
+          "pnpm": {
+            "repoRuleId": "@@aspect_rules_js+//npm/private:npm_import.bzl%npm_import_rule",
+            "attributes": {
+              "package": "pnpm",
+              "version": "8.6.7",
+              "root_package": "",
+              "link_workspace": "",
+              "link_packages": {},
+              "integrity": "sha512-vRIWpD/L4phf9Bk2o/O2TDR8fFoJnpYrp2TKqTIZF/qZ2/rgL3qKXzHofHgbXsinwMoSEigz28sqk3pQ+yMEQQ==",
+              "url": "",
+              "commit": "",
+              "patch_args": [
+                "-p0"
+              ],
+              "patches": [],
+              "custom_postinstall": "",
+              "npm_auth": "",
+              "npm_auth_basic": "",
+              "npm_auth_username": "",
+              "npm_auth_password": "",
+              "lifecycle_hooks": [],
+              "extra_build_content": "load(\"@aspect_rules_js//js:defs.bzl\", \"js_binary\")\njs_binary(name = \"pnpm\", data = glob([\"package/**\"]), entry_point = \"package/dist/pnpm.cjs\", visibility = [\"//visibility:public\"])",
+              "extract_full_archive": true,
+              "exclude_package_contents": [],
+              "system_tar": "auto"
+            }
+          },
+          "pnpm__links": {
+            "repoRuleId": "@@aspect_rules_js+//npm/private:npm_import.bzl%npm_import_links",
+            "attributes": {
+              "package": "pnpm",
+              "version": "8.6.7",
+              "dev": false,
+              "root_package": "",
+              "link_packages": {},
+              "deps": {},
+              "transitive_closure": {},
+              "lifecycle_build_target": false,
+              "lifecycle_hooks_env": [],
+              "lifecycle_hooks_execution_requirements": [
+                "no-sandbox"
+              ],
+              "lifecycle_hooks_use_default_shell_env": false,
+              "bins": {},
+              "package_visibility": [
+                "//visibility:public"
+              ],
+              "exclude_package_contents": []
+            }
+          }
+        }
+      }
+    },
     "@@aspect_rules_ts+//ts:extensions.bzl%ext": {
       "general": {
         "bzlTransitiveDigest": "XQyG/pNDNTKYobWyPdbo1p8twKShTk51G5mVUm9v4/4=",
@@ -388,6 +464,50 @@
         }
       }
     },
+    "@@bazel_bats+//:extensions.bzl%bazel_bats_deps": {
+      "general": {
+        "bzlTransitiveDigest": "TnMwZEqV5pd/K7+pDevN3p1X7EF+RiaJoowW6hMk50A=",
+        "usagesDigest": "t+ex/oJhALiD6nk6VMpJT83/RVXO6TaIVwWMSo4V6sA=",
+        "recordedInputs": [
+          "REPO_MAPPING:bazel_bats+,bazel_tools bazel_tools"
+        ],
+        "generatedRepoSpecs": {
+          "bats_core": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file_content": "\nsh_library(\n    name = \"bats_lib\",\n    srcs = glob([\"libexec/**\"]),\n)\n\nsh_binary(\n    name = \"bats\",\n    srcs = [\"bin/bats\"],\n    visibility = [\"//visibility:public\"],\n    deps = [\":bats_lib\"],\n)\n\nsh_library(\n    name = \"file_setup_teardown_lib\",\n    srcs = [\"test/file_setup_teardown.bats\"],\n    visibility = [\"//visibility:public\"],\n    data = glob([\"test/fixtures/file_setup_teardown/**\"]),\n)\n\nsh_library(\n    name = \"junit_formatter_lib\",\n    srcs = [\"test/junit-formatter.bats\"],\n    visibility = [\"//visibility:public\"],\n    data = glob([\"test/fixtures/junit-formatter/**\"]),\n)\n\nsh_library(\n    name = \"parallel_lib\",\n    srcs = [\"test/parallel.bats\"],\n    visibility = [\"//visibility:public\"],\n    data = glob([\n        \"test/concurrent-coordination.bash\",\n        \"test/fixtures/parallel/**\",\n    ]),\n)\n\nsh_library(\n    name = \"run_lib\",\n    srcs = [\"test/run.bats\"],\n    visibility = [\"//visibility:public\"],\n    data = glob([\"test/fixtures/run/**\"]),\n)\n\nsh_library(\n    name = \"suite_lib\",\n    srcs = [\"test/suite.bats\"],\n    visibility = [\"//visibility:public\"],\n    data = glob([\"test/fixtures/suite/**\"]),\n)\n\nsh_library(\n    name = \"test_helper\",\n    srcs = [\"test/test_helper.bash\"],\n    visibility = [\"//visibility:public\"],\n)\n\nsh_library(\n    name = \"trace_lib\",\n    srcs = [\"test/trace.bats\"],\n    visibility = [\"//visibility:public\"],\n    data = glob([\"test/fixtures/trace/**\"]),\n)\n\nexports_files(glob([\"test/*.bats\"]))\n",
+              "urls": [
+                "https://github.com/bats-core/bats-core/archive/refs/tags/v1.7.0.tar.gz"
+              ],
+              "strip_prefix": "bats-core-1.7.0",
+              "sha256": "ac70c2a153f108b1ac549c2eaa4154dea4a7c1cc421e3352f0ce6ea49435454e"
+            }
+          },
+          "bats_assert": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file_content": "\nfilegroup(\n    name = \"load_files\",\n    srcs = [\n        \"load.bash\",\n    ] + glob([\n        \"src/**/*.bash\",\n    ]),\n    visibility = [\"//visibility:public\"],\n)\n",
+              "sha256": "15dbf1abb98db785323b9327c86ee2b3114541fe5aa150c410a1632ec06d9903",
+              "strip_prefix": "bats-assert-2.0.0",
+              "urls": [
+                "https://github.com/bats-core/bats-assert/archive/refs/tags/v2.0.0.tar.gz"
+              ]
+            }
+          },
+          "bats_support": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file_content": "\nfilegroup(\n    name = \"load_files\",\n    srcs = [\n        \"load.bash\",\n    ] + glob([\n        \"src/**/*.bash\",\n    ]),\n    visibility = [\"//visibility:public\"],\n)\n",
+              "sha256": "7815237aafeb42ddcc1b8c698fc5808026d33317d8701d5ec2396e9634e2918f",
+              "strip_prefix": "bats-support-0.3.0",
+              "urls": [
+                "https://github.com/bats-core/bats-support/archive/refs/tags/v0.3.0.tar.gz"
+              ]
+            }
+          }
+        }
+      }
+    },
     "@@cgrindel_bazel_starlib+//tools/git:extensions.bzl%local_git_ext": {
       "general": {
         "bzlTransitiveDigest": "Q/NQyKFI2DljjsevKbLpWlOrT/bOsP3m/A8uvcXQb40=",
@@ -397,6 +517,62 @@
           "bazel_starlib_git_toolchains": {
             "repoRuleId": "@@cgrindel_bazel_starlib+//tools/git:local_git.bzl%local_git",
             "attributes": {}
+          }
+        }
+      }
+    },
+    "@@protobuf+//python/dist:system_python.bzl%system_python_extension": {
+      "general": {
+        "bzlTransitiveDigest": "pmsA+awieucfllLc2n7k8xEoPp0i5LF9Hw6mGX0cqSQ=",
+        "usagesDigest": "A+RWmbKdBBwZcBbNGNvfPbqG2vYZRjVrFp6x1iRUrAk=",
+        "recordedInputs": [],
+        "generatedRepoSpecs": {
+          "system_python": {
+            "repoRuleId": "@@protobuf+//python/dist:system_python.bzl%system_python",
+            "attributes": {
+              "minimum_python_version": "3.9"
+            }
+          }
+        }
+      }
+    },
+    "@@pybind11_bazel+//:internal_configure.bzl%internal_configure_extension": {
+      "general": {
+        "bzlTransitiveDigest": "Ilz4hu4VWEbx3OM4ZIpgYmYXuPq6ewOVgzv5F0ziWS8=",
+        "usagesDigest": "tVQNvLoXMWAbiK39am3yovKGpwINdftfn7RpDyN+JZc=",
+        "recordedInputs": [
+          "REPO_MAPPING:pybind11_bazel+,bazel_tools bazel_tools"
+        ],
+        "generatedRepoSpecs": {
+          "pybind11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@pybind11_bazel+//:pybind11-BUILD.bazel",
+              "strip_prefix": "pybind11-2.13.6",
+              "url": "https://github.com/pybind/pybind11/archive/refs/tags/v2.13.6.tar.gz",
+              "integrity": "sha256-4Iy4f0dz2pf6e18DXeh2OrxlbYfVdz5i9toFh9Hw7CA="
+            }
+          }
+        }
+      }
+    },
+    "@@rules_android+//bzlmod_extensions:apksig.bzl%apksig_extension": {
+      "general": {
+        "bzlTransitiveDigest": "O/gCjP4/VVnaP+zTRGN3DFrkkxLE5GMbE4M1HG3noGQ=",
+        "usagesDigest": "wLrLUdBOQnztFcFQraEsWu+M4xtuF82/ZGmnhyxO5/Q=",
+        "recordedInputs": [
+          "REPO_MAPPING:rules_android+,bazel_tools bazel_tools"
+        ],
+        "generatedRepoSpecs": {
+          "apksig": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/android.googlesource.com/platform/tools/apksig/+archive/24e3075e68ebe17c0b529bb24bfda819db5e2f3b.tar.gz"
+              ],
+              "sha256": "12e44fdbd219c5e1cc62099c2a01d775957603d2d4f693f8285f9d95d9a04e77",
+              "build_file": "@@rules_android+//bzlmod_extensions:apksig.BUILD"
+            }
           }
         }
       }
@@ -1197,7 +1373,7 @@
           "REPO_MAPPING:rules_swift_package_manager+,bazel_skylib bazel_skylib+",
           "REPO_MAPPING:rules_swift_package_manager+,bazel_tools bazel_tools",
           "REPO_MAPPING:rules_swift_package_manager+,cgrindel_bazel_starlib cgrindel_bazel_starlib+",
-          "FILE:@@//xcode/Package.resolved 32cec8db57528c1e30c85cbfa19db1cf4a16a82f2dd60a4842380efc33249112"
+          "FILE:@@//xcode/Package.resolved cadfa13f7fdd2b2579d9c0011a622ed984650d26d540ae61253d5ed0f30f7f3a"
         ],
         "generatedRepoSpecs": {
           "swift_package": {
@@ -1221,13 +1397,13 @@
               "target_deps": {}
             }
           },
-          "swiftpkg_swiftlint": {
+          "swiftpkg_mint": {
             "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
             "attributes": {
-              "bazel_package_name": "swiftpkg_swiftlint",
-              "commit": "88952528a590ed366c6f76f6bfb980b5ebdcefc1",
-              "remote": "https://github.com/realm/SwiftLint.git",
-              "version": "0.63.2",
+              "bazel_package_name": "swiftpkg_mint",
+              "commit": "7bc67a0b925b949c8becc327bc08f56eeadc0051",
+              "remote": "https://github.com/yonaskolb/Mint.git",
+              "version": "0.18.0",
               "env": {},
               "env_inherit": [],
               "cached_json_directory": "",
@@ -1249,13 +1425,13 @@
               "target_deps": {}
             }
           },
-          "swiftpkg_collectionconcurrencykit": {
+          "swiftpkg_pathkit": {
             "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
             "attributes": {
-              "bazel_package_name": "swiftpkg_collectionconcurrencykit",
-              "commit": "b4f23e24b5a1bff301efc5e70871083ca029ff95",
-              "remote": "https://github.com/JohnSundell/CollectionConcurrencyKit.git",
-              "version": "0.2.0",
+              "bazel_package_name": "swiftpkg_pathkit",
+              "commit": "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
+              "remote": "https://github.com/kylef/PathKit.git",
+              "version": "1.0.1",
               "env": {},
               "env_inherit": [],
               "cached_json_directory": "",
@@ -1263,13 +1439,13 @@
               "target_deps": {}
             }
           },
-          "swiftpkg_cryptoswift": {
+          "swiftpkg_rainbow": {
             "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
             "attributes": {
-              "bazel_package_name": "swiftpkg_cryptoswift",
-              "commit": "e45a26384239e028ec87fbcc788f513b67e10d8f",
-              "remote": "https://github.com/krzyzanowskim/CryptoSwift.git",
-              "version": "1.9.0",
+              "bazel_package_name": "swiftpkg_rainbow",
+              "commit": "cdf146ae671b2624917648b61c908d1244b98ca1",
+              "remote": "https://github.com/onevcat/Rainbow.git",
+              "version": "4.2.1",
               "env": {},
               "env_inherit": [],
               "cached_json_directory": "",
@@ -1277,13 +1453,13 @@
               "target_deps": {}
             }
           },
-          "swiftpkg_sourcekitten": {
+          "swiftpkg_spectre": {
             "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
             "attributes": {
-              "bazel_package_name": "swiftpkg_sourcekitten",
-              "commit": "6529c17fe80dd94843a3df7ed3e6a239790d5c91",
-              "remote": "https://github.com/jpsim/SourceKitten.git",
-              "version": "0.37.3",
+              "bazel_package_name": "swiftpkg_spectre",
+              "commit": "26cc5e9ae0947092c7139ef7ba612e34646086c7",
+              "remote": "https://github.com/kylef/Spectre.git",
+              "version": "0.10.1",
               "env": {},
               "env_inherit": [],
               "cached_json_directory": "",
@@ -1291,13 +1467,13 @@
               "target_deps": {}
             }
           },
-          "swiftpkg_swift_argument_parser": {
+          "swiftpkg_swiftcli": {
             "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
             "attributes": {
-              "bazel_package_name": "swiftpkg_swift_argument_parser",
-              "commit": "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
-              "remote": "https://github.com/apple/swift-argument-parser.git",
-              "version": "1.7.1",
+              "bazel_package_name": "swiftpkg_swiftcli",
+              "commit": "2e949055d9797c1a6bddcda0e58dada16cc8e970",
+              "remote": "https://github.com/jakeheis/SwiftCLI.git",
+              "version": "6.0.3",
               "env": {},
               "env_inherit": [],
               "cached_json_directory": "",
@@ -1305,69 +1481,13 @@
               "target_deps": {}
             }
           },
-          "swiftpkg_swift_filename_matcher": {
+          "swiftpkg_version": {
             "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
             "attributes": {
-              "bazel_package_name": "swiftpkg_swift_filename_matcher",
-              "commit": "eef5ac0b6b3cdc64b3039b037bed2def8a1edaeb",
-              "remote": "https://github.com/ileitch/swift-filename-matcher",
-              "version": "2.0.1",
-              "env": {},
-              "env_inherit": [],
-              "cached_json_directory": "",
-              "replace_scm_with_registry": false,
-              "target_deps": {}
-            }
-          },
-          "swiftpkg_swift_syntax": {
-            "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
-            "attributes": {
-              "bazel_package_name": "swiftpkg_swift_syntax",
-              "commit": "65b02a90ad2cc213e09309faeb7f6909e0a8577a",
-              "remote": "https://github.com/swiftlang/swift-syntax.git",
-              "version": "604.0.0-prerelease-2026-01-20",
-              "env": {},
-              "env_inherit": [],
-              "cached_json_directory": "",
-              "replace_scm_with_registry": false,
-              "target_deps": {}
-            }
-          },
-          "swiftpkg_swiftytexttable": {
-            "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
-            "attributes": {
-              "bazel_package_name": "swiftpkg_swiftytexttable",
-              "commit": "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
-              "remote": "https://github.com/scottrhoyt/SwiftyTextTable.git",
-              "version": "0.9.0",
-              "env": {},
-              "env_inherit": [],
-              "cached_json_directory": "",
-              "replace_scm_with_registry": false,
-              "target_deps": {}
-            }
-          },
-          "swiftpkg_swxmlhash": {
-            "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
-            "attributes": {
-              "bazel_package_name": "swiftpkg_swxmlhash",
-              "commit": "a853604c9e9a83ad9954c7e3d2a565273982471f",
-              "remote": "https://github.com/drmohundro/SWXMLHash.git",
-              "version": "7.0.2",
-              "env": {},
-              "env_inherit": [],
-              "cached_json_directory": "",
-              "replace_scm_with_registry": false,
-              "target_deps": {}
-            }
-          },
-          "swiftpkg_yams": {
-            "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
-            "attributes": {
-              "bazel_package_name": "swiftpkg_yams",
-              "commit": "deaf82e867fa2cbd3cd865978b079bfcf384ac28",
-              "remote": "https://github.com/jpsim/Yams.git",
-              "version": "6.2.1",
+              "bazel_package_name": "swiftpkg_version",
+              "commit": "3043fcd2a50375db76d89ff206a612471833d1c2",
+              "remote": "https://github.com/mxcl/Version.git",
+              "version": "2.2.1",
               "env": {},
               "env_inherit": [],
               "cached_json_directory": "",
@@ -1379,7 +1499,7 @@
         "moduleExtensionMetadata": {
           "explicitRootModuleDirectDeps": [
             "swiftpkg_swift_hooks",
-            "swiftpkg_swiftlint",
+            "swiftpkg_mint",
             "swiftpkg_viewinspector",
             "swift_package"
           ],

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1373,7 +1373,7 @@
           "REPO_MAPPING:rules_swift_package_manager+,bazel_skylib bazel_skylib+",
           "REPO_MAPPING:rules_swift_package_manager+,bazel_tools bazel_tools",
           "REPO_MAPPING:rules_swift_package_manager+,cgrindel_bazel_starlib cgrindel_bazel_starlib+",
-          "FILE:@@//xcode/Package.resolved cadfa13f7fdd2b2579d9c0011a622ed984650d26d540ae61253d5ed0f30f7f3a"
+          "FILE:@@//xcode/Package.resolved abff48d3b78be89d4c5a57e4692f87a96a754a9c71c6810e735cf65f729c76ac"
         ],
         "generatedRepoSpecs": {
           "swift_package": {
@@ -1397,13 +1397,27 @@
               "target_deps": {}
             }
           },
-          "swiftpkg_mint": {
+          "swiftpkg_swiftlint": {
             "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
             "attributes": {
-              "bazel_package_name": "swiftpkg_mint",
-              "commit": "7bc67a0b925b949c8becc327bc08f56eeadc0051",
-              "remote": "https://github.com/yonaskolb/Mint.git",
-              "version": "0.18.0",
+              "bazel_package_name": "swiftpkg_swiftlint",
+              "commit": "88952528a590ed366c6f76f6bfb980b5ebdcefc1",
+              "remote": "https://github.com/realm/SwiftLint.git",
+              "version": "0.63.2",
+              "env": {},
+              "env_inherit": [],
+              "cached_json_directory": "",
+              "replace_scm_with_registry": false,
+              "target_deps": {}
+            }
+          },
+          "swiftpkg_swiftformat": {
+            "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
+            "attributes": {
+              "bazel_package_name": "swiftpkg_swiftformat",
+              "commit": "397309e73621d6355d3a7fb832ca233ac9dd5254",
+              "remote": "https://github.com/nicklockwood/SwiftFormat.git",
+              "version": "0.61.0",
               "env": {},
               "env_inherit": [],
               "cached_json_directory": "",
@@ -1425,13 +1439,13 @@
               "target_deps": {}
             }
           },
-          "swiftpkg_pathkit": {
+          "swiftpkg_collectionconcurrencykit": {
             "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
             "attributes": {
-              "bazel_package_name": "swiftpkg_pathkit",
-              "commit": "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
-              "remote": "https://github.com/kylef/PathKit.git",
-              "version": "1.0.1",
+              "bazel_package_name": "swiftpkg_collectionconcurrencykit",
+              "commit": "b4f23e24b5a1bff301efc5e70871083ca029ff95",
+              "remote": "https://github.com/JohnSundell/CollectionConcurrencyKit.git",
+              "version": "0.2.0",
               "env": {},
               "env_inherit": [],
               "cached_json_directory": "",
@@ -1439,13 +1453,13 @@
               "target_deps": {}
             }
           },
-          "swiftpkg_rainbow": {
+          "swiftpkg_cryptoswift": {
             "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
             "attributes": {
-              "bazel_package_name": "swiftpkg_rainbow",
-              "commit": "cdf146ae671b2624917648b61c908d1244b98ca1",
-              "remote": "https://github.com/onevcat/Rainbow.git",
-              "version": "4.2.1",
+              "bazel_package_name": "swiftpkg_cryptoswift",
+              "commit": "f2a627b84c1ff96f21ac2fcb623ab36142dd5512",
+              "remote": "https://github.com/krzyzanowskim/CryptoSwift.git",
+              "version": "1.10.0",
               "env": {},
               "env_inherit": [],
               "cached_json_directory": "",
@@ -1453,13 +1467,13 @@
               "target_deps": {}
             }
           },
-          "swiftpkg_spectre": {
+          "swiftpkg_sourcekitten": {
             "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
             "attributes": {
-              "bazel_package_name": "swiftpkg_spectre",
-              "commit": "26cc5e9ae0947092c7139ef7ba612e34646086c7",
-              "remote": "https://github.com/kylef/Spectre.git",
-              "version": "0.10.1",
+              "bazel_package_name": "swiftpkg_sourcekitten",
+              "commit": "6529c17fe80dd94843a3df7ed3e6a239790d5c91",
+              "remote": "https://github.com/jpsim/SourceKitten.git",
+              "version": "0.37.3",
               "env": {},
               "env_inherit": [],
               "cached_json_directory": "",
@@ -1467,13 +1481,13 @@
               "target_deps": {}
             }
           },
-          "swiftpkg_swiftcli": {
+          "swiftpkg_swift_argument_parser": {
             "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
             "attributes": {
-              "bazel_package_name": "swiftpkg_swiftcli",
-              "commit": "2e949055d9797c1a6bddcda0e58dada16cc8e970",
-              "remote": "https://github.com/jakeheis/SwiftCLI.git",
-              "version": "6.0.3",
+              "bazel_package_name": "swiftpkg_swift_argument_parser",
+              "commit": "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+              "remote": "https://github.com/apple/swift-argument-parser.git",
+              "version": "1.8.2",
               "env": {},
               "env_inherit": [],
               "cached_json_directory": "",
@@ -1481,13 +1495,69 @@
               "target_deps": {}
             }
           },
-          "swiftpkg_version": {
+          "swiftpkg_swift_filename_matcher": {
             "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
             "attributes": {
-              "bazel_package_name": "swiftpkg_version",
-              "commit": "3043fcd2a50375db76d89ff206a612471833d1c2",
-              "remote": "https://github.com/mxcl/Version.git",
-              "version": "2.2.1",
+              "bazel_package_name": "swiftpkg_swift_filename_matcher",
+              "commit": "eef5ac0b6b3cdc64b3039b037bed2def8a1edaeb",
+              "remote": "https://github.com/ileitch/swift-filename-matcher",
+              "version": "2.0.1",
+              "env": {},
+              "env_inherit": [],
+              "cached_json_directory": "",
+              "replace_scm_with_registry": false,
+              "target_deps": {}
+            }
+          },
+          "swiftpkg_swift_syntax": {
+            "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
+            "attributes": {
+              "bazel_package_name": "swiftpkg_swift_syntax",
+              "commit": "65b02a90ad2cc213e09309faeb7f6909e0a8577a",
+              "remote": "https://github.com/swiftlang/swift-syntax.git",
+              "version": "604.0.0-prerelease-2026-01-20",
+              "env": {},
+              "env_inherit": [],
+              "cached_json_directory": "",
+              "replace_scm_with_registry": false,
+              "target_deps": {}
+            }
+          },
+          "swiftpkg_swiftytexttable": {
+            "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
+            "attributes": {
+              "bazel_package_name": "swiftpkg_swiftytexttable",
+              "commit": "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
+              "remote": "https://github.com/scottrhoyt/SwiftyTextTable.git",
+              "version": "0.9.0",
+              "env": {},
+              "env_inherit": [],
+              "cached_json_directory": "",
+              "replace_scm_with_registry": false,
+              "target_deps": {}
+            }
+          },
+          "swiftpkg_swxmlhash": {
+            "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
+            "attributes": {
+              "bazel_package_name": "swiftpkg_swxmlhash",
+              "commit": "a853604c9e9a83ad9954c7e3d2a565273982471f",
+              "remote": "https://github.com/drmohundro/SWXMLHash.git",
+              "version": "7.0.2",
+              "env": {},
+              "env_inherit": [],
+              "cached_json_directory": "",
+              "replace_scm_with_registry": false,
+              "target_deps": {}
+            }
+          },
+          "swiftpkg_yams": {
+            "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
+            "attributes": {
+              "bazel_package_name": "swiftpkg_yams",
+              "commit": "a27b21e0c81c5bf42049b897a62aaf387e80f279",
+              "remote": "https://github.com/jpsim/Yams.git",
+              "version": "6.2.2",
               "env": {},
               "env_inherit": [],
               "cached_json_directory": "",
@@ -1499,7 +1569,8 @@
         "moduleExtensionMetadata": {
           "explicitRootModuleDirectDeps": [
             "swiftpkg_swift_hooks",
-            "swiftpkg_mint",
+            "swiftpkg_swiftlint",
+            "swiftpkg_swiftformat",
             "swiftpkg_viewinspector",
             "swift_package"
           ],

--- a/Mintfile
+++ b/Mintfile
@@ -1,0 +1,2 @@
+nicklockwood/SwiftFormat@0.61.0
+realm/SwiftLint@0.63.2

--- a/Mintfile
+++ b/Mintfile
@@ -1,2 +1,0 @@
-nicklockwood/SwiftFormat@0.61.0
-realm/SwiftLint@0.63.2

--- a/ios/core/Sources/CorePlugins/JSBasePlugin.swift
+++ b/ios/core/Sources/CorePlugins/JSBasePlugin.swift
@@ -8,12 +8,16 @@
 import Foundation
 import JavaScriptCore
 
-/**
- Base class for wrapping and loading javascript plugins
- */
+/// Base class for wrapping and loading javascript plugins
 open class JSBasePlugin {
     /// Reference to the plugin inside the context
     public var pluginRef: JSValue?
+
+    /// The filename to load this plugin from
+    public let fileName: String
+
+    /// The name of the plugin to construct
+    public let pluginName: String
 
     /// The context of the plugin
     public var context: JSContext? {
@@ -24,63 +28,67 @@ open class JSBasePlugin {
         }
     }
 
-    /// The filename to load this plugin from
-    public let fileName: String
-
-    /// The name of the plugin to construct
-    public let pluginName: String
-
-    /**
-     Constructs the plugin
-     - parameters:
-        - fileName: The filename of the js plugin in the framework resources
-        - pluginName: The object name to construct the plugin from
-     */
+    /// Constructs the plugin
+    /// - parameters:
+    ///   - fileName: The filename of the js plugin in the framework resources
+    ///   - pluginName: The object name to construct the plugin from
     public init(fileName: String, pluginName: String) {
         self.fileName = fileName
         self.pluginName = pluginName
     }
 
-    /**
-     Constructs the JS Plugin in the given context
-     - parameters:
-        - context: The context to load the plugin into
-     */
+    /// Constructs the JS Plugin in the given context
+    /// - parameters:
+    ///   - context: The context to load the plugin into
     open func setup(context: JSContext) {
-        pluginRef = getPlugin(context: context, fileName: fileName, pluginName: pluginName, arguments: getArguments())
+        pluginRef = getPlugin(
+            context: context,
+            fileName: fileName,
+            pluginName: pluginName,
+            arguments: getArguments()
+        )
     }
 
-    /**
-     Retrieves the arguments for deferred construction of the plugin
-     - returns: An array of arguments to pass to the JS constructor
-     */
-    open func getArguments() -> [Any] { [] }
+    /// Retrieves the arguments for deferred construction of the plugin
+    /// - returns: An array of arguments to pass to the JS constructor
+    open func getArguments() -> [Any] {
+        []
+    }
 
-    /**
-     Function to get the URL for a file.
-     This should be overridden by plugins that are outside of the PlayerUI bundle
-     - parameters:
-        - fileName: The name of the JS file to load
-     - returns: A URL to the file in the bundle if found
-     */
+    /// Function to get the URL for a file.
+    /// This should be overridden by plugins that are outside of the PlayerUI bundle
+    /// - parameters:
+    ///   - fileName: The name of the JS file to load
+    /// - returns: A URL to the file in the bundle if found
     open func getUrlForFile(fileName: String) -> URL? {
         #if SWIFT_PACKAGE
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
+            ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
         #else
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle(for: JSBasePlugin.self), pathComponent: "PlayerUI.bundle")
+            ResourceUtilities.urlForFile(
+                name: fileName,
+                ext: "js",
+                bundle: Bundle(for: JSBasePlugin.self),
+                pathComponent: "PlayerUI.bundle"
+            )
         #endif
     }
 
-    /**
-     Retrieves the JS Binding for the constructed plugin
-     - parameters:
-        - context: The context to load the plugin into
-     - returns:
-        The JS Binding to the plugin
-     */
-    private func getPlugin(context: JSContext, fileName: String, pluginName: String, arguments: [Any] = []) -> JSValue {
+    /// Retrieves the JS Binding for the constructed plugin
+    /// - parameters:
+    ///   - context: The context to load the plugin into
+    /// - returns:
+    ///   The JS Binding to the plugin
+    private func getPlugin(
+        context: JSContext,
+        fileName: String,
+        pluginName: String,
+        arguments: [Any] = []
+    ) -> JSValue {
         guard
-            let plugin = context.getClassReference(pluginName, load: {loadJSResource(into: $0, fileName: fileName)}), !plugin.isUndefined,
+            let plugin = context.getClassReference(
+                pluginName,
+                load: { loadJSResource(into: $0, fileName: fileName) }
+            ), !plugin.isUndefined,
             let pluginValue = plugin.construct(withArguments: arguments)
         else {
             fatalError("Unable To Construct \(pluginName)")

--- a/ios/core/Sources/CorePlugins/JSBasePlugin.swift
+++ b/ios/core/Sources/CorePlugins/JSBasePlugin.swift
@@ -8,12 +8,16 @@
 import Foundation
 import JavaScriptCore
 
-/**
- Base class for wrapping and loading javascript plugins
- */
+/// Base class for wrapping and loading javascript plugins
 open class JSBasePlugin {
     /// Reference to the plugin inside the context
     public var pluginRef: JSValue?
+
+    /// The filename to load this plugin from
+    public let fileName: String
+
+    /// The name of the plugin to construct
+    public let pluginName: String
 
     /// The context of the plugin
     public var context: JSContext? {
@@ -24,59 +28,58 @@ open class JSBasePlugin {
         }
     }
 
-    /// The filename to load this plugin from
-    public let fileName: String
-
-    /// The name of the plugin to construct
-    public let pluginName: String
-
-    /**
-     Constructs the plugin
-     - parameters:
-        - fileName: The filename of the js plugin in the framework resources
-        - pluginName: The object name to construct the plugin from
-     */
+    /// Constructs the plugin
+    /// - parameters:
+    ///   - fileName: The filename of the js plugin in the framework resources
+    ///   - pluginName: The object name to construct the plugin from
     public init(fileName: String, pluginName: String) {
         self.fileName = fileName
         self.pluginName = pluginName
     }
 
-    /**
-     Constructs the JS Plugin in the given context
-     - parameters:
-        - context: The context to load the plugin into
-     */
+    /// Constructs the JS Plugin in the given context
+    /// - parameters:
+    ///   - context: The context to load the plugin into
     open func setup(context: JSContext) {
-        pluginRef = getPlugin(context: context, fileName: fileName, pluginName: pluginName, arguments: getArguments())
+        pluginRef = getPlugin(
+            context: context,
+            fileName: fileName,
+            pluginName: pluginName,
+            arguments: getArguments()
+        )
     }
 
-    /**
-     Retrieves the arguments for deferred construction of the plugin
-     - returns: An array of arguments to pass to the JS constructor
-     */
-    open func getArguments() -> [Any] { [] }
+    /// Retrieves the arguments for deferred construction of the plugin
+    /// - returns: An array of arguments to pass to the JS constructor
+    open func getArguments() -> [Any] {
+        []
+    }
 
-    /**
-     Function to get the URL for a file.
-     This should be overridden by plugins that are outside of the PlayerUI bundle
-     - parameters:
-        - fileName: The name of the JS file to load
-     - returns: A URL to the file in the bundle if found
-     */
+    /// Function to get the URL for a file.
+    /// This should be overridden by plugins that are outside of the PlayerUI bundle
+    /// - parameters:
+    ///   - fileName: The name of the JS file to load
+    /// - returns: A URL to the file in the bundle if found
     open func getUrlForFile(fileName: String) -> URL? {
         ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
     }
 
-    /**
-     Retrieves the JS Binding for the constructed plugin
-     - parameters:
-        - context: The context to load the plugin into
-     - returns:
-        The JS Binding to the plugin
-     */
-    private func getPlugin(context: JSContext, fileName: String, pluginName: String, arguments: [Any] = []) -> JSValue {
+    /// Retrieves the JS Binding for the constructed plugin
+    /// - parameters:
+    ///   - context: The context to load the plugin into
+    /// - returns:
+    ///   The JS Binding to the plugin
+    private func getPlugin(
+        context: JSContext,
+        fileName: String,
+        pluginName: String,
+        arguments: [Any] = []
+    ) -> JSValue {
         guard
-            let plugin = context.getClassReference(pluginName, load: {loadJSResource(into: $0, fileName: fileName)}), !plugin.isUndefined,
+            let plugin = context.getClassReference(
+                pluginName,
+                load: { loadJSResource(into: $0, fileName: fileName) }
+            ), !plugin.isUndefined,
             let pluginValue = plugin.construct(withArguments: arguments)
         else {
             fatalError("Unable To Construct \(pluginName)")

--- a/ios/core/Sources/CorePlugins/NativePlugin.swift
+++ b/ios/core/Sources/CorePlugins/NativePlugin.swift
@@ -8,21 +8,17 @@
 import Foundation
 import JavaScriptCore
 
-/**
- Required functions for a Native Plugin to register with the `Player`
- */
+/// Required functions for a Native Plugin to register with the `Player`
 public protocol NativePlugin {
     /// The name of this plugin
     var pluginName: String { get }
 
-    /**
-     Apply the plugin to Player
-     - parameters:
-        - player: Player to apply to
-     */
+    /// Apply the plugin to Player
+    /// - parameters:
+    ///   - player: Player to apply to
     func apply<P: HeadlessPlayer>(player: P)
 }
 
 public extension NativePlugin {
-    func apply<P>(player: P) where P: HeadlessPlayer {}
+    func apply<P: HeadlessPlayer>(player _: P) {}
 }

--- a/ios/core/Sources/CorePlugins/NativePlugin.swift
+++ b/ios/core/Sources/CorePlugins/NativePlugin.swift
@@ -16,9 +16,9 @@ public protocol NativePlugin {
     /// Apply the plugin to Player
     /// - parameters:
     ///   - player: Player to apply to
-    func apply<P: HeadlessPlayer>(player: P)
+    func apply(player: some HeadlessPlayer)
 }
 
 public extension NativePlugin {
-    func apply<P: HeadlessPlayer>(player _: P) {}
+    func apply(player _: some HeadlessPlayer) {}
 }

--- a/ios/core/Sources/CorePlugins/PartialMatchFingerprintPlugin.swift
+++ b/ios/core/Sources/CorePlugins/PartialMatchFingerprintPlugin.swift
@@ -1,5 +1,5 @@
 //
-//  PartialMatchRegistry.swift
+//  PartialMatchFingerprintPlugin.swift
 //  PlayerUI
 //
 //  Created by Borawski, Harris on 5/19/20.
@@ -8,13 +8,9 @@
 import Foundation
 import JavaScriptCore
 
-/**
- Plugin used to register match dictionaries and an associated index for use in the AssetRegistry
- */
+/// Plugin used to register match dictionaries and an associated index for use in the AssetRegistry
 public class PartialMatchFingerprintPlugin: JSBasePlugin, NativePlugin {
-    /**
-     Initializes a PartialMatchFingerprintPlugin
-     */
+    /// Initializes a PartialMatchFingerprintPlugin
     public convenience init() {
         self.init(
             fileName: "PartialMatchFingerprintPlugin.native",
@@ -22,60 +18,52 @@ public class PartialMatchFingerprintPlugin: JSBasePlugin, NativePlugin {
         )
     }
 
-    /**
-     Retrieves arguments for the JS plugin construction
-     - returns: An array of arguments for construction
-     */
-    override public func getArguments() -> [Any] {
-        guard let context = self.context else { return [] }
-        let registry = PartialMatchRegistry()
-        registry.context = context
-        return [registry.pluginRef as Any]
-    }
-
-    /**
-     Register a match object with an index
-     A match object is a dictionary describing the structure of desired keys to match an asset
-     ```swift
-     ["type": "action": "metaData": ["role": "back"]]
-     ```
-     - parameters:
-        - match: The dictionary object to register as a match structure
-        - index: The index to register this match object with
-     */
+    /// Register a match object with an index
+    /// A match object is a dictionary describing the structure of desired keys to match an asset
+    /// ```swift
+    /// ["type": "action": "metaData": ["role": "back"]]
+    /// ```
+    /// - parameters:
+    ///   - match: The dictionary object to register as a match structure
+    ///   - index: The index to register this match object with
     public func register(match: [String: Any], index: Int) {
-        guard let context = self.context, let matchObj = JSValue(object: match, in: context) else { return }
+        guard let context,
+              let matchObj = JSValue(object: match, in: context) else { return }
         pluginRef?.invokeMethod("register", withArguments: [matchObj, index])
     }
 
-    /**
-     Retrieves the stored index for an asset Id if it exists in the registry
-     - parameters:
-        - assetId: The asset Id to get the index for
-     - returns: The index if it exists
-     */
+    /// Retrieves the stored index for an asset Id if it exists in the registry
+    /// - parameters:
+    ///   - assetId: The asset Id to get the index for
+    /// - returns: The index if it exists
     public func get(assetId: String) -> Int? {
         pluginRef?.invokeMethod("get", withArguments: [assetId])?.toObject() as? Int
     }
 
-    /**
-     **For testing only** , forcefully sets an index in the registry for an assetId
-     - parameters:
-        - assetId: The asset Id to set an index for
-        - index: The index to set
-     */
+    /// For testing only** , forcefully sets an index in the registry for an assetId
+    /// - parameters:
+    ///   - assetId: The asset Id to set an index for
+    ///   - index: The index to set
     public func setMapping(assetId: String, index: Int) {
-        pluginRef?.objectForKeyedSubscript("mapping")?.invokeMethod("set", withArguments: [assetId, index])
+        pluginRef?.objectForKeyedSubscript("mapping")?.invokeMethod(
+            "set",
+            withArguments: [assetId, index]
+        )
+    }
+
+    /// Retrieves arguments for the JS plugin construction
+    /// - returns: An array of arguments for construction
+    override public func getArguments() -> [Any] {
+        guard let context else { return [] }
+        let registry = PartialMatchRegistry()
+        registry.context = context
+        return [registry.pluginRef as Any]
     }
 }
 
-/**
- Wrapper to instantiate @player-ui/partial-match-registry
- */
+/// Wrapper to instantiate @player-ui/partial-match-registry
 class PartialMatchRegistry: JSBasePlugin {
-    /**
-     Constructs a PartialMatchRegistry JS object
-     */
+    /// Constructs a PartialMatchRegistry JS object
     convenience init() {
         self.init(fileName: "Registry.native", pluginName: "Registry.Registry")
     }

--- a/ios/core/Sources/Player/HeadlessPlayer.swift
+++ b/ios/core/Sources/Player/HeadlessPlayer.swift
@@ -8,14 +8,12 @@
 import Foundation
 import JavaScriptCore
 #if SWIFT_PACKAGE
-import PlayerUILogger
+    import PlayerUILogger
 #endif
 
 // MARK: PlayerError
 
-/**
- Represents the different errors that occur in Player lifecycle
- */
+/// Represents the different errors that occur in Player lifecycle
 public enum PlayerError: Error {
     /// There was an issue converting a native binding into a JSValue in the context
     case jsConversionFailure
@@ -33,7 +31,7 @@ public enum PlayerError: Error {
 extension PlayerError: JSConvertibleError {
     public var jsDescription: String {
         switch self {
-        case .unknownResponse(let error):
+        case let .unknownResponse(error):
             return error.playerDescription
         default: return localizedDescription
         }
@@ -41,9 +39,8 @@ extension PlayerError: JSConvertibleError {
 }
 
 // MARK: CoreHooks
-/**
- Defines the minimum hooks that need to be available on a player
- */
+
+/// Defines the minimum hooks that need to be available on a player
 public protocol CoreHooks {
     associatedtype DataControllerType: BaseDataController, CreatedFromJSValue
 
@@ -68,9 +65,7 @@ public protocol CoreHooks {
 
 // MARK: PlayerRegistry
 
-/**
- Defines the minimum required functionality for a registry
- */
+/// Defines the minimum required functionality for a registry
 public protocol PlayerRegistry {
     /// The type of asset that is being used by this player
     associatedtype AssetType
@@ -80,51 +75,43 @@ public protocol PlayerRegistry {
     /// Logger instance from the attached player
     var logger: TapableLogger? { get set }
 
-    /**
-     Register an asset to decode a type, this is converted to ["type": <type>]
-     - parameters:
-        - type: The string type the asset should decode
-        - asset: The swift type representing the asset
-     */
+    /// Register an asset to decode a type, this is converted to ["type": <type>]
+    /// - parameters:
+    ///   - type: The string type the asset should decode
+    ///   - asset: The swift type representing the asset
     func register(_: String, asset: AssetType.Type)
-    /**
-     Register and asset to decode based on matching the specified object
-     This allows registration of multiple assets for the same type, but can match based on other parts of the object
-
-     Example:
-     ```swift
-     register(["type": "action", "metaData": ["role": "back"]], BackActionAsset.self)
-     ```
-     This asset will only be used when decoding a view in the JSON tree that is type action, and has the `back` role.
-     This means the custom asset gets the `run` function that regular actions get
-     - parameters:
-        - match: The object to match this asset to
-        - for: The Asset type to associate with the match
-     */
+    /// Register and asset to decode based on matching the specified object
+    /// This allows registration of multiple assets for the same type, but can match based on other
+    /// parts of the object
+    ///
+    /// Example:
+    /// ```swift
+    /// register(["type": "action", "metaData": ["role": "back"]], BackActionAsset.self)
+    /// ```
+    /// This asset will only be used when decoding a view in the JSON tree that is type action, and
+    /// has the `back` role.
+    /// This means the custom asset gets the `run` function that regular actions get
+    /// - parameters:
+    ///   - match: The object to match this asset to
+    ///   - for: The Asset type to associate with the match
     func register(_: [String: Any], for: AssetType.Type)
 
-    /**
-     Decodes a JSValue into an Asset
-     - parameters:
-        - value: The JSValue representing an asset
-     - returns: A decoded Asset
-     */
+    /// Decodes a JSValue into an Asset
+    /// - parameters:
+    ///   - value: The JSValue representing an asset
+    /// - returns: A decoded Asset
     func decode(_: JSValue) throws -> AssetType
 
-    /**
-     Decodes a JSValue into a `WrapperType`
-     - parameters:
-        - value: The JSValue representing an asset
-     - returns: A decoded Asset
-     */
+    /// Decodes a JSValue into a `WrapperType`
+    /// - parameters:
+    ///   - value: The JSValue representing an asset
+    /// - returns: A decoded Asset
     func decodeWrapper(_ value: JSValue) throws -> WrapperType
 }
 
 // MARK: HeadlessPlayer
 
-/**
- A base implementation of a player
- */
+/// A base implementation of a player
 public protocol HeadlessPlayer {
     /// The type of hooks that this player has
     associatedtype HooksType: CoreHooks
@@ -143,52 +130,45 @@ public protocol HeadlessPlayer {
     /// A reference to the Key/Value store for constants and context for player
     var constantsController: ConstantsController? { get }
 
-    /**
-     Sets up the core javascript player in the given context
-     - parameters:
-        - context: The context to use for initializing the core player
-        - logger: The logger to bind to the javascript logger
-     - returns: Reference to the created JS player
-     */
+    /// Sets up the core javascript player in the given context
+    /// - parameters:
+    ///   - context: The context to use for initializing the core player
+    ///   - logger: The logger to bind to the javascript logger
+    /// - returns: Reference to the created JS player
     func setupPlayer(context: JSContext, plugins: [NativePlugin]) -> JSValue?
 
-    /**
-     Starts the given flow
-     - parameters:
-        - flow: The JSON Flow
-        - completion: A completion handler for when the flow has completed
-     */
+    /// Starts the given flow
+    /// - parameters:
+    ///   - flow: The JSON Flow
+    ///   - completion: A completion handler for when the flow has completed
     func start(flow: String, completion: @escaping (Result<CompletedState, PlayerError>) -> Void)
 }
 
 // MARK: HeadlessPlayer Extension
 
-/**
- Default Implementation for player methods
- */
+/// Default Implementation for player methods
 public extension HeadlessPlayer {
     /// The current state of Player
     var state: BaseFlowState? {
-        return jsPlayerReference?.getState()
+        jsPlayerReference?.getState()
     }
-    
+
     /// The constants and context for player
     var constantsController: ConstantsController? {
-        guard 
-            let constantControllerJSValue = jsPlayerReference?.objectForKeyedSubscript("constantsController") 
+        guard
+            let constantControllerJSValue = jsPlayerReference?
+            .objectForKeyedSubscript("constantsController")
         else {
             return nil
         }
         return ConstantsController(constantsController: constantControllerJSValue)
     }
 
-    /**
-     Sets up the core javascript player in the given context
-     - parameters:
-        - context: The context to use for initializing the core player
-        - logger: The logger to bind to the javascript logger
-     - returns: Reference to the created JS player
-     */
+    /// Sets up the core javascript player in the given context
+    /// - parameters:
+    ///   - context: The context to use for initializing the core player
+    ///   - logger: The logger to bind to the javascript logger
+    /// - returns: Reference to the created JS player
     func setupPlayer(context: JSContext, plugins: [NativePlugin] = []) -> JSValue? {
         JSGarbageCollect(context.jsGlobalContextRef)
         JSUtilities.polyfill(context)
@@ -207,14 +187,14 @@ public extension HeadlessPlayer {
         return context
             .getClassReference("Player.Player", load: loadCore(into:))?
             .construct(withArguments: [[
-                "plugins": plugins.compactMap({$0 as? JSBasePlugin}).map(\.pluginRef),
+                "plugins": plugins.compactMap { $0 as? JSBasePlugin }.map(\.pluginRef),
                 "logger": [
                     "trace": trace,
                     "debug": debug,
                     "info": info,
                     "warn": warn,
-                    "error": error
-                ]
+                    "error": error,
+                ],
             ]])
     }
 
@@ -222,19 +202,21 @@ public extension HeadlessPlayer {
     /// Primarily for plugins to be able to add other plugins to player
     /// - Parameter plugin: The plugin to register
     func registerPlugin<P: JSBasePlugin>(_ plugin: P) {
-        assert(jsPlayerReference != nil, "Cannot register plugins before setuPlayer(context:plugins:) is called")
+        assert(
+            jsPlayerReference != nil,
+            "Cannot register plugins before setuPlayer(context:plugins:) is called"
+        )
         plugin.context = jsPlayerReference?.context
         jsPlayerReference?.invokeMethod("registerPlugin", withArguments: [plugin.pluginRef as Any])
     }
 
-    /**
-     Starts Player for the given flow
-     - parameters:
-        - flow: The JSON Flow
-        - completion: A completion handler for when the flow has completed
-     */
+    /// Starts Player for the given flow
+    /// - parameters:
+    ///   - flow: The JSON Flow
+    ///   - completion: A completion handler for when the flow has completed
     func start(flow: String, completion: @escaping (Result<CompletedState, PlayerError>) -> Void) {
-        // declare these variables outside and reference them inside the errorHandler to prevent retain cycle
+        // declare these variables outside and reference them inside the errorHandler to prevent
+        // retain cycle
         let loggerRef = logger
 
         let promiseHandler: @convention(block) (JSValue?) -> Void = { completedState in
@@ -267,28 +249,26 @@ public extension HeadlessPlayer {
             return completion(.failure(PlayerError.jsConversionFailure))
         }
 
-        // Should not be possible due to fatalError in constructor, but just for handling optionals safely
-        guard let player = jsPlayerReference else { return completion(.failure(PlayerError.playerNotInstantiated)) }
+        // Should not be possible due to fatalError in constructor, but just for handling optionals
+        // safely
+        guard let player = jsPlayerReference
+        else { return completion(.failure(PlayerError.playerNotInstantiated)) }
         player
             .invokeMethod("start", withArguments: [flowObject])
             .invokeMethod("then", withArguments: [callback])
             .invokeMethod("catch", withArguments: [catchCallback])
     }
 
-    /**
-     Loads the headless player into the context
-     - parameters:
-        - context: The context to load the headless player into
-     */
+    /// Loads the headless player into the context
+    /// - parameters:
+    ///   - context: The context to load the headless player into
     private func loadCore(into context: JSContext) {
         context.loadCore()
     }
 
-    /**
-     Attaches an exception handler into the JS environment
-     - parameters:
-        - context: The context to attach the exception handler to
-     */
+    /// Attaches an exception handler into the JS environment
+    /// - parameters:
+    ///   - context: The context to attach the exception handler to
     private func attachExceptionHandler(to context: JSContext) {
         let loggerRef = logger
         context.exceptionHandler = { (_: JSContext!, value: JSValue!) in
@@ -299,9 +279,9 @@ public extension HeadlessPlayer {
     }
 
     func findPlugin<Plugin: WithSymbol>(_ plugin: Plugin.Type) -> JSValue? {
-        return jsPlayerReference?
+        jsPlayerReference?
             .invokeMethod("findPlugin", withArguments: [
-                jsPlayerReference?.context.getSymbol(plugin.symbol) as Any
+                jsPlayerReference?.context.getSymbol(plugin.symbol) as Any,
             ])
     }
 
@@ -315,17 +295,27 @@ public protocol WithSymbol {
     static var symbol: String { get }
 }
 
-// Needed to reference the resource bundle, can't use a protocol for referencing
-internal class ResourceBundleShim {}
+/// Needed to reference the resource bundle, can't use a protocol for referencing
+class ResourceBundleShim {}
 
-internal extension JSContext {
+extension JSContext {
     var coreBundle: URL? {
         #if SWIFT_PACKAGE
-        return ResourceUtilities.urlForFile(name: "Player.native", ext: "js", bundle: Bundle.module)
+            return ResourceUtilities.urlForFile(
+                name: "Player.native",
+                ext: "js",
+                bundle: Bundle.module
+            )
         #else
-        return ResourceUtilities.urlForFile(name: "Player.native", ext: "js", bundle: Bundle(for: ResourceBundleShim.self), pathComponent: "PlayerUI.bundle")
+            return ResourceUtilities.urlForFile(
+                name: "Player.native",
+                ext: "js",
+                bundle: Bundle(for: ResourceBundleShim.self),
+                pathComponent: "PlayerUI.bundle"
+            )
         #endif
     }
+
     /// Loads the core player bundle into the give JSContext
     func loadCore() {
         guard
@@ -337,18 +327,18 @@ internal extension JSContext {
 
     func getSymbol(_ symbolName: String) -> JSValue? {
         guard
-            let ref = getClassReference(symbolName, load: {_ in}),
+            let ref = getClassReference(symbolName, load: { _ in }),
             ref.isSymbol
         else { return nil }
         return ref
     }
-    /**
-     Gets a reference to a class in the JSContext, loading the resource if it is not found
-     - parameters:
-        - className: The name of the class to retrieve
-        - load: A closure to load the JS related to the class if it hasn't been loaded in this context
-     - returns: A reference to the class if it was able to be found
-     */
+
+    /// Gets a reference to a class in the JSContext, loading the resource if it is not found
+    /// - parameters:
+    ///   - className: The name of the class to retrieve
+    ///   - load: A closure to load the JS related to the class if it hasn't been loaded in this
+    /// context
+    /// - returns: A reference to the class if it was able to be found
     func getClassReference(_ className: String, load: (JSContext) -> Void) -> JSValue? {
         if objectAtPath(className)?.toObject() == nil {
             load(self)
@@ -371,9 +361,10 @@ internal extension JSContext {
 }
 
 private extension JSValue {
-    // put getState in extension so it can be accessed by the computed property in HeadlessPlayer.state and also inside the ErrorHandler by the playerReference
+    /// put getState in extension so it can be accessed by the computed property in
+    /// HeadlessPlayer.state and also inside the ErrorHandler by the playerReference
     func getState() -> BaseFlowState? {
-        guard let jsState = self.invokeMethod("getState", withArguments: [])
+        guard let jsState = invokeMethod("getState", withArguments: [])
         else { return nil }
         return BaseFlowState.createInstance(value: jsState)
     }

--- a/ios/core/Sources/Player/HeadlessPlayer.swift
+++ b/ios/core/Sources/Player/HeadlessPlayer.swift
@@ -11,9 +11,7 @@ import PlayerUILogger
 
 // MARK: PlayerError
 
-/**
- Represents the different errors that occur in Player lifecycle
- */
+/// Represents the different errors that occur in Player lifecycle
 public enum PlayerError: Error {
     /// There was an issue converting a native binding into a JSValue in the context
     case jsConversionFailure
@@ -31,7 +29,7 @@ public enum PlayerError: Error {
 extension PlayerError: JSConvertibleError {
     public var jsDescription: String {
         switch self {
-        case .unknownResponse(let error):
+        case let .unknownResponse(error):
             return error.playerDescription
         default: return localizedDescription
         }
@@ -39,9 +37,8 @@ extension PlayerError: JSConvertibleError {
 }
 
 // MARK: CoreHooks
-/**
- Defines the minimum hooks that need to be available on a player
- */
+
+/// Defines the minimum hooks that need to be available on a player
 public protocol CoreHooks {
     associatedtype DataControllerType: BaseDataController, CreatedFromJSValue
 
@@ -69,9 +66,7 @@ public protocol CoreHooks {
 
 // MARK: PlayerRegistry
 
-/**
- Defines the minimum required functionality for a registry
- */
+/// Defines the minimum required functionality for a registry
 public protocol PlayerRegistry {
     /// The type of asset that is being used by this player
     associatedtype AssetType
@@ -81,51 +76,43 @@ public protocol PlayerRegistry {
     /// Logger instance from the attached player
     var logger: TapableLogger? { get set }
 
-    /**
-     Register an asset to decode a type, this is converted to ["type": <type>]
-     - parameters:
-        - type: The string type the asset should decode
-        - asset: The swift type representing the asset
-     */
+    /// Register an asset to decode a type, this is converted to ["type": <type>]
+    /// - parameters:
+    ///   - type: The string type the asset should decode
+    ///   - asset: The swift type representing the asset
     func register(_: String, asset: AssetType.Type)
-    /**
-     Register and asset to decode based on matching the specified object
-     This allows registration of multiple assets for the same type, but can match based on other parts of the object
-
-     Example:
-     ```swift
-     register(["type": "action", "metaData": ["role": "back"]], BackActionAsset.self)
-     ```
-     This asset will only be used when decoding a view in the JSON tree that is type action, and has the `back` role.
-     This means the custom asset gets the `run` function that regular actions get
-     - parameters:
-        - match: The object to match this asset to
-        - for: The Asset type to associate with the match
-     */
+    /// Register and asset to decode based on matching the specified object
+    /// This allows registration of multiple assets for the same type, but can match based on other
+    /// parts of the object
+    ///
+    /// Example:
+    /// ```swift
+    /// register(["type": "action", "metaData": ["role": "back"]], BackActionAsset.self)
+    /// ```
+    /// This asset will only be used when decoding a view in the JSON tree that is type action, and
+    /// has the `back` role.
+    /// This means the custom asset gets the `run` function that regular actions get
+    /// - parameters:
+    ///   - match: The object to match this asset to
+    ///   - for: The Asset type to associate with the match
     func register(_: [String: Any], for: AssetType.Type)
 
-    /**
-     Decodes a JSValue into an Asset
-     - parameters:
-        - value: The JSValue representing an asset
-     - returns: A decoded Asset
-     */
+    /// Decodes a JSValue into an Asset
+    /// - parameters:
+    ///   - value: The JSValue representing an asset
+    /// - returns: A decoded Asset
     func decode(_: JSValue) throws -> AssetType
 
-    /**
-     Decodes a JSValue into a `WrapperType`
-     - parameters:
-        - value: The JSValue representing an asset
-     - returns: A decoded Asset
-     */
+    /// Decodes a JSValue into a `WrapperType`
+    /// - parameters:
+    ///   - value: The JSValue representing an asset
+    /// - returns: A decoded Asset
     func decodeWrapper(_ value: JSValue) throws -> WrapperType
 }
 
 // MARK: HeadlessPlayer
 
-/**
- A base implementation of a player
- */
+/// A base implementation of a player
 public protocol HeadlessPlayer {
     /// The type of hooks that this player has
     associatedtype HooksType: CoreHooks
@@ -144,52 +131,45 @@ public protocol HeadlessPlayer {
     /// A reference to the Key/Value store for constants and context for player
     var constantsController: ConstantsController? { get }
 
-    /**
-     Sets up the core javascript player in the given context
-     - parameters:
-        - context: The context to use for initializing the core player
-        - logger: The logger to bind to the javascript logger
-     - returns: Reference to the created JS player
-     */
+    /// Sets up the core javascript player in the given context
+    /// - parameters:
+    ///   - context: The context to use for initializing the core player
+    ///   - logger: The logger to bind to the javascript logger
+    /// - returns: Reference to the created JS player
     func setupPlayer(context: JSContext, plugins: [NativePlugin]) -> JSValue?
 
-    /**
-     Starts the given flow
-     - parameters:
-        - flow: The JSON Flow
-        - completion: A completion handler for when the flow has completed
-     */
+    /// Starts the given flow
+    /// - parameters:
+    ///   - flow: The JSON Flow
+    ///   - completion: A completion handler for when the flow has completed
     func start(flow: String, completion: @escaping (Result<CompletedState, PlayerError>) -> Void)
 }
 
 // MARK: HeadlessPlayer Extension
 
-/**
- Default Implementation for player methods
- */
+/// Default Implementation for player methods
 public extension HeadlessPlayer {
     /// The current state of Player
     var state: BaseFlowState? {
-        return jsPlayerReference?.getState()
+        jsPlayerReference?.getState()
     }
-    
+
     /// The constants and context for player
     var constantsController: ConstantsController? {
-        guard 
-            let constantControllerJSValue = jsPlayerReference?.objectForKeyedSubscript("constantsController") 
+        guard
+            let constantControllerJSValue = jsPlayerReference?
+            .objectForKeyedSubscript("constantsController")
         else {
             return nil
         }
         return ConstantsController(constantsController: constantControllerJSValue)
     }
 
-    /**
-     Sets up the core javascript player in the given context
-     - parameters:
-        - context: The context to use for initializing the core player
-        - logger: The logger to bind to the javascript logger
-     - returns: Reference to the created JS player
-     */
+    /// Sets up the core javascript player in the given context
+    /// - parameters:
+    ///   - context: The context to use for initializing the core player
+    ///   - logger: The logger to bind to the javascript logger
+    /// - returns: Reference to the created JS player
     func setupPlayer(context: JSContext, plugins: [NativePlugin] = []) -> JSValue? {
         JSGarbageCollect(context.jsGlobalContextRef)
         JSUtilities.polyfill(context)
@@ -208,14 +188,14 @@ public extension HeadlessPlayer {
         return context
             .getClassReference("Player.Player", load: loadCore(into:))?
             .construct(withArguments: [[
-                "plugins": plugins.compactMap({$0 as? JSBasePlugin}).map(\.pluginRef),
+                "plugins": plugins.compactMap { $0 as? JSBasePlugin }.map(\.pluginRef),
                 "logger": [
                     "trace": trace,
                     "debug": debug,
                     "info": info,
                     "warn": warn,
-                    "error": error
-                ]
+                    "error": error,
+                ],
             ]])
     }
 
@@ -223,13 +203,17 @@ public extension HeadlessPlayer {
     /// Primarily for plugins to be able to add other plugins to player
     /// - Parameter plugin: The plugin to register
     func registerPlugin<P: JSBasePlugin>(_ plugin: P) {
-        assert(jsPlayerReference != nil, "Cannot register plugins before setuPlayer(context:plugins:) is called")
+        assert(
+            jsPlayerReference != nil,
+            "Cannot register plugins before setuPlayer(context:plugins:) is called"
+        )
         plugin.context = jsPlayerReference?.context
         jsPlayerReference?.invokeMethod("registerPlugin", withArguments: [plugin.pluginRef as Any])
     }
 
     /// Registers a NativePlugin with player after instantiation
-    /// For JSBasePlugin instances, delegates to the typed overload; for other NativePlugins, calls apply directly
+    /// For JSBasePlugin instances, delegates to the typed overload; for other NativePlugins, calls
+    /// apply directly
     /// - Parameter plugin: The plugin to register
     func registerPlugin(_ plugin: NativePlugin) {
         if let jsPlugin = plugin as? JSBasePlugin {
@@ -239,14 +223,13 @@ public extension HeadlessPlayer {
         }
     }
 
-    /**
-     Starts Player for the given flow
-     - parameters:
-        - flow: The JSON Flow
-        - completion: A completion handler for when the flow has completed
-     */
+    /// Starts Player for the given flow
+    /// - parameters:
+    ///   - flow: The JSON Flow
+    ///   - completion: A completion handler for when the flow has completed
     func start(flow: String, completion: @escaping (Result<CompletedState, PlayerError>) -> Void) {
-        // declare these variables outside and reference them inside the errorHandler to prevent retain cycle
+        // declare these variables outside and reference them inside the errorHandler to prevent
+        // retain cycle
         let loggerRef = logger
 
         let promiseHandler: @convention(block) (JSValue?) -> Void = { completedState in
@@ -279,28 +262,26 @@ public extension HeadlessPlayer {
             return completion(.failure(PlayerError.jsConversionFailure))
         }
 
-        // Should not be possible due to fatalError in constructor, but just for handling optionals safely
-        guard let player = jsPlayerReference else { return completion(.failure(PlayerError.playerNotInstantiated)) }
+        // Should not be possible due to fatalError in constructor, but just for handling optionals
+        // safely
+        guard let player = jsPlayerReference
+        else { return completion(.failure(PlayerError.playerNotInstantiated)) }
         player
             .invokeMethod("start", withArguments: [flowObject])
             .invokeMethod("then", withArguments: [callback])
             .invokeMethod("catch", withArguments: [catchCallback])
     }
 
-    /**
-     Loads the headless player into the context
-     - parameters:
-        - context: The context to load the headless player into
-     */
+    /// Loads the headless player into the context
+    /// - parameters:
+    ///   - context: The context to load the headless player into
     private func loadCore(into context: JSContext) {
         context.loadCore()
     }
 
-    /**
-     Attaches an exception handler into the JS environment
-     - parameters:
-        - context: The context to attach the exception handler to
-     */
+    /// Attaches an exception handler into the JS environment
+    /// - parameters:
+    ///   - context: The context to attach the exception handler to
     private func attachExceptionHandler(to context: JSContext) {
         let loggerRef = logger
         context.exceptionHandler = { (_: JSContext!, value: JSValue!) in
@@ -311,9 +292,9 @@ public extension HeadlessPlayer {
     }
 
     func findPlugin<Plugin: WithSymbol>(_ plugin: Plugin.Type) -> JSValue? {
-        return jsPlayerReference?
+        jsPlayerReference?
             .invokeMethod("findPlugin", withArguments: [
-                jsPlayerReference?.context.getSymbol(plugin.symbol) as Any
+                jsPlayerReference?.context.getSymbol(plugin.symbol) as Any,
             ])
     }
 
@@ -327,10 +308,11 @@ public protocol WithSymbol {
     static var symbol: String { get }
 }
 
-internal extension JSContext {
+extension JSContext {
     var coreBundle: URL? {
-        return ResourceUtilities.urlForFile(name: "Player.native", ext: "js", bundle: Bundle.module)
+        ResourceUtilities.urlForFile(name: "Player.native", ext: "js", bundle: Bundle.module)
     }
+
     /// Loads the core player bundle into the give JSContext
     func loadCore() {
         guard
@@ -342,18 +324,18 @@ internal extension JSContext {
 
     func getSymbol(_ symbolName: String) -> JSValue? {
         guard
-            let ref = getClassReference(symbolName, load: {_ in}),
+            let ref = getClassReference(symbolName, load: { _ in }),
             ref.isSymbol
         else { return nil }
         return ref
     }
-    /**
-     Gets a reference to a class in the JSContext, loading the resource if it is not found
-     - parameters:
-        - className: The name of the class to retrieve
-        - load: A closure to load the JS related to the class if it hasn't been loaded in this context
-     - returns: A reference to the class if it was able to be found
-     */
+
+    /// Gets a reference to a class in the JSContext, loading the resource if it is not found
+    /// - parameters:
+    ///   - className: The name of the class to retrieve
+    ///   - load: A closure to load the JS related to the class if it hasn't been loaded in this
+    /// context
+    /// - returns: A reference to the class if it was able to be found
     func getClassReference(_ className: String, load: (JSContext) -> Void) -> JSValue? {
         if objectAtPath(className)?.toObject() == nil {
             load(self)
@@ -376,9 +358,9 @@ internal extension JSContext {
 }
 
 private extension JSValue {
-    // put getState in extension so it can be accessed by the computed property in HeadlessPlayer.state and also inside the ErrorHandler by the playerReference
+    /// put getState in extension so it can be accessed by the computed property in HeadlessPlayer.state and also inside the ErrorHandler by the playerReference
     func getState() -> BaseFlowState? {
-        guard let jsState = self.invokeMethod("getState", withArguments: [])
+        guard let jsState = invokeMethod("getState", withArguments: [])
         else { return nil }
         return BaseFlowState.createInstance(value: jsState)
     }

--- a/ios/core/Sources/Player/HeadlessPlayer.swift
+++ b/ios/core/Sources/Player/HeadlessPlayer.swift
@@ -358,7 +358,9 @@ extension JSContext {
 }
 
 private extension JSValue {
-    /// put getState in extension so it can be accessed by the computed property in HeadlessPlayer.state and also inside the ErrorHandler by the playerReference
+    /// put getState in extension so it can be accessed by the computed property in
+    /// HeadlessPlayer.state and
+    /// also inside the ErrorHandler by the playerReference
     func getState() -> BaseFlowState? {
         guard let jsState = invokeMethod("getState", withArguments: [])
         else { return nil }

--- a/ios/core/Sources/Player/HeadlessPlayer.swift
+++ b/ios/core/Sources/Player/HeadlessPlayer.swift
@@ -30,8 +30,8 @@ extension PlayerError: JSConvertibleError {
     public var jsDescription: String {
         switch self {
         case let .unknownResponse(error):
-            return error.playerDescription
-        default: return localizedDescription
+            error.playerDescription
+        default: localizedDescription
         }
     }
 }
@@ -202,7 +202,7 @@ public extension HeadlessPlayer {
     /// Registers a plugin with player after instantiation
     /// Primarily for plugins to be able to add other plugins to player
     /// - Parameter plugin: The plugin to register
-    func registerPlugin<P: JSBasePlugin>(_ plugin: P) {
+    func registerPlugin(_ plugin: some JSBasePlugin) {
         assert(
             jsPlayerReference != nil,
             "Cannot register plugins before setuPlayer(context:plugins:) is called"
@@ -291,14 +291,14 @@ public extension HeadlessPlayer {
         }
     }
 
-    func findPlugin<Plugin: WithSymbol>(_ plugin: Plugin.Type) -> JSValue? {
+    func findPlugin(_ plugin: (some WithSymbol).Type) -> JSValue? {
         jsPlayerReference?
             .invokeMethod("findPlugin", withArguments: [
                 jsPlayerReference?.context.getSymbol(plugin.symbol) as Any,
             ])
     }
 
-    func applyTo<Plugin: WithSymbol>(_ plugin: Plugin.Type, apply: @escaping (JSValue) -> Void) {
+    func applyTo(_ plugin: (some WithSymbol).Type, apply: @escaping (JSValue) -> Void) {
         guard let plugin = findPlugin(plugin) else { return }
         apply(plugin)
     }

--- a/ios/core/Sources/Types/Assets/BaseAssetRegistry.swift
+++ b/ios/core/Sources/Types/Assets/BaseAssetRegistry.swift
@@ -100,7 +100,7 @@ open class BaseAssetRegistry<WrapperType: Decodable & AssetContainer>: PlayerReg
             if asset == registry[index].assetType {
                 logger?
                     .t(
-                        "Duplicate Registration skipped for \(String(describing: match)) asset: \(String(describing: asset))"
+                        "Duplicate Registration skipped for \(String(describing: match)) asset: \(String(describing: asset))" // swiftlint:disable:this line_length
                     )
             } else {
                 logger?.w("Overriding registration for match: \(String(describing: match))")
@@ -225,6 +225,7 @@ extension JSValue {
 public extension Decoder {
     /// A `CodingUserInfoKey` to fetch the decoding function for this decoder
     var decodeFunctionKey: CodingUserInfoKey {
+        // swiftlint:disable:next force_unwrapping
         CodingUserInfoKey(rawValue: "decodeFunction")!
     }
 }

--- a/ios/core/Sources/Types/Assets/BaseAssetRegistry.swift
+++ b/ios/core/Sources/Types/Assets/BaseAssetRegistry.swift
@@ -1,5 +1,5 @@
 //
-//  AssetRegistry.swift
+//  BaseAssetRegistry.swift
 //
 //
 //  Created by Borawski, Harris on 2/13/20.
@@ -8,12 +8,10 @@
 import Foundation
 import JavaScriptCore
 #if SWIFT_PACKAGE
-import PlayerUILogger
+    import PlayerUILogger
 #endif
 
-/**
- Represents the different errors that occur when decoding
- */
+/// Represents the different errors that occur when decoding
 public enum DecodingError: Error {
     /// Unable to decode a base asset, does not contain keys: `id` and `type`
     case baseAssetNotDecodable
@@ -21,7 +19,8 @@ public enum DecodingError: Error {
     /// The provided type was not registered with the AssetRegistry
     case typeNotRegistered(type: String)
 
-    /// The type was registered with the AssetRegistry, but the provided value could not decode to it
+    /// The type was registered with the AssetRegistry, but the provided value could not decode to
+    /// it
     case typeNotDecodable(type: String)
 
     /// The decoder being used was not an AssetDecoder
@@ -34,21 +33,10 @@ public enum DecodingError: Error {
     case malformedData
 }
 
-/**
- A registry of assets used to decode the view tree returned by Player
- */
-open class BaseAssetRegistry<WrapperType>: PlayerRegistry where
-    WrapperType: Decodable,
-    WrapperType: AssetContainer,
+/// A registry of assets used to decode the view tree returned by Player
+open class BaseAssetRegistry<WrapperType: Decodable & AssetContainer>: PlayerRegistry where
     WrapperType.AssetType: Decodable {
-
-    /// A type representing an entry in the registry
-    public typealias RegistryEntry = (assetType: AssetType.Type, match: [String: Any])
-
-    /// A read-only look at the types of assets that are registered
-    public var registeredAssets: [AssetType.Type] {
-        return registry.map({ $0.0 })
-    }
+    public let decoder: JSONDecoder = .init()
 
     /// The registry plugin that wraps the partial-match-registry
     public var partialMatchRegistry: PartialMatchFingerprintPlugin? {
@@ -69,51 +57,53 @@ open class BaseAssetRegistry<WrapperType>: PlayerRegistry where
         }
     }
 
-    public let decoder = JSONDecoder()
+    /// A read-only look at the types of assets that are registered
+    public var registeredAssets: [AssetType.Type] {
+        registry.map(\.0)
+    }
 
-    /**
-     Initializes an empty registry
-     - parameters:
-        - logger: A `TapableLogger` instance to log with
-     */
+    /// Initializes an empty registry
+    /// - parameters:
+    ///   - logger: A `TapableLogger` instance to log with
     public init(logger: TapableLogger? = nil) {
         self.logger = logger
         decoder.setDecodeAssetFunction(decodeFunction(_:))
         decoder.setLogger(logger)
     }
 
-    /**
-     Register an asset to decode a type, this is converted to ["type": <type>]
-     - parameters:
-        - type: The string type the asset should decode
-        - asset: The swift type representing the asset
-     */
+    /// Register an asset to decode a type, this is converted to ["type": <type>]
+    /// - parameters:
+    ///   - type: The string type the asset should decode
+    ///   - asset: The swift type representing the asset
     public func register(_ type: String, asset: WrapperType.AssetType.Type) {
-        self.register(["type": type], for: asset)
+        register(["type": type], for: asset)
     }
 
-    /**
-     Register and asset to decode based on matching the specified object
-     This allows registration of multiple assets for the same type, but can match based on other parts of the object
-
-     Example:
-     ```swift
-     register(["type": "action", "metaData": ["role": "back"]], BackActionAsset.self)
-     ```
-     This asset will only be used when decoding a view in the JSON tree that is type action, and has the `back` role.
-     This means the custom asset gets the `run` function that regular actions get
-     - parameters:
-        - match: The object to match this asset to
-        - for: The Asset type to associate with the match
-     */
+    /// Register and asset to decode based on matching the specified object
+    /// This allows registration of multiple assets for the same type, but can match based on other
+    /// parts of the object
+    ///
+    /// Example:
+    /// ```swift
+    /// register(["type": "action", "metaData": ["role": "back"]], BackActionAsset.self)
+    /// ```
+    /// This asset will only be used when decoding a view in the JSON tree that is type action, and
+    /// has the `back` role.
+    /// This means the custom asset gets the `run` function that regular actions get
+    /// - parameters:
+    ///   - match: The object to match this asset to
+    ///   - for: The Asset type to associate with the match
     public func register(_ match: [String: Any], for asset: WrapperType.AssetType.Type) {
         if let index = registry.firstIndex(where: { matched in
-            return NSDictionary(dictionary: match).isEqual(to: matched.match)
+            NSDictionary(dictionary: match).isEqual(to: matched.match)
         }) {
             if asset == registry[index].assetType {
-                self.logger?.t("Duplicate Registration skipped for \(String(describing: match)) asset: \(String(describing: asset))")
+                logger?
+                    .t(
+                        "Duplicate Registration skipped for \(String(describing: match)) asset: \(String(describing: asset))"
+                    )
             } else {
-                self.logger?.w("Overriding registration for match: \(String(describing: match))")
+                logger?.w("Overriding registration for match: \(String(describing: match))")
                 registry[index] = (assetType: asset, match: match)
             }
         } else {
@@ -121,21 +111,38 @@ open class BaseAssetRegistry<WrapperType>: PlayerRegistry where
         }
     }
 
-    /**
-     Helper function to register or reregister all assets with the partial match registry
-     */
+    /// Decodes a JSValue into an Asset
+    /// - parameters:
+    ///   - value: The JSValue representing an asset
+    /// - returns: A decoded Asset
+    public func decode(_ value: JSValue) throws -> WrapperType.AssetType {
+        assert(Thread.isMainThread, "decoder must be accessed from main")
+        typealias Shim = RegistryDecodeShim<WrapperType.AssetType>
+        let localDecoder = AnyTypeDecodingContext(value).map { $0.inject(to: decoder) } ?? decoder
+        return try localDecoder.decode(Shim.self, from: value).asset
+    }
+
+    /// Decodes a JSValue into an AssetWrapper
+    /// - parameters:
+    ///   - value: The JSValue representing an asset
+    /// - returns: A decoded Asset
+    public func decodeWrapper(_ value: JSValue) throws -> WrapperType {
+        assert(Thread.isMainThread, "decoder must be accessed from main")
+        let localDecoder = AnyTypeDecodingContext(value).map { $0.inject(to: decoder) } ?? decoder
+        return try localDecoder.decode(WrapperType.self, from: value)
+    }
+
+    /// Helper function to register or reregister all assets with the partial match registry
     private func registerWithPlugin() {
         for (index, entry) in registry.enumerated() {
             partialMatchRegistry?.register(match: entry.match, index: index)
         }
     }
 
-    /**
-     Retrieves an asset type from the partial match registry based on the ID
-     - parameters:
-        - id: The ID of the asset to get the type for
-     - returns: The type to decode as
-     */
+    /// Retrieves an asset type from the partial match registry based on the ID
+    /// - parameters:
+    ///   - id: The ID of the asset to get the type for
+    /// - returns: The type to decode as
     private func getAssetType(id: String) -> WrapperType.AssetType.Type? {
         guard let index = partialMatchRegistry?.get(assetId: id) else { return nil }
         return registry[index].assetType
@@ -151,35 +158,13 @@ open class BaseAssetRegistry<WrapperType>: PlayerRegistry where
         return try decoder.singleValueContainer().decode(type)
     }
 
+    /// A type representing an entry in the registry
+    public typealias RegistryEntry = (assetType: AssetType.Type, match: [String: Any])
+
     /// This is used by `decodeFunction` to pickup an `id` to pass to the partial match registry.
     private struct TypeCheck: Decodable {
         let id: String
         let type: String?
-    }
-
-    /**
-     Decodes a JSValue into an Asset
-     - parameters:
-        - value: The JSValue representing an asset
-     - returns: A decoded Asset
-     */
-    public func decode(_ value: JSValue) throws -> WrapperType.AssetType {
-        assert(Thread.isMainThread, "decoder must be accessed from main")
-        typealias Shim = RegistryDecodeShim<WrapperType.AssetType>
-        let localDecoder = AnyTypeDecodingContext(value).map { $0.inject(to: decoder) } ?? decoder
-        return try localDecoder.decode(Shim.self, from: value).asset
-    }
-
-    /**
-     Decodes a JSValue into an AssetWrapper
-     - parameters:
-        - value: The JSValue representing an asset
-     - returns: A decoded Asset
-     */
-    public func decodeWrapper(_ value: JSValue) throws -> WrapperType {
-        assert(Thread.isMainThread, "decoder must be accessed from main")
-        let localDecoder = AnyTypeDecodingContext(value).map { $0.inject(to: decoder) } ?? decoder
-        return try localDecoder.decode(WrapperType.self, from: value)
     }
 }
 
@@ -203,7 +188,8 @@ extension AnyTypeDecodingContext {
 }
 
 extension JSValue {
-    /// Returns the contents of this value encoded into UTF-8 string data. Throws DecodingError.malformedData
+    /// Returns the contents of this value encoded into UTF-8 string data. Throws
+    /// DecodingError.malformedData
     /// if this value can't be transformed.
     func jsonData(pretty: Bool = false) throws -> Data {
         guard
@@ -212,7 +198,8 @@ extension JSValue {
             !json.isNull,
             // replace functions with placeholders, since we retrieve the value in WrappedFunction
             // with the coding path
-            let replacer = context?.evaluateScript("(key, value) => (typeof value === 'function' ? {} : value)"),
+            let replacer = context?
+            .evaluateScript("(key, value) => (typeof value === 'function' ? {} : value)"),
             let output = json.invokeMethod(
                 "stringify",
                 withArguments: [
@@ -220,7 +207,7 @@ extension JSValue {
                     replacer as Any,
                     (
                         pretty ? 2 : nil
-                    ) as Any
+                    ) as Any,
                 ]
             ),
             !output.isUndefined,
@@ -234,32 +221,36 @@ extension JSValue {
 }
 
 // MARK: Decoder Extension
+
 public extension Decoder {
     /// A `CodingUserInfoKey` to fetch the decoding function for this decoder
-    var decodeFunctionKey: CodingUserInfoKey { CodingUserInfoKey(rawValue: "decodeFunction")! }
+    var decodeFunctionKey: CodingUserInfoKey {
+        CodingUserInfoKey(rawValue: "decodeFunction")!
+    }
 }
 
 /// A function that decodes an `Asset`
-typealias DecodeAssetFunction<Asset> = ((Decoder) throws -> Asset)
+typealias DecodeAssetFunction<Asset> = (Decoder) throws -> Asset
 
-extension Decoder {
+public extension Decoder {
     /// A logger that can be used to track useful decoding details
-    public var logger: TapableLogger? { userInfo[.logger] as? TapableLogger }
+    var logger: TapableLogger? {
+        userInfo[.logger] as? TapableLogger
+    }
 
-    /**
-     Retrieves a `DecodeAssetFunction<Asset>` if the decoder has one
-     - returns: A `DecodeSwiftUIFunction`
-     */
-    func getDecodeAssetFunction<Asset>() throws -> DecodeAssetFunction<Asset> {
+    /// Retrieves a `DecodeAssetFunction<Asset>` if the decoder has one
+    /// - returns: A `DecodeSwiftUIFunction`
+    internal func getDecodeAssetFunction<Asset>() throws -> DecodeAssetFunction<Asset> {
         guard let decodeFunction = userInfo[.decodeSUI] as? DecodeAssetFunction<Asset> else {
             throw DecodingError.decoderNotAnAssetDecoder
         }
         return decodeFunction
     }
 
-    /// Returns the JSValue found at the current coding path, or throws an error if decoding was not started
+    /// Returns the JSValue found at the current coding path, or throws an error if decoding was not
+    /// started
     /// with `JSONDecoder.decoder(_:from:)` provided a `JSValue` value.
-    public func getJSValue() throws -> JSValue {
+    func getJSValue() throws -> JSValue {
         guard let rootJS = userInfo[.rootJS] as? JSValue else {
             throw DecodingError.decoderNotAnAssetDecoder
         }
@@ -278,8 +269,9 @@ extension Decoder {
 extension JSONDecoder {
     /// Attempts to decode an object of type T from the JSON data found in value.
     /// During decoding calls to `decoder.getJSValue()` will return the object subscripted in value
-    /// at the current coding path. A decode function might use this to update RawValueBacked entities.
-    public func decode<T>(_ type: T.Type, from value: JSValue) throws -> T where T: Decodable {
+    /// at the current coding path. A decode function might use this to update RawValueBacked
+    /// entities.
+    public func decode<T: Decodable>(_: T.Type, from value: JSValue) throws -> T {
         setRootJS(value)
         defer { setRootJS(nil) }
 
@@ -301,7 +293,9 @@ extension JSONDecoder {
     }
 
     /// A logger that can be used to track useful decoding details
-    var logger: TapableLogger? { userInfo[.logger] as? TapableLogger }
+    var logger: TapableLogger? {
+        userInfo[.logger] as? TapableLogger
+    }
 
     func setLogger(_ logger: TapableLogger?) {
         userInfo[.logger] = logger

--- a/ios/core/Sources/Types/Assets/BaseAssetRegistry.swift
+++ b/ios/core/Sources/Types/Assets/BaseAssetRegistry.swift
@@ -98,7 +98,8 @@ open class BaseAssetRegistry<WrapperType: Decodable & AssetContainer>: PlayerReg
             if asset == registry[index].assetType {
                 logger?
                     .t(
-                        "Duplicate Registration skipped for \(String(describing: match)) asset: \(String(describing: asset))"
+                        "Duplicate Registration skipped for \(String(describing: match)) "
+                            + "asset: \(String(describing: asset))"
                     )
             } else {
                 logger?.w("Overriding registration for match: \(String(describing: match))")
@@ -223,7 +224,7 @@ extension JSValue {
 public extension Decoder {
     /// A `CodingUserInfoKey` to fetch the decoding function for this decoder
     var decodeFunctionKey: CodingUserInfoKey {
-        CodingUserInfoKey(rawValue: "decodeFunction")!
+        CodingUserInfoKey.decodeSUI
     }
 }
 

--- a/ios/core/Sources/Types/Assets/BaseAssetRegistry.swift
+++ b/ios/core/Sources/Types/Assets/BaseAssetRegistry.swift
@@ -1,5 +1,5 @@
 //
-//  AssetRegistry.swift
+//  BaseAssetRegistry.swift
 //
 //
 //  Created by Borawski, Harris on 2/13/20.
@@ -9,9 +9,7 @@ import Foundation
 import JavaScriptCore
 import PlayerUILogger
 
-/**
- Represents the different errors that occur when decoding
- */
+/// Represents the different errors that occur when decoding
 public enum DecodingError: Error {
     /// Unable to decode a base asset, does not contain keys: `id` and `type`
     case baseAssetNotDecodable
@@ -19,7 +17,8 @@ public enum DecodingError: Error {
     /// The provided type was not registered with the AssetRegistry
     case typeNotRegistered(type: String)
 
-    /// The type was registered with the AssetRegistry, but the provided value could not decode to it
+    /// The type was registered with the AssetRegistry, but the provided value could not decode to
+    /// it
     case typeNotDecodable(type: String)
 
     /// The decoder being used was not an AssetDecoder
@@ -32,21 +31,10 @@ public enum DecodingError: Error {
     case malformedData
 }
 
-/**
- A registry of assets used to decode the view tree returned by Player
- */
-open class BaseAssetRegistry<WrapperType>: PlayerRegistry where
-    WrapperType: Decodable,
-    WrapperType: AssetContainer,
+/// A registry of assets used to decode the view tree returned by Player
+open class BaseAssetRegistry<WrapperType: Decodable & AssetContainer>: PlayerRegistry where
     WrapperType.AssetType: Decodable {
-
-    /// A type representing an entry in the registry
-    public typealias RegistryEntry = (assetType: AssetType.Type, match: [String: Any])
-
-    /// A read-only look at the types of assets that are registered
-    public var registeredAssets: [AssetType.Type] {
-        return registry.map({ $0.0 })
-    }
+    public let decoder: JSONDecoder = .init()
 
     /// The registry plugin that wraps the partial-match-registry
     public var partialMatchRegistry: PartialMatchFingerprintPlugin? {
@@ -67,51 +55,53 @@ open class BaseAssetRegistry<WrapperType>: PlayerRegistry where
         }
     }
 
-    public let decoder = JSONDecoder()
+    /// A read-only look at the types of assets that are registered
+    public var registeredAssets: [AssetType.Type] {
+        registry.map(\.0)
+    }
 
-    /**
-     Initializes an empty registry
-     - parameters:
-        - logger: A `TapableLogger` instance to log with
-     */
+    /// Initializes an empty registry
+    /// - parameters:
+    ///   - logger: A `TapableLogger` instance to log with
     public init(logger: TapableLogger? = nil) {
         self.logger = logger
         decoder.setDecodeAssetFunction(decodeFunction(_:))
         decoder.setLogger(logger)
     }
 
-    /**
-     Register an asset to decode a type, this is converted to ["type": <type>]
-     - parameters:
-        - type: The string type the asset should decode
-        - asset: The swift type representing the asset
-     */
+    /// Register an asset to decode a type, this is converted to ["type": <type>]
+    /// - parameters:
+    ///   - type: The string type the asset should decode
+    ///   - asset: The swift type representing the asset
     public func register(_ type: String, asset: WrapperType.AssetType.Type) {
-        self.register(["type": type], for: asset)
+        register(["type": type], for: asset)
     }
 
-    /**
-     Register and asset to decode based on matching the specified object
-     This allows registration of multiple assets for the same type, but can match based on other parts of the object
-
-     Example:
-     ```swift
-     register(["type": "action", "metaData": ["role": "back"]], BackActionAsset.self)
-     ```
-     This asset will only be used when decoding a view in the JSON tree that is type action, and has the `back` role.
-     This means the custom asset gets the `run` function that regular actions get
-     - parameters:
-        - match: The object to match this asset to
-        - for: The Asset type to associate with the match
-     */
+    /// Register and asset to decode based on matching the specified object
+    /// This allows registration of multiple assets for the same type, but can match based on other
+    /// parts of the object
+    ///
+    /// Example:
+    /// ```swift
+    /// register(["type": "action", "metaData": ["role": "back"]], BackActionAsset.self)
+    /// ```
+    /// This asset will only be used when decoding a view in the JSON tree that is type action, and
+    /// has the `back` role.
+    /// This means the custom asset gets the `run` function that regular actions get
+    /// - parameters:
+    ///   - match: The object to match this asset to
+    ///   - for: The Asset type to associate with the match
     public func register(_ match: [String: Any], for asset: WrapperType.AssetType.Type) {
         if let index = registry.firstIndex(where: { matched in
-            return NSDictionary(dictionary: match).isEqual(to: matched.match)
+            NSDictionary(dictionary: match).isEqual(to: matched.match)
         }) {
             if asset == registry[index].assetType {
-                self.logger?.t("Duplicate Registration skipped for \(String(describing: match)) asset: \(String(describing: asset))")
+                logger?
+                    .t(
+                        "Duplicate Registration skipped for \(String(describing: match)) asset: \(String(describing: asset))"
+                    )
             } else {
-                self.logger?.w("Overriding registration for match: \(String(describing: match))")
+                logger?.w("Overriding registration for match: \(String(describing: match))")
                 registry[index] = (assetType: asset, match: match)
             }
         } else {
@@ -119,21 +109,38 @@ open class BaseAssetRegistry<WrapperType>: PlayerRegistry where
         }
     }
 
-    /**
-     Helper function to register or reregister all assets with the partial match registry
-     */
+    /// Decodes a JSValue into an Asset
+    /// - parameters:
+    ///   - value: The JSValue representing an asset
+    /// - returns: A decoded Asset
+    public func decode(_ value: JSValue) throws -> WrapperType.AssetType {
+        assert(Thread.isMainThread, "decoder must be accessed from main")
+        typealias Shim = RegistryDecodeShim<WrapperType.AssetType>
+        let localDecoder = AnyTypeDecodingContext(value).map { $0.inject(to: decoder) } ?? decoder
+        return try localDecoder.decode(Shim.self, from: value).asset
+    }
+
+    /// Decodes a JSValue into an AssetWrapper
+    /// - parameters:
+    ///   - value: The JSValue representing an asset
+    /// - returns: A decoded Asset
+    public func decodeWrapper(_ value: JSValue) throws -> WrapperType {
+        assert(Thread.isMainThread, "decoder must be accessed from main")
+        let localDecoder = AnyTypeDecodingContext(value).map { $0.inject(to: decoder) } ?? decoder
+        return try localDecoder.decode(WrapperType.self, from: value)
+    }
+
+    /// Helper function to register or reregister all assets with the partial match registry
     private func registerWithPlugin() {
         for (index, entry) in registry.enumerated() {
             partialMatchRegistry?.register(match: entry.match, index: index)
         }
     }
 
-    /**
-     Retrieves an asset type from the partial match registry based on the ID
-     - parameters:
-        - id: The ID of the asset to get the type for
-     - returns: The type to decode as
-     */
+    /// Retrieves an asset type from the partial match registry based on the ID
+    /// - parameters:
+    ///   - id: The ID of the asset to get the type for
+    /// - returns: The type to decode as
     private func getAssetType(id: String) -> WrapperType.AssetType.Type? {
         guard let index = partialMatchRegistry?.get(assetId: id) else { return nil }
         return registry[index].assetType
@@ -149,35 +156,13 @@ open class BaseAssetRegistry<WrapperType>: PlayerRegistry where
         return try decoder.singleValueContainer().decode(type)
     }
 
+    /// A type representing an entry in the registry
+    public typealias RegistryEntry = (assetType: AssetType.Type, match: [String: Any])
+
     /// This is used by `decodeFunction` to pickup an `id` to pass to the partial match registry.
     private struct TypeCheck: Decodable {
         let id: String
         let type: String?
-    }
-
-    /**
-     Decodes a JSValue into an Asset
-     - parameters:
-        - value: The JSValue representing an asset
-     - returns: A decoded Asset
-     */
-    public func decode(_ value: JSValue) throws -> WrapperType.AssetType {
-        assert(Thread.isMainThread, "decoder must be accessed from main")
-        typealias Shim = RegistryDecodeShim<WrapperType.AssetType>
-        let localDecoder = AnyTypeDecodingContext(value).map { $0.inject(to: decoder) } ?? decoder
-        return try localDecoder.decode(Shim.self, from: value).asset
-    }
-
-    /**
-     Decodes a JSValue into an AssetWrapper
-     - parameters:
-        - value: The JSValue representing an asset
-     - returns: A decoded Asset
-     */
-    public func decodeWrapper(_ value: JSValue) throws -> WrapperType {
-        assert(Thread.isMainThread, "decoder must be accessed from main")
-        let localDecoder = AnyTypeDecodingContext(value).map { $0.inject(to: decoder) } ?? decoder
-        return try localDecoder.decode(WrapperType.self, from: value)
     }
 }
 
@@ -201,7 +186,8 @@ extension AnyTypeDecodingContext {
 }
 
 extension JSValue {
-    /// Returns the contents of this value encoded into UTF-8 string data. Throws DecodingError.malformedData
+    /// Returns the contents of this value encoded into UTF-8 string data. Throws
+    /// DecodingError.malformedData
     /// if this value can't be transformed.
     func jsonData(pretty: Bool = false) throws -> Data {
         guard
@@ -210,7 +196,8 @@ extension JSValue {
             !json.isNull,
             // replace functions with placeholders, since we retrieve the value in WrappedFunction
             // with the coding path
-            let replacer = context?.evaluateScript("(key, value) => (typeof value === 'function' ? {} : value)"),
+            let replacer = context?
+            .evaluateScript("(key, value) => (typeof value === 'function' ? {} : value)"),
             let output = json.invokeMethod(
                 "stringify",
                 withArguments: [
@@ -218,7 +205,7 @@ extension JSValue {
                     replacer as Any,
                     (
                         pretty ? 2 : nil
-                    ) as Any
+                    ) as Any,
                 ]
             ),
             !output.isUndefined,
@@ -232,32 +219,36 @@ extension JSValue {
 }
 
 // MARK: Decoder Extension
+
 public extension Decoder {
     /// A `CodingUserInfoKey` to fetch the decoding function for this decoder
-    var decodeFunctionKey: CodingUserInfoKey { CodingUserInfoKey(rawValue: "decodeFunction")! }
+    var decodeFunctionKey: CodingUserInfoKey {
+        CodingUserInfoKey(rawValue: "decodeFunction")!
+    }
 }
 
 /// A function that decodes an `Asset`
-typealias DecodeAssetFunction<Asset> = ((Decoder) throws -> Asset)
+typealias DecodeAssetFunction<Asset> = (Decoder) throws -> Asset
 
-extension Decoder {
+public extension Decoder {
     /// A logger that can be used to track useful decoding details
-    public var logger: TapableLogger? { userInfo[.logger] as? TapableLogger }
+    var logger: TapableLogger? {
+        userInfo[.logger] as? TapableLogger
+    }
 
-    /**
-     Retrieves a `DecodeAssetFunction<Asset>` if the decoder has one
-     - returns: A `DecodeSwiftUIFunction`
-     */
-    func getDecodeAssetFunction<Asset>() throws -> DecodeAssetFunction<Asset> {
+    /// Retrieves a `DecodeAssetFunction<Asset>` if the decoder has one
+    /// - returns: A `DecodeSwiftUIFunction`
+    internal func getDecodeAssetFunction<Asset>() throws -> DecodeAssetFunction<Asset> {
         guard let decodeFunction = userInfo[.decodeSUI] as? DecodeAssetFunction<Asset> else {
             throw DecodingError.decoderNotAnAssetDecoder
         }
         return decodeFunction
     }
 
-    /// Returns the JSValue found at the current coding path, or throws an error if decoding was not started
+    /// Returns the JSValue found at the current coding path, or throws an error if decoding was not
+    /// started
     /// with `JSONDecoder.decoder(_:from:)` provided a `JSValue` value.
-    public func getJSValue() throws -> JSValue {
+    func getJSValue() throws -> JSValue {
         guard let rootJS = userInfo[.rootJS] as? JSValue else {
             throw DecodingError.decoderNotAnAssetDecoder
         }
@@ -276,8 +267,9 @@ extension Decoder {
 extension JSONDecoder {
     /// Attempts to decode an object of type T from the JSON data found in value.
     /// During decoding calls to `decoder.getJSValue()` will return the object subscripted in value
-    /// at the current coding path. A decode function might use this to update RawValueBacked entities.
-    public func decode<T>(_ type: T.Type, from value: JSValue) throws -> T where T: Decodable {
+    /// at the current coding path. A decode function might use this to update RawValueBacked
+    /// entities.
+    public func decode<T: Decodable>(_: T.Type, from value: JSValue) throws -> T {
         setRootJS(value)
         defer { setRootJS(nil) }
 
@@ -299,7 +291,9 @@ extension JSONDecoder {
     }
 
     /// A logger that can be used to track useful decoding details
-    var logger: TapableLogger? { userInfo[.logger] as? TapableLogger }
+    var logger: TapableLogger? {
+        userInfo[.logger] as? TapableLogger
+    }
 
     func setLogger(_ logger: TapableLogger?) {
         userInfo[.logger] = logger

--- a/ios/core/Sources/Types/Assets/BaseAssetRegistry.swift
+++ b/ios/core/Sources/Types/Assets/BaseAssetRegistry.swift
@@ -283,7 +283,7 @@ extension JSONDecoder {
         return try decode(T.self, from: data)
     }
 
-    func setDecodeAssetFunction<Asset>(_ function: @escaping DecodeAssetFunction<Asset>) {
+    func setDecodeAssetFunction(_ function: @escaping DecodeAssetFunction<some Any>) {
         userInfo[.decodeSUI] = function
     }
 

--- a/ios/core/Sources/Types/Assets/Wrappers.swift
+++ b/ios/core/Sources/Types/Assets/Wrappers.swift
@@ -8,9 +8,7 @@
 import Foundation
 import JavaScriptCore
 
-/**
- Protocol for container objects that can contain some type of asset
- */
+/// Protocol for container objects that can contain some type of asset
 public protocol AssetContainer {
     /// The type of the Asset contained in this container
     associatedtype AssetType: PlayerAsset
@@ -18,17 +16,13 @@ public protocol AssetContainer {
     /// Mutable property for the asset, must be mutable for resolution between view updates
     var asset: AssetType? { get set }
 
-    /**
-     Creates a container with the given asset
-     - parameters:
-        - forAsset: The asset to put in this container
-     */
+    /// Creates a container with the given asset
+    /// - parameters:
+    ///   - forAsset: The asset to put in this container
     init(forAsset: AssetType)
 }
 
-/**
- Protocol for Asset Implementations, in order to work with `BaseAssetRegistry`
- */
+/// Protocol for Asset Implementations, in order to work with `BaseAssetRegistry`
 public protocol PlayerAsset {
     /// The ID of this asset in the Flow
     var id: String { get }
@@ -37,25 +31,21 @@ public protocol PlayerAsset {
     var type: String { get }
 }
 
-/**
- Protocol for Non asset _reference_ types that still exist in the JS tree hierarchy, and have an associated JSValue
- */
+/// Protocol for Non asset _reference_ types that still exist in the JS tree hierarchy, and have an
+/// associated JSValue
 public protocol JSValueRepresentable: AnyObject, JSValueBacked {
     /// the `JSValue` that represents this object
     var rawValue: JSValue? { get set }
 }
 
-/**
- Protocol for Non asset _value_ types that still exist in the JS tree hierarchy, and have an associated JSValue
- */
+/// Protocol for Non asset _value_ types that still exist in the JS tree hierarchy, and have an
+/// associated JSValue
 public protocol JSValueBacked {
     /// the `JSValue` that represents this object
     var rawValue: JSValue? { get }
 }
 
-/**
- A protocol for defining the minimum amount of data an asset needs to contain
- */
+/// A protocol for defining the minimum amount of data an asset needs to contain
 public protocol AssetData: Decodable {
     /// The ID of the asset
     var id: String { get }
@@ -63,27 +53,28 @@ public protocol AssetData: Decodable {
     /// The type of the asset
     var type: String { get }
 
-    /// Compare this asset data to `other` for equality. This is used instead of Equatable conformance
+    /// Compare this asset data to `other` for equality. This is used instead of Equatable
+    /// conformance
     /// to avoid generic constraint restrictions.
     func isEqual(_ other: AssetData) -> Bool
 }
 
-// by default asset data does not equal other asset data
-extension AssetData {
-    public func isEqual(_ other: AssetData) -> Bool { false }
+/// by default asset data does not equal other asset data
+public extension AssetData {
+    func isEqual(_: AssetData) -> Bool {
+        false
+    }
 }
 
-// when asset data is Equatable then support checking `other` for equality
-extension AssetData where Self: Equatable {
-    public func isEqual(_ other: AssetData) -> Bool {
+/// when asset data is Equatable then support checking `other` for equality
+public extension AssetData where Self: Equatable {
+    func isEqual(_ other: AssetData) -> Bool {
         guard let other = other as? Self else { return false }
         return self == other
     }
 }
 
-/**
- MetaData associated with an asset
- */
+/// MetaData associated with an asset
 public struct MetaData: Codable, Hashable {
     /// Additional data to include when beaconing this asset
     public var beacon: AnyType?

--- a/ios/core/Sources/Types/Beacon.swift
+++ b/ios/core/Sources/Types/Beacon.swift
@@ -7,9 +7,7 @@
 
 import Foundation
 
-/**
- An object representing a beacon fired from an `Asset`
- */
+/// An object representing a beacon fired from an `Asset`
 public struct AssetBeacon: Codable, Equatable {
     /// The action that caused the beacon
     public var action: String
@@ -84,15 +82,13 @@ public struct BeaconableAsset: Codable, Equatable {
     ) {
         self.id = id
         self.type = type
-        self.metaData = nil
+        metaData = nil
     }
 }
 
 extension MetaData: BeaconableMetaData {}
 
-/**
- All potential Beacon Element types
- */
+/// All potential Beacon Element types
 public enum BeaconElement: String, Codable {
     /// The Element was represented as a buttton
     case button
@@ -131,9 +127,7 @@ public enum BeaconElement: String, Codable {
     case view
 }
 
-/**
- All possible Beacon Actions
- */
+/// All possible Beacon Actions
 public enum BeaconAction: String, Codable {
     /// The action taken was a tap
     case clicked

--- a/ios/core/Sources/Types/Beacon.swift
+++ b/ios/core/Sources/Types/Beacon.swift
@@ -62,10 +62,10 @@ public struct BeaconableAsset: Codable, Equatable {
     ///   - id: The ID of the asset that fired the beacon
     ///   - type: The type of the asset that fired the beacon
     ///   - metaData: Beacon applicable metaData from the asset that fired the beacon
-    public init<MetaDataType: BeaconableMetaData>(
+    public init(
         id: String,
         type: String? = nil,
-        metaData: MetaDataType? = nil
+        metaData: (some BeaconableMetaData)? = nil
     ) {
         self.id = id
         self.type = type

--- a/ios/core/Sources/Types/Core/BindingParser.swift
+++ b/ios/core/Sources/Types/Core/BindingParser.swift
@@ -3,8 +3,8 @@ import JavaScriptCore
 
 /// A parser for creating bindings from a string
 public class BindingParser {
-    internal var value: JSValue?
-    internal var options: BindingParserOptions
+    var value: JSValue?
+    var options: BindingParserOptions
 
     /// Create a BindingParser
     /// - Parameters:
@@ -19,7 +19,7 @@ public class BindingParser {
         value = context
             .getClassReference("Player.BindingParser", load: { $0.loadCore() })?
             .construct(withArguments: [[
-                "get": JSValue(object: getCallback, in: context) as Any
+                "get": JSValue(object: getCallback, in: context) as Any,
             ]])
     }
 
@@ -35,7 +35,7 @@ public class BindingParser {
 
 /// A path in the data model
 public class BindingInstance: Decodable {
-    internal var value: JSValue?
+    var value: JSValue?
 
     /// Create a BindingInstance, a path to data in the data model
     /// - Parameters:
@@ -53,25 +53,25 @@ public class BindingInstance: Decodable {
         self.value = value
     }
 
-    ///Create a BindingInstance from a decoder
-    required public init(from decoder: Decoder) throws {
+    /// Create a BindingInstance from a decoder
+    public required init(from decoder: Decoder) throws {
         value = try decoder.getJSValue()
     }
 
     /// Retrieve this Binding as an array
     /// - Returns: The array of segments in the binding
     public func asArray() -> [String]? {
-        return value?
+        value?
             .invokeMethod("asArray", withArguments: [])
             .toArray()
-            /// Array indices are automatically treated as ints, so we need to map
+            // Array indices are automatically treated as ints, so we need to map
             .map { $0 as? String ?? String(describing: $0) }
     }
 
     /// Retrieve this Binding as its string form
     /// - Returns: The string representation of this binding
     public func asString() -> String? {
-        return value?.invokeMethod("asString", withArguments: []).toString()
+        value?.invokeMethod("asString", withArguments: []).toString()
     }
 }
 
@@ -92,14 +92,15 @@ public struct BindingParserOptions {
 /// A data model that stores things in an in-memory JS object
 public class LocalModel {
     /// Reference to the JavaScript LocalModel
-    internal var value: JSValue?
+    var value: JSValue?
 
     /// Create a new LocalModel
     /// - Parameters:
     ///   - data: The data to start with
     ///   - context: The JSContext to create it in
     public init(data: [String: Any] = [:], in context: JSContext) {
-        value = context.getClassReference("Player.LocalModel", load: { $0.loadCore() })?.construct(withArguments: [data])
+        value = context.getClassReference("Player.LocalModel", load: { $0.loadCore() })?
+            .construct(withArguments: [data])
     }
 
     /// Get a value in the model for a given binding
@@ -110,9 +111,13 @@ public class LocalModel {
     }
 
     /// Set data in the model
-    /// - Parameter transaction: An array of transaction objects, tuples of ``BindingInstance`` and the value to set
+    /// - Parameter transaction: An array of transaction objects, tuples of ``BindingInstance`` and
+    /// the value to set
     public func set(transaction: [(BindingInstance, Any)]) {
-        value?.invokeMethod("set", withArguments: [transaction.map { [$0.0.value as Any, $0.1] as [Any] }])
+        value?.invokeMethod(
+            "set",
+            withArguments: [transaction.map { [$0.0.value as Any, $0.1] as [Any] }]
+        )
     }
 
     /// Get a value in the model for a given path

--- a/ios/core/Sources/Types/Core/CompletedState.swift
+++ b/ios/core/Sources/Types/Core/CompletedState.swift
@@ -8,12 +8,8 @@
 import Foundation
 import JavaScriptCore
 
-/**
- Object for access to the controllers during a flow
- */
+/// Object for access to the controllers during a flow
 public class PlayerControllers {
-    private let rawValue: JSValue
-
     /// The DataController for the current flow
     public let data: DataController
 
@@ -26,19 +22,20 @@ public class PlayerControllers {
     /// The ExpressionEvaluator for the current flow
     public let expression: ExpressionEvaluator
 
+    private let rawValue: JSValue
+
     public init?(from value: JSValue?) {
         guard let controllers = value else { return nil }
         rawValue = controllers
         data = DataController.createInstance(value: rawValue.objectForKeyedSubscript("data"))
         flow = FlowController.createInstance(value: rawValue.objectForKeyedSubscript("flow"))
         view = ViewController.createInstance(value: rawValue.objectForKeyedSubscript("view"))
-        expression = ExpressionEvaluator.createInstance(value: rawValue.objectForKeyedSubscript("expression"))
+        expression = ExpressionEvaluator
+            .createInstance(value: rawValue.objectForKeyedSubscript("expression"))
     }
 }
 
-/**
- Enum with the different possible states of the player
- */
+/// Enum with the different possible states of the player
 public enum PlayerFlowStatus: String {
     /// The Flow has not been started
     case notStarted = "not-started"
@@ -53,18 +50,14 @@ public enum PlayerFlowStatus: String {
     case error
 }
 
-/**
- Common properties for all flow states
- */
+/// Common properties for all flow states
 open class BaseFlowState {
     /// The status of the state
     var status: PlayerFlowStatus
 
-    /**
-     Creates a BaseFlowState
-     - parameters:
-        - status: The status of this state
-     */
+    /// Creates a BaseFlowState
+    /// - parameters:
+    ///   - status: The status of this state
     public init(status: PlayerFlowStatus) {
         self.status = status
     }
@@ -74,16 +67,14 @@ extension BaseFlowState: CreatedFromJSValue {
     /// Typealias for CreatedFromJSValue protocol
     public typealias T = BaseFlowState
 
-    /**
-     Creates the appropriate state from the given `JSValue`
-     - parameters:
-        - value: The JSValue to construct the state from
-     */
+    /// Creates the appropriate state from the given `JSValue`
+    /// - parameters:
+    ///   - value: The JSValue to construct the state from
     public static func createInstance(value: JSValue) -> BaseFlowState {
         guard
             let rawStatus = value.objectForKeyedSubscript("status")?.toString(),
             let status = PlayerFlowStatus(rawValue: rawStatus),
-            let state = {() -> BaseFlowState? in
+            let state = { () -> BaseFlowState? in
                 switch status {
                 case .notStarted:
                     return NotStartedState.createInstance(from: value)
@@ -100,9 +91,7 @@ extension BaseFlowState: CreatedFromJSValue {
     }
 }
 
-/**
- Common properties for States that contain Player Flow Data
- */
+/// Common properties for States that contain Player Flow Data
 public protocol PlayerFlowExecutionData {
     /// The flow associated with this execution
     var flow: Flow { get }
@@ -110,9 +99,7 @@ public protocol PlayerFlowExecutionData {
 
 public typealias EndState = NavigationFlowEndState
 
-/**
- A structure that holds the data of a completed Fuego Flow
- */
+/// A structure that holds the data of a completed Fuego Flow
 public class CompletedState: BaseFlowState, PlayerFlowExecutionData {
     /// The flow object for the completed state
     public var flow: Flow
@@ -123,12 +110,17 @@ public class CompletedState: BaseFlowState, PlayerFlowExecutionData {
     /// The local data from the flow
     public var data: [String: Any]
 
-    /**
-     Create an instance of `CompletedState` from a JSValue
-     - parameters:
-        -  value: The JSValue representing the CompletedState
-     - returns: A CompletedState object if the JSValue was one
-     */
+    private init(flow: Flow, endState: NavigationFlowEndState?, data: [String: Any]) {
+        self.flow = flow
+        self.endState = endState
+        self.data = data
+        super.init(status: .completed)
+    }
+
+    /// Create an instance of `CompletedState` from a JSValue
+    /// - parameters:
+    ///   -  value: The JSValue representing the CompletedState
+    /// - returns: A CompletedState object if the JSValue was one
     public static func createInstance(from value: JSValue?) -> CompletedState? {
         guard
             let flow = value?.objectForKeyedSubscript("flow")
@@ -139,37 +131,24 @@ public class CompletedState: BaseFlowState, PlayerFlowExecutionData {
             data: value?.objectForKeyedSubscript("data")?.toObject() as? [String: Any] ?? [:]
         )
     }
-
-    private init(flow: Flow, endState: NavigationFlowEndState?, data: [String: Any]) {
-        self.flow = flow
-        self.endState = endState
-        self.data = data
-        super.init(status: .completed)
-    }
 }
 
-/**
- A structure that holds the data of a Fuego Flow that hasnt been started
- */
+/// A structure that holds the data of a Fuego Flow that hasnt been started
 public class NotStartedState: BaseFlowState {
-    /**
-    Create an instance of `NotStartedState` from a JSValue
-    - parameters:
-       -  value: The JSValue representing the NotStartedState
-    - returns: A NotStartedState object if the JSValue was one
-    */
-    public static func createInstance(from value: JSValue?) -> NotStartedState? {
-        return NotStartedState()
-    }
-
     init() {
         super.init(status: .notStarted)
     }
+
+    /// Create an instance of `NotStartedState` from a JSValue
+    /// - parameters:
+    ///   -  value: The JSValue representing the NotStartedState
+    /// - returns: A NotStartedState object if the JSValue was one
+    public static func createInstance(from _: JSValue?) -> NotStartedState? {
+        NotStartedState()
+    }
 }
 
-/**
- A structure that holds the data of a Fuego Flow that is in progress
- */
+/// A structure that holds the data of a Fuego Flow that is in progress
 public class InProgressState: BaseFlowState, PlayerFlowExecutionData {
     /// The flow object that is currently in progress
     public var flow: Flow
@@ -186,25 +165,6 @@ public class InProgressState: BaseFlowState, PlayerFlowExecutionData {
     /// A function to force the player to a failed state
     public let fail: (PlayerError) -> Void
 
-    /**
-    Create an instance of `InProgressState` from a JSValue
-    - parameters:
-       -  value: The JSValue representing the InProgressState
-    - returns: A InProgressState object if the JSValue was one
-    */
-    public static func createInstance(from value: JSValue?) -> InProgressState? {
-        guard
-            let flow = value?.objectForKeyedSubscript("flow")
-        else { return nil }
-        return InProgressState(
-            flow: Flow.createInstance(value: flow),
-            flowResult: value.map { NavigationFlowEndState($0.objectForKeyedSubscript("flowResult")) },
-            controllers: PlayerControllers(from: value?.objectForKeyedSubscript("controllers")),
-            logger: JSLogger(from: value?.objectForKeyedSubscript("logger")),
-            fail: { value?.objectForKeyedSubscript("fail")?.call(withArguments: [value?.context.error(for: $0) as Any]) }
-        )
-    }
-
     private init(
         flow: Flow,
         flowResult: NavigationFlowEndState?,
@@ -219,11 +179,30 @@ public class InProgressState: BaseFlowState, PlayerFlowExecutionData {
         self.fail = fail
         super.init(status: .inProgress)
     }
+
+    /// Create an instance of `InProgressState` from a JSValue
+    /// - parameters:
+    ///   -  value: The JSValue representing the InProgressState
+    /// - returns: A InProgressState object if the JSValue was one
+    public static func createInstance(from value: JSValue?) -> InProgressState? {
+        guard
+            let flow = value?.objectForKeyedSubscript("flow")
+        else { return nil }
+        return InProgressState(
+            flow: Flow.createInstance(value: flow),
+            flowResult: value
+                .map { NavigationFlowEndState($0.objectForKeyedSubscript("flowResult")) },
+            controllers: PlayerControllers(from: value?.objectForKeyedSubscript("controllers")),
+            logger: JSLogger(from: value?.objectForKeyedSubscript("logger")),
+            fail: {
+                value?.objectForKeyedSubscript("fail")?
+                    .call(withArguments: [value?.context.error(for: $0) as Any])
+            }
+        )
+    }
 }
 
-/**
-A structure that holds the data of a Fuego Flow that has errored
-*/
+/// A structure that holds the data of a Fuego Flow that has errored
 public class ErrorState: BaseFlowState, PlayerFlowExecutionData {
     /// The flow object that is currently in progress
     public var flow: Flow
@@ -231,12 +210,16 @@ public class ErrorState: BaseFlowState, PlayerFlowExecutionData {
     /// The error message
     public var error: String
 
-    /**
-    Create an instance of `ErrorState` from a JSValue
-    - parameters:
-       -  value: The JSValue representing the ErrorState
-    - returns: A ErrorState object if the JSValue was one
-    */
+    private init(flow: Flow, error: String) {
+        self.flow = flow
+        self.error = error
+        super.init(status: .error)
+    }
+
+    /// Create an instance of `ErrorState` from a JSValue
+    /// - parameters:
+    ///   -  value: The JSValue representing the ErrorState
+    /// - returns: A ErrorState object if the JSValue was one
     public static func createInstance(from value: JSValue?) -> ErrorState? {
         guard let flow = value?.objectForKeyedSubscript("flow") else { return nil }
 
@@ -252,11 +235,5 @@ public class ErrorState: BaseFlowState, PlayerFlowExecutionData {
         }
 
         return ErrorState(flow: Flow.createInstance(value: flow), error: message)
-    }
-
-    private init(flow: Flow, error: String) {
-        self.flow = flow
-        self.error = error
-        super.init(status: .error)
     }
 }

--- a/ios/core/Sources/Types/Core/CompletedState.swift
+++ b/ios/core/Sources/Types/Core/CompletedState.swift
@@ -8,12 +8,8 @@
 import Foundation
 import JavaScriptCore
 
-/**
- Object for access to the controllers during a flow
- */
+/// Object for access to the controllers during a flow
 public class PlayerControllers {
-    private let rawValue: JSValue
-
     /// The DataController for the current flow
     public let data: DataController
 
@@ -29,20 +25,21 @@ public class PlayerControllers {
     /// The ErrorController for the current flow
     public let error: ErrorController
 
+    private let rawValue: JSValue
+
     public init?(from value: JSValue?) {
         guard let controllers = value else { return nil }
         rawValue = controllers
         data = DataController.createInstance(value: rawValue.objectForKeyedSubscript("data"))
         flow = FlowController.createInstance(value: rawValue.objectForKeyedSubscript("flow"))
         view = ViewController.createInstance(value: rawValue.objectForKeyedSubscript("view"))
-        expression = ExpressionEvaluator.createInstance(value: rawValue.objectForKeyedSubscript("expression"))
+        expression = ExpressionEvaluator
+            .createInstance(value: rawValue.objectForKeyedSubscript("expression"))
         error = ErrorController.createInstance(value: rawValue.objectForKeyedSubscript("error"))
     }
 }
 
-/**
- Enum with the different possible states of the player
- */
+/// Enum with the different possible states of the player
 public enum PlayerFlowStatus: String {
     /// The Flow has not been started
     case notStarted = "not-started"
@@ -57,18 +54,14 @@ public enum PlayerFlowStatus: String {
     case error
 }
 
-/**
- Common properties for all flow states
- */
+/// Common properties for all flow states
 open class BaseFlowState {
     /// The status of the state
     var status: PlayerFlowStatus
 
-    /**
-     Creates a BaseFlowState
-     - parameters:
-        - status: The status of this state
-     */
+    /// Creates a BaseFlowState
+    /// - parameters:
+    ///   - status: The status of this state
     public init(status: PlayerFlowStatus) {
         self.status = status
     }
@@ -78,16 +71,14 @@ extension BaseFlowState: CreatedFromJSValue {
     /// Typealias for CreatedFromJSValue protocol
     public typealias T = BaseFlowState
 
-    /**
-     Creates the appropriate state from the given `JSValue`
-     - parameters:
-        - value: The JSValue to construct the state from
-     */
+    /// Creates the appropriate state from the given `JSValue`
+    /// - parameters:
+    ///   - value: The JSValue to construct the state from
     public static func createInstance(value: JSValue) -> BaseFlowState {
         guard
             let rawStatus = value.objectForKeyedSubscript("status")?.toString(),
             let status = PlayerFlowStatus(rawValue: rawStatus),
-            let state = {() -> BaseFlowState? in
+            let state = { () -> BaseFlowState? in
                 switch status {
                 case .notStarted:
                     return NotStartedState.createInstance(from: value)
@@ -104,9 +95,7 @@ extension BaseFlowState: CreatedFromJSValue {
     }
 }
 
-/**
- Common properties for States that contain Player Flow Data
- */
+/// Common properties for States that contain Player Flow Data
 public protocol PlayerFlowExecutionData {
     /// The flow associated with this execution
     var flow: Flow { get }
@@ -114,9 +103,7 @@ public protocol PlayerFlowExecutionData {
 
 public typealias EndState = NavigationFlowEndState
 
-/**
- A structure that holds the data of a completed Fuego Flow
- */
+/// A structure that holds the data of a completed Fuego Flow
 public class CompletedState: BaseFlowState, PlayerFlowExecutionData {
     /// The flow object for the completed state
     public var flow: Flow
@@ -130,17 +117,23 @@ public class CompletedState: BaseFlowState, PlayerFlowExecutionData {
     /// Read-only controllers to allow data access after the flow has ended
     public var controllers: Controllers
 
-    public struct Controllers {
-        /// A read only instance of the Data Controller
-        public var data: ReadOnlyDataController
+    private init(
+        flow: Flow,
+        endState: NavigationFlowEndState?,
+        data: [String: Any],
+        controllers: Controllers
+    ) {
+        self.flow = flow
+        self.endState = endState
+        self.data = data
+        self.controllers = controllers
+        super.init(status: .completed)
     }
 
-    /**
-     Create an instance of `CompletedState` from a JSValue
-     - parameters:
-        -  value: The JSValue representing the CompletedState
-     - returns: A CompletedState object if the JSValue was one
-     */
+    /// Create an instance of `CompletedState` from a JSValue
+    /// - parameters:
+    ///   -  value: The JSValue representing the CompletedState
+    /// - returns: A CompletedState object if the JSValue was one
     public static func createInstance(from value: JSValue?) -> CompletedState? {
         guard
             let flow = value?.objectForKeyedSubscript("flow"),
@@ -156,42 +149,28 @@ public class CompletedState: BaseFlowState, PlayerFlowExecutionData {
         )
     }
 
-    private init(
-        flow: Flow,
-        endState: NavigationFlowEndState?,
-        data: [String: Any],
-        controllers: Controllers
-    ) {
-        self.flow = flow
-        self.endState = endState
-        self.data = data
-        self.controllers = controllers
-        super.init(status: .completed)
+    public struct Controllers {
+        /// A read only instance of the Data Controller
+        public var data: ReadOnlyDataController
     }
 }
 
-/**
- A structure that holds the data of a Fuego Flow that hasnt been started
- */
+/// A structure that holds the data of a Fuego Flow that hasnt been started
 public class NotStartedState: BaseFlowState {
-    /**
-    Create an instance of `NotStartedState` from a JSValue
-    - parameters:
-       -  value: The JSValue representing the NotStartedState
-    - returns: A NotStartedState object if the JSValue was one
-    */
-    public static func createInstance(from value: JSValue?) -> NotStartedState? {
-        return NotStartedState()
-    }
-
     init() {
         super.init(status: .notStarted)
     }
+
+    /// Create an instance of `NotStartedState` from a JSValue
+    /// - parameters:
+    ///   -  value: The JSValue representing the NotStartedState
+    /// - returns: A NotStartedState object if the JSValue was one
+    public static func createInstance(from _: JSValue?) -> NotStartedState? {
+        NotStartedState()
+    }
 }
 
-/**
- A structure that holds the data of a Fuego Flow that is in progress
- */
+/// A structure that holds the data of a Fuego Flow that is in progress
 public class InProgressState: BaseFlowState, PlayerFlowExecutionData {
     /// The flow object that is currently in progress
     public var flow: Flow
@@ -208,25 +187,6 @@ public class InProgressState: BaseFlowState, PlayerFlowExecutionData {
     /// A function to force the player to a failed state
     public let fail: (PlayerError) -> Void
 
-    /**
-    Create an instance of `InProgressState` from a JSValue
-    - parameters:
-       -  value: The JSValue representing the InProgressState
-    - returns: A InProgressState object if the JSValue was one
-    */
-    public static func createInstance(from value: JSValue?) -> InProgressState? {
-        guard
-            let flow = value?.objectForKeyedSubscript("flow")
-        else { return nil }
-        return InProgressState(
-            flow: Flow.createInstance(value: flow),
-            flowResult: value.map { NavigationFlowEndState($0.objectForKeyedSubscript("flowResult")) },
-            controllers: PlayerControllers(from: value?.objectForKeyedSubscript("controllers")),
-            logger: JSLogger(from: value?.objectForKeyedSubscript("logger")),
-            fail: { value?.objectForKeyedSubscript("fail")?.call(withArguments: [value?.context.error(for: $0) as Any]) }
-        )
-    }
-
     private init(
         flow: Flow,
         flowResult: NavigationFlowEndState?,
@@ -241,11 +201,30 @@ public class InProgressState: BaseFlowState, PlayerFlowExecutionData {
         self.fail = fail
         super.init(status: .inProgress)
     }
+
+    /// Create an instance of `InProgressState` from a JSValue
+    /// - parameters:
+    ///   -  value: The JSValue representing the InProgressState
+    /// - returns: A InProgressState object if the JSValue was one
+    public static func createInstance(from value: JSValue?) -> InProgressState? {
+        guard
+            let flow = value?.objectForKeyedSubscript("flow")
+        else { return nil }
+        return InProgressState(
+            flow: Flow.createInstance(value: flow),
+            flowResult: value
+                .map { NavigationFlowEndState($0.objectForKeyedSubscript("flowResult")) },
+            controllers: PlayerControllers(from: value?.objectForKeyedSubscript("controllers")),
+            logger: JSLogger(from: value?.objectForKeyedSubscript("logger")),
+            fail: {
+                value?.objectForKeyedSubscript("fail")?
+                    .call(withArguments: [value?.context.error(for: $0) as Any])
+            }
+        )
+    }
 }
 
-/**
-A structure that holds the data of a Fuego Flow that has errored
-*/
+/// A structure that holds the data of a Fuego Flow that has errored
 public class ErrorState: BaseFlowState, PlayerFlowExecutionData {
     /// The flow object that is currently in progress
     public var flow: Flow
@@ -253,24 +232,25 @@ public class ErrorState: BaseFlowState, PlayerFlowExecutionData {
     /// The error message
     public var error: JSValueError
 
-    /**
-    Create an instance of `ErrorState` from a JSValue
-    - parameters:
-       -  value: The JSValue representing the ErrorState
-    - returns: A ErrorState object if the JSValue was one
-    */
+    private init(flow: Flow, error: JSValueError) {
+        self.flow = flow
+        self.error = error
+        super.init(status: .error)
+    }
+
+    /// Create an instance of `ErrorState` from a JSValue
+    /// - parameters:
+    ///   -  value: The JSValue representing the ErrorState
+    /// - returns: A ErrorState object if the JSValue was one
     public static func createInstance(from value: JSValue?) -> ErrorState? {
         guard
             let flow = value?.objectForKeyedSubscript("flow"),
             let err = value?.objectForKeyedSubscript("error")
         else { return nil }
-        
-        return ErrorState(flow: Flow.createInstance(value: flow), error: JSValueError.createInstance(value: err))
-    }
 
-    private init(flow: Flow, error: JSValueError) {
-        self.flow = flow
-        self.error = error
-        super.init(status: .error)
+        return ErrorState(
+            flow: Flow.createInstance(value: flow),
+            error: JSValueError.createInstance(value: err)
+        )
     }
 }

--- a/ios/core/Sources/Types/Core/ConstantsController.swift
+++ b/ios/core/Sources/Types/Core/ConstantsController.swift
@@ -2,45 +2,52 @@ import JavaScriptCore
 
 public class ConstantsController {
     var constantsController: JSValue?
-    
+
+    public init(constantsController: JSValue) {
+        self.constantsController = constantsController
+    }
+
     /// Function to retrieve constants from the providers store
     /// - Parameters:
     ///   - key: Key used for the store access
     ///   - namespace: Namespace values were loaded under
-    ///   - fallback:Optional - if key doesn't exist in namespace what to return (will return unknown if not provided)
+    ///   - fallback:Optional - if key doesn't exist in namespace what to return (will return
+    /// unknown if not provided)
     /// - Returns: Constant values from store
     public func getConstants<T>(key: Any, namespace: String, fallback: Any? = nil) -> T? {
         if let fallbackValue = fallback {
-            let value = self.constantsController?.invokeMethod("getConstants", withArguments: [key, namespace, fallbackValue])
+            let value = constantsController?.invokeMethod(
+                "getConstants",
+                withArguments: [key, namespace, fallbackValue]
+            )
             return value?.toObject() as? T
         } else {
-            let value = self.constantsController?.invokeMethod("getConstants", withArguments: [key, namespace])
+            let value = constantsController?.invokeMethod(
+                "getConstants",
+                withArguments: [key, namespace]
+            )
             return value?.toObject() as? T
         }
     }
-    
+
     /// Function to add constants to the providers store
     /// - Parameters:
     ///   - data: Values to add to the constants store
     ///   - namespace: Namespace values to be added under
-    public func addConstants(data: Any, namespace: String) -> Void {
-        self.constantsController?.invokeMethod("addConstants", withArguments: [data, namespace])
+    public func addConstants(data: Any, namespace: String) {
+        constantsController?.invokeMethod("addConstants", withArguments: [data, namespace])
     }
-    
+
     /// Function to set values to temporarily override certain keys in the perminant store
     /// - Parameters:
     ///   - data: Values to override store with
     ///   - namespace: Namespace to override
-    public func setTemporaryValues(data: Any, namespace: String) -> Void {
-        self.constantsController?.invokeMethod("setTemporaryValues", withArguments: [data, namespace])
-    }
-    
-    /// Clears any temporary values that were previously set
-    public func clearTemporaryValues() -> Void {
-        self.constantsController?.invokeMethod("clearTemporaryValues", withArguments: [])
+    public func setTemporaryValues(data: Any, namespace: String) {
+        constantsController?.invokeMethod("setTemporaryValues", withArguments: [data, namespace])
     }
 
-    public init(constantsController: JSValue) {
-        self.constantsController = constantsController
+    /// Clears any temporary values that were previously set
+    public func clearTemporaryValues() {
+        constantsController?.invokeMethod("clearTemporaryValues", withArguments: [])
     }
 }

--- a/ios/core/Sources/Types/Core/DataController.swift
+++ b/ios/core/Sources/Types/Core/DataController.swift
@@ -1,6 +1,6 @@
 //
 //  DataController.swift
-//  
+//
 //
 //  Created by Borawski, Harris on 2/12/20.
 //
@@ -8,56 +8,46 @@
 import Foundation
 import JavaScriptCore
 
-/**
-A wrapper around the JS DataController in the core player
-*/
+/// A wrapper around the JS DataController in the core player
 open class BaseDataController {
-
     /// The JSValue that backs this wrapper
     public let value: JSValue
 
     /// The hooks that can be tapped into
     public let hooks: DataControllerHooks
 
-    /**
-    Construct a DataController from a JSValue
-    - parameters:
-       - value: The JSValue that is the DataController
-    */
+    /// Construct a DataController from a JSValue
+    /// - parameters:
+    ///   - value: The JSValue that is the DataController
     public init(_ value: JSValue) {
         self.value = value
-        self.hooks = DataControllerHooks(
+        hooks = DataControllerHooks(
             onUpdate: HookDecode<[Update]>(baseValue: self.value, name: "onUpdate")
         )
     }
 
-    /**
-     Gets the underlying model from the DataController
-     - returns: A JSValue representing the model
-     */
-    public func getModel() -> JSValue? {
-        return self.value.invokeMethod("getModel", withArguments: [])
-    }
-
-    /**
-     Sets new data for the given transaction
-     - parameters:
-        - transaction: The transaction to process
-     */
+    /// Sets new data for the given transaction
+    /// - parameters:
+    ///   - transaction: The transaction to process
     open func set(transaction: RawSetTransaction) {
-        self.value.invokeMethod("set", withArguments: [transaction])
+        value.invokeMethod("set", withArguments: [transaction])
     }
 
-    /**
-     Gets the value of a given binding
-     - parameters:
-        - binding: The binding to fetch data for
-     - returns: The data for the binding
-     */
+    /// Gets the underlying model from the DataController
+    /// - returns: A JSValue representing the model
+    public func getModel() -> JSValue? {
+        value.invokeMethod("getModel", withArguments: [])
+    }
+
+    /// Gets the value of a given binding
+    /// - parameters:
+    ///   - binding: The binding to fetch data for
+    /// - returns: The data for the binding
     public func get(binding: RawBinding) -> Any? {
-        return self.value.invokeMethod("get", withArguments: [binding])?.toObject()
+        value.invokeMethod("get", withArguments: [binding])?.toObject()
     }
 }
+
 /// A dictionary representing a transaction
 public typealias RawSetTransaction = [String: Any]
 
@@ -68,22 +58,20 @@ public typealias RawBindingSegment = String
 public typealias RawBinding = String
 
 public class DataController: BaseDataController, CreatedFromJSValue {
-    /// Typealias for associated type
-    public typealias T = DataController
-
-    /**
-    Creates an instance from a JSValue, used for generic construction
-    - parameters:
-       - value: The JSValue to construct from
-    */
-    public static func createInstance(value: JSValue) -> DataController { DataController(value) }
-
-    /**
-    Construct a DataController from a JSValue
-    - parameters:
-       - value: The JSValue that is the DataController
-    */
-    public override init(_ value: JSValue) {
+    /// Construct a DataController from a JSValue
+    /// - parameters:
+    ///   - value: The JSValue that is the DataController
+    override public init(_ value: JSValue) {
         super.init(value)
     }
+
+    /// Creates an instance from a JSValue, used for generic construction
+    /// - parameters:
+    ///   - value: The JSValue to construct from
+    public static func createInstance(value: JSValue) -> DataController {
+        DataController(value)
+    }
+
+    /// Typealias for associated type
+    public typealias T = DataController
 }

--- a/ios/core/Sources/Types/Core/DataController.swift
+++ b/ios/core/Sources/Types/Core/DataController.swift
@@ -1,6 +1,6 @@
 //
 //  DataController.swift
-//  
+//
 //
 //  Created by Borawski, Harris on 2/12/20.
 //
@@ -8,62 +8,53 @@
 import Foundation
 import JavaScriptCore
 
-/**
-A wrapper around the JS DataController in the core player
-*/
+/// A wrapper around the JS DataController in the core player
 open class BaseDataController {
-
     /// The JSValue that backs this wrapper
     public let value: JSValue
 
     /// The hooks that can be tapped into
     public let hooks: DataControllerHooks
 
-    /**
-    Construct a DataController from a JSValue
-    - parameters:
-       - value: The JSValue that is the DataController
-    */
+    /// Construct a DataController from a JSValue
+    /// - parameters:
+    ///   - value: The JSValue that is the DataController
     public init(_ value: JSValue) {
         self.value = value
-        self.hooks = DataControllerHooks(
+        hooks = DataControllerHooks(
             onUpdate: HookDecode<[Update]>(baseValue: self.value, name: "onUpdate")
         )
     }
 
-    /**
-     Gets the underlying model from the DataController
-     - returns: A JSValue representing the model
-     */
-    public func getModel() -> JSValue? {
-        return self.value.invokeMethod("getModel", withArguments: [])
-    }
-
-    /**
-     Sets new data for the given transaction
-     - parameters:
-        - transaction: The transaction to process
-     */
+    /// Sets new data for the given transaction
+    /// - parameters:
+    ///   - transaction: The transaction to process
     open func set(transaction: RawSetTransaction) {
-        self.value.invokeMethod("set", withArguments: [transaction])
+        value.invokeMethod("set", withArguments: [transaction])
     }
 
-    /**
-     Gets the value of a given binding
-     - parameters:
-        - binding: The binding to fetch data for
-     - returns: The data for the binding
-     */
+    /// Gets the underlying model from the DataController
+    /// - returns: A JSValue representing the model
+    public func getModel() -> JSValue? {
+        value.invokeMethod("getModel", withArguments: [])
+    }
+
+    /// Gets the value of a given binding
+    /// - parameters:
+    ///   - binding: The binding to fetch data for
+    /// - returns: The data for the binding
     public func get(binding: RawBinding) -> Any? {
-        return self.value.invokeMethod("get", withArguments: [binding])?.toObject()
+        value.invokeMethod("get", withArguments: [binding])?.toObject()
     }
 
-    /// Return a read-only version of this Data Controller to provide player functionality after the flow has ended
+    /// Return a read-only version of this Data Controller to provide player functionality after the
+    /// flow has ended
     public func makeReadOnly() -> ReadOnlyDataController? {
         value.invokeMethod("makeReadOnly", withArguments: [])
             .map { .createInstance(value: $0) }
     }
 }
+
 /// A dictionary representing a transaction
 public typealias RawSetTransaction = [String: Any]
 
@@ -74,45 +65,44 @@ public typealias RawBindingSegment = String
 public typealias RawBinding = String
 
 public class DataController: BaseDataController, CreatedFromJSValue {
-    /// Typealias for associated type
-    public typealias T = DataController
-
-    /**
-    Creates an instance from a JSValue, used for generic construction
-    - parameters:
-       - value: The JSValue to construct from
-    */
-    public static func createInstance(value: JSValue) -> DataController { DataController(value) }
-
-    /**
-    Construct a DataController from a JSValue
-    - parameters:
-       - value: The JSValue that is the DataController
-    */
-    public override init(_ value: JSValue) {
+    /// Construct a DataController from a JSValue
+    /// - parameters:
+    ///   - value: The JSValue that is the DataController
+    override public init(_ value: JSValue) {
         super.init(value)
     }
+
+    /// Creates an instance from a JSValue, used for generic construction
+    /// - parameters:
+    ///   - value: The JSValue to construct from
+    public static func createInstance(value: JSValue) -> DataController {
+        DataController(value)
+    }
+
+    /// Typealias for associated type
+    public typealias T = DataController
 }
 
 /// A read-only version of the Data Controller
 public class ReadOnlyDataController: CreatedFromJSValue {
-    public typealias T = ReadOnlyDataController
-
     private let value: JSValue
-    /// Construct a ReadOnlyDataController from a JSValue
-    private init(_ value: JSValue) { self.value = value }
 
-    static public func createInstance(value: JSValue) -> ReadOnlyDataController {
-        ReadOnlyDataController(value)
+    /// Construct a ReadOnlyDataController from a JSValue
+    private init(_ value: JSValue) {
+        self.value = value
     }
 
-    /**
-     Gets the value of a given binding
-     - parameters:
-        - binding: The binding to fetch data for
-     - returns: The data for the binding
-     */
+    /// Gets the value of a given binding
+    /// - parameters:
+    ///   - binding: The binding to fetch data for
+    /// - returns: The data for the binding
     public func get(binding: RawBinding) -> Any? {
         value.invokeMethod("get", withArguments: [binding])?.toObject()
     }
+
+    public static func createInstance(value: JSValue) -> ReadOnlyDataController {
+        ReadOnlyDataController(value)
+    }
+
+    public typealias T = ReadOnlyDataController
 }

--- a/ios/core/Sources/Types/Core/ErrorController.swift
+++ b/ios/core/Sources/Types/Core/ErrorController.swift
@@ -53,6 +53,7 @@ public enum ErrorTypes: Equatable {
         }
     }
 
+    // swiftlint:disable:next cyclomatic_complexity
     public init(_ rawValue: String) {
         switch rawValue {
         case "expression": self = .expression

--- a/ios/core/Sources/Types/Core/ErrorController.swift
+++ b/ios/core/Sources/Types/Core/ErrorController.swift
@@ -37,19 +37,19 @@ public enum ErrorTypes: Equatable {
 
     public var rawValue: String {
         switch self {
-        case .expression: return "expression"
-        case .binding: return "binding"
-        case .view: return "view"
-        case .asset: return "asset"
-        case .navigation: return "navigation"
-        case .validation: return "validation"
-        case .data: return "data"
-        case .schema: return "schema"
-        case .network: return "network"
-        case .plugin: return "plugin"
-        case .render: return "render"
-        case .externalState: return "externalState"
-        case let .unknown(value): return value
+        case .expression: "expression"
+        case .binding: "binding"
+        case .view: "view"
+        case .asset: "asset"
+        case .navigation: "navigation"
+        case .validation: "validation"
+        case .data: "data"
+        case .schema: "schema"
+        case .network: "network"
+        case .plugin: "plugin"
+        case .render: "render"
+        case .externalState: "externalState"
+        case let .unknown(value): value
         }
     }
 

--- a/ios/core/Sources/Types/Core/ErrorController.swift
+++ b/ios/core/Sources/Types/Core/ErrorController.swift
@@ -35,6 +35,24 @@ public enum ErrorTypes: Equatable {
     /// An error type not recognized by this version of the SDK.
     case unknown(String)
 
+    public var rawValue: String {
+        switch self {
+        case .expression: return "expression"
+        case .binding: return "binding"
+        case .view: return "view"
+        case .asset: return "asset"
+        case .navigation: return "navigation"
+        case .validation: return "validation"
+        case .data: return "data"
+        case .schema: return "schema"
+        case .network: return "network"
+        case .plugin: return "plugin"
+        case .render: return "render"
+        case .externalState: return "externalState"
+        case let .unknown(value): return value
+        }
+    }
+
     public init(_ rawValue: String) {
         switch rawValue {
         case "expression": self = .expression
@@ -52,41 +70,15 @@ public enum ErrorTypes: Equatable {
         default: self = .unknown(rawValue)
         }
     }
-
-    public var rawValue: String {
-        switch self {
-        case .expression: return "expression"
-        case .binding: return "binding"
-        case .view: return "view"
-        case .asset: return "asset"
-        case .navigation: return "navigation"
-        case .validation: return "validation"
-        case .data: return "data"
-        case .schema: return "schema"
-        case .network: return "network"
-        case .plugin: return "plugin"
-        case .render: return "render"
-        case .externalState: return "externalState"
-        case .unknown(let value): return value
-        }
-    }
 }
 
 /// A wrapper around the JS ErrorController in the core player
 public class ErrorController: CreatedFromJSValue {
-    /// Typealias for associated type
-    public typealias T = ErrorController
-
-    /// Creates an instance from a JSValue, used for generic construction
-    /// - Parameters:
-    ///   - value: The JSValue to construct from
-    public static func createInstance(value: JSValue) -> ErrorController { ErrorController(value) }
+    /// The hooks that can be tapped into
+    public let hooks: ErrorControllerHooks
 
     /// The JSValue that backs this wrapper
     private let value: JSValue
-
-    /// The hooks that can be tapped into
-    public let hooks: ErrorControllerHooks
 
     /// Construct an ErrorController from a JSValue
     /// - Parameters:
@@ -106,10 +98,12 @@ public class ErrorController: CreatedFromJSValue {
     public func captureError(
         error: Error
     ) -> Bool {
-        let convertibleError = (error as? JSConvertibleError & Error) ?? PlayerError.unknownResponse(error)
+        let convertibleError = (error as? JSConvertibleError & Error) ?? PlayerError
+            .unknownResponse(error)
         let args = [value.context.error(for: convertibleError) as Any]
 
-        guard let result = value.invokeMethod("captureError", withArguments: args), result.isBoolean else {
+        guard let result = value.invokeMethod("captureError", withArguments: args),
+              result.isBoolean else {
             return false
         }
         return result.toBool()
@@ -118,13 +112,13 @@ public class ErrorController: CreatedFromJSValue {
     /// Get the most recent error
     /// - Returns: The current error as a JSValue if one exists
     public func getCurrentError() -> JSValue? {
-        return value.invokeMethod("getCurrentError", withArguments: [])
+        value.invokeMethod("getCurrentError", withArguments: [])
     }
 
     /// Get the complete error history
     /// - Returns: JSValue representing the array of errors
     public func getErrors() -> JSValue? {
-        return value.invokeMethod("getErrors", withArguments: [])
+        value.invokeMethod("getErrors", withArguments: [])
     }
 
     /// Clear all errors (history + current + data model)
@@ -136,4 +130,14 @@ public class ErrorController: CreatedFromJSValue {
     public func clearCurrentError() {
         value.invokeMethod("clearCurrentError", withArguments: [])
     }
+
+    /// Creates an instance from a JSValue, used for generic construction
+    /// - Parameters:
+    ///   - value: The JSValue to construct from
+    public static func createInstance(value: JSValue) -> ErrorController {
+        ErrorController(value)
+    }
+
+    /// Typealias for associated type
+    public typealias T = ErrorController
 }

--- a/ios/core/Sources/Types/Core/ExpressionEvaluator.swift
+++ b/ios/core/Sources/Types/Core/ExpressionEvaluator.swift
@@ -7,48 +7,42 @@
 
 import Foundation
 import JavaScriptCore
-/**
- A wrapper around the JS ExpressionEvaluator in the core player
- */
+
+/// A wrapper around the JS ExpressionEvaluator in the core player
 public class ExpressionEvaluator: CreatedFromJSValue {
-    /// Typealias for associated type
-    public typealias T = ExpressionEvaluator
-
-    /**
-     Creates an instance from a JSValue, used for generic construction
-     - parameters:
-        - value: The JSValue to construct from
-     */
-    public static func createInstance(value: JSValue) -> ExpressionEvaluator { ExpressionEvaluator(value) }
-
     private let value: JSValue
 
-    /**
-     Creates an instance from a JSValue
-     - parameters:
-        - value: The JSValue to construct from
-     */
+    /// Creates an instance from a JSValue
+    /// - parameters:
+    ///   - value: The JSValue to construct from
     public init(_ value: JSValue) {
         self.value = value
     }
 
-    /**
-     Evaluate an expression and retrieve the result
-     - parameters:
-        - expression: The expression to evaluate
-     - returns: A result if the expression produces one
-     */
+    /// Evaluate an expression and retrieve the result
+    /// - parameters:
+    ///   - expression: The expression to evaluate
+    /// - returns: A result if the expression produces one
     @discardableResult public func evaluate(_ expression: String) -> Any? {
-        return self.value.invokeMethod("evaluate", withArguments: [expression])?.toObject()
+        value.invokeMethod("evaluate", withArguments: [expression])?.toObject()
     }
 
-    /**
-     Evaluate an array expression and retrieve the result
-     - parameters:
-        - expressions: The expressions to evaluate
-     - returns: A result if the expressions produces one
-     */
+    /// Evaluate an array expression and retrieve the result
+    /// - parameters:
+    ///   - expressions: The expressions to evaluate
+    /// - returns: A result if the expressions produces one
     @discardableResult public func evaluate(_ expressions: [String]) -> Any? {
-        return self.value.invokeMethod("evaluate", withArguments: [expressions])?.toObject()
+        value.invokeMethod("evaluate", withArguments: [expressions])?.toObject()
     }
+
+    /// Creates an instance from a JSValue, used for generic construction
+    /// - parameters:
+    ///   - value: The JSValue to construct from
+    public static func createInstance(value: JSValue)
+        -> ExpressionEvaluator {
+        ExpressionEvaluator(value)
+    }
+
+    /// Typealias for associated type
+    public typealias T = ExpressionEvaluator
 }

--- a/ios/core/Sources/Types/Core/Flow.swift
+++ b/ios/core/Sources/Types/Core/Flow.swift
@@ -8,53 +8,64 @@
 import Foundation
 import JavaScriptCore
 
-/**
-A wrapper around the JS Flow in the core player
-*/
+/// A wrapper around the JS Flow in the core player
 public class Flow: CreatedFromJSValue {
-    /// Typealias for associated type
-    public typealias T = Flow
-
-    /// The ID of this flow
-    public var id: String? { value.objectForKeyedSubscript("id")?.toString() }
-
-    /// The original data associated with this flow
-    public var data: [String: Any]? { value.objectForKeyedSubscript("data")?.toObject() as? [String: Any] }
-
-    /// The name of this flow
-    public var currentState: NamedState? { value.objectForKeyedSubscript("currentState").map { NamedState($0) } }
-
     /// Lifecycle hooks
     public let hooks: FlowHooks
-
-    /**
-    Creates an instance from a JSValue, used for generic construction
-    - parameters:
-       - value: The JSValue to construct from
-    */
-    public static func createInstance(value: JSValue) -> Flow { Flow(value) }
 
     /// The JSValue that backs this wrapper
     private let value: JSValue
 
-    /**
-    Construct a Flow from a JSValue
-    - parameters:
-       - value: The JSValue that is the Flow
-    */
+    /// The ID of this flow
+    public var id: String? {
+        value.objectForKeyedSubscript("id")?.toString()
+    }
+
+    /// The original data associated with this flow
+    public var data: [String: Any]? {
+        value.objectForKeyedSubscript("data")?.toObject() as? [String: Any]
+    }
+
+    /// The name of this flow
+    public var currentState: NamedState? {
+        value.objectForKeyedSubscript("currentState").map { NamedState($0) }
+    }
+
+    /// Construct a Flow from a JSValue
+    /// - parameters:
+    ///   - value: The JSValue that is the Flow
     public init(_ value: JSValue) {
         self.value = value
         hooks = FlowHooks(
-            beforeTransition: SyncWaterfallHook2JS<NavigationBaseState, NavigationBaseState, String>(baseValue: value, name: "beforeTransition"),
+            beforeTransition: SyncWaterfallHook2JS<NavigationBaseState, NavigationBaseState,
+                String>(
+                baseValue: value,
+                name: "beforeTransition"
+            ),
             transition: Hook2(baseValue: value, name: "transition"),
             afterTransition: Hook(baseValue: value, name: "afterTransition")
         )
     }
+
+    /// Creates an instance from a JSValue, used for generic construction
+    /// - parameters:
+    ///   - value: The JSValue to construct from
+    public static func createInstance(value: JSValue) -> Flow {
+        Flow(value)
+    }
+
+    /// Typealias for associated type
+    public typealias T = Flow
 }
 
 public struct FlowHooks {
-    /// Fires before a transition with (state, transitionValue); return state (pass-through or modified).
-    public var beforeTransition: SyncWaterfallHook2JS<NavigationBaseState, NavigationBaseState, String>
+    /// Fires before a transition with (state, transitionValue); return state (pass-through or
+    /// modified).
+    public var beforeTransition: SyncWaterfallHook2JS<
+        NavigationBaseState,
+        NavigationBaseState,
+        String
+    >
 
     /// A hook that fires when transitioning states and giving the old and new states as parameters
     public var transition: Hook2<NamedState?, NamedState>
@@ -64,10 +75,6 @@ public struct FlowHooks {
 }
 
 public struct NamedState: CreatedFromJSValue {
-    public typealias T = NamedState
-
-    public static func createInstance(value: JSValue) -> NamedState { .init(value) }
-
     /// The name of the navigation node
     public let name: String
 
@@ -75,7 +82,14 @@ public struct NamedState: CreatedFromJSValue {
     public let value: NavigationBaseState?
 
     init(_ value: JSValue) {
-        self.name = value.objectForKeyedSubscript("name").toString()
-        self.value = NavigationBaseState.createInstance(value: value.objectForKeyedSubscript("value"))
+        name = value.objectForKeyedSubscript("name").toString()
+        self.value = NavigationBaseState
+            .createInstance(value: value.objectForKeyedSubscript("value"))
     }
+
+    public static func createInstance(value: JSValue) -> NamedState {
+        .init(value)
+    }
+
+    public typealias T = NamedState
 }

--- a/ios/core/Sources/Types/Core/FlowController.swift
+++ b/ios/core/Sources/Types/Core/FlowController.swift
@@ -1,6 +1,6 @@
 //
-//  File.swift
-//  
+//  FlowController.swift
+//
 //
 //  Created by Borawski, Harris on 2/12/20.
 //
@@ -8,20 +8,8 @@
 import Foundation
 import JavaScriptCore
 
-/**
-A wrapper around the JS FlowController in the core player
-*/
+/// A wrapper around the JS FlowController in the core player
 public class FlowController: CreatedFromJSValue {
-    /// Typealias for associated type
-    public typealias T = FlowController
-
-    /**
-    Creates an instance from a JSValue, used for generic construction
-    - parameters:
-       - value: The JSValue to construct from
-    */
-    public static func createInstance(value: JSValue) -> FlowController { FlowController(value) }
-
     /// The JSValue that backs this wrapper
     public let value: JSValue
 
@@ -33,22 +21,28 @@ public class FlowController: CreatedFromJSValue {
         value.objectForKeyedSubscript("current").map { Flow($0) }
     }
 
-    /**
-    Construct a FlowController from a JSValue
-    - parameters:
-       - value: The JSValue that is the FlowController
-    */
+    /// Construct a FlowController from a JSValue
+    /// - parameters:
+    ///   - value: The JSValue that is the FlowController
     public init(_ value: JSValue) {
         self.value = value
         hooks = FlowControllerHooks(flow: Hook(baseValue: value, name: "flow"))
     }
 
-    /**
-     Transition the FlowController with a given action
-     - parameters:
-        - action: The action to use for transitioning
-     */
+    /// Transition the FlowController with a given action
+    /// - parameters:
+    ///   - action: The action to use for transitioning
     public func transition(with action: String) throws {
-        try self.value.objectForKeyedSubscript("transition").tryCatch(args: [action])
+        try value.objectForKeyedSubscript("transition").tryCatch(args: [action])
     }
+
+    /// Creates an instance from a JSValue, used for generic construction
+    /// - parameters:
+    ///   - value: The JSValue to construct from
+    public static func createInstance(value: JSValue) -> FlowController {
+        FlowController(value)
+    }
+
+    /// Typealias for associated type
+    public typealias T = FlowController
 }

--- a/ios/core/Sources/Types/Core/FlowController.swift
+++ b/ios/core/Sources/Types/Core/FlowController.swift
@@ -1,6 +1,6 @@
 //
-//  File.swift
-//  
+//  FlowController.swift
+//
 //
 //  Created by Borawski, Harris on 2/12/20.
 //
@@ -8,20 +8,8 @@
 import Foundation
 import JavaScriptCore
 
-/**
-A wrapper around the JS FlowController in the core player
-*/
+/// A wrapper around the JS FlowController in the core player
 public class FlowController: CreatedFromJSValue {
-    /// Typealias for associated type
-    public typealias T = FlowController
-
-    /**
-    Creates an instance from a JSValue, used for generic construction
-    - parameters:
-       - value: The JSValue to construct from
-    */
-    public static func createInstance(value: JSValue) -> FlowController { FlowController(value) }
-
     /// The JSValue that backs this wrapper
     public let value: JSValue
 
@@ -33,22 +21,28 @@ public class FlowController: CreatedFromJSValue {
         value.objectForKeyedSubscript("current").map { Flow($0) }
     }
 
-    /**
-    Construct a FlowController from a JSValue
-    - parameters:
-       - value: The JSValue that is the FlowController
-    */
+    /// Construct a FlowController from a JSValue
+    /// - parameters:
+    ///   - value: The JSValue that is the FlowController
     public init(_ value: JSValue) {
         self.value = value
         hooks = FlowControllerHooks(flow: Hook(baseValue: value, name: "flow"))
     }
 
-    /**
-     Transition the FlowController with a given action
-     - parameters:
-        - action: The action to use for transitioning
-     */
+    /// Transition the FlowController with a given action
+    /// - parameters:
+    ///   - action: The action to use for transitioning
     public func transition(with action: String) throws {
-        try self.value.objectForKeyedSubscript("transition").callWithErrorHandling(args: [action])
+        try value.objectForKeyedSubscript("transition").callWithErrorHandling(args: [action])
     }
+
+    /// Creates an instance from a JSValue, used for generic construction
+    /// - parameters:
+    ///   - value: The JSValue to construct from
+    public static func createInstance(value: JSValue) -> FlowController {
+        FlowController(value)
+    }
+
+    /// Typealias for associated type
+    public typealias T = FlowController
 }

--- a/ios/core/Sources/Types/Core/FlowType.swift
+++ b/ios/core/Sources/Types/Core/FlowType.swift
@@ -8,36 +8,37 @@
 import Foundation
 import JavaScriptCore
 
-/**
-A wrapper around the JS FlowType in the core player
-The JSON payload for running Player, different from the Flow class which is the Flow Instance which contains the navigation state machine
-*/
+/// A wrapper around the JS FlowType in the core player
+/// The JSON payload for running Player, different from the Flow class which is the Flow Instance
+/// which contains the navigation state machine
 public class FlowType: CreatedFromJSValue {
-    /// Typealias for associated type
-    public typealias T = FlowType
-
-    /// The ID of this flow
-    public var id: String? { value.objectForKeyedSubscript("id")?.toString() }
-
-    /// The original data associated with this flow
-    public var data: [String: Any]? { value.objectForKeyedSubscript("data")?.toObject() as? [String: Any] }
-
-    /**
-    Creates an instance from a JSValue, used for generic construction
-    - parameters:
-       - value: The JSValue to construct from
-    */
-    public static func createInstance(value: JSValue) -> FlowType { FlowType(value) }
-
     /// The JSValue that backs this wrapper
     public private(set) var value: JSValue
 
-    /**
-    Construct a Flow from a JSValue
-    - parameters:
-       - value: The JSValue that is the Flow
-    */
+    /// The ID of this flow
+    public var id: String? {
+        value.objectForKeyedSubscript("id")?.toString()
+    }
+
+    /// The original data associated with this flow
+    public var data: [String: Any]? {
+        value.objectForKeyedSubscript("data")?.toObject() as? [String: Any]
+    }
+
+    /// Construct a Flow from a JSValue
+    /// - parameters:
+    ///   - value: The JSValue that is the Flow
     public init(_ value: JSValue) {
         self.value = value
     }
+
+    /// Creates an instance from a JSValue, used for generic construction
+    /// - parameters:
+    ///   - value: The JSValue to construct from
+    public static func createInstance(value: JSValue) -> FlowType {
+        FlowType(value)
+    }
+
+    /// Typealias for associated type
+    public typealias T = FlowType
 }

--- a/ios/core/Sources/Types/Core/Modifiers.swift
+++ b/ios/core/Sources/Types/Core/Modifiers.swift
@@ -7,9 +7,7 @@
 
 import Foundation
 
-/**
- MetaData associated with a `Modifier`
- */
+/// MetaData associated with a `Modifier`
 public struct ModifierMetaData: Decodable, Hashable {
     /// A ref for the link modifier
     public let ref: String?
@@ -17,9 +15,7 @@ public struct ModifierMetaData: Decodable, Hashable {
     public let mimeType: String?
     public let maxLine: Int?
 
-    /**
-     Create a ModifierMetaData instance
-     */
+    /// Create a ModifierMetaData instance
     public init(ref: String?, source: String? = nil, mimeType: String? = nil, maxLine: Int? = nil) {
         self.ref = ref
         self.source = source
@@ -34,20 +30,14 @@ public struct ModifierMetaData: Decodable, Hashable {
         case maxLine
     }
 }
-/**
- A modifier for an asset
- */
+
+/// A modifier for an asset
 public typealias Modifier = ModifierContainer<ModifierMetaData>
 
-/**
- A ModifierContainer allows any type of MetaData to be decoded from an asset tree.
- */
-public struct ModifierContainer<MetaData>: Decodable, Hashable where MetaData: Decodable&Hashable {
+/// A ModifierContainer allows any type of MetaData to be decoded from an asset tree.
+public struct ModifierContainer<MetaData: Decodable & Hashable>: Decodable, Hashable {
     /// The type of modifier
     public let type: String
-
-    /// The value to use for this modification
-    private let _value: JSONValue?
 
     /// Optional name of a modifier to use as reference in a string
     public let name: String?
@@ -55,12 +45,18 @@ public struct ModifierContainer<MetaData>: Decodable, Hashable where MetaData: D
     /// metaData
     public let metaData: MetaData?
 
-    /**
-     Create  a Modifier instance
-     */
-    public init(type: String, value: JSONValue? = nil, name: String? = nil, metaData: MetaData? = nil) {
+    /// The value to use for this modification
+    private let _value: JSONValue?
+
+    /// Create  a Modifier instance
+    public init(
+        type: String,
+        value: JSONValue? = nil,
+        name: String? = nil,
+        metaData: MetaData? = nil
+    ) {
         self.type = type
-        self._value = value
+        _value = value
         self.name = name
         self.metaData = metaData
     }
@@ -70,22 +66,22 @@ public struct ModifierContainer<MetaData>: Decodable, Hashable where MetaData: D
 
 /// A JSONValue might contain a string, or a number (either int or double).
 public enum JSONValue: Hashable {
-    case string (String)
+    case string(String)
     case integer(Int)
-    case double (Double)
+    case double(Double)
 
     public var stringValue: String? {
-        guard case .string(let string) = self else { return nil }
+        guard case let .string(string) = self else { return nil }
         return string
     }
 
     var intValue: Int? {
-        guard case .integer(let int) = self else { return nil }
+        guard case let .integer(int) = self else { return nil }
         return int
     }
 
     var doubleValue: Double? {
-        guard case .double(let double) = self else { return nil }
+        guard case let .double(double) = self else { return nil }
         return double
     }
 }
@@ -94,9 +90,9 @@ public extension ModifierContainer {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         try self.init(
-                type: container.decode(String.self, forKey: .type),
-               value: container.decodeIfPresent(JSONValue.self, forKey: .value),
-                name: container.decodeIfPresent(String.self, forKey: .name),
+            type: container.decode(String.self, forKey: .type),
+            value: container.decodeIfPresent(JSONValue.self, forKey: .value),
+            name: container.decodeIfPresent(String.self, forKey: .name),
             metaData: container.decodeIfPresent(MetaData.self, forKey: .metaData)
         )
     }
@@ -105,11 +101,17 @@ public extension ModifierContainer {
         self.init(type: type, value: .string(value), name: name, metaData: metaData)
     }
 
-    var value: String? { _value?.stringValue }
+    var value: String? {
+        _value?.stringValue
+    }
 
-    var intValue: Int? { _value?.intValue }
+    var intValue: Int? {
+        _value?.intValue
+    }
 
-    var doubleValue: Double? { _value?.doubleValue }
+    var doubleValue: Double? {
+        _value?.doubleValue
+    }
 
     private enum CodingKeys: String, CodingKey {
         case name
@@ -124,8 +126,8 @@ extension JSONValue: Decodable {
         let container = try decoder.singleValueContainer()
         // attempt to decode a string, then an int, then a double, then fail
         self = try
-            (try? .string(container.decode(String.self))) ??
-            (try? .integer(container.decode(Int.self   ))) ??
-            (try  .double(container.decode(Double.self)))
+            try (try? .string(container.decode(String.self))) ??
+            (try? .integer(container.decode(Int.self))) ??
+            .double(container.decode(Double.self))
     }
 }

--- a/ios/core/Sources/Types/Core/NavigationFlowStateType.swift
+++ b/ios/core/Sources/Types/Core/NavigationFlowStateType.swift
@@ -22,6 +22,19 @@ public enum NavigationFlowStateType: Equatable {
     /// if new state types are added on the JS side.
     case unknown(String)
 
+    /// The raw `state_type` string as it appears in the flow JSON.
+    public var rawValue: String {
+        switch self {
+        case .view: return "VIEW"
+        case .action: return "ACTION"
+        case .asyncAction: return "ASYNC_ACTION"
+        case .flow: return "FLOW"
+        case .external: return "EXTERNAL"
+        case .end: return "END"
+        case let .unknown(value): return value
+        }
+    }
+
     /// Creates a `NavigationFlowStateType` from the raw `state_type` string in the flow JSON.
     /// Unrecognized values are captured as `.unknown(rawValue)` rather than discarded.
     public init(_ rawValue: String) {
@@ -34,19 +47,6 @@ public enum NavigationFlowStateType: Equatable {
         case "END": self = .end
         default:
             self = .unknown(rawValue)
-        }
-    }
-
-    /// The raw `state_type` string as it appears in the flow JSON.
-    public var rawValue: String {
-        switch self {
-        case .view: return "VIEW"
-        case .action: return "ACTION"
-        case .asyncAction: return "ASYNC_ACTION"
-        case .flow: return "FLOW"
-        case .external: return "EXTERNAL"
-        case .end: return "END"
-        case .unknown(let value): return value
         }
     }
 }

--- a/ios/core/Sources/Types/Core/NavigationFlowStateType.swift
+++ b/ios/core/Sources/Types/Core/NavigationFlowStateType.swift
@@ -25,13 +25,13 @@ public enum NavigationFlowStateType: Equatable {
     /// The raw `state_type` string as it appears in the flow JSON.
     public var rawValue: String {
         switch self {
-        case .view: return "VIEW"
-        case .action: return "ACTION"
-        case .asyncAction: return "ASYNC_ACTION"
-        case .flow: return "FLOW"
-        case .external: return "EXTERNAL"
-        case .end: return "END"
-        case let .unknown(value): return value
+        case .view: "VIEW"
+        case .action: "ACTION"
+        case .asyncAction: "ASYNC_ACTION"
+        case .flow: "FLOW"
+        case .external: "EXTERNAL"
+        case .end: "END"
+        case let .unknown(value): value
         }
     }
 

--- a/ios/core/Sources/Types/Core/NavigationStates.swift
+++ b/ios/core/Sources/Types/Core/NavigationStates.swift
@@ -3,15 +3,21 @@ import JavaScriptCore
 
 /// The base representation of a state within a Flow
 open class NavigationBaseState: CreatedFromJSValue, JSValueProviding {
-    public typealias T = NavigationBaseState
-
     /// A property to determine the type of state this is
     public let stateType: NavigationFlowStateType
 
-    internal let rawValue: JSValue
+    let rawValue: JSValue
 
-    /// Backing JSValue for returning from waterfall hooks. Use when returning this state from a waterfall hook (e.g. beforeTransition).
-    public var jsValue: JSValue { rawValue }
+    /// Backing JSValue for returning from waterfall hooks. Use when returning this state from a
+    /// waterfall hook (e.g. beforeTransition).
+    public var jsValue: JSValue {
+        rawValue
+    }
+
+    public init(_ value: JSValue) {
+        rawValue = value
+        stateType = NavigationFlowStateType(value.objectForKeyedSubscript("state_type").toString())
+    }
 
     public static func createInstance(value: JSValue) -> NavigationBaseState {
         let base = NavigationBaseState(value)
@@ -26,10 +32,7 @@ open class NavigationBaseState: CreatedFromJSValue, JSValueProviding {
         }
     }
 
-    public init(_ value: JSValue) {
-        rawValue = value
-        stateType = NavigationFlowStateType(value.objectForKeyedSubscript("state_type").toString())
-    }
+    public typealias T = NavigationBaseState
 }
 
 /// A generic state that can transition to another state
@@ -44,7 +47,9 @@ open class NavigationFlowTransitionableState: NavigationBaseState {
 @dynamicMemberLookup
 public class NavigationFlowViewState: NavigationFlowTransitionableState {
     /// An id corresponding to a view from the 'views' array
-    public var ref: String { rawValue.objectForKeyedSubscript("ref").toString() }
+    public var ref: String {
+        rawValue.objectForKeyedSubscript("ref").toString()
+    }
 
     /// View meta-properties
     public var attributes: [String: Any]? {
@@ -56,8 +61,10 @@ public class NavigationFlowViewState: NavigationFlowTransitionableState {
     }
 }
 
-/// External Flow states represent states in the FSM that can't be resolved internally in the player.
-/// The flow will wait for the embedded application to manage moving to the next state via a transition
+/// External Flow states represent states in the FSM that can't be resolved internally in the
+/// player.
+/// The flow will wait for the embedded application to manage moving to the next state via a
+/// transition
 @dynamicMemberLookup
 public class NavigationFlowExternalState: NavigationFlowTransitionableState {
     /// A reference for this external state
@@ -73,12 +80,13 @@ public class NavigationFlowExternalState: NavigationFlowTransitionableState {
 /// An END state of the flow
 @dynamicMemberLookup
 public class NavigationFlowEndState: NavigationBaseState {
-
     /// A description of _how_ the flow ended.
-    public var outcome: String { rawValue.objectForKeyedSubscript("outcome").toString() }
+    public var outcome: String {
+        rawValue.objectForKeyedSubscript("outcome").toString()
+    }
 
     public convenience init?(from value: JSValue?) {
-        guard let value = value else { return nil }
+        guard let value else { return nil }
         self.init(value)
     }
 
@@ -88,12 +96,16 @@ public class NavigationFlowEndState: NavigationBaseState {
 }
 
 public extension NavigationFlowEndState {
-    var param: [String: Any]? { rawValue.objectForKeyedSubscript("param").toObject() as? [String: Any] }
+    var param: [String: Any]? {
+        rawValue.objectForKeyedSubscript("param").toObject() as? [String: Any]
+    }
 }
 
 public class NavigationFlowFlowState: NavigationFlowTransitionableState {
     /// A reference to a FLOW id state to run
-    public var ref: String { rawValue.objectForKeyedSubscript("ref").toString() }
+    public var ref: String {
+        rawValue.objectForKeyedSubscript("ref").toString()
+    }
 }
 
 /// Action states execute an expression to determine the next state to transition to
@@ -124,7 +136,9 @@ public class NavigationFlowAsyncActionState: NavigationFlowTransitionableState {
         }
     }
 
-    public var await: Bool { rawValue.objectForKeyedSubscript("await").toBool() }
+    public var await: Bool {
+        rawValue.objectForKeyedSubscript("await").toBool()
+    }
 
     public enum Expression {
         case single(exp: String)

--- a/ios/core/Sources/Types/Core/NavigationStates.swift
+++ b/ios/core/Sources/Types/Core/NavigationStates.swift
@@ -113,9 +113,9 @@ public class NavigationFlowActionState: NavigationFlowTransitionableState {
     /// An expression to execute. The return value determines the transition to take
     public var exp: Expression {
         if let multi = rawValue.objectForKeyedSubscript("exp").toObject() as? [String] {
-            return .multi(exp: multi)
+            .multi(exp: multi)
         } else {
-            return .single(exp: rawValue.objectForKeyedSubscript("exp").toString())
+            .single(exp: rawValue.objectForKeyedSubscript("exp").toString())
         }
     }
 
@@ -130,9 +130,9 @@ public class NavigationFlowAsyncActionState: NavigationFlowTransitionableState {
     /// An expression to execute. The return value determines the transition to take
     public var exp: Expression {
         if let multi = rawValue.objectForKeyedSubscript("exp").toObject() as? [String] {
-            return .multi(exp: multi)
+            .multi(exp: multi)
         } else {
-            return .single(exp: rawValue.objectForKeyedSubscript("exp").toString())
+            .single(exp: rawValue.objectForKeyedSubscript("exp").toString())
         }
     }
 

--- a/ios/core/Sources/Types/Core/PlayerView.swift
+++ b/ios/core/Sources/Types/Core/PlayerView.swift
@@ -1,6 +1,6 @@
 //
-//  File.swift
-//  
+//  PlayerView.swift
+//
 //
 //  Created by Borawski, Harris on 2/12/20.
 //
@@ -8,41 +8,37 @@
 import Foundation
 import JavaScriptCore
 
-/**
-A wrapper around the JS View in the core player
-*/
+/// A wrapper around the JS View in the core player
 public class PlayerView: CreatedFromJSValue {
-    /// Typealias for associated type
-    public typealias T = PlayerView
-
-    /**
-    Creates an instance from a JSValue, used for generic construction
-    - parameters:
-       - value: The JSValue to construct from
-    */
-    public static func createInstance(value: JSValue) -> PlayerView { PlayerView(value) }
-
-    /// The JSValue that backs this wrapper
-    internal let value: JSValue
-
     /// The hooks that can be tapped into
     public let hooks: ViewHooks
 
-    /**
-    Construct a View from a JSValue
-    - parameters:
-       - value: The JSValue that is the View
-    */
-    public init(_ value: JSValue) {
-        self.value = value
-        self.hooks = ViewHooks(onUpdate: Hook<JSValue>(baseValue: self.value, name: "onUpdate"))
-    }
+    /// The JSValue that backs this wrapper
+    let value: JSValue
 
     /// Gets the ID for this view
     public var id: String {
-        return value
+        value
             .objectForKeyedSubscript("initialView")?
             .objectForKeyedSubscript("id")?
             .toString() ?? "something went really wrong and this view has no id"
     }
+
+    /// Construct a View from a JSValue
+    /// - parameters:
+    ///   - value: The JSValue that is the View
+    public init(_ value: JSValue) {
+        self.value = value
+        hooks = ViewHooks(onUpdate: Hook<JSValue>(baseValue: self.value, name: "onUpdate"))
+    }
+
+    /// Creates an instance from a JSValue, used for generic construction
+    /// - parameters:
+    ///   - value: The JSValue to construct from
+    public static func createInstance(value: JSValue) -> PlayerView {
+        PlayerView(value)
+    }
+
+    /// Typealias for associated type
+    public typealias T = PlayerView
 }

--- a/ios/core/Sources/Types/Core/ViewController.swift
+++ b/ios/core/Sources/Types/Core/ViewController.swift
@@ -1,6 +1,6 @@
 //
 //  ViewController.swift
-//  
+//
 //
 //  Created by Borawski, Harris on 2/12/20.
 //
@@ -8,25 +8,13 @@
 import Foundation
 import JavaScriptCore
 
-/**
- A wrapper around the JS ViewController in the core player
- */
+/// A wrapper around the JS ViewController in the core player
 public class ViewController: CreatedFromJSValue {
-    /// Typealias for associated type
-    public typealias T = ViewController
-
-    /**
-     Creates an instance from a JSValue, used for generic construction
-     - parameters:
-        - value: The JSValue to construct from
-     */
-    public static func createInstance(value: JSValue) -> ViewController { ViewController(value) }
+    /// The hooks that can be tapped into
+    public let hooks: ViewControllerHooks
 
     /// The JSValue that backs this wrapper
     private let value: JSValue
-
-    /// The hooks that can be tapped into
-    public let hooks: ViewControllerHooks
 
     /// The current view being managed by the View Controller
     public var currentView: PlayerView? {
@@ -34,15 +22,23 @@ public class ViewController: CreatedFromJSValue {
         return PlayerView(view)
     }
 
-    /**
-     Construct a ViewController from a JSValue
-     - parameters:
-        - value: The JSValue that is the ViewController
-     */
+    /// Construct a ViewController from a JSValue
+    /// - parameters:
+    ///   - value: The JSValue that is the ViewController
     public init(_ value: JSValue) {
         self.value = value
-        self.hooks = ViewControllerHooks(
+        hooks = ViewControllerHooks(
             view: Hook<PlayerView>(baseValue: self.value, name: "view")
         )
     }
+
+    /// Creates an instance from a JSValue, used for generic construction
+    /// - parameters:
+    ///   - value: The JSValue to construct from
+    public static func createInstance(value: JSValue) -> ViewController {
+        ViewController(value)
+    }
+
+    /// Typealias for associated type
+    public typealias T = ViewController
 }

--- a/ios/core/Sources/Types/Generic/AnyType.swift
+++ b/ios/core/Sources/Types/Generic/AnyType.swift
@@ -49,7 +49,7 @@ public enum AnyType: Hashable {
     /// The underlying data was not in a known format
     case unknownData
 
-    // swiftlint:disable cyclomatic_complexity
+    // swiftlint:disable:next cyclomatic_complexity
     public func hash(into hasher: inout Hasher) {
         switch self {
         case let .string(data):
@@ -81,7 +81,7 @@ public enum AnyType: Hashable {
 }
 
 extension AnyType: Equatable {
-    // swiftlint:disable cyclomatic_complexity
+    // swiftlint:disable:next cyclomatic_complexity
     public static func == (lhs: AnyType, rhs: AnyType) -> Bool {
         switch (lhs, rhs) {
         case let (.string(lhv), .string(rhv)): return lhv == rhv
@@ -107,7 +107,7 @@ extension AnyType: Decodable {
     /// Construct AnyType by decoding
     /// - parameters:
     ///   - decoder: A decoder to decode from
-    // swiftlint:disable cyclomatic_complexity
+    // swiftlint:disable:next cyclomatic_complexity
     public init(from decoder: Decoder) throws {
         if let dictionary = try? decoder.singleValueContainer().decode([String: String].self) {
             self = .dictionary(data: dictionary)
@@ -194,6 +194,7 @@ extension AnyType: Encodable {
     /// Encode to an encoder
     /// - parameters:
     ///   - encoder: The encoder to encode the value to
+    // swiftlint:disable:next cyclomatic_complexity
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self {
@@ -239,7 +240,8 @@ extension AnyType: Encodable {
 }
 
 public struct AnyTypeDecodingContext {
-    static let key: CodingUserInfoKey = (rawValue: "AnyTypeDecodingContext")!
+    // swiftlint:disable:next force_unwrapping
+    static let key: CodingUserInfoKey = .init(rawValue: "AnyTypeDecodingContext")!
 
     public var rawData: Data
 

--- a/ios/core/Sources/Types/Generic/AnyType.swift
+++ b/ios/core/Sources/Types/Generic/AnyType.swift
@@ -7,40 +7,8 @@
 
 import Foundation
 
-/**
- A union type to match the JS core players any type
- */
+/// A union type to match the JS core players any type
 public enum AnyType: Hashable {
-    // swiftlint:disable cyclomatic_complexity
-    public func hash(into hasher: inout Hasher) {
-        switch self {
-        case .string(let data):
-            hasher.combine(data)
-        case .bool(let data):
-            hasher.combine(data)
-        case .number(let data):
-            hasher.combine(data)
-        case .dictionary(let data):
-            hasher.combine(data)
-        case .numberDictionary(let data):
-            hasher.combine(data)
-        case .booleanDictionary(let data):
-            hasher.combine(data)
-        case .array(let data):
-            hasher.combine(data)
-        case .numberArray(let data):
-            hasher.combine(data)
-        case .booleanArray(let data):
-            hasher.combine(data)
-        case .anyDictionary(let data):
-            hasher.combine(data as NSDictionary)
-        case .anyArray(let data):
-            hasher.combine(data as NSArray)
-        case .unknownData:
-            return
-        }
-    }
-
     /// The underlying data was a string
     case string(data: String)
 
@@ -68,60 +36,84 @@ public enum AnyType: Hashable {
     /// The underlying data was an array of booleans
     case booleanArray(data: [Bool])
 
-    /**
-     The underlying data was a dictionary of varied value types
-
-     **This requires the decoder to add `AnyTypeDecodingContext` to the decoders userInfo**
-     */
+    /// The underlying data was a dictionary of varied value types
+    ///
+    /// **This requires the decoder to add `AnyTypeDecodingContext` to the decoders userInfo**
     case anyDictionary(data: [String: Any])
 
-    /**
-     The underlying data was an array of varied value types
-
-     **This requires the decoder to add `AnyTypeDecodingContext` to the decoders userInfo**
-     */
+    /// The underlying data was an array of varied value types
+    ///
+    /// **This requires the decoder to add `AnyTypeDecodingContext` to the decoders userInfo**
     case anyArray(data: [Any])
 
     /// The underlying data was not in a known format
     case unknownData
+
+    // swiftlint:disable cyclomatic_complexity
+    public func hash(into hasher: inout Hasher) {
+        switch self {
+        case let .string(data):
+            hasher.combine(data)
+        case let .bool(data):
+            hasher.combine(data)
+        case let .number(data):
+            hasher.combine(data)
+        case let .dictionary(data):
+            hasher.combine(data)
+        case let .numberDictionary(data):
+            hasher.combine(data)
+        case let .booleanDictionary(data):
+            hasher.combine(data)
+        case let .array(data):
+            hasher.combine(data)
+        case let .numberArray(data):
+            hasher.combine(data)
+        case let .booleanArray(data):
+            hasher.combine(data)
+        case let .anyDictionary(data):
+            hasher.combine(data as NSDictionary)
+        case let .anyArray(data):
+            hasher.combine(data as NSArray)
+        case .unknownData:
+            return
+        }
+    }
 }
 
 extension AnyType: Equatable {
     // swiftlint:disable cyclomatic_complexity
     public static func == (lhs: AnyType, rhs: AnyType) -> Bool {
         switch (lhs, rhs) {
-        case (.string(let lhv), .string(let rhv)): return lhv == rhv
-        case (.bool(let lhv), .bool(let rhv)): return lhv == rhv
-        case (.number(let lhv), .number(let rhv)): return lhv == rhv
-        case (.dictionary(let lhv), .dictionary(let rhv)): return lhv == rhv
-        case (.numberDictionary(let lhv), .numberDictionary(let rhv)): return lhv == rhv
-        case (.booleanDictionary(let lhv), .booleanDictionary(let rhv)): return lhv == rhv
-        case (.array(let lhv), .array(let rhv)): return lhv == rhv
-        case (.numberArray(let lhv), .numberArray(let rhv)): return lhv == rhv
-        case (.booleanArray(let lhv), .booleanArray(let rhv)): return lhv == rhv
-        case (.anyDictionary(let lhv), .anyDictionary(let rhv)): return (lhv as NSDictionary).isEqual(to: rhv)
-        case (.anyArray(let lhv), .anyArray(let rhv)): return (lhv as NSArray).isEqual(to: rhv)
+        case let (.string(lhv), .string(rhv)): return lhv == rhv
+        case let (.bool(lhv), .bool(rhv)): return lhv == rhv
+        case let (.number(lhv), .number(rhv)): return lhv == rhv
+        case let (.dictionary(lhv), .dictionary(rhv)): return lhv == rhv
+        case let (.numberDictionary(lhv), .numberDictionary(rhv)): return lhv == rhv
+        case let (.booleanDictionary(lhv), .booleanDictionary(rhv)): return lhv == rhv
+        case let (.array(lhv), .array(rhv)): return lhv == rhv
+        case let (.numberArray(lhv), .numberArray(rhv)): return lhv == rhv
+        case let (.booleanArray(lhv), .booleanArray(rhv)): return lhv == rhv
+        case let (.anyDictionary(lhv), .anyDictionary(rhv)): return (lhv as NSDictionary)
+            .isEqual(to: rhv)
+        case let (.anyArray(lhv), .anyArray(rhv)): return (lhv as NSArray).isEqual(to: rhv)
         case (.unknownData, .unknownData): return true
         default: return false
         }
     }
 }
 
-/**
- Make AnyType Decodable
- */
+/// Make AnyType Decodable
 extension AnyType: Decodable {
-    /**
-     Construct AnyType by decoding
-     - parameters:
-        - decoder: A decoder to decode from
-     */
+    /// Construct AnyType by decoding
+    /// - parameters:
+    ///   - decoder: A decoder to decode from
     // swiftlint:disable cyclomatic_complexity
     public init(from decoder: Decoder) throws {
         if let dictionary = try? decoder.singleValueContainer().decode([String: String].self) {
             self = .dictionary(data: dictionary)
             return
-        } else if let dictionary = try? decoder.singleValueContainer().decode([String: Double].self) {
+        } else if let dictionary = try? decoder.singleValueContainer()
+            .decode([String: Double].self) {
             self = .numberDictionary(data: dictionary)
             return
         } else if let dictionary = try? decoder.singleValueContainer().decode([String: Bool].self) {
@@ -145,7 +137,8 @@ extension AnyType: Decodable {
         } else if let number = try? decoder.singleValueContainer().decode(Double.self) {
             self = .number(data: number)
             return
-        } else if let context = decoder.userInfo[AnyTypeDecodingContext.key] as? AnyTypeDecodingContext {
+        } else if let context = decoder
+            .userInfo[AnyTypeDecodingContext.key] as? AnyTypeDecodingContext {
             let obj = try context.objectFor(path: decoder.singleValueContainer().codingPath)
             if let dictionary = obj as? [String: Any] {
                 self = .anyDictionary(data: dictionary)
@@ -156,71 +149,73 @@ extension AnyType: Decodable {
             }
         }
         self = .unknownData
-        return
     }
 }
 
-// Custom CodingKey for dynamic key name
-// and to try to coerce `Any` into `Encodable`
+/// Custom CodingKey for dynamic key name
+/// and to try to coerce `Any` into `Encodable`
 struct CustomEncodable: CodingKey {
     var data: Encodable?
-    init(_ encodable: Any?, key: String) {
-        self.stringValue = key
-        if let encodable = encodable as? Encodable {
-            self.data = encodable
-        } else if
-            let encodable,
-            let data = try? JSONSerialization.data(withJSONObject: encodable, options: .fragmentsAllowed),
-            let decoded = try? AnyTypeDecodingContext(rawData: data).inject(to: JSONDecoder()).decode(AnyType.self, from: data)
-        {
-            self.data = decoded
-        }
-    }
     var stringValue: String
-
-    init?(stringValue: String) {
-        return nil
-    }
 
     var intValue: Int?
 
-    init?(intValue: Int) {
-        return nil
+    init(_ encodable: Any?, key: String) {
+        stringValue = key
+        if let encodable = encodable as? Encodable {
+            data = encodable
+        } else if
+            let encodable,
+            let data = try? JSONSerialization.data(
+                withJSONObject: encodable,
+                options: .fragmentsAllowed
+            ),
+            let decoded = try? AnyTypeDecodingContext(rawData: data)
+            .inject(to: JSONDecoder())
+            .decode(
+                AnyType.self,
+                from: data
+            ) {
+            self.data = decoded
+        }
     }
 
+    init?(stringValue _: String) {
+        nil
+    }
+
+    init?(intValue _: Int) {
+        nil
+    }
 }
 
-/**
- Make AnyType Encodable
- */
+/// Make AnyType Encodable
 extension AnyType: Encodable {
-    /**
-     Encode to an encoder
-     - parameters:
-        - encoder: The encoder to encode the value to
-     */
+    /// Encode to an encoder
+    /// - parameters:
+    ///   - encoder: The encoder to encode the value to
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self {
-        case .string(let string):
+        case let .string(string):
             try container.encode(string)
-        case .bool(let boolean):
+        case let .bool(boolean):
             try container.encode(boolean)
-        case .number(let number):
+        case let .number(number):
             try container.encode(number)
-        case .array(let stringArray):
+        case let .array(stringArray):
             try container.encode(stringArray)
-        case .numberArray(let numberArray):
+        case let .numberArray(numberArray):
             try container.encode(numberArray)
-        case .booleanArray(let booleanArray):
+        case let .booleanArray(booleanArray):
             try container.encode(booleanArray)
-        case .dictionary(let dictionary):
+        case let .dictionary(dictionary):
             try container.encode(dictionary)
-        case .numberDictionary(let dictionary):
+        case let .numberDictionary(dictionary):
             try container.encode(dictionary)
-        case .booleanDictionary(let dictionary):
+        case let .booleanDictionary(dictionary):
             try container.encode(dictionary)
-        case .anyDictionary(data: let dictionary):
+        case let .anyDictionary(data: dictionary):
             var keyed = encoder.container(keyedBy: CustomEncodable.self)
             for key in dictionary.keys {
                 let customEncodable = CustomEncodable(dictionary[key], key: key)
@@ -228,7 +223,7 @@ extension AnyType: Encodable {
                     try keyed.encode(value, forKey: customEncodable)
                 }
             }
-        case .anyArray(data: let array):
+        case let .anyArray(data: array):
             var indexed = encoder.unkeyedContainer()
             for value in array {
                 let encodable = CustomEncodable(value, key: "")
@@ -236,7 +231,6 @@ extension AnyType: Encodable {
                     try indexed.encode(data)
                 }
             }
-
         default:
             try container.encodeNil()
             return
@@ -245,7 +239,7 @@ extension AnyType: Encodable {
 }
 
 public struct AnyTypeDecodingContext {
-    static let key = CodingUserInfoKey(rawValue: "AnyTypeDecodingContext")!
+    static let key: CodingUserInfoKey = (rawValue: "AnyTypeDecodingContext")!
 
     public var rawData: Data
 
@@ -258,6 +252,11 @@ public struct AnyTypeDecodingContext {
         return traverse(path: path, in: jsonData)
     }
 
+    public func inject(to decoder: JSONDecoder) -> JSONDecoder {
+        decoder.userInfo[AnyTypeDecodingContext.key] = self
+        return decoder
+    }
+
     private func traverse(path: [CodingKey], in obj: Any) -> Any {
         path.reduce(obj) { partialResult, key in
             if let index = key.intValue {
@@ -265,10 +264,5 @@ public struct AnyTypeDecodingContext {
             }
             return (partialResult as? [String: Any])?[key.stringValue] as Any
         }
-    }
-
-    public func inject(to decoder: JSONDecoder) -> JSONDecoder {
-        decoder.userInfo[AnyTypeDecodingContext.key] = self
-        return decoder
     }
 }

--- a/ios/core/Sources/Types/Generic/AnyType.swift
+++ b/ios/core/Sources/Types/Generic/AnyType.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+// swiftlint:disable file_length
+
 /// A union type to match the JS core players any type
 ///
 /// This type is `Sendable` and uses recursive cases for complex types.
@@ -55,7 +57,7 @@ public enum AnyType: Hashable, Sendable {
     /// The underlying data was not in a known format. For example, it was a "null".
     case unknownData
 
-    // swiftlint:disable cyclomatic_complexity
+    // swiftlint:disable:next cyclomatic_complexity
     public func hash(into hasher: inout Hasher) {
         switch self {
         case let .string(data):
@@ -111,6 +113,7 @@ public extension AnyType {
     /// let dict = AnyType.anyDictionary(data: ["title": .string(data: "Hello")])
     /// let title: String? = dict["title"]?.as(String.self)
     /// ```
+    // swiftlint:disable:next cyclomatic_complexity
     func `as`<T>(_: T.Type) -> T? {
         switch self {
         case let .string(data):
@@ -171,7 +174,7 @@ public extension AnyType {
 }
 
 extension AnyType: Equatable {
-    // swiftlint:disable cyclomatic_complexity
+    // swiftlint:disable:next cyclomatic_complexity
     public static func == (lhs: AnyType, rhs: AnyType) -> Bool {
         switch (lhs, rhs) {
         case let (.string(lhv), .string(rhv)): return lhv == rhv
@@ -196,7 +199,6 @@ extension AnyType: Decodable {
     /// Construct AnyType by decoding
     /// - parameters:
     ///   - decoder: A decoder to decode from
-    // swiftlint:disable cyclomatic_complexity
     public init(from decoder: Decoder) throws {
         if let dictionary = try? decoder.singleValueContainer().decode([String: String].self) {
             self = .dictionary(data: dictionary)
@@ -263,6 +265,7 @@ extension AnyType: Encodable {
     /// Encode to an encoder
     /// - parameters:
     ///   - encoder: The encoder to encode the value to
+    // swiftlint:disable:next cyclomatic_complexity
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self {
@@ -309,7 +312,7 @@ extension AnyType: Encodable {
 ///
 /// - Note: Required when decoding JSON containing mixed-type arrays or dictionaries
 public struct AnyTypeDecodingContext {
-    static let key: CodingUserInfoKey = (rawValue: "AnyTypeDecodingContext")!
+    static let key: CodingUserInfoKey! = CodingUserInfoKey(rawValue: "AnyTypeDecodingContext")
 
     private var rawData: Data
 
@@ -346,6 +349,7 @@ public struct AnyTypeDecodingContext {
     }
 
     /// Decodes a raw JSON object to AnyType
+    // swiftlint:disable:next cyclomatic_complexity
     private static func decode(from value: Any) -> AnyType {
         // Handle primitives
         if let string = value as? String {
@@ -398,7 +402,8 @@ public enum AnyTypeDecodingError: Error {
         switch self {
         case .missingDecodingContext:
             return """
-            Attempted to decode data as an AnyType.anyArray, AnyType.anyDictionary, or AnyType.unknownData but `AnyTypeDecodingContext` is missing.
+            Attempted to decode data as an AnyType.anyArray, AnyType.anyDictionary, or \
+            AnyType.unknownData but `AnyTypeDecodingContext` is missing.
             Create a context with `let context = AnyTypeDecodingContext(rawData: data)`.
             Add the context to the decoder's userInfo by calling `context.inject(to: decoder)`.
             """

--- a/ios/core/Sources/Types/Generic/AnyType.swift
+++ b/ios/core/Sources/Types/Generic/AnyType.swift
@@ -7,46 +7,10 @@
 
 import Foundation
 
-/**
- A union type to match the JS core players any type
- 
- This type is `Sendable` and uses recursive cases for complex types.
- */
+/// A union type to match the JS core players any type
+///
+/// This type is `Sendable` and uses recursive cases for complex types.
 public enum AnyType: Hashable, Sendable {
-    // swiftlint:disable cyclomatic_complexity
-    public func hash(into hasher: inout Hasher) {
-        switch self {
-        case .string(let data):
-            hasher.combine(data)
-        case .bool(let data):
-            hasher.combine(data)
-        case .number(let data):
-            hasher.combine(data)
-        case .dictionary(let data):
-            hasher.combine(data)
-        case .numberDictionary(let data):
-            hasher.combine(data)
-        case .booleanDictionary(let data):
-            hasher.combine(data)
-        case .array(let data):
-            hasher.combine(data)
-        case .numberArray(let data):
-            hasher.combine(data)
-        case .booleanArray(let data):
-            hasher.combine(data)
-        case .anyDictionary(let data):
-            // Hash the dictionary by combining sorted keys and their values
-            for key in data.keys.sorted() {
-                hasher.combine(key)
-                hasher.combine(data[key])
-            }
-        case .anyArray(let data):
-            hasher.combine(data)
-        case .unknownData:
-            return
-        }
-    }
-
     /// The underlying data was a string
     case string(data: String)
 
@@ -74,104 +38,131 @@ public enum AnyType: Hashable, Sendable {
     /// The underlying data was an array of booleans
     case booleanArray(data: [Bool])
 
-    /**
-     The underlying data was a dictionary of varied value types
-     
-     This case uses recursive `AnyType` values to maintain `Sendable` conformance.
-
-     - Note: This requires the decoder to add `AnyTypeDecodingContext` to the decoder's userInfo
-     */
+    /// The underlying data was a dictionary of varied value types
+    ///
+    /// This case uses recursive `AnyType` values to maintain `Sendable` conformance.
+    ///
+    /// - Note: This requires the decoder to add `AnyTypeDecodingContext` to the decoder's userInfo
     case anyDictionary(data: [String: AnyType])
 
-    /**
-     The underlying data was an array of varied value types
-     
-     This case uses recursive `AnyType` values to maintain `Sendable` conformance.
-
-     - Note: This requires the decoder to add `AnyTypeDecodingContext` to the decoder's userInfo
-     */
+    /// The underlying data was an array of varied value types
+    ///
+    /// This case uses recursive `AnyType` values to maintain `Sendable` conformance.
+    ///
+    /// - Note: This requires the decoder to add `AnyTypeDecodingContext` to the decoder's userInfo
     case anyArray(data: [AnyType])
 
     /// The underlying data was not in a known format. For example, it was a "null".
     case unknownData
+
+    // swiftlint:disable cyclomatic_complexity
+    public func hash(into hasher: inout Hasher) {
+        switch self {
+        case let .string(data):
+            hasher.combine(data)
+        case let .bool(data):
+            hasher.combine(data)
+        case let .number(data):
+            hasher.combine(data)
+        case let .dictionary(data):
+            hasher.combine(data)
+        case let .numberDictionary(data):
+            hasher.combine(data)
+        case let .booleanDictionary(data):
+            hasher.combine(data)
+        case let .array(data):
+            hasher.combine(data)
+        case let .numberArray(data):
+            hasher.combine(data)
+        case let .booleanArray(data):
+            hasher.combine(data)
+        case let .anyDictionary(data):
+            // Hash the dictionary by combining sorted keys and their values
+            for key in data.keys.sorted() {
+                hasher.combine(key)
+                hasher.combine(data[key])
+            }
+        case let .anyArray(data):
+            hasher.combine(data)
+        case .unknownData:
+            return
+        }
+    }
 }
 
 // MARK: - Value Extraction
 
-extension AnyType {
-    /**
-     Cast to expected type automatically.
-     
-     This method provides a convenient way to extract the underlying value and cast it to a specific type
-     without explicit pattern matching on each case.
-     
-     - Parameter type: The target type to cast to
-     - Returns: The value cast to the specified type, or `nil` if the cast fails
-     
-     - Example:
-     ```swift
-     let anyType = AnyType.string(data: "Hello")
-     let title: String? = anyType.as(String.self)  // "Hello"
-     
-     // Usage with subscripts
-     let dict = AnyType.anyDictionary(data: ["title": .string(data: "Hello")])
-     let title: String? = dict["title"]?.as(String.self)
-     ```
-     */
-    public func `as`<T>(_ type: T.Type) -> T? {
+public extension AnyType {
+    /// Cast to expected type automatically.
+    ///
+    /// This method provides a convenient way to extract the underlying value and cast it to a
+    /// specific type
+    /// without explicit pattern matching on each case.
+    ///
+    /// - Parameter type: The target type to cast to
+    /// - Returns: The value cast to the specified type, or `nil` if the cast fails
+    ///
+    /// - Example:
+    /// ```swift
+    /// let anyType = AnyType.string(data: "Hello")
+    /// let title: String? = anyType.as(String.self)  // "Hello"
+    ///
+    /// // Usage with subscripts
+    /// let dict = AnyType.anyDictionary(data: ["title": .string(data: "Hello")])
+    /// let title: String? = dict["title"]?.as(String.self)
+    /// ```
+    func `as`<T>(_: T.Type) -> T? {
         switch self {
-        case .string(let data):
+        case let .string(data):
             return data as? T
-        case .bool(let data):
+        case let .bool(data):
             return data as? T
-        case .number(let data):
+        case let .number(data):
             return data as? T
-        case .dictionary(let data):
+        case let .dictionary(data):
             return data as? T
-        case .numberDictionary(let data):
+        case let .numberDictionary(data):
             return data as? T
-        case .booleanDictionary(let data):
+        case let .booleanDictionary(data):
             return data as? T
-        case .array(let data):
+        case let .array(data):
             return data as? T
-        case .numberArray(let data):
+        case let .numberArray(data):
             return data as? T
-        case .booleanArray(let data):
+        case let .booleanArray(data):
             return data as? T
-        case .anyDictionary(let data):
+        case let .anyDictionary(data):
             return data as? T
-        case .anyArray(let data):
+        case let .anyArray(data):
             return data as? T
         case .unknownData:
             return nil
         }
     }
-    
-    /**
-     Subscript access for dictionary-like `AnyType` values.
-     
-     Provides convenient access to values in `anyDictionary`, `dictionary`, `numberDictionary`,
-     and `booleanDictionary` cases.
-     
-     - Parameter key: The key to look up
-     - Returns: The value associated with the key, or `nil` if the key doesn't exist
-               or if this is not a dictionary-like case
-     
-     - Example:
-     ```swift
-     let dict = AnyType.anyDictionary(data: ["title": .string(data: "Hello")])
-     let title: String? = dict["title"]?.as(String.self)
-     ```
-     */
-    public subscript(key: String) -> AnyType? {
+
+    /// Subscript access for dictionary-like `AnyType` values.
+    ///
+    /// Provides convenient access to values in `anyDictionary`, `dictionary`, `numberDictionary`,
+    /// and `booleanDictionary` cases.
+    ///
+    /// - Parameter key: The key to look up
+    /// - Returns: The value associated with the key, or `nil` if the key doesn't exist
+    ///          or if this is not a dictionary-like case
+    ///
+    /// - Example:
+    /// ```swift
+    /// let dict = AnyType.anyDictionary(data: ["title": .string(data: "Hello")])
+    /// let title: String? = dict["title"]?.as(String.self)
+    /// ```
+    subscript(key: String) -> AnyType? {
         switch self {
-        case .dictionary(let data):
+        case let .dictionary(data):
             return data[key].map { .string(data: $0) }
-        case .numberDictionary(let data):
+        case let .numberDictionary(data):
             return data[key].map { .number(data: $0) }
-        case .booleanDictionary(let data):
+        case let .booleanDictionary(data):
             return data[key].map { .bool(data: $0) }
-        case .anyDictionary(let data):
+        case let .anyDictionary(data):
             return data[key]
         default:
             return nil
@@ -183,38 +174,35 @@ extension AnyType: Equatable {
     // swiftlint:disable cyclomatic_complexity
     public static func == (lhs: AnyType, rhs: AnyType) -> Bool {
         switch (lhs, rhs) {
-        case (.string(let lhv), .string(let rhv)): return lhv == rhv
-        case (.bool(let lhv), .bool(let rhv)): return lhv == rhv
-        case (.number(let lhv), .number(let rhv)): return lhv == rhv
-        case (.dictionary(let lhv), .dictionary(let rhv)): return lhv == rhv
-        case (.numberDictionary(let lhv), .numberDictionary(let rhv)): return lhv == rhv
-        case (.booleanDictionary(let lhv), .booleanDictionary(let rhv)): return lhv == rhv
-        case (.array(let lhv), .array(let rhv)): return lhv == rhv
-        case (.numberArray(let lhv), .numberArray(let rhv)): return lhv == rhv
-        case (.booleanArray(let lhv), .booleanArray(let rhv)): return lhv == rhv
-        case (.anyDictionary(let lhv), .anyDictionary(let rhv)): return lhv == rhv
-        case (.anyArray(let lhv), .anyArray(let rhv)): return lhv == rhv
+        case let (.string(lhv), .string(rhv)): return lhv == rhv
+        case let (.bool(lhv), .bool(rhv)): return lhv == rhv
+        case let (.number(lhv), .number(rhv)): return lhv == rhv
+        case let (.dictionary(lhv), .dictionary(rhv)): return lhv == rhv
+        case let (.numberDictionary(lhv), .numberDictionary(rhv)): return lhv == rhv
+        case let (.booleanDictionary(lhv), .booleanDictionary(rhv)): return lhv == rhv
+        case let (.array(lhv), .array(rhv)): return lhv == rhv
+        case let (.numberArray(lhv), .numberArray(rhv)): return lhv == rhv
+        case let (.booleanArray(lhv), .booleanArray(rhv)): return lhv == rhv
+        case let (.anyDictionary(lhv), .anyDictionary(rhv)): return lhv == rhv
+        case let (.anyArray(lhv), .anyArray(rhv)): return lhv == rhv
         case (.unknownData, .unknownData): return true
         default: return false
         }
     }
 }
 
-/**
- Make AnyType Decodable
- */
+/// Make AnyType Decodable
 extension AnyType: Decodable {
-    /**
-     Construct AnyType by decoding
-     - parameters:
-        - decoder: A decoder to decode from
-     */
+    /// Construct AnyType by decoding
+    /// - parameters:
+    ///   - decoder: A decoder to decode from
     // swiftlint:disable cyclomatic_complexity
     public init(from decoder: Decoder) throws {
         if let dictionary = try? decoder.singleValueContainer().decode([String: String].self) {
             self = .dictionary(data: dictionary)
             return
-        } else if let dictionary = try? decoder.singleValueContainer().decode([String: Double].self) {
+        } else if let dictionary = try? decoder.singleValueContainer()
+            .decode([String: Double].self) {
             self = .numberDictionary(data: dictionary)
             return
         } else if let dictionary = try? decoder.singleValueContainer().decode([String: Bool].self) {
@@ -239,15 +227,17 @@ extension AnyType: Decodable {
             self = .number(data: number)
             return
         }
-        
+
         // anyArray, anyDictionary, or "null" (which becomes unknownData)
-        guard let context = decoder.userInfo[AnyTypeDecodingContext.key] as? AnyTypeDecodingContext else {
+        guard let context = decoder.userInfo[AnyTypeDecodingContext.key] as? AnyTypeDecodingContext
+        else {
             throw AnyTypeDecodingError.missingDecodingContext
         }
 
-        /* Handle mixed-type collections using the context. We could handle every case with this,
-         but it would be slower because of the JSON serialization. So we only use this for anyArray
-         and anyDictionary */
+        // Handle mixed-type collections using the context. We could handle every case with this,
+        // but it would be slower because of the JSON serialization. So we only use this for
+        // anyArray
+        // and anyDictionary
         self = try context.decode(path: decoder.codingPath)
     }
 }
@@ -256,56 +246,52 @@ extension AnyType: Decodable {
 struct CustomEncodable: CodingKey {
     var stringValue: String
 
+    var intValue: Int?
+
     init?(stringValue: String) {
         self.stringValue = stringValue
     }
 
-    var intValue: Int?
-
-    // Required by CodingKey protocol but not used since anyArray uses unkeyedContainer
-    init?(intValue: Int) {
-        return nil
+    /// Required by CodingKey protocol but not used since anyArray uses unkeyedContainer
+    init?(intValue _: Int) {
+        nil
     }
 }
 
-/**
- Make AnyType Encodable
- */
+/// Make AnyType Encodable
 extension AnyType: Encodable {
-    /**
-     Encode to an encoder
-     - parameters:
-        - encoder: The encoder to encode the value to
-     */
+    /// Encode to an encoder
+    /// - parameters:
+    ///   - encoder: The encoder to encode the value to
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self {
-        case .string(let string):
+        case let .string(string):
             try container.encode(string)
-        case .bool(let boolean):
+        case let .bool(boolean):
             try container.encode(boolean)
-        case .number(let number):
+        case let .number(number):
             try container.encode(number)
-        case .array(let stringArray):
+        case let .array(stringArray):
             try container.encode(stringArray)
-        case .numberArray(let numberArray):
+        case let .numberArray(numberArray):
             try container.encode(numberArray)
-        case .booleanArray(let booleanArray):
+        case let .booleanArray(booleanArray):
             try container.encode(booleanArray)
-        case .dictionary(let dictionary):
+        case let .dictionary(dictionary):
             try container.encode(dictionary)
-        case .numberDictionary(let dictionary):
+        case let .numberDictionary(dictionary):
             try container.encode(dictionary)
-        case .booleanDictionary(let dictionary):
+        case let .booleanDictionary(dictionary):
             try container.encode(dictionary)
-        case .anyDictionary(data: let dictionary):
+        case let .anyDictionary(data: dictionary):
             var keyed = encoder.container(keyedBy: CustomEncodable.self)
             for (key, value) in dictionary {
                 if let codingKey = CustomEncodable(stringValue: key) {
                     try keyed.encode(value, forKey: codingKey)
                 }
             }
-        case .anyArray(data: let array):
+        case let .anyArray(data: array):
             var indexed = encoder.unkeyedContainer()
             for value in array {
                 try indexed.encode(value)
@@ -316,16 +302,14 @@ extension AnyType: Encodable {
     }
 }
 
-/**
- Context for decoding mixed-type collections (anyDictionary and anyArray)
-
- This context turns serializes the data into JSON data to enable decoding of heterogeneous
- collections that cannot be directly decoded through Swift's standard Codable system.
-
- - Note: Required when decoding JSON containing mixed-type arrays or dictionaries
- */
+/// Context for decoding mixed-type collections (anyDictionary and anyArray)
+///
+/// This context turns serializes the data into JSON data to enable decoding of heterogeneous
+/// collections that cannot be directly decoded through Swift's standard Codable system.
+///
+/// - Note: Required when decoding JSON containing mixed-type arrays or dictionaries
 public struct AnyTypeDecodingContext {
-    static let key = CodingUserInfoKey(rawValue: "AnyTypeDecodingContext")!
+    static let key: CodingUserInfoKey = (rawValue: "AnyTypeDecodingContext")!
 
     private var rawData: Data
 
@@ -382,7 +366,7 @@ public struct AnyTypeDecodingContext {
                 return .booleanDictionary(data: boolDict)
             }
             // Mixed dictionary - recurse
-            var result: [String: AnyType] = [:]
+            var result = [String: AnyType]()
             for (key, val) in dict {
                 result[key] = decode(from: val)
             }
@@ -397,7 +381,7 @@ public struct AnyTypeDecodingContext {
                 return .booleanArray(data: boolArray)
             }
             // Mixed array - recurse
-            var result: [AnyType] = []
+            var result = [AnyType]()
             for val in array {
                 result.append(decode(from: val))
             }

--- a/ios/core/Sources/Types/Generic/AnyType.swift
+++ b/ios/core/Sources/Types/Generic/AnyType.swift
@@ -160,15 +160,15 @@ public extension AnyType {
     subscript(key: String) -> AnyType? {
         switch self {
         case let .dictionary(data):
-            return data[key].map { .string(data: $0) }
+            data[key].map { .string(data: $0) }
         case let .numberDictionary(data):
-            return data[key].map { .number(data: $0) }
+            data[key].map { .number(data: $0) }
         case let .booleanDictionary(data):
-            return data[key].map { .bool(data: $0) }
+            data[key].map { .bool(data: $0) }
         case let .anyDictionary(data):
-            return data[key]
+            data[key]
         default:
-            return nil
+            nil
         }
     }
 }
@@ -177,19 +177,19 @@ extension AnyType: Equatable {
     // swiftlint:disable:next cyclomatic_complexity
     public static func == (lhs: AnyType, rhs: AnyType) -> Bool {
         switch (lhs, rhs) {
-        case let (.string(lhv), .string(rhv)): return lhv == rhv
-        case let (.bool(lhv), .bool(rhv)): return lhv == rhv
-        case let (.number(lhv), .number(rhv)): return lhv == rhv
-        case let (.dictionary(lhv), .dictionary(rhv)): return lhv == rhv
-        case let (.numberDictionary(lhv), .numberDictionary(rhv)): return lhv == rhv
-        case let (.booleanDictionary(lhv), .booleanDictionary(rhv)): return lhv == rhv
-        case let (.array(lhv), .array(rhv)): return lhv == rhv
-        case let (.numberArray(lhv), .numberArray(rhv)): return lhv == rhv
-        case let (.booleanArray(lhv), .booleanArray(rhv)): return lhv == rhv
-        case let (.anyDictionary(lhv), .anyDictionary(rhv)): return lhv == rhv
-        case let (.anyArray(lhv), .anyArray(rhv)): return lhv == rhv
-        case (.unknownData, .unknownData): return true
-        default: return false
+        case let (.string(lhv), .string(rhv)): lhv == rhv
+        case let (.bool(lhv), .bool(rhv)): lhv == rhv
+        case let (.number(lhv), .number(rhv)): lhv == rhv
+        case let (.dictionary(lhv), .dictionary(rhv)): lhv == rhv
+        case let (.numberDictionary(lhv), .numberDictionary(rhv)): lhv == rhv
+        case let (.booleanDictionary(lhv), .booleanDictionary(rhv)): lhv == rhv
+        case let (.array(lhv), .array(rhv)): lhv == rhv
+        case let (.numberArray(lhv), .numberArray(rhv)): lhv == rhv
+        case let (.booleanArray(lhv), .booleanArray(rhv)): lhv == rhv
+        case let (.anyDictionary(lhv), .anyDictionary(rhv)): lhv == rhv
+        case let (.anyArray(lhv), .anyArray(rhv)): lhv == rhv
+        case (.unknownData, .unknownData): true
+        default: false
         }
     }
 }
@@ -401,7 +401,7 @@ public enum AnyTypeDecodingError: Error {
     public var localizedDescription: String {
         switch self {
         case .missingDecodingContext:
-            return """
+            """
             Attempted to decode data as an AnyType.anyArray, AnyType.anyDictionary, or \
             AnyType.unknownData but `AnyTypeDecodingContext` is missing.
             Create a context with `let context = AnyTypeDecodingContext(rawData: data)`.

--- a/ios/core/Sources/Types/Hooks/DataControllerHooks.swift
+++ b/ios/core/Sources/Types/Hooks/DataControllerHooks.swift
@@ -8,22 +8,20 @@
 import Foundation
 import JavaScriptCore
 
-/**
-Hooks that can be tapped into for the DataController
-This lets users tap into events in the JS environment
-*/
+/// Hooks that can be tapped into for the DataController
+/// This lets users tap into events in the JS environment
 public struct DataControllerHooks {
     /// Fired when the data changes
     public var onUpdate: HookDecode<[Update]>
 }
 
 public struct Update: Decodable {
-    /** The updated binding */
+    /// The updated binding
     var binding: BindingInstance
-    /** The old value */
+    /// The old value
     var oldValue: AnyType
-    /** The new value */
+    /// The new value
     var newValue: AnyType
-    /** Force the Update to be included even if no data changed */
+    /// Force the Update to be included even if no data changed
     var force: Bool?
 }

--- a/ios/core/Sources/Types/Hooks/ErrorControllerHooks.swift
+++ b/ios/core/Sources/Types/Hooks/ErrorControllerHooks.swift
@@ -8,17 +8,12 @@
 import Foundation
 import JavaScriptCore
 
-/**
- Hooks that can be tapped into for the ErrorController
- This lets users tap into error events in the JS environment
- */
+/// Hooks that can be tapped into for the ErrorController
+/// This lets users tap into error events in the JS environment
 public struct ErrorControllerHooks {
-    /**
-     Fired when any error is captured
-     - The callback receives a PlayerErrorInfo object
-     - Return true from the callback to bail and prevent error state navigation
-     - Return nil/false to allow automatic navigation to continue
-     */
+    /// Fired when any error is captured
+    /// - The callback receives a PlayerErrorInfo object
+    /// - Return true from the callback to bail and prevent error state navigation
+    /// - Return nil/false to allow automatic navigation to continue
     public var onError: HookWithResult<JSValueError, Bool>
 }
-

--- a/ios/core/Sources/Types/Hooks/FlowControllerHooks.swift
+++ b/ios/core/Sources/Types/Hooks/FlowControllerHooks.swift
@@ -1,6 +1,6 @@
 //
 //  FlowControllerHooks.swift
-//  
+//
 //
 //  Created by Borawski, Harris on 2/12/20.
 //
@@ -8,10 +8,8 @@
 import Foundation
 import JavaScriptCore
 
-/**
- Hooks that can be tapped into for the FlowController
- This lets users tap into events in the JS environment
- */
+/// Hooks that can be tapped into for the FlowController
+/// This lets users tap into events in the JS environment
 public struct FlowControllerHooks {
     /// Fired for new Flows
     public var flow: Hook<Flow>

--- a/ios/core/Sources/Types/Hooks/Hook.swift
+++ b/ios/core/Sources/Types/Hooks/Hook.swift
@@ -10,17 +10,21 @@ import JavaScriptCore
 
 /// A base for implementing JS backed hooks
 open class BaseJSHook {
-    private let baseValue: JSValue
-    
-    /// The JS reference to the hook
-    public var hook: JSValue { baseValue.objectForKeyedSubscript("hooks").objectForKeyedSubscript(name) }
-    
-    /// The JSContext for the hook
-    public var context: JSContext { hook.context }
-    
     /// The name of the hook
     public let name: String
-    
+
+    private let baseValue: JSValue
+
+    /// The JS reference to the hook
+    public var hook: JSValue {
+        baseValue.objectForKeyedSubscript("hooks").objectForKeyedSubscript(name)
+    }
+
+    /// The JSContext for the hook
+    public var context: JSContext {
+        hook.context
+    }
+
     /// Retrieves a hook by name from an object in JS
     /// - Parameters:
     ///   - baseValue: The object that has `hooks`
@@ -36,15 +40,15 @@ public class BaseAsyncJSHook: BaseJSHook {
     /// Creates a promise with common error handling for async operations
     /// - Parameter asyncWork: The async work to execute
     /// - Returns: A JavaScript promise
-    internal func createAsyncPromise<Result>(_ asyncWork: @escaping () async throws -> Result) -> JSValue {
-        let promise = JSUtilities.createPromise(context: self.context) { (resolve, reject) in
+    func createAsyncPromise<Result>(_ asyncWork: @escaping () async throws -> Result) -> JSValue {
+        let promise = JSUtilities.createPromise(context: context) { resolve, reject in
             Task {
                 do {
                     let result = try await asyncWork()
                     DispatchQueue.main.async {
                         resolve(result as Any)
                     }
-                } catch let error {
+                } catch {
                     let message = error.playerDescription
                     DispatchQueue.main.async {
                         reject("Async hook threw with error '\(message)'")
@@ -56,18 +60,14 @@ public class BaseAsyncJSHook: BaseJSHook {
     }
 }
 
-/**
- This class represents an object in the JS runtime that can be tapped into
- to receive JS events
- */
-public class Hook<T>: BaseJSHook where T: CreatedFromJSValue {
-    /**
-     Attach a closure to the hook, so when the hook is fired in the JS runtime
-     we receive the event in the native runtime
-     
-     - parameters:
-     - hook: A function to run when the JS hook is fired
-     */
+/// This class represents an object in the JS runtime that can be tapped into
+/// to receive JS events
+public class Hook<T: CreatedFromJSValue>: BaseJSHook {
+    /// Attach a closure to the hook, so when the hook is fired in the JS runtime
+    /// we receive the event in the native runtime
+    ///
+    /// - parameters:
+    /// - hook: A function to run when the JS hook is fired
     public func tap(_ hook: @escaping (T) -> Void) {
         let tapMethod: @convention(block) (JSValue?) -> Void = { value in
             guard
@@ -76,23 +76,22 @@ public class Hook<T>: BaseJSHook where T: CreatedFromJSValue {
             else { return }
             hook(hookValue)
         }
-        
-        self.hook.invokeMethod("tap", withArguments: [name, JSValue(object: tapMethod, in: context) as Any])
+
+        self.hook.invokeMethod(
+            "tap",
+            withArguments: [name, JSValue(object: tapMethod, in: context) as Any]
+        )
     }
 }
 
-/**
- This class represents an object in the JS runtime that can be tapped into
- to receive JS events that has 2 parameters
- */
-public class Hook2<T, U>: BaseJSHook where T: CreatedFromJSValue, U: CreatedFromJSValue {
-    /**
-     Attach a closure to the hook, so when the hook is fired in the JS runtime
-     we receive the event in the native runtime
-     
-     - parameters:
-     - hook: A function to run when the JS hook is fired
-     */
+/// This class represents an object in the JS runtime that can be tapped into
+/// to receive JS events that has 2 parameters
+public class Hook2<T: CreatedFromJSValue, U: CreatedFromJSValue>: BaseJSHook {
+    /// Attach a closure to the hook, so when the hook is fired in the JS runtime
+    /// we receive the event in the native runtime
+    ///
+    /// - parameters:
+    /// - hook: A function to run when the JS hook is fired
     public func tap<R>(_ hook: @escaping (T, U) -> R) {
         let tapMethod: @convention(block) (JSValue?, JSValue?) -> Any? = { value, value2 in
             guard
@@ -103,8 +102,11 @@ public class Hook2<T, U>: BaseJSHook where T: CreatedFromJSValue, U: CreatedFrom
             else { return nil }
             return hook(hookValue, hookValue2)
         }
-        
-        self.hook.invokeMethod("tap", withArguments: [name, JSValue(object: tapMethod, in: context) as Any])
+
+        self.hook.invokeMethod(
+            "tap",
+            withArguments: [name, JSValue(object: tapMethod, in: context) as Any]
+        )
     }
 }
 
@@ -114,25 +116,36 @@ public protocol JSValueProviding {
 }
 
 /// Waterfall hook with 2 args (T, U) returning R. Aligns with web SyncWaterfallHook<[T, U]>.
-public class SyncWaterfallHook2JS<T, R, U>: BaseJSHook where T: CreatedFromJSValue, R: CreatedFromJSValue & JSValueProviding {
+public class SyncWaterfallHook2JS<
+    T: CreatedFromJSValue,
+    R: CreatedFromJSValue & JSValueProviding,
+    U
+>: BaseJSHook {
     public func tap(_ hook: @escaping (T, U) -> R) {
         let tapMethod: @convention(block) (JSValue?, JSValue?) -> JSValue? = { value1, value2 in
             guard let value1, let value2,
                   let hookValue1 = T.createInstance(value: value1) as? T else {
                 return nil
             }
-            // Prefer toObject(); fallback to toString() for JS string primitives (e.g. U == String).
+            // Prefer toObject(); fallback to toString() for JS string primitives (e.g. U ==
+            // String).
             let hookValue2: U? = (value2.toObject() as? U) ?? ((value2.toString() as Any) as? U)
             guard let hookValue2 else { return nil }
             let returnValue = hook(hookValue1, hookValue2)
             return returnValue.jsValue
         }
-        self.hook.invokeMethod("tap", withArguments: [name, JSValue(object: tapMethod, in: context) as Any])
+        self.hook.invokeMethod(
+            "tap",
+            withArguments: [name, JSValue(object: tapMethod, in: context) as Any]
+        )
     }
 }
 
 /// Waterfall hook with 1 arg T returning R. Aligns with web SyncWaterfallHook<[T]>.
-public class SyncWaterfallHookJS<T, R>: BaseJSHook where T: CreatedFromJSValue, R: CreatedFromJSValue & JSValueProviding {
+public class SyncWaterfallHookJS<
+    T: CreatedFromJSValue,
+    R: CreatedFromJSValue & JSValueProviding
+>: BaseJSHook {
     public func tap(_ hook: @escaping (T) -> R) {
         let tapMethod: @convention(block) (JSValue?) -> JSValue? = { value in
             guard let val = value,
@@ -142,22 +155,21 @@ public class SyncWaterfallHookJS<T, R>: BaseJSHook where T: CreatedFromJSValue, 
             let returnValue = hook(hookValue)
             return returnValue.jsValue
         }
-        self.hook.invokeMethod("tap", withArguments: [name, JSValue(object: tapMethod, in: context) as Any])
+        self.hook.invokeMethod(
+            "tap",
+            withArguments: [name, JSValue(object: tapMethod, in: context) as Any]
+        )
     }
 }
 
-/**
- This class represents an object in the JS runtime that can be tapped into
- to receive JS events
- */
-public class HookDecode<T>: BaseJSHook where T: Decodable {
-    /**
-     Attach a closure to the hook, so when the hook is fired in the JS runtime
-     we receive the event in the native runtime
-     
-     - parameters:
-     - hook: A function to run when the JS hook is fired
-     */
+/// This class represents an object in the JS runtime that can be tapped into
+/// to receive JS events
+public class HookDecode<T: Decodable>: BaseJSHook {
+    /// Attach a closure to the hook, so when the hook is fired in the JS runtime
+    /// we receive the event in the native runtime
+    ///
+    /// - parameters:
+    /// - hook: A function to run when the JS hook is fired
     public func tap(_ hook: @escaping (T) -> Void) {
         let tapMethod: @convention(block) (JSValue?) -> Void = { value in
             guard
@@ -166,26 +178,24 @@ public class HookDecode<T>: BaseJSHook where T: Decodable {
             else { return }
             hook(hookValue)
         }
-        
-        self.hook.invokeMethod("tap", withArguments: [name, JSValue(object: tapMethod, in: context) as Any])
+
+        self.hook.invokeMethod(
+            "tap",
+            withArguments: [name, JSValue(object: tapMethod, in: context) as Any]
+        )
     }
 }
 
-/**
- This class represents an object in the JS runtime that can be tapped into
- to receive JS events that has 2 parameters
- */
-public class Hook2Decode<T, U>: BaseJSHook where T: Decodable, U: Decodable {
-    /**
-     Attach a closure to the hook, so when the hook is fired in the JS runtime
-     we receive the event in the native runtime
-     
-     - parameters:
-     - hook: A function to run when the JS hook is fired
-     */
+/// This class represents an object in the JS runtime that can be tapped into
+/// to receive JS events that has 2 parameters
+public class Hook2Decode<T: Decodable, U: Decodable>: BaseJSHook {
+    /// Attach a closure to the hook, so when the hook is fired in the JS runtime
+    /// we receive the event in the native runtime
+    ///
+    /// - parameters:
+    /// - hook: A function to run when the JS hook is fired
     public func tap(_ hook: @escaping (T, U) -> Void) {
         let tapMethod: @convention(block) (JSValue?, JSValue?) -> Void = { value, value2 in
-            
             let decoder = JSONDecoder()
             guard
                 let val = value,
@@ -195,56 +205,52 @@ public class Hook2Decode<T, U>: BaseJSHook where T: Decodable, U: Decodable {
             else { return }
             hook(hookValue, hookValue2)
         }
-        
-        self.hook.invokeMethod("tap", withArguments: [name, JSValue(object: tapMethod, in: context) as Any])
+
+        self.hook.invokeMethod(
+            "tap",
+            withArguments: [name, JSValue(object: tapMethod, in: context) as Any]
+        )
     }
 }
 
-/**
- This class represents an object in the JS runtime that can be tapped into
- to receive JS events that has 3 parameters
- */
-public class Hook3Decode<T, U, S>: BaseJSHook where T: Decodable, U: Decodable, S: Decodable {
-    /**
-     Attach a closure to the hook, so when the hook is fired in the JS runtime
-     we receive the event in the native runtime
-
-     - parameters:
-     - hook: A function to run when the JS hook is fired
-     */
+/// This class represents an object in the JS runtime that can be tapped into
+/// to receive JS events that has 3 parameters
+public class Hook3Decode<T: Decodable, U: Decodable, S: Decodable>: BaseJSHook {
+    /// Attach a closure to the hook, so when the hook is fired in the JS runtime
+    /// we receive the event in the native runtime
+    ///
+    /// - parameters:
+    /// - hook: A function to run when the JS hook is fired
     public func tap(_ hook: @escaping (T, U, S) -> Void) {
-        let tapMethod: @convention(block) (JSValue?, JSValue?, JSValue?) -> Void = { value, value2, value3 in
+        let tapMethod: @convention(block) (JSValue?, JSValue?, JSValue?)
+            -> Void = { value, value2, value3 in
+                let decoder = JSONDecoder()
+                guard
+                    let val = value,
+                    let val2 = value2,
+                    let val3 = value3,
+                    let hookValue = try? decoder.decode(T.self, from: val),
+                    let hookValue2 = try? decoder.decode(U.self, from: val2),
+                    let hookValue3 = try? decoder.decode(S.self, from: val3)
+                else { return }
+                hook(hookValue, hookValue2, hookValue3)
+            }
 
-            let decoder = JSONDecoder()
-            guard
-                let val = value,
-                let val2 = value2,
-                let val3 = value3,
-                let hookValue = try? decoder.decode(T.self, from: val),
-                let hookValue2 = try? decoder.decode(U.self, from: val2),
-                let hookValue3 = try? decoder.decode(S.self, from: val3)
-            else { return }
-            hook(hookValue, hookValue2, hookValue3)
-        }
-
-        self.hook.invokeMethod("tap", withArguments: [name, JSValue(object: tapMethod, in: context) as Any])
+        self.hook.invokeMethod(
+            "tap",
+            withArguments: [name, JSValue(object: tapMethod, in: context) as Any]
+        )
     }
 }
 
-/**
- This class represents an object in the JS runtime that can be tapped into
- and returns a promise that resolves when the asynchronous task is completed
- */
-public class AsyncHook<T>: BaseAsyncJSHook where T: CreatedFromJSValue {
-    public typealias AsyncHookHandler = (T) async throws -> JSValue?
-    
-    /**
-     Attach a closure to the hook, so when the hook is fired in the JS runtime
-     we receive the event in the native runtime
-     
-     - parameters:
-     - hook: A function to run when the JS hook is fired
-     */
+/// This class represents an object in the JS runtime that can be tapped into
+/// and returns a promise that resolves when the asynchronous task is completed
+public class AsyncHook<T: CreatedFromJSValue>: BaseAsyncJSHook {
+    /// Attach a closure to the hook, so when the hook is fired in the JS runtime
+    /// we receive the event in the native runtime
+    ///
+    /// - parameters:
+    /// - hook: A function to run when the JS hook is fired
     public func tap(_ hook: @escaping AsyncHookHandler) {
         let tapMethod: @convention(block) (JSValue?) -> JSValue = { [weak self] value in
             guard
@@ -252,46 +258,51 @@ public class AsyncHook<T>: BaseAsyncJSHook where T: CreatedFromJSValue {
                 let val = value,
                 let hookValue = T.createInstance(value: val) as? T
             else { return JSValue() }
-            
+
             return self.createAsyncPromise {
                 try await hook(hookValue)
             }
         }
-        
-        self.hook.invokeMethod("tap", withArguments: [name, JSValue(object: tapMethod, in: context) as Any])
+
+        self.hook.invokeMethod(
+            "tap",
+            withArguments: [name, JSValue(object: tapMethod, in: context) as Any]
+        )
     }
+
+    public typealias AsyncHookHandler = (T) async throws -> JSValue?
 }
 
-/**
- This class represents an object in the JS runtime that can be tapped into
- to receive JS events that has 2 parameters and
- returns a promise that resolves when the asynchronous task is completed
- */
-public class AsyncHook2<T, U>: BaseAsyncJSHook where T: CreatedFromJSValue, U: CreatedFromJSValue {
-    public typealias AsyncHookHandler = (T, U) async throws -> JSValue?
-    
-    /**
-     Attach a closure to the hook, so when the hook is fired in the JS runtime
-     we receive the event in the native runtime
-     
-     - parameters:
-     - hook: A function to run when the JS hook is fired
-     */
+/// This class represents an object in the JS runtime that can be tapped into
+/// to receive JS events that has 2 parameters and
+/// returns a promise that resolves when the asynchronous task is completed
+public class AsyncHook2<T: CreatedFromJSValue, U: CreatedFromJSValue>: BaseAsyncJSHook {
+    /// Attach a closure to the hook, so when the hook is fired in the JS runtime
+    /// we receive the event in the native runtime
+    ///
+    /// - parameters:
+    /// - hook: A function to run when the JS hook is fired
     public func tap(_ hook: @escaping AsyncHookHandler) {
-        let tapMethod: @convention(block) (JSValue?, JSValue?) -> JSValue = { [weak self] value, value2 in
-            guard
-                let self = self,
-                let val = value,
-                let val2 = value2,
-                let hookValue = T.createInstance(value: val) as? T,
-                let hookValue2 = U.createInstance(value: val2) as? U
-            else { return JSValue() }
-            
-            return self.createAsyncPromise {
-                try await hook(hookValue, hookValue2)
+        let tapMethod: @convention(block) (JSValue?, JSValue?)
+            -> JSValue = { [weak self] value, value2 in
+                guard
+                    let self,
+                    let val = value,
+                    let val2 = value2,
+                    let hookValue = T.createInstance(value: val) as? T,
+                    let hookValue2 = U.createInstance(value: val2) as? U
+                else { return JSValue() }
+
+                return self.createAsyncPromise {
+                    try await hook(hookValue, hookValue2)
+                }
             }
-        }
-        
-        self.hook.invokeMethod("tap", withArguments: [name, JSValue(object: tapMethod, in: context) as Any])
+
+        self.hook.invokeMethod(
+            "tap",
+            withArguments: [name, JSValue(object: tapMethod, in: context) as Any]
+        )
     }
+
+    public typealias AsyncHookHandler = (T, U) async throws -> JSValue?
 }

--- a/ios/core/Sources/Types/Hooks/Hook.swift
+++ b/ios/core/Sources/Types/Hooks/Hook.swift
@@ -40,7 +40,7 @@ public class BaseAsyncJSHook: BaseJSHook {
     /// Creates a promise with common error handling for async operations
     /// - Parameter asyncWork: The async work to execute
     /// - Returns: A JavaScript promise
-    func createAsyncPromise<Result>(_ asyncWork: @escaping () async throws -> Result) -> JSValue {
+    func createAsyncPromise(_ asyncWork: @escaping () async throws -> some Any) -> JSValue {
         let promise = JSUtilities.createPromise(context: context) { resolve, reject in
             Task {
                 do {
@@ -118,7 +118,7 @@ public class Hook2<T: CreatedFromJSValue, U: CreatedFromJSValue>: BaseJSHook {
     ///
     /// - parameters:
     /// - hook: A function to run when the JS hook is fired
-    public func tap<R>(_ hook: @escaping (T, U) -> R) {
+    public func tap(_ hook: @escaping (T, U) -> some Any) {
         let tapMethod: @convention(block) (JSValue?, JSValue?) -> Any? = { value, value2 in
             guard
                 let val = value,
@@ -285,7 +285,7 @@ public class AsyncHook<T: CreatedFromJSValue>: BaseAsyncJSHook {
                 let hookValue = T.createInstance(value: val) as? T
             else { return JSValue() }
 
-            return self.createAsyncPromise {
+            return createAsyncPromise {
                 try await hook(hookValue)
             }
         }
@@ -319,7 +319,7 @@ public class AsyncHook2<T: CreatedFromJSValue, U: CreatedFromJSValue>: BaseAsync
                     let hookValue2 = U.createInstance(value: val2) as? U
                 else { return JSValue() }
 
-                return self.createAsyncPromise {
+                return createAsyncPromise {
                     try await hook(hookValue, hookValue2)
                 }
             }

--- a/ios/core/Sources/Types/Hooks/Hook.swift
+++ b/ios/core/Sources/Types/Hooks/Hook.swift
@@ -10,17 +10,21 @@ import JavaScriptCore
 
 /// A base for implementing JS backed hooks
 open class BaseJSHook {
-    private let baseValue: JSValue
-    
-    /// The JS reference to the hook
-    public var hook: JSValue { baseValue.objectForKeyedSubscript("hooks").objectForKeyedSubscript(name) }
-    
-    /// The JSContext for the hook
-    public var context: JSContext { hook.context }
-    
     /// The name of the hook
     public let name: String
-    
+
+    private let baseValue: JSValue
+
+    /// The JS reference to the hook
+    public var hook: JSValue {
+        baseValue.objectForKeyedSubscript("hooks").objectForKeyedSubscript(name)
+    }
+
+    /// The JSContext for the hook
+    public var context: JSContext {
+        hook.context
+    }
+
     /// Retrieves a hook by name from an object in JS
     /// - Parameters:
     ///   - baseValue: The object that has `hooks`
@@ -36,15 +40,15 @@ public class BaseAsyncJSHook: BaseJSHook {
     /// Creates a promise with common error handling for async operations
     /// - Parameter asyncWork: The async work to execute
     /// - Returns: A JavaScript promise
-    internal func createAsyncPromise<Result>(_ asyncWork: @escaping () async throws -> Result) -> JSValue {
-        let promise = JSUtilities.createPromise(context: self.context) { (resolve, reject) in
+    func createAsyncPromise<Result>(_ asyncWork: @escaping () async throws -> Result) -> JSValue {
+        let promise = JSUtilities.createPromise(context: context) { resolve, reject in
             Task {
                 do {
                     let result = try await asyncWork()
                     DispatchQueue.main.async {
                         resolve(result as Any)
                     }
-                } catch let error {
+                } catch {
                     let message = error.playerDescription
                     DispatchQueue.main.async {
                         reject("Async hook threw with error '\(message)'")
@@ -56,18 +60,14 @@ public class BaseAsyncJSHook: BaseJSHook {
     }
 }
 
-/**
- This class represents an object in the JS runtime that can be tapped into
- to receive JS events
- */
-public class Hook<T>: BaseJSHook where T: CreatedFromJSValue {
-    /**
-     Attach a closure to the hook, so when the hook is fired in the JS runtime
-     we receive the event in the native runtime
-     
-     - parameters:
-     - hook: A function to run when the JS hook is fired
-     */
+/// This class represents an object in the JS runtime that can be tapped into
+/// to receive JS events
+public class Hook<T: CreatedFromJSValue>: BaseJSHook {
+    /// Attach a closure to the hook, so when the hook is fired in the JS runtime
+    /// we receive the event in the native runtime
+    ///
+    /// - parameters:
+    /// - hook: A function to run when the JS hook is fired
     public func tap(_ hook: @escaping (T) -> Void) {
         let tapMethod: @convention(block) (JSValue?) -> Void = { value in
             guard
@@ -76,49 +76,48 @@ public class Hook<T>: BaseJSHook where T: CreatedFromJSValue {
             else { return }
             hook(hookValue)
         }
-        
-        self.hook.invokeMethod("tap", withArguments: [name, JSValue(object: tapMethod, in: context) as Any])
+
+        self.hook.invokeMethod(
+            "tap",
+            withArguments: [name, JSValue(object: tapMethod, in: context) as Any]
+        )
     }
 }
 
-/**
- This class represents a JS Hook with the ability to return a result. This can work for a Waterfall or Bail hook.
- */
-public class HookWithResult<T, R>: BaseJSHook where T: CreatedFromJSValue {
-    /**
-     Attach a closure to the hook, so when the hook is fired in the JS runtime
-     we receive the event in the native runtime and can return a value to bail
-     
-     - parameters:
-     - hook: A function to run when the JS hook is fired, return Bool? to bail (return nil to continue)
-     */
+/// This class represents a JS Hook with the ability to return a result. This can work for a
+/// Waterfall or Bail hook.
+public class HookWithResult<T: CreatedFromJSValue, R>: BaseJSHook {
+    /// Attach a closure to the hook, so when the hook is fired in the JS runtime
+    /// we receive the event in the native runtime and can return a value to bail
+    ///
+    /// - parameters:
+    /// - hook: A function to run when the JS hook is fired, return Bool? to bail (return nil to
+    /// continue)
     public func tap(_ hook: @escaping (T) -> R?) {
         let tapMethod: @convention(block) (JSValue?) -> Any? = { value in
             guard
                 let val = value,
                 let hookValue = T.createInstance(value: val) as? T
             else { return nil }
-            
+
             return hook(hookValue)
-            
         }
-        
-        self.hook.invokeMethod("tap", withArguments: [name, JSValue(object: tapMethod, in: context) as Any])
+
+        self.hook.invokeMethod(
+            "tap",
+            withArguments: [name, JSValue(object: tapMethod, in: context) as Any]
+        )
     }
 }
 
-/**
- This class represents an object in the JS runtime that can be tapped into
- to receive JS events that has 2 parameters
- */
-public class Hook2<T, U>: BaseJSHook where T: CreatedFromJSValue, U: CreatedFromJSValue {
-    /**
-     Attach a closure to the hook, so when the hook is fired in the JS runtime
-     we receive the event in the native runtime
-     
-     - parameters:
-     - hook: A function to run when the JS hook is fired
-     */
+/// This class represents an object in the JS runtime that can be tapped into
+/// to receive JS events that has 2 parameters
+public class Hook2<T: CreatedFromJSValue, U: CreatedFromJSValue>: BaseJSHook {
+    /// Attach a closure to the hook, so when the hook is fired in the JS runtime
+    /// we receive the event in the native runtime
+    ///
+    /// - parameters:
+    /// - hook: A function to run when the JS hook is fired
     public func tap<R>(_ hook: @escaping (T, U) -> R) {
         let tapMethod: @convention(block) (JSValue?, JSValue?) -> Any? = { value, value2 in
             guard
@@ -129,8 +128,11 @@ public class Hook2<T, U>: BaseJSHook where T: CreatedFromJSValue, U: CreatedFrom
             else { return nil }
             return hook(hookValue, hookValue2)
         }
-        
-        self.hook.invokeMethod("tap", withArguments: [name, JSValue(object: tapMethod, in: context) as Any])
+
+        self.hook.invokeMethod(
+            "tap",
+            withArguments: [name, JSValue(object: tapMethod, in: context) as Any]
+        )
     }
 }
 
@@ -140,25 +142,36 @@ public protocol JSValueProviding {
 }
 
 /// Waterfall hook with 2 args (T, U) returning R. Aligns with web SyncWaterfallHook<[T, U]>.
-public class SyncWaterfallHook2JS<T, R, U>: BaseJSHook where T: CreatedFromJSValue, R: CreatedFromJSValue & JSValueProviding {
+public class SyncWaterfallHook2JS<
+    T: CreatedFromJSValue,
+    R: CreatedFromJSValue & JSValueProviding,
+    U
+>: BaseJSHook {
     public func tap(_ hook: @escaping (T, U) -> R) {
         let tapMethod: @convention(block) (JSValue?, JSValue?) -> JSValue? = { value1, value2 in
             guard let value1, let value2,
                   let hookValue1 = T.createInstance(value: value1) as? T else {
                 return nil
             }
-            // Prefer toObject(); fallback to toString() for JS string primitives (e.g. U == String).
+            // Prefer toObject(); fallback to toString() for JS string primitives (e.g. U ==
+            // String).
             let hookValue2: U? = (value2.toObject() as? U) ?? ((value2.toString() as Any) as? U)
             guard let hookValue2 else { return nil }
             let returnValue = hook(hookValue1, hookValue2)
             return returnValue.jsValue
         }
-        self.hook.invokeMethod("tap", withArguments: [name, JSValue(object: tapMethod, in: context) as Any])
+        self.hook.invokeMethod(
+            "tap",
+            withArguments: [name, JSValue(object: tapMethod, in: context) as Any]
+        )
     }
 }
 
 /// Waterfall hook with 1 arg T returning R. Aligns with web SyncWaterfallHook<[T]>.
-public class SyncWaterfallHookJS<T, R>: BaseJSHook where T: CreatedFromJSValue, R: CreatedFromJSValue & JSValueProviding {
+public class SyncWaterfallHookJS<
+    T: CreatedFromJSValue,
+    R: CreatedFromJSValue & JSValueProviding
+>: BaseJSHook {
     public func tap(_ hook: @escaping (T) -> R) {
         let tapMethod: @convention(block) (JSValue?) -> JSValue? = { value in
             guard let val = value,
@@ -168,22 +181,21 @@ public class SyncWaterfallHookJS<T, R>: BaseJSHook where T: CreatedFromJSValue, 
             let returnValue = hook(hookValue)
             return returnValue.jsValue
         }
-        self.hook.invokeMethod("tap", withArguments: [name, JSValue(object: tapMethod, in: context) as Any])
+        self.hook.invokeMethod(
+            "tap",
+            withArguments: [name, JSValue(object: tapMethod, in: context) as Any]
+        )
     }
 }
 
-/**
- This class represents an object in the JS runtime that can be tapped into
- to receive JS events
- */
-public class HookDecode<T>: BaseJSHook where T: Decodable {
-    /**
-     Attach a closure to the hook, so when the hook is fired in the JS runtime
-     we receive the event in the native runtime
-     
-     - parameters:
-     - hook: A function to run when the JS hook is fired
-     */
+/// This class represents an object in the JS runtime that can be tapped into
+/// to receive JS events
+public class HookDecode<T: Decodable>: BaseJSHook {
+    /// Attach a closure to the hook, so when the hook is fired in the JS runtime
+    /// we receive the event in the native runtime
+    ///
+    /// - parameters:
+    /// - hook: A function to run when the JS hook is fired
     public func tap(_ hook: @escaping (T) -> Void) {
         let tapMethod: @convention(block) (JSValue?) -> Void = { value in
             guard
@@ -192,26 +204,24 @@ public class HookDecode<T>: BaseJSHook where T: Decodable {
             else { return }
             hook(hookValue)
         }
-        
-        self.hook.invokeMethod("tap", withArguments: [name, JSValue(object: tapMethod, in: context) as Any])
+
+        self.hook.invokeMethod(
+            "tap",
+            withArguments: [name, JSValue(object: tapMethod, in: context) as Any]
+        )
     }
 }
 
-/**
- This class represents an object in the JS runtime that can be tapped into
- to receive JS events that has 2 parameters
- */
-public class Hook2Decode<T, U>: BaseJSHook where T: Decodable, U: Decodable {
-    /**
-     Attach a closure to the hook, so when the hook is fired in the JS runtime
-     we receive the event in the native runtime
-     
-     - parameters:
-     - hook: A function to run when the JS hook is fired
-     */
+/// This class represents an object in the JS runtime that can be tapped into
+/// to receive JS events that has 2 parameters
+public class Hook2Decode<T: Decodable, U: Decodable>: BaseJSHook {
+    /// Attach a closure to the hook, so when the hook is fired in the JS runtime
+    /// we receive the event in the native runtime
+    ///
+    /// - parameters:
+    /// - hook: A function to run when the JS hook is fired
     public func tap(_ hook: @escaping (T, U) -> Void) {
         let tapMethod: @convention(block) (JSValue?, JSValue?) -> Void = { value, value2 in
-            
             let decoder = JSONDecoder()
             guard
                 let val = value,
@@ -221,56 +231,52 @@ public class Hook2Decode<T, U>: BaseJSHook where T: Decodable, U: Decodable {
             else { return }
             hook(hookValue, hookValue2)
         }
-        
-        self.hook.invokeMethod("tap", withArguments: [name, JSValue(object: tapMethod, in: context) as Any])
+
+        self.hook.invokeMethod(
+            "tap",
+            withArguments: [name, JSValue(object: tapMethod, in: context) as Any]
+        )
     }
 }
 
-/**
- This class represents an object in the JS runtime that can be tapped into
- to receive JS events that has 3 parameters
- */
-public class Hook3Decode<T, U, S>: BaseJSHook where T: Decodable, U: Decodable, S: Decodable {
-    /**
-     Attach a closure to the hook, so when the hook is fired in the JS runtime
-     we receive the event in the native runtime
-
-     - parameters:
-     - hook: A function to run when the JS hook is fired
-     */
+/// This class represents an object in the JS runtime that can be tapped into
+/// to receive JS events that has 3 parameters
+public class Hook3Decode<T: Decodable, U: Decodable, S: Decodable>: BaseJSHook {
+    /// Attach a closure to the hook, so when the hook is fired in the JS runtime
+    /// we receive the event in the native runtime
+    ///
+    /// - parameters:
+    /// - hook: A function to run when the JS hook is fired
     public func tap(_ hook: @escaping (T, U, S) -> Void) {
-        let tapMethod: @convention(block) (JSValue?, JSValue?, JSValue?) -> Void = { value, value2, value3 in
+        let tapMethod: @convention(block) (JSValue?, JSValue?, JSValue?)
+            -> Void = { value, value2, value3 in
+                let decoder = JSONDecoder()
+                guard
+                    let val = value,
+                    let val2 = value2,
+                    let val3 = value3,
+                    let hookValue = try? decoder.decode(T.self, from: val),
+                    let hookValue2 = try? decoder.decode(U.self, from: val2),
+                    let hookValue3 = try? decoder.decode(S.self, from: val3)
+                else { return }
+                hook(hookValue, hookValue2, hookValue3)
+            }
 
-            let decoder = JSONDecoder()
-            guard
-                let val = value,
-                let val2 = value2,
-                let val3 = value3,
-                let hookValue = try? decoder.decode(T.self, from: val),
-                let hookValue2 = try? decoder.decode(U.self, from: val2),
-                let hookValue3 = try? decoder.decode(S.self, from: val3)
-            else { return }
-            hook(hookValue, hookValue2, hookValue3)
-        }
-
-        self.hook.invokeMethod("tap", withArguments: [name, JSValue(object: tapMethod, in: context) as Any])
+        self.hook.invokeMethod(
+            "tap",
+            withArguments: [name, JSValue(object: tapMethod, in: context) as Any]
+        )
     }
 }
 
-/**
- This class represents an object in the JS runtime that can be tapped into
- and returns a promise that resolves when the asynchronous task is completed
- */
-public class AsyncHook<T>: BaseAsyncJSHook where T: CreatedFromJSValue {
-    public typealias AsyncHookHandler = (T) async throws -> JSValue?
-    
-    /**
-     Attach a closure to the hook, so when the hook is fired in the JS runtime
-     we receive the event in the native runtime
-     
-     - parameters:
-     - hook: A function to run when the JS hook is fired
-     */
+/// This class represents an object in the JS runtime that can be tapped into
+/// and returns a promise that resolves when the asynchronous task is completed
+public class AsyncHook<T: CreatedFromJSValue>: BaseAsyncJSHook {
+    /// Attach a closure to the hook, so when the hook is fired in the JS runtime
+    /// we receive the event in the native runtime
+    ///
+    /// - parameters:
+    /// - hook: A function to run when the JS hook is fired
     public func tap(_ hook: @escaping AsyncHookHandler) {
         let tapMethod: @convention(block) (JSValue?) -> JSValue = { [weak self] value in
             guard
@@ -278,46 +284,51 @@ public class AsyncHook<T>: BaseAsyncJSHook where T: CreatedFromJSValue {
                 let val = value,
                 let hookValue = T.createInstance(value: val) as? T
             else { return JSValue() }
-            
+
             return self.createAsyncPromise {
                 try await hook(hookValue)
             }
         }
-        
-        self.hook.invokeMethod("tap", withArguments: [name, JSValue(object: tapMethod, in: context) as Any])
+
+        self.hook.invokeMethod(
+            "tap",
+            withArguments: [name, JSValue(object: tapMethod, in: context) as Any]
+        )
     }
+
+    public typealias AsyncHookHandler = (T) async throws -> JSValue?
 }
 
-/**
- This class represents an object in the JS runtime that can be tapped into
- to receive JS events that has 2 parameters and
- returns a promise that resolves when the asynchronous task is completed
- */
-public class AsyncHook2<T, U>: BaseAsyncJSHook where T: CreatedFromJSValue, U: CreatedFromJSValue {
-    public typealias AsyncHookHandler = (T, U) async throws -> JSValue?
-    
-    /**
-     Attach a closure to the hook, so when the hook is fired in the JS runtime
-     we receive the event in the native runtime
-     
-     - parameters:
-     - hook: A function to run when the JS hook is fired
-     */
+/// This class represents an object in the JS runtime that can be tapped into
+/// to receive JS events that has 2 parameters and
+/// returns a promise that resolves when the asynchronous task is completed
+public class AsyncHook2<T: CreatedFromJSValue, U: CreatedFromJSValue>: BaseAsyncJSHook {
+    /// Attach a closure to the hook, so when the hook is fired in the JS runtime
+    /// we receive the event in the native runtime
+    ///
+    /// - parameters:
+    /// - hook: A function to run when the JS hook is fired
     public func tap(_ hook: @escaping AsyncHookHandler) {
-        let tapMethod: @convention(block) (JSValue?, JSValue?) -> JSValue = { [weak self] value, value2 in
-            guard
-                let self = self,
-                let val = value,
-                let val2 = value2,
-                let hookValue = T.createInstance(value: val) as? T,
-                let hookValue2 = U.createInstance(value: val2) as? U
-            else { return JSValue() }
-            
-            return self.createAsyncPromise {
-                try await hook(hookValue, hookValue2)
+        let tapMethod: @convention(block) (JSValue?, JSValue?)
+            -> JSValue = { [weak self] value, value2 in
+                guard
+                    let self,
+                    let val = value,
+                    let val2 = value2,
+                    let hookValue = T.createInstance(value: val) as? T,
+                    let hookValue2 = U.createInstance(value: val2) as? U
+                else { return JSValue() }
+
+                return self.createAsyncPromise {
+                    try await hook(hookValue, hookValue2)
+                }
             }
-        }
-        
-        self.hook.invokeMethod("tap", withArguments: [name, JSValue(object: tapMethod, in: context) as Any])
+
+        self.hook.invokeMethod(
+            "tap",
+            withArguments: [name, JSValue(object: tapMethod, in: context) as Any]
+        )
     }
+
+    public typealias AsyncHookHandler = (T, U) async throws -> JSValue?
 }

--- a/ios/core/Sources/Types/Hooks/ViewControllerHooks.swift
+++ b/ios/core/Sources/Types/Hooks/ViewControllerHooks.swift
@@ -1,6 +1,6 @@
 //
 //  ViewControllerHooks.swift
-//  
+//
 //
 //  Created by Borawski, Harris on 2/12/20.
 //
@@ -8,10 +8,8 @@
 import Foundation
 import JavaScriptCore
 
-/**
-Hooks that can be tapped into for the ViewController
-This lets users tap into events in the JS environment
-*/
+/// Hooks that can be tapped into for the ViewController
+/// This lets users tap into events in the JS environment
 public struct ViewControllerHooks {
     /// Fired when the view changes
     public var view: Hook<PlayerView>

--- a/ios/core/Sources/Types/Hooks/ViewHooks.swift
+++ b/ios/core/Sources/Types/Hooks/ViewHooks.swift
@@ -1,6 +1,6 @@
 //
 //  ViewHooks.swift
-//  
+//
 //
 //  Created by Borawski, Harris on 2/12/20.
 //
@@ -8,10 +8,8 @@
 import Foundation
 import JavaScriptCore
 
-/**
-Hooks that can be tapped into for the View
-This lets users tap into events in the JS environment
-*/
+/// Hooks that can be tapped into for the View
+/// This lets users tap into events in the JS environment
 public struct ViewHooks {
     /// Fired when the view updates
     public var onUpdate: Hook<JSValue>

--- a/ios/core/Sources/Types/JSLogger.swift
+++ b/ios/core/Sources/Types/JSLogger.swift
@@ -1,6 +1,6 @@
 //
 //  JSLogger.swift
-//  
+//
 //
 //  Created by Borawski, Harris on 2/12/20.
 //
@@ -8,64 +8,50 @@
 import Foundation
 import JavaScriptCore
 
-/**
- The logger instance from the actively running player
- */
+/// The logger instance from the actively running player
 public struct JSLogger {
     /// The JSValue that backs this object
     private var value: JSValue
 
-    /**
-    Construct a JSLogger from a JSValue
-    - parameters:
-       - value: The JSValue that is the DataController
-    */
+    /// Construct a JSLogger from a JSValue
+    /// - parameters:
+    ///   - value: The JSValue that is the DataController
     public init?(from value: JSValue?) {
-        guard let value = value else { return nil}
+        guard let value else { return nil }
         self.value = value
     }
 
-    /**
-     Used to log trace messages
-     - parameters:
-        - items: The parts of the message to log
-     */
+    /// Used to log trace messages
+    /// - parameters:
+    ///   - items: The parts of the message to log
     public func trace(_ items: String...) {
         value.invokeMethod("trace", withArguments: items)
     }
 
-    /**
-     Used to log debug messages
-     - parameters:
-        - items: The parts of the message to log
-     */
+    /// Used to log debug messages
+    /// - parameters:
+    ///   - items: The parts of the message to log
     public func debug(_ items: String...) {
         value.invokeMethod("debug", withArguments: items)
     }
 
-    /**
-     Used to log info messages
-     - parameters:
-        - items: The parts of the message to log
-     */
+    /// Used to log info messages
+    /// - parameters:
+    ///   - items: The parts of the message to log
     public func info(_ items: String...) {
         value.invokeMethod("info", withArguments: items)
     }
 
-    /**
-     Used to log warn messages
-     - parameters:
-        - items: The parts of the message to log
-     */
+    /// Used to log warn messages
+    /// - parameters:
+    ///   - items: The parts of the message to log
     public func warn(_ items: String...) {
         value.invokeMethod("warn", withArguments: items)
     }
 
-    /**
-     Used to log error messages
-     - parameters:
-        - items: The parts of the message to log
-     */
+    /// Used to log error messages
+    /// - parameters:
+    ///   - items: The parts of the message to log
     public func error(_ items: String...) {
         value.invokeMethod("error", withArguments: items)
     }

--- a/ios/core/Sources/utilities/DebugValue.swift
+++ b/ios/core/Sources/utilities/DebugValue.swift
@@ -1,6 +1,6 @@
 //
-//  File.swift
-//  
+//  DebugValue.swift
+//
 //
 //  Created by Borawski, Harris on 2/13/20.
 //
@@ -8,29 +8,25 @@
 import Foundation
 import JavaScriptCore
 
-/**
-A wrapper for debugging to fake-decode JSValues, so they can be inspected in the debugger
-*/
+/// A wrapper for debugging to fake-decode JSValues, so they can be inspected in the debugger
 public class DebugValue: CreatedFromJSValue {
-    /// Typealias for associated type
-    public typealias T = DebugValue
-
-    /**
-    Creates an instance from a JSValue, used for generic construction
-    - parameters:
-       - value: The JSValue to construct from
-    */
-    public static func createInstance(value: JSValue) -> DebugValue { DebugValue(value) }
-
     /// The JSValue that backs this wrapper
     public let value: JSValue
 
-    /**
-    Construct a DebugValue from a JSValue, for debugging unknown return types on JSValues
-    - parameters:
-       - value: The JSValue that is the value to debug
-    */
+    /// Construct a DebugValue from a JSValue, for debugging unknown return types on JSValues
+    /// - parameters:
+    ///   - value: The JSValue that is the value to debug
     public init(_ value: JSValue) {
         self.value = value
     }
+
+    /// Creates an instance from a JSValue, used for generic construction
+    /// - parameters:
+    ///   - value: The JSValue to construct from
+    public static func createInstance(value: JSValue) -> DebugValue {
+        DebugValue(value)
+    }
+
+    /// Typealias for associated type
+    public typealias T = DebugValue
 }

--- a/ios/core/Sources/utilities/ErrorUtilites.swift
+++ b/ios/core/Sources/utilities/ErrorUtilites.swift
@@ -7,10 +7,9 @@
 
 import Foundation
 
-extension Error {
-
+public extension Error {
     /// Creates error descriptions logged by Player.
-    public var playerDescription: String {
+    var playerDescription: String {
         if let decodingError = self as? Swift.DecodingError {
             return decodingError.prettyDescription
         }
@@ -19,15 +18,12 @@ extension Error {
 }
 
 extension Swift.DecodingError {
-
-    /// Constructs a more human readable message to make it easier to identify and debug decoding errors
+    /// Constructs a more human readable message to make it easier to identify and debug decoding
+    /// errors
     var prettyDescription: String {
-
         let codingPathForDecodingErrorContext = { (context: Context) -> String in
             return context.codingPath
-                .map {
-                    $0.stringValue
-                }
+                .map(\.stringValue)
                 .map {
                     let prefix = "Index "
                     if $0.hasPrefix(prefix) {
@@ -42,25 +38,25 @@ extension Swift.DecodingError {
         let messageForDecodingErrorContext = { (context: Context) -> String in
             let message = context.debugDescription
             let codingPath = codingPathForDecodingErrorContext(context)
-            if 0 < codingPath.count {
+            if !codingPath.isEmpty {
                 return message + " (coding path \(codingPath))"
             }
             return message
         }
 
         switch self {
-        case .typeMismatch(_, let context):
+        case let .typeMismatch(_, context):
             return messageForDecodingErrorContext(context)
-        case .valueNotFound(_, let context):
+        case let .valueNotFound(_, context):
             return "Value not found at coding path \(codingPathForDecodingErrorContext(context))."
-        case .keyNotFound(let key, let context):
+        case let .keyNotFound(key, context):
             var keyPath = codingPathForDecodingErrorContext(context)
-            if 0 < keyPath.count {
+            if !keyPath.isEmpty {
                 keyPath.append(".")
             }
             keyPath.append(key.stringValue)
             return "Key not found at coding path \(keyPath)."
-        case .dataCorrupted(let context):
+        case let .dataCorrupted(context):
             return messageForDecodingErrorContext(context)
         @unknown default:
             return "\(self)"

--- a/ios/core/Sources/utilities/ErrorUtilites.swift
+++ b/ios/core/Sources/utilities/ErrorUtilites.swift
@@ -32,7 +32,7 @@ extension Swift.DecodingError {
                     return $0
                 }
                 .joined(separator: ".")
-                .replacingOccurrences(of: ".[", with: "[")
+                .replacing(".[", with: "[")
         }
 
         let messageForDecodingErrorContext = { (context: Context) -> String in

--- a/ios/core/Sources/utilities/ErrorUtilites.swift
+++ b/ios/core/Sources/utilities/ErrorUtilites.swift
@@ -32,7 +32,7 @@ extension Swift.DecodingError {
                     return $0
                 }
                 .joined(separator: ".")
-                .replacing(".[", with: "[")
+                .replacingOccurrences(of: ".[", with: "[")
         }
 
         let messageForDecodingErrorContext = { (context: Context) -> String in

--- a/ios/core/Sources/utilities/GenericInterfaces.swift
+++ b/ios/core/Sources/utilities/GenericInterfaces.swift
@@ -1,6 +1,6 @@
 //
-//  File.swift
-//  
+//  GenericInterfaces.swift
+//
 //
 //  Created by Borawski, Harris on 2/12/20.
 //
@@ -8,37 +8,31 @@
 import Foundation
 import JavaScriptCore
 
-/**
- A protocol for objects that are constructed generically from a JSValue
- This is used for hooks
- */
+/// A protocol for objects that are constructed generically from a JSValue
+/// This is used for hooks
 public protocol CreatedFromJSValue {
-    /**
-     Creates an instance of the associated type using the JSValue
-     - parameters:
-        - value: The value to use for construction
-     - returns:
-        An instance of the associated type
-     */
+    /// Creates an instance of the associated type using the JSValue
+    /// - parameters:
+    ///   - value: The value to use for construction
+    /// - returns:
+    ///   An instance of the associated type
     static func createInstance(value: JSValue) -> T
 
     /// The type associated with this instance
     associatedtype T
 }
 
-/**
- Allows a JSValue to be created from itself for debugging purposes
- */
+/// Allows a JSValue to be created from itself for debugging purposes
 extension JSValue: CreatedFromJSValue {
     /// The type used for generic creation
     public typealias T = JSValue
 
-    /**
-     Returns this JSValue for debugging
-     - parameters:
-        - value: The JSValue to use for creation
-     */
-    public static func createInstance(value: JSValue) -> JSValue { value }
+    /// Returns this JSValue for debugging
+    /// - parameters:
+    ///   - value: The JSValue to use for creation
+    public static func createInstance(value: JSValue) -> JSValue {
+        value
+    }
 }
 
 extension Optional: CreatedFromJSValue where Wrapped: CreatedFromJSValue {

--- a/ios/core/Sources/utilities/JSUtilities.swift
+++ b/ios/core/Sources/utilities/JSUtilities.swift
@@ -8,50 +8,42 @@
 import Foundation
 import JavaScriptCore
 
-/**
- Class to hold context-agnostic JS utility functions
- */
+/// Class to hold context-agnostic JS utility functions
 public class JSUtilities {
-    /**
-     Polyfills functions needed for plugins with native versions
-     - parameters:
-        - context: The context to polyfill
-     */
+    /// Polyfills functions needed for plugins with native versions
+    /// - parameters:
+    ///   - context: The context to polyfill
     public static func polyfill(_ context: JSContext) {
-        let setTimeout: @convention(block) (JSValue?, JSValue?) -> Void = { (function, timeout) in
-            guard let function = function, let timeout = timeout?.toInt32() else { return }
+        let setTimeout: @convention(block) (JSValue?, JSValue?) -> Void = { function, timeout in
+            guard let function, let timeout = timeout?.toInt32() else { return }
             DispatchQueue
                 .global(qos: .background)
-                .asyncAfter(deadline: .now() + .milliseconds(Int(timeout)), execute: {
+                .asyncAfter(deadline: .now() + .milliseconds(Int(timeout))) {
                     DispatchQueue.main.async {
                         function.call(withArguments: [])
                     }
-            })
+                }
         }
         guard let val = JSValue(object: setTimeout, in: context) else { return }
         context.setObject(val, forKeyedSubscript: "setTimeout" as NSString)
     }
 
-    /// A function used to indicate a promise has completed async operations successfully
-    public typealias Resolve = (Any...) -> Void
-    /// A function used to indicate a promise has failed to complete async operations
-    public typealias Reject = (Any...) -> Void
-
-    /**
-     Creates a javascript promise in the given context, to execute native code
-     - parameters:
-        - context: The JSContext to create the promise in
-        - handler: A completion handler that is used in place of the JS closure used to construct promises
-     - returns: A reference to the promise in the context if successfully created
-     */
-    public static func createPromise(context: JSContext, handler: @escaping (@escaping Resolve, @escaping Reject) -> Void) -> JSValue? {
+    /// Creates a javascript promise in the given context, to execute native code
+    /// - parameters:
+    ///   - context: The JSContext to create the promise in
+    ///   - handler: A completion handler that is used in place of the JS closure used to construct
+    /// promises
+    /// - returns: A reference to the promise in the context if successfully created
+    public static func createPromise(
+        context: JSContext,
+        handler: @escaping (@escaping Resolve, @escaping Reject) -> Void
+    ) -> JSValue? {
         let constructor: @convention(block) (JSValue, JSValue) -> Void = { resolve, reject in
-            handler({(args: Any...) in
-                    resolve.call(withArguments: args)
-                }, {(args: Any...) in
-                    reject.call(withArguments: args)
-                }
-            )
+            handler({ (args: Any...) in
+                resolve.call(withArguments: args)
+            }, { (args: Any...) in
+                reject.call(withArguments: args)
+            })
         }
         guard
             let closure = JSValue(object: constructor, in: context),
@@ -59,10 +51,15 @@ public class JSUtilities {
         else { return nil }
         return promise
     }
+
+    /// A function used to indicate a promise has completed async operations successfully
+    public typealias Resolve = (Any...) -> Void
+    /// A function used to indicate a promise has failed to complete async operations
+    public typealias Reject = (Any...) -> Void
 }
 
-internal extension JSContext {
-    func error<E>(for error: E) -> JSValue? where E: Error, E: JSConvertibleError {
+extension JSContext {
+    func error<E: Error & JSConvertibleError>(for error: E) -> JSValue? {
         objectForKeyedSubscript("Error").construct(withArguments: [error.jsDescription])
     }
 }

--- a/ios/core/Sources/utilities/JSUtilities.swift
+++ b/ios/core/Sources/utilities/JSUtilities.swift
@@ -72,7 +72,7 @@ extension JSContext {
         getJSClass(jsClass)?.construct(withArguments: withArguments)
     }
 
-    func error<E: Error & JSConvertibleError>(for error: E) -> JSValue? {
+    func error(for error: some Error & JSConvertibleError) -> JSValue? {
         if let jsValueError = error as? JSValueError {
             // If the error originated in JS, just return the original object
             return jsValueError.originalJSError

--- a/ios/core/Sources/utilities/JSUtilities.swift
+++ b/ios/core/Sources/utilities/JSUtilities.swift
@@ -8,50 +8,42 @@
 import Foundation
 import JavaScriptCore
 
-/**
- Class to hold context-agnostic JS utility functions
- */
+/// Class to hold context-agnostic JS utility functions
 public class JSUtilities {
-    /**
-     Polyfills functions needed for plugins with native versions
-     - parameters:
-        - context: The context to polyfill
-     */
+    /// Polyfills functions needed for plugins with native versions
+    /// - parameters:
+    ///   - context: The context to polyfill
     public static func polyfill(_ context: JSContext) {
-        let setTimeout: @convention(block) (JSValue?, JSValue?) -> Void = { (function, timeout) in
-            guard let function = function, let timeout = timeout?.toInt32() else { return }
+        let setTimeout: @convention(block) (JSValue?, JSValue?) -> Void = { function, timeout in
+            guard let function, let timeout = timeout?.toInt32() else { return }
             DispatchQueue
                 .global(qos: .background)
-                .asyncAfter(deadline: .now() + .milliseconds(Int(timeout)), execute: {
+                .asyncAfter(deadline: .now() + .milliseconds(Int(timeout))) {
                     DispatchQueue.main.async {
                         function.call(withArguments: [])
                     }
-            })
+                }
         }
         guard let val = JSValue(object: setTimeout, in: context) else { return }
         context.setObject(val, forKeyedSubscript: "setTimeout" as NSString)
     }
 
-    /// A function used to indicate a promise has completed async operations successfully
-    public typealias Resolve = (Any...) -> Void
-    /// A function used to indicate a promise has failed to complete async operations
-    public typealias Reject = (Any...) -> Void
-
-    /**
-     Creates a javascript promise in the given context, to execute native code
-     - parameters:
-        - context: The JSContext to create the promise in
-        - handler: A completion handler that is used in place of the JS closure used to construct promises
-     - returns: A reference to the promise in the context if successfully created
-     */
-    public static func createPromise(context: JSContext, handler: @escaping (@escaping Resolve, @escaping Reject) -> Void) -> JSValue? {
+    /// Creates a javascript promise in the given context, to execute native code
+    /// - parameters:
+    ///   - context: The JSContext to create the promise in
+    ///   - handler: A completion handler that is used in place of the JS closure used to construct
+    /// promises
+    /// - returns: A reference to the promise in the context if successfully created
+    public static func createPromise(
+        context: JSContext,
+        handler: @escaping (@escaping Resolve, @escaping Reject) -> Void
+    ) -> JSValue? {
         let constructor: @convention(block) (JSValue, JSValue) -> Void = { resolve, reject in
-            handler({(args: Any...) in
-                    resolve.call(withArguments: args)
-                }, {(args: Any...) in
-                    reject.call(withArguments: args)
-                }
-            )
+            handler({ (args: Any...) in
+                resolve.call(withArguments: args)
+            }, { (args: Any...) in
+                reject.call(withArguments: args)
+            })
         }
         guard
             let closure = JSValue(object: constructor, in: context),
@@ -59,36 +51,45 @@ public class JSUtilities {
         else { return nil }
         return promise
     }
+
+    /// A function used to indicate a promise has completed async operations successfully
+    public typealias Resolve = (Any...) -> Void
+    /// A function used to indicate a promise has failed to complete async operations
+    public typealias Reject = (Any...) -> Void
 }
 
-internal enum JSClass: String {
+enum JSClass: String {
     case error = "Error"
     case promise = "Promise"
 }
 
-internal extension JSContext {
+extension JSContext {
     func getJSClass(_ jsClass: JSClass) -> JSValue? {
         objectForKeyedSubscript(jsClass.rawValue)
     }
+
     func constructClass(_ jsClass: JSClass, withArguments: [Any]?) -> JSValue? {
         getJSClass(jsClass)?.construct(withArguments: withArguments)
     }
-    
-    func error<E>(for error: E) -> JSValue? where E: Error, E: JSConvertibleError {
+
+    func error<E: Error & JSConvertibleError>(for error: E) -> JSValue? {
         if let jsValueError = error as? JSValueError {
             // If the error originated in JS, just return the original object
             return jsValueError.originalJSError
         }
-        
+
         let errObj = constructClass(.error, withArguments: [error.jsDescription])
         if let errorWithMetadata = error as? ErrorWithMetadata, let err = errObj {
             err.setValue(errorWithMetadata.type.rawValue, forProperty: JSValueError.JSKeys.type)
-            err.setValue(errorWithMetadata.severity?.rawValue, forProperty: JSValueError.JSKeys.severity)
+            err.setValue(
+                errorWithMetadata.severity?.rawValue,
+                forProperty: JSValueError.JSKeys.severity
+            )
             if let metadata = errorWithMetadata.metadata {
                 err.setValue(metadata, forProperty: JSValueError.JSKeys.metadata)
             }
         }
-        
+
         return errObj
     }
 }

--- a/ios/core/Sources/utilities/JSValue+Extensions.swift
+++ b/ios/core/Sources/utilities/JSValue+Extensions.swift
@@ -8,34 +8,33 @@
 import Foundation
 import JavaScriptCore
 
-extension JSValue {
-
-
-    /**
-     A way to catch errors for functions not called inside a player process. Can be called on functions with a return value and void with discardableResult.
-     - parameters:
-        - args: List of arguments taken by the function
-     */
+public extension JSValue {
+    /// A way to catch errors for functions not called inside a player process. Can be called on
+    /// functions with a return value and void with discardableResult.
+    /// - parameters:
+    ///   - args: List of arguments taken by the function
     @discardableResult
-    public func tryCatch(args: Any...) throws -> JSValue? {
+    func tryCatch(args: Any...) throws -> JSValue? {
         var tryCatchWrapper: JSValue? {
-            self.context.evaluateScript(
-            """
-               (fn, args) => {
-                   try {
-                       return fn(...args)
-                   } catch(e) {
-                       return e
+            context.evaluateScript(
+                """
+                   (fn, args) => {
+                       try {
+                           return fn(...args)
+                       } catch(e) {
+                           return e
+                       }
                    }
-               }
-            """)
+                """
+            )
         }
 
         var errorCheckWrapper: JSValue? {
-            self.context.evaluateScript(
-            """
-                    (obj) => (obj instanceof Error)
-            """)
+            context.evaluateScript(
+                """
+                        (obj) => (obj instanceof Error)
+                """
+            )
         }
         let result = tryCatchWrapper?.call(withArguments: [self, args])
 
@@ -51,9 +50,7 @@ extension JSValue {
     }
 }
 
-/**
- Represents the different errors that occur when evaluating JSValue
- */
+/// Represents the different errors that occur when evaluating JSValue
 public enum JSValueError: Error, Equatable {
     case thrownFromJS(message: String)
 }

--- a/ios/core/Sources/utilities/JSValue+Extensions.swift
+++ b/ios/core/Sources/utilities/JSValue+Extensions.swift
@@ -9,34 +9,34 @@ import Foundation
 import JavaScriptCore
 
 extension JSValue {
-    
-    internal enum TryCatchResultKeys {
+    enum TryCatchResultKeys {
         static let success = "success"
         static let result = "result"
     }
 
-
-    /// Calls the JS function with error handling. Throws a `JSValueError` if the JS function throws.
+    /// Calls the JS function with error handling. Throws a `JSValueError` if the JS function
+    /// throws.
     /// - Parameter args: List of arguments taken by the function
     @discardableResult
     public func callWithErrorHandling(args: Any...) throws -> JSValue? {
         var wrapper: JSValue? {
-            self.context.evaluateScript(
-            """
-               (fn, args) => {
-                   try {
-                       return {
-                           \(TryCatchResultKeys.result): fn(...args),
-                           \(TryCatchResultKeys.success): true
-                       }
-                   } catch(error) {
-                       return {
-                           \(TryCatchResultKeys.result): error,
-                           \(TryCatchResultKeys.success): false
+            context.evaluateScript(
+                """
+                   (fn, args) => {
+                       try {
+                           return {
+                               \(TryCatchResultKeys.result): fn(...args),
+                               \(TryCatchResultKeys.success): true
+                           }
+                       } catch(error) {
+                           return {
+                               \(TryCatchResultKeys.result): error,
+                               \(TryCatchResultKeys.success): false
+                           }
                        }
                    }
-               }
-            """)
+                """
+            )
         }
 
         let result = wrapper?.call(withArguments: [self, args])
@@ -50,38 +50,27 @@ extension JSValue {
         if !success {
             throw JSValueError.createInstance(value: resultValue)
         }
-        
+
         return resultValue
     }
 }
 
-/**
- Represents the different errors that occur when evaluating JSValue
- */
+/// Represents the different errors that occur when evaluating JSValue
 public struct JSValueError: CreatedFromJSValue, ErrorWithMetadata {
-    private static let defaultMessage: String  = "Unknown JS Error"
-    private static let defaultType: ErrorTypes  = .unknown("")
+    private static let defaultMessage: String = "Unknown JS Error"
+    private static let defaultType: ErrorTypes = .unknown("")
 
     public let message: String
     public let type: ErrorTypes
     public let severity: ErrorSeverity?
     public let metadata: [String: Any]?
-    public var jsDescription: String { message }
-
     /// Flag to determine if the javascript error conformed to the ErrorWithMetadata protocol
     public let isErrorWithMetadata: Bool
 
     public let originalJSError: JSValue
 
-    internal enum JSKeys {
-        static let message = "message"
-        static let type = "type"
-        static let severity = "severity"
-        static let metadata = "metadata"
-    }
-
-    public static func createInstance(value: JSValue) -> JSValueError {
-        return JSValueError(value)
+    public var jsDescription: String {
+        message
     }
 
     public init(_ jsErrorObject: JSValue) {
@@ -98,23 +87,37 @@ public struct JSValueError: CreatedFromJSValue, ErrorWithMetadata {
             isErrorWithMetadata = false
             return
         }
-        
-        if let messageProperty = jsErrorObject.objectForKeyedSubscript(JSKeys.message), messageProperty.isString == true {
+
+        if let messageProperty = jsErrorObject.objectForKeyedSubscript(JSKeys.message),
+           messageProperty.isString == true {
             message = messageProperty.toString()
         } else {
             message = JSValueError.defaultMessage
         }
-        
-        if let typeProperty = jsErrorObject.objectForKeyedSubscript(JSKeys.type), typeProperty.isString == true {
+
+        if let typeProperty = jsErrorObject.objectForKeyedSubscript(JSKeys.type),
+           typeProperty.isString == true {
             isErrorWithMetadata = true
             type = ErrorTypes(typeProperty.toString())
         } else {
             isErrorWithMetadata = false
             type = JSValueError.defaultType
         }
-        
-        severity = ErrorSeverity(rawValue: jsErrorObject.objectForKeyedSubscript(JSKeys.severity)?.toString() ?? "")
-        metadata = jsErrorObject.objectForKeyedSubscript(JSKeys.metadata)?.toDictionary() as? [String: Any]
+
+        severity = ErrorSeverity(rawValue: jsErrorObject.objectForKeyedSubscript(JSKeys.severity)?
+            .toString() ?? "")
+        metadata = jsErrorObject.objectForKeyedSubscript(JSKeys.metadata)?
+            .toDictionary() as? [String: Any]
+    }
+
+    public static func createInstance(value: JSValue) -> JSValueError {
+        JSValueError(value)
+    }
+
+    enum JSKeys {
+        static let message = "message"
+        static let type = "type"
+        static let severity = "severity"
+        static let metadata = "metadata"
     }
 }
-

--- a/ios/core/Sources/utilities/ResourceUtilities.swift
+++ b/ios/core/Sources/utilities/ResourceUtilities.swift
@@ -7,27 +7,30 @@
 
 import Foundation
 
-/**
- Utilities for loading resource files
- */
+/// Utilities for loading resource files
 public class ResourceUtilities {
-    /**
-     Gets the URL for a file in the bundle
-     Example:
-     ```
-     ResourceUtilities.urlForFile(name: "plugin", ext: "js", bundle: Bundle(for: SomeClass.self), pathComponent: "MyPodName.bundle")
-     ```
-
-     - parameters:
-        - name: The name of the file
-        - ext: The extension of the file
-        - bundle: The bundle to load URLs from
-        - pathComponent: The string bundle path to append to the bundle resource URL
-     - returns:
-        A URL to the file if the bundle can be loaded
-     */
-    public static func urlForFile(name: String, ext: String, bundle: Bundle, pathComponent: String? = nil) -> URL? {
-        let baseURL = pathComponent.map { bundle.resourceURL?.appendingPathComponent($0) } ?? bundle.resourceURL
+    /// Gets the URL for a file in the bundle
+    /// Example:
+    /// ```
+    /// ResourceUtilities.urlForFile(name: "plugin", ext: "js", bundle: Bundle(for: SomeClass.self),
+    /// pathComponent: "MyPodName.bundle")
+    /// ```
+    ///
+    /// - parameters:
+    ///   - name: The name of the file
+    ///   - ext: The extension of the file
+    ///   - bundle: The bundle to load URLs from
+    ///   - pathComponent: The string bundle path to append to the bundle resource URL
+    /// - returns:
+    ///   A URL to the file if the bundle can be loaded
+    public static func urlForFile(
+        name: String,
+        ext: String,
+        bundle: Bundle,
+        pathComponent: String? = nil
+    ) -> URL? {
+        let baseURL = pathComponent.map { bundle.resourceURL?.appendingPathComponent($0) } ?? bundle
+            .resourceURL
         guard let bundleURL = baseURL else { return nil }
         return Bundle(url: bundleURL)?.url(forResource: name, withExtension: ext)
     }

--- a/ios/core/Sources/utilities/ResourceUtilities.swift
+++ b/ios/core/Sources/utilities/ResourceUtilities.swift
@@ -7,24 +7,20 @@
 
 import Foundation
 
-/**
- Utilities for loading resource files
- */
+/// Utilities for loading resource files
 public class ResourceUtilities {
-    /**
-     Gets the URL for a file in the bundle
-     Example:
-     ```
-     ResourceUtilities.urlForFile(name: "plugin", ext: "js", bundle: Bundle.module)
-     ```
-
-     - parameters:
-        - name: The name of the file
-        - ext: The extension of the file
-        - bundle: The bundle to load URLs from
-     - returns:
-        A URL to the file if the bundle can be loaded
-     */
+    /// Gets the URL for a file in the bundle
+    /// Example:
+    /// ```
+    /// ResourceUtilities.urlForFile(name: "plugin", ext: "js", bundle: Bundle.module)
+    /// ```
+    ///
+    /// - parameters:
+    ///   - name: The name of the file
+    ///   - ext: The extension of the file
+    ///   - bundle: The bundle to load URLs from
+    /// - returns:
+    ///   A URL to the file if the bundle can be loaded
     public static func urlForFile(name: String, ext: String, bundle: Bundle) -> URL? {
         guard let bundleURL = bundle.resourceURL else { return nil }
         return Bundle(url: bundleURL)?.url(forResource: name, withExtension: ext)

--- a/ios/core/Tests/CorePlugins/PartialMatchFingerprintPluginTests.swift
+++ b/ios/core/Tests/CorePlugins/PartialMatchFingerprintPluginTests.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 import JavaScriptCore
-import XCTest
 @testable import PlayerUI
+import XCTest
 
 class PartialMatchFingerprintPluginTests: XCTestCase {
     func testMapping() {

--- a/ios/core/Tests/ErrorControllerTests.swift
+++ b/ios/core/Tests/ErrorControllerTests.swift
@@ -6,52 +6,45 @@
 //
 
 import Foundation
-import XCTest
 import JavaScriptCore
 @testable import PlayerUI
 @testable import PlayerUIInternalTestUtilities
 @testable import PlayerUITestUtilitiesCore
+import XCTest
 
 private struct ErrorWithAnyMetadata: ErrorWithMetadata {
-    public var message: String
-    public var type: ErrorTypes
-    public var severity: ErrorSeverity?
-    public var metadata: [String: Any]?
-    public var jsDescription: String { message }
+    var message: String
+    var type: ErrorTypes
+    var severity: ErrorSeverity?
+    var metadata: [String: Any]?
+
+    var jsDescription: String {
+        message
+    }
 }
 
 class ErrorControllerTests: XCTestCase {
-    var player: HeadlessPlayerImpl!
-    
-    override func setUp() {
-        super.setUp()
-        player = HeadlessPlayerImpl(plugins: [])
-    }
-    
-    override func tearDown() {
-        player = nil
-        super.tearDown()
-    }
-    
+    private var player: HeadlessPlayerImpl!
+
     // MARK: - Hook Tests
-    
+
     func testErrorControllerHookIsCalled() {
         let errorHookCalled = expectation(description: "Error hook called")
-        
+
         player.hooks?.errorController.tap { errorController in
             XCTAssertNotNil(errorController)
             XCTAssertNotNil(errorController.hooks.onError)
             errorHookCalled.fulfill()
         }
-        
+
         player.start(flow: FlowData.COUNTER) { _ in }
-        
+
         wait(for: [errorHookCalled], timeout: 2)
     }
-    
+
     func testOnErrorHookIsTapped() {
         let onErrorCalled = expectation(description: "onError hook called")
-        
+
         player.hooks?.errorController.tap { errorController in
             errorController.hooks.onError.tap { errorInfo in
                 XCTAssertNotNil(errorInfo)
@@ -61,184 +54,202 @@ class ErrorControllerTests: XCTestCase {
                 onErrorCalled.fulfill()
                 return nil
             }
-            
+
             // Capture a test error
             errorController.captureError(
-                error: ErrorWithAnyMetadata(message: "Error", type: .validation, severity: .error, metadata: ["testKey": "testValue"])
+                error: ErrorWithAnyMetadata(
+                    message: "Error",
+                    type: .validation,
+                    severity: .error,
+                    metadata: ["testKey": "testValue"]
+                )
             )
         }
-        
+
         player.start(flow: FlowData.COUNTER) { _ in }
-        
+
         wait(for: [onErrorCalled], timeout: 2)
     }
-    
+
     // MARK: - Error Capture Tests
-    
-    func testCaptureErrorWithAllParameters() {
+
+    func testCaptureErrorWithAllParameters() throws {
         player.start(flow: FlowData.COUNTER) { _ in }
-        
+
         guard let state = player.state as? InProgressState else {
             return XCTFail("Player not in progress")
         }
-        
-        guard let errorController = state.controllers?.error else {
-            XCTFail("Error controller not found")
-            return
-        }
-        
-        let testError = ErrorWithAnyMetadata(message: "Error", type: .network, severity: .error, metadata: ["url": "https://example.com", "statusCode": 404])
-        
+
+        let errorController = try XCTUnwrap(state.controllers?.error, "Error controller not found")
+
+        let testError = ErrorWithAnyMetadata(
+            message: "Error",
+            type: .network,
+            severity: .error,
+            metadata: ["url": "https://example.com", "statusCode": 404]
+        )
+
         let result = errorController.captureError(
             error: testError
         )
-        
+
         XCTAssertFalse(result)
-        
+
         let capturedErrorValue = errorController.getCurrentError()
-        
+
         // Convert JSValue to PlayerErrorInfo
         guard let jsValue = capturedErrorValue else {
             return XCTFail("No error captured")
         }
-        
+
         let capturedError = JSValueError.createInstance(value: jsValue)
         XCTAssertEqual(capturedError.message, "Error")
         XCTAssertEqual(capturedError.type, .network)
         XCTAssertEqual(capturedError.severity, .error)
         XCTAssertNotNil(capturedError.metadata)
     }
-    
+
     func testCaptureErrorWithMinimalParameters() {
         player.start(flow: FlowData.COUNTER) { _ in }
-        
-        guard let state = player.state as? InProgressState, let errorController = state.controllers?.error else {
+
+        guard let state = player.state as? InProgressState,
+              let errorController = state.controllers?.error else {
             return XCTFail("Player not in progress")
         }
-        
+
         let testError = ErrorWithAnyMetadata(message: "Error", type: .plugin)
-        
+
         let result = errorController.captureError(
             error: testError
         )
-        
+
         XCTAssertFalse(result)
         let capturedErrorValue = errorController.getCurrentError()
-        
+
         // Convert JSValue to PlayerErrorInfo
         guard let jsValue = capturedErrorValue else {
             return XCTFail("No error captured")
         }
-        
+
         let capturedError = JSValueError.createInstance(value: jsValue)
         XCTAssertEqual(capturedError.message, "Error")
         XCTAssertEqual(capturedError.type, .plugin)
         XCTAssertNil(capturedError.severity)
         XCTAssertNil(capturedError.metadata)
     }
-    
+
     func testCaptureMultipleErrorsAndCurrentErrorUpdates() {
         player.start(flow: FlowData.COUNTER) { _ in }
-        
-        guard let state = player.state as? InProgressState, let errorController = state.controllers?.error else {
+
+        guard let state = player.state as? InProgressState,
+              let errorController = state.controllers?.error else {
             return XCTFail("Player not in progress")
         }
-        
+
         // Capture first error
         errorController.captureError(
-            error: ErrorWithAnyMetadata(message: "First Error", type: .validation, severity: .warning)
+            error: ErrorWithAnyMetadata(
+                message: "First Error",
+                type: .validation,
+                severity: .warning
+            )
         )
-        
+
         // Verify current error is the first one
-        guard let firstErrorValue = errorController.getCurrentError(), !firstErrorValue.isUndefined else {
+        guard let firstErrorValue = errorController.getCurrentError(),
+              !firstErrorValue.isUndefined else {
             return XCTFail("First error not found")
         }
-        
+
         XCTAssertEqual(JSValueError.createInstance(value: firstErrorValue).message, "First Error")
-        
+
         // Capture second error
         errorController.captureError(
             error: ErrorWithAnyMetadata(message: "Second Error", type: .binding, severity: .error)
         )
-        
+
         // Current error should be updated to the second one
-        guard let secondErrorValue = errorController.getCurrentError(), !secondErrorValue.isUndefined else {
+        guard let secondErrorValue = errorController.getCurrentError(),
+              !secondErrorValue.isUndefined else {
             return XCTFail("Second error not found")
         }
-        
+
         XCTAssertEqual(JSValueError.createInstance(value: secondErrorValue).message, "Second Error")
-        
+
         // Capture third error
         errorController.captureError(
             error: ErrorWithAnyMetadata(message: "Third Error", type: .view, severity: .fatal)
         )
-        
+
         // Current error should be updated to the third one
-        guard let thirdErrorValue = errorController.getCurrentError(), !thirdErrorValue.isUndefined else {
+        guard let thirdErrorValue = errorController.getCurrentError(),
+              !thirdErrorValue.isUndefined else {
             return XCTFail("Third error not found")
         }
-        
+
         XCTAssertEqual(JSValueError.createInstance(value: thirdErrorValue).message, "Third Error")
-        
+
         // Get all errors and verify history
         guard let errorsValue = errorController.getErrors(),
               let errorsArray = errorsValue.toArray() else {
             return XCTFail("Could not get errors array")
         }
-        
+
         // Verify we have 3 errors
         XCTAssertEqual(errorsArray.count, 3, "Expected 3 errors in history")
-        
+
         // Verify the errors by accessing them as JSValues directly from the errorsValue
         let firstError = JSValueError.createInstance(value: errorsValue.atIndex(0))
         let secondError = JSValueError.createInstance(value: errorsValue.atIndex(1))
         let thirdError = JSValueError.createInstance(value: errorsValue.atIndex(2))
-        
+
         XCTAssertEqual(firstError.message, "First Error")
         XCTAssertEqual(secondError.message, "Second Error")
         XCTAssertEqual(thirdError.message, "Third Error")
     }
-    
+
     // MARK: - Get Current Error Tests
-    
+
     func testGetCurrentError() {
         player.start(flow: FlowData.COUNTER) { _ in }
-        
-        guard let state = player.state as? InProgressState, let errorController = state.controllers?.error else {
+
+        guard let state = player.state as? InProgressState,
+              let errorController = state.controllers?.error else {
             return XCTFail("Player not in progress")
         }
-        
+
         // Initially no current error
         let initialError = errorController.getCurrentError()
         XCTAssertTrue(initialError?.isUndefined ?? false)
-        
+
         // Capture an error
         let testError = ErrorWithAnyMetadata(message: "Error", type: .data, severity: .error)
-        
+
         errorController.captureError(
             error: testError
         )
-        
+
         // Now should have a current error
         guard let currentErrorValue = errorController.getCurrentError(),
               !currentErrorValue.isUndefined else {
             return XCTFail("Current error should exist")
         }
-        
+
         let currentError = JSValueError.createInstance(value: currentErrorValue)
         XCTAssertEqual(currentError.message, "Error")
         XCTAssertEqual(currentError.type, .data)
     }
-    
+
     // MARK: - Clear Errors Tests
-    
+
     func testClearAllErrors() {
         player.start(flow: FlowData.COUNTER) { _ in }
-        
-        guard let state = player.state as? InProgressState, let errorController = state.controllers?.error else {
+
+        guard let state = player.state as? InProgressState,
+              let errorController = state.controllers?.error else {
             return XCTFail("Player not in progress")
         }
-        
+
         // Capture multiple errors
         errorController.captureError(
             error: ErrorWithAnyMetadata(message: "Error 1", type: .validation)
@@ -246,30 +257,31 @@ class ErrorControllerTests: XCTestCase {
         errorController.captureError(
             error: ErrorWithAnyMetadata(message: "Error 2", type: .binding)
         )
-        
+
         let errorsBeforeCount = errorController.getErrors()?.toArray()?.count ?? 0
         XCTAssertEqual(errorsBeforeCount, 2)
-        
+
         let currentErrorBefore = errorController.getCurrentError()
         XCTAssertFalse(currentErrorBefore?.isUndefined ?? true)
-        
+
         // Clear all errors
         errorController.clearErrors()
-        
+
         let errorsAfterCount = errorController.getErrors()?.toArray()?.count ?? 0
         XCTAssertEqual(errorsAfterCount, 0)
-        
+
         let currentErrorAfter = errorController.getCurrentError()
         XCTAssertTrue(currentErrorAfter?.isUndefined ?? false)
     }
-    
+
     func testClearCurrentError() {
         player.start(flow: FlowData.COUNTER) { _ in }
-        
-        guard let state = player.state as? InProgressState, let errorController = state.controllers?.error else {
+
+        guard let state = player.state as? InProgressState,
+              let errorController = state.controllers?.error else {
             return XCTFail("Player not in progress")
         }
-        
+
         // Capture multiple errors
         errorController.captureError(
             error: ErrorWithAnyMetadata(message: "Error 1", type: .validation)
@@ -277,34 +289,34 @@ class ErrorControllerTests: XCTestCase {
         errorController.captureError(
             error: ErrorWithAnyMetadata(message: "Error 2", type: .binding)
         )
-        
+
         let errorsBeforeCount = errorController.getErrors()?.toArray()?.count ?? 0
         XCTAssertEqual(errorsBeforeCount, 2)
-        
+
         let currentErrorBefore = errorController.getCurrentError()
         XCTAssertFalse(currentErrorBefore?.isUndefined ?? true)
-        
+
         // Clear only current error
         errorController.clearCurrentError()
-        
+
         // History should be preserved
         let errorsAfterCount = errorController.getErrors()?.toArray()?.count ?? 0
         XCTAssertEqual(errorsAfterCount, 2)
-        
+
         // Current error should be cleared
         let currentErrorAfter = errorController.getCurrentError()
         XCTAssertTrue(currentErrorAfter?.isUndefined ?? false)
     }
 
     // MARK: - PlayerControllers Integration Test
-    
+
     func testPlayerControllersIncludesErrorController() {
         player.start(flow: FlowData.COUNTER) { _ in }
-        
+
         guard let state = player.state as? InProgressState else {
             return XCTFail("Player not in progress")
         }
-        
+
         let controllers = state.controllers
         XCTAssertNotNil(controllers)
         XCTAssertNotNil(controllers?.data)
@@ -313,34 +325,40 @@ class ErrorControllerTests: XCTestCase {
         XCTAssertNotNil(controllers?.expression)
         XCTAssertNotNil(controllers?.error)
     }
-    
+
     // MARK: - Error Metadata Tests
-    
+
     func testErrorMetadataCapture() {
         player.start(flow: FlowData.COUNTER) { _ in }
-        
-        guard let state = player.state as? InProgressState, let errorController = state.controllers?.error else {
+
+        guard let state = player.state as? InProgressState,
+              let errorController = state.controllers?.error else {
             return XCTFail("Player not in progress")
         }
-        
+
         let metadata: [String: Any] = [
             "binding": "data.user.name",
             "attemptedValue": "invalid",
             "validationRule": "minLength",
             "component": "TextInput",
-            "timestamp": Date().timeIntervalSince1970
+            "timestamp": Date().timeIntervalSince1970,
         ]
-        
+
         errorController.captureError(
-            error: ErrorWithAnyMetadata(message: "Error 1", type: .validation, severity: .error, metadata: metadata)
+            error: ErrorWithAnyMetadata(
+                message: "Error 1",
+                type: .validation,
+                severity: .error,
+                metadata: metadata
+            )
         )
-        
+
         let capturedErrorValue = errorController.getCurrentError()
-        
+
         guard let jsValue = capturedErrorValue else {
             return XCTFail("Error should be captured")
         }
-        
+
         let capturedError = JSValueError.createInstance(value: jsValue)
         XCTAssertNotNil(capturedError.metadata)
         XCTAssertEqual(capturedError.metadata?["binding"] as? String, "data.user.name")
@@ -348,24 +366,33 @@ class ErrorControllerTests: XCTestCase {
         XCTAssertEqual(capturedError.metadata?["validationRule"] as? String, "minLength")
         XCTAssertEqual(capturedError.metadata?["component"] as? String, "TextInput")
     }
-    
+
     // MARK: - Error Controller Accessibility from Controllers
-    
+
     func testErrorControllerAccessibleViaControllers() {
         let errorControllerAccessed = expectation(description: "Error controller accessed")
-        
+
         player.hooks?.state.tap { state in
             guard let inProgress = state as? InProgressState else { return }
-            
+
             if let errorController = inProgress.controllers?.error {
                 XCTAssertNotNil(errorController)
                 errorControllerAccessed.fulfill()
             }
         }
-        
+
         player.start(flow: FlowData.COUNTER) { _ in }
-        
+
         wait(for: [errorControllerAccessed], timeout: 2)
     }
-}
 
+    override func setUp() {
+        super.setUp()
+        player = HeadlessPlayerImpl(plugins: [])
+    }
+
+    override func tearDown() {
+        player = nil
+        super.tearDown()
+    }
+}

--- a/ios/core/Tests/FlowStateTests.swift
+++ b/ios/core/Tests/FlowStateTests.swift
@@ -6,22 +6,25 @@
 //
 
 import Foundation
-import XCTest
 import JavaScriptCore
 @testable import PlayerUI
 @testable import PlayerUIInternalTestUtilities
 @testable import PlayerUITestUtilitiesCore
+import XCTest
 
 class FlowStateTests: XCTestCase {
     func testViewFlowState() {
         let player = HeadlessPlayerImpl(plugins: [])
 
-        player.start(flow: FlowData.COUNTER) { _ in}
+        player.start(flow: FlowData.COUNTER) { _ in }
 
-        guard let inProgress = player.state as? InProgressState else { return XCTFail("State not in progress") }
+        guard let inProgress = player.state as? InProgressState
+        else { return XCTFail("State not in progress") }
 
-        XCTAssertNotNil(inProgress.controllers?.flow.current?.currentState?.value as? NavigationFlowViewState)
-        let view = inProgress.controllers?.flow.current?.currentState?.value as? NavigationFlowViewState
+        XCTAssertNotNil(inProgress.controllers?.flow.current?.currentState?
+            .value as? NavigationFlowViewState)
+        let view = inProgress.controllers?.flow.current?.currentState?
+            .value as? NavigationFlowViewState
 
         XCTAssertEqual(view?.attributes?["test"] as? String, "value")
     }
@@ -29,11 +32,13 @@ class FlowStateTests: XCTestCase {
     func testExternalFlowState() {
         let player = HeadlessPlayerImpl(plugins: [])
 
-        player.start(flow: FlowData.externalFlow) { _ in}
+        player.start(flow: FlowData.externalFlow) { _ in }
 
-        guard let inProgress = player.state as? InProgressState else { return XCTFail("State not in progress") }
+        guard let inProgress = player.state as? InProgressState
+        else { return XCTFail("State not in progress") }
 
-        XCTAssertNotNil(inProgress.controllers?.flow.current?.currentState?.value as? NavigationFlowExternalState)
+        XCTAssertNotNil(inProgress.controllers?.flow.current?.currentState?
+            .value as? NavigationFlowExternalState)
     }
 
     func testActionFlowState() {
@@ -45,43 +50,41 @@ class FlowStateTests: XCTestCase {
             XCTAssertEqual(flow.data as? [String: Int], ["count": 0])
         }
 
-        player.hooks?.flowController.tap({ flowController in
+        player.hooks?.flowController.tap { flowController in
             flowController.hooks.flow.tap { flow in
                 flow.hooks.transition.tap { oldState, _ in
                     guard
                         let old = oldState?.value as? NavigationFlowActionState,
-                        case .single(let exp) = old.exp
+                        case let .single(exp) = old.exp
                     else { return }
                     XCTAssertEqual(exp, "{{foo}}")
                     hitActionNode.fulfill()
                 }
             }
-        })
-        player.start(flow: FlowData.actionFlow) { _ in}
+        }
+        player.start(flow: FlowData.actionFlow) { _ in }
 
         wait(for: [hitActionNode], timeout: 1)
-
     }
 
     func testActionMultiExpFlowState() {
         let player = HeadlessPlayerImpl(plugins: [])
         let hitActionNode = expectation(description: "ACTION state hit")
-        player.hooks?.flowController.tap({ flowController in
+        player.hooks?.flowController.tap { flowController in
             flowController.hooks.flow.tap { flow in
                 flow.hooks.transition.tap { oldState, _ in
                     guard
                         let old = oldState?.value as? NavigationFlowActionState,
-                        case .multi(let exp) = old.exp
+                        case let .multi(exp) = old.exp
                     else { return }
                     XCTAssertEqual(exp, ["{{foo}}", "{{bar}}"])
                     hitActionNode.fulfill()
                 }
             }
-        })
-        player.start(flow: FlowData.actionMultiExpFlow) { _ in}
+        }
+        player.start(flow: FlowData.actionMultiExpFlow) { _ in }
 
         wait(for: [hitActionNode], timeout: 1)
-
     }
 
     func testEndFlowState() {
@@ -89,7 +92,7 @@ class FlowStateTests: XCTestCase {
         let endStateHit = expectation(description: "Flow Ended")
         player.start(flow: FlowData.actionFlow) { result in
             switch result {
-            case .success(let completed):
+            case let .success(completed):
                 XCTAssertEqual(completed.endState?.outcome, "done")
                 XCTAssertEqual(completed.endState?.param?["someKey"] as? String, "someValue")
                 let extraKey: String? = completed.endState?.extraKey
@@ -102,31 +105,33 @@ class FlowStateTests: XCTestCase {
         }
 
         wait(for: [endStateHit], timeout: 1)
-
     }
 
-    /// Mirrors JVM FlowControllerIntegrationTest: beforeTransition, transition, and afterTransition hooks fire as expected.
+    /// Mirrors JVM FlowControllerIntegrationTest: beforeTransition, transition, and afterTransition
+    /// hooks fire as expected.
     func testFlowControllerBeforeTransitionHook() {
         let player = HeadlessPlayerImpl(plugins: [])
         var pendingTransition: (NamedState?, String)?
         var completedTransition: (NamedState?, NamedState)?
         var flowInstanceAfterTransition: Flow?
 
-        player.hooks?.flowController.tap { flowController in
-            flowController.hooks.flow.tap { flow in
-                flow.hooks.beforeTransition.tap { state, transitionValue in
-                    pendingTransition = (flow.currentState, transitionValue)
-                    return state
-                }
-                flow.hooks.transition.tap { from, to in
-                    if pendingTransition?.0?.name != from?.name { pendingTransition = nil }
-                    completedTransition = (from, to)
-                }
-                flow.hooks.afterTransition.tap { flowInstance in
-                    flowInstanceAfterTransition = flowInstance
+        player.hooks?
+            .flowController
+            .tap { flowController in
+                flowController.hooks.flow.tap { flow in
+                    flow.hooks.beforeTransition.tap { state, transitionValue in
+                        pendingTransition = (flow.currentState, transitionValue)
+                        return state
+                    }
+                    flow.hooks.transition.tap { from, to in
+                        if pendingTransition?.0?.name != from?.name { pendingTransition = nil }
+                        completedTransition = (from, to)
+                    }
+                    flow.hooks.afterTransition.tap { flowInstance in
+                        flowInstanceAfterTransition = flowInstance
+                    }
                 }
             }
-        }
 
         let inProgress = expectation(description: "in progress")
         player.hooks?.state.tap { newState in

--- a/ios/core/Tests/HeadlessPlayerTests.swift
+++ b/ios/core/Tests/HeadlessPlayerTests.swift
@@ -7,11 +7,11 @@
 //
 
 import Foundation
-import XCTest
 import JavaScriptCore
 @testable import PlayerUI
 @testable import PlayerUIInternalTestUtilities
 @testable import PlayerUITestUtilitiesCore
+import XCTest
 
 class HeadlessPlayerTests: XCTestCase {
     func testViewId() {
@@ -22,7 +22,7 @@ class HeadlessPlayerTests: XCTestCase {
                 XCTAssertEqual(viewController.currentView?.id, "action")
             }
         }
-        player.start(flow: FlowData.COUNTER) { _ in}
+        player.start(flow: FlowData.COUNTER) { _ in }
     }
 
     // func testApplyTo() {
@@ -39,7 +39,7 @@ class HeadlessPlayerTests: XCTestCase {
 
     func testUpdateHook() {
         let player = HeadlessPlayerImpl(plugins: [])
-        // this func only exists because the compiler thinks XCTAssertThrowsError throws when it does not
+        /// this func only exists because the compiler thinks XCTAssertThrowsError throws when it does not
         func checkUnregisteredAssetDecodeFails(_ assetJsValue: JSValue) {
             XCTAssertThrowsError(try player.assetRegistry.decode(assetJsValue))
         }
@@ -49,11 +49,11 @@ class HeadlessPlayerTests: XCTestCase {
             }
         }
 
-        player.start(flow: FlowData.COUNTER) { (result) in
+        player.start(flow: FlowData.COUNTER) { result in
             switch result {
-            case .success(let result):
+            case let .success(result):
                 print(result)
-            case .failure(let error):
+            case let .failure(error):
                 print(error.localizedDescription)
             }
         }
@@ -63,16 +63,16 @@ class HeadlessPlayerTests: XCTestCase {
         let player = HeadlessPlayerImpl(plugins: [])
         let inProgress = expectation(description: "inProgress state")
         let completed = expectation(description: "completed state")
-        player.hooks?.state.tap({ (newState) in
+        player.hooks?.state.tap { newState in
             if (newState as? InProgressState) != nil {
                 inProgress.fulfill()
             }
             if (newState as? CompletedState) != nil {
                 completed.fulfill()
             }
-        })
+        }
 
-        player.start(flow: FlowData.COUNTER, completion: {_ in})
+        player.start(flow: FlowData.COUNTER, completion: { _ in })
         do {
             try (player.state as? InProgressState)?.controllers?.flow.transition(with: "NEXT")
         } catch {
@@ -86,17 +86,18 @@ class HeadlessPlayerTests: XCTestCase {
         let player = HeadlessPlayerImpl(plugins: [])
         let inProgress = expectation(description: "inProgress state")
         let completed = expectation(description: "completed state")
-        player.hooks?.state.tap({ (newState) in
+        player.hooks?.state.tap { newState in
             if (newState as? InProgressState) != nil {
                 inProgress.fulfill()
             }
             if (newState as? ErrorState) != nil {
                 completed.fulfill()
             }
-        })
+        }
 
-        player.start(flow: FlowData.COUNTER, completion: {_ in})
-        (player.state as? InProgressState)?.fail(PlayerError.unknownResponse(DecodingError.baseAssetNotDecodable))
+        player.start(flow: FlowData.COUNTER, completion: { _ in })
+        (player.state as? InProgressState)?
+            .fail(PlayerError.unknownResponse(DecodingError.baseAssetNotDecodable))
 
         wait(for: [inProgress, completed], timeout: 5)
     }
@@ -105,17 +106,18 @@ class HeadlessPlayerTests: XCTestCase {
         let player = HeadlessPlayerImpl(plugins: [])
         let inProgress = expectation(description: "inProgress state")
         let completed = expectation(description: "completed state")
-        player.hooks?.state.tap({ (newState) in
+        player.hooks?.state.tap { newState in
             if (newState as? InProgressState) != nil {
                 inProgress.fulfill()
             }
             if (newState as? ErrorState) != nil {
                 completed.fulfill()
             }
-        })
+        }
 
-        player.start(flow: FlowData.COUNTER, completion: {_ in})
-        (player.state as? InProgressState)?.fail(PlayerError.unknownResponse(PlayerError.jsConversionFailure))
+        player.start(flow: FlowData.COUNTER, completion: { _ in })
+        (player.state as? InProgressState)?
+            .fail(PlayerError.unknownResponse(PlayerError.jsConversionFailure))
 
         wait(for: [inProgress, completed], timeout: 5)
     }
@@ -123,13 +125,13 @@ class HeadlessPlayerTests: XCTestCase {
     func testTransition() {
         let player = HeadlessPlayerImpl(plugins: [])
         XCTAssertNotNil(player.state as? NotStartedState)
-        player.hooks?.dataController.tap({ dataController in
+        player.hooks?.dataController.tap { dataController in
             dataController.set(transaction: ["count": 5])
-        })
+        }
 
-        player.start(flow: FlowData.COUNTER) { (result) in
+        player.start(flow: FlowData.COUNTER) { result in
             switch result {
-            case .success(let result):
+            case let .success(result):
                 print(result)
                 XCTAssertNotNil(player.state as? CompletedState)
                 XCTAssertEqual(result.endState?.outcome, "done")
@@ -142,7 +144,7 @@ class HeadlessPlayerTests: XCTestCase {
                 XCTAssertEqual(result.flow.id, "counter-flow")
                 XCTAssertEqual(result.flow.data?["count"] as? Int, 0)
                 XCTAssertEqual(result.data["count"] as? Int, 5)
-            case .failure(let error):
+            case let .failure(error):
                 print(error.localizedDescription)
                 XCTFail("flow should have succeeded")
             }
@@ -159,9 +161,10 @@ class HeadlessPlayerTests: XCTestCase {
     func testPlayerControllers() {
         let player = HeadlessPlayerImpl(plugins: [])
 
-        player.start(flow: FlowData.COUNTER) { _ in  }
+        player.start(flow: FlowData.COUNTER) { _ in }
         XCTAssertNotNil(player.state as? InProgressState)
-        guard let state = player.state as? InProgressState else { return XCTFail("state was not InProgressState") }
+        guard let state = player.state as? InProgressState
+        else { return XCTFail("state was not InProgressState") }
         XCTAssertNotNil(state.controllers)
     }
 
@@ -171,11 +174,11 @@ class HeadlessPlayerTests: XCTestCase {
                 self.init(fileName: "", pluginName: "")
             }
 
-            override func setup(context: JSContext) {}
+            override func setup(context _: JSContext) {}
         }
         let player = HeadlessPlayerImpl(plugins: [])
 
-        player.start(flow: FlowData.COUNTER) { _ in  }
+        player.start(flow: FlowData.COUNTER) { _ in }
 
         let plugin = RegisterMePlugin()
 
@@ -186,15 +189,18 @@ class HeadlessPlayerTests: XCTestCase {
 
     func testEmptyFlowObject() {
         let player = HeadlessPlayerImpl(plugins: [])
-        player.start(flow: "{}") { (result) in
+        player.start(flow: "{}") { result in
             switch result {
-            case .success(let result):
+            case let .success(result):
                 print(result)
                 XCTFail("should have failed")
-            case .failure(let error):
+            case let .failure(error):
                 switch error {
-                case .promiseRejected(let errorState):
-                    XCTAssertEqual(errorState.error, "undefined is not an object (evaluating 'this.navigation.BEGIN')")
+                case let .promiseRejected(errorState):
+                    XCTAssertEqual(
+                        errorState.error,
+                        "undefined is not an object (evaluating 'this.navigation.BEGIN')"
+                    )
                 default: break
                 }
             }
@@ -203,15 +209,18 @@ class HeadlessPlayerTests: XCTestCase {
 
     func testEmptyStringFlow() {
         let player = HeadlessPlayerImpl(plugins: [])
-        player.start(flow: "") { (result) in
+        player.start(flow: "") { result in
             switch result {
-            case .success(let result):
+            case let .success(result):
                 print(result)
                 XCTFail("should have failed")
-            case .failure(let error):
+            case let .failure(error):
                 switch error {
-                case .promiseRejected(let errorState):
-                    XCTAssertEqual(errorState.error, "undefined is not an object (evaluating \'o.navigation\')")
+                case let .promiseRejected(errorState):
+                    XCTAssertEqual(
+                        errorState.error,
+                        "undefined is not an object (evaluating \'o.navigation\')"
+                    )
                 default: break
                 }
             }
@@ -220,12 +229,12 @@ class HeadlessPlayerTests: XCTestCase {
 
     func testBadStringFlow() {
         let player = HeadlessPlayerImpl(plugins: [])
-        player.start(flow: ")") { (result) in
+        player.start(flow: ")") { result in
             switch result {
-            case .success(let result):
+            case let .success(result):
                 print(result)
                 XCTFail("Should have failed")
-            case .failure(let error):
+            case let .failure(error):
                 switch error {
                 case .jsConversionFailure:
                     XCTAssertTrue(true)
@@ -238,12 +247,12 @@ class HeadlessPlayerTests: XCTestCase {
     func testStartNoContext() {
         let player = HeadlessPlayerImpl(plugins: [])
         player.jsPlayerReference = nil
-        player.start(flow: "{}") { (result) in
+        player.start(flow: "{}") { result in
             switch result {
-            case .success(let result):
+            case let .success(result):
                 print(result)
                 XCTFail("Should have failed")
-            case .failure(let error):
+            case let .failure(error):
                 switch error {
                 case .jsConversionFailure:
                     XCTAssertTrue(true)
@@ -259,7 +268,7 @@ class HeadlessPlayerTests: XCTestCase {
         let updateExp = expectation(description: "Data Updated")
 
         XCTAssertNotNil(player.state as? NotStartedState)
-        player.hooks?.dataController.tap({ dataController in
+        player.hooks?.dataController.tap { dataController in
             dataController.hooks.onUpdate.tap { updates in
                 XCTAssertEqual(updates.first?.binding.asString(), "count")
                 XCTAssertEqual(updates.first?.oldValue, AnyType.number(data: 0))
@@ -268,75 +277,98 @@ class HeadlessPlayerTests: XCTestCase {
             }
 
             dataController.set(transaction: ["count": 5])
-        })
+        }
 
-        player.start(flow: FlowData.COUNTER) { _ in}
+        player.start(flow: FlowData.COUNTER) { _ in }
         wait(for: [updateExp], timeout: 1)
     }
 
-    func testConstantsController() {
+    func testConstantsController() throws {
         let player = HeadlessPlayerImpl(plugins: [])
-        
-        guard let constantsController = player.constantsController else { return }
-        
+
+        let constantsController = try XCTUnwrap(player.constantsController)
+
         // Basic get/set tests
         let data: Any = [
             "firstname": "john",
             "lastname": "doe",
             "favorite": [
-                "color": "red"
+                "color": "red",
             ],
-            "age": 1
+            "age": 1,
         ]
-        
+
         constantsController.addConstants(data: data, namespace: "constants")
 
-        let firstname: String? = constantsController.getConstants(key: "firstname", namespace: "constants")
+        let firstname: String? = constantsController.getConstants(
+            key: "firstname",
+            namespace: "constants"
+        )
         XCTAssertEqual(firstname, "john")
 
-        let middleName: String? = constantsController.getConstants(key:"middlename", namespace: "constants")
+        let middleName: String? = constantsController.getConstants(
+            key: "middlename",
+            namespace: "constants"
+        )
         XCTAssertNil(middleName)
 
-        let middleNameSafe: String? = constantsController.getConstants(key:"middlename", namespace: "constants", fallback: "A")
+        let middleNameSafe: String? = constantsController.getConstants(
+            key: "middlename",
+            namespace: "constants",
+            fallback: "A"
+        )
         XCTAssertEqual(middleNameSafe, "A")
 
-        let favoriteColor: String? = constantsController.getConstants(key:"favorite.color", namespace: "constants")
+        let favoriteColor: String? = constantsController.getConstants(
+            key: "favorite.color",
+            namespace: "constants"
+        )
         XCTAssertEqual(favoriteColor, "red")
-        
-        let age: Int? = constantsController.getConstants(key:"age", namespace: "constants")
+
+        let age: Int? = constantsController.getConstants(key: "age", namespace: "constants")
         XCTAssertEqual(age, 1)
 
-        let nonExistantNamespace: String? = constantsController.getConstants(key:"test", namespace: "foo")
+        let nonExistantNamespace: String? = constantsController.getConstants(
+            key: "test",
+            namespace: "foo"
+        )
         XCTAssertNil(nonExistantNamespace)
 
-        let nonExistantNamespaceWithFallback: String? = constantsController.getConstants(key:"test", namespace: "foo", fallback: "B")
+        let nonExistantNamespaceWithFallback: String? = constantsController.getConstants(
+            key: "test",
+            namespace: "foo",
+            fallback: "B"
+        )
         XCTAssertEqual(nonExistantNamespaceWithFallback, "B")
-        
+
         // Test and make sure keys override properly
         let newData: Any = [
-           "favorite": [
-             "color": "blue",
-           ],
-        ];
+            "favorite": [
+                "color": "blue",
+            ],
+        ]
 
-        constantsController.addConstants(data: newData, namespace: "constants");
-        
-        let newFavoriteColor: String? = constantsController.getConstants(key: "favorite.color", namespace:"constants")
+        constantsController.addConstants(data: newData, namespace: "constants")
+
+        let newFavoriteColor: String? = constantsController.getConstants(
+            key: "favorite.color",
+            namespace: "constants"
+        )
         XCTAssertEqual(newFavoriteColor, "blue")
     }
-    
-    func testConstantsControllerTempValues() {
+
+    func testConstantsControllerTempValues() throws {
         let player = HeadlessPlayerImpl(plugins: [])
-        
-        guard let constantsController = player.constantsController else { return }
-        
+
+        let constantsController = try XCTUnwrap(player.constantsController)
+
         // Add initial constants
         let data: Any = [
             "firstname": "john",
             "lastname": "doe",
             "favorite": [
-                "color": "red"
-            ]
+                "color": "red",
+            ],
         ]
         constantsController.addConstants(data: data, namespace: "constants")
 
@@ -344,42 +376,58 @@ class HeadlessPlayerTests: XCTestCase {
         let tempData: Any = [
             "firstname": "jane",
             "favorite": [
-                "color": "blue"
-            ]
+                "color": "blue",
+            ],
         ]
-        constantsController.setTemporaryValues(data:tempData, namespace: "constants")
+        constantsController.setTemporaryValues(data: tempData, namespace: "constants")
 
         // Test temporary override
-        let firstnameTemp: String? = constantsController.getConstants(key:"firstname", namespace: "constants")
+        let firstnameTemp: String? = constantsController.getConstants(
+            key: "firstname",
+            namespace: "constants"
+        )
         XCTAssertEqual(firstnameTemp, "jane")
 
-        let favoriteColorTemp: String? = constantsController.getConstants(key: "favorite.color", namespace: "constants")
+        let favoriteColorTemp: String? = constantsController.getConstants(
+            key: "favorite.color",
+            namespace: "constants"
+        )
         XCTAssertEqual(favoriteColorTemp, "blue")
 
         // Test fallback to original values when temporary values are not present
-        let lastnameTemp: String? = constantsController.getConstants(key: "lastname", namespace: "constants")
+        let lastnameTemp: String? = constantsController.getConstants(
+            key: "lastname",
+            namespace: "constants"
+        )
         XCTAssertEqual(lastnameTemp, "doe")
-        
+
         // Reset temp and values should be the same as the original data
-        constantsController.clearTemporaryValues();
-        
-        let firstname: String? = constantsController.getConstants(key:"firstname", namespace: "constants")
+        constantsController.clearTemporaryValues()
+
+        let firstname: String? = constantsController.getConstants(
+            key: "firstname",
+            namespace: "constants"
+        )
         XCTAssertEqual(firstname, "john")
 
-        let favoriteColor: String? = constantsController.getConstants(key: "favorite.color", namespace: "constants")
+        let favoriteColor: String? = constantsController.getConstants(
+            key: "favorite.color",
+            namespace: "constants"
+        )
         XCTAssertEqual(favoriteColor, "red")
 
-        let lastname: String? = constantsController.getConstants(key: "lastname", namespace: "constants")
+        let lastname: String? = constantsController.getConstants(
+            key: "lastname",
+            namespace: "constants"
+        )
         XCTAssertEqual(lastname, "doe")
     }
 }
 
 class FakePlugin: JSBasePlugin, NativePlugin {
-    override func setup(context: JSContext) {
-
-    }
-
     convenience init() {
         self.init(fileName: "", pluginName: "")
     }
+
+    override func setup(context _: JSContext) {}
 }

--- a/ios/core/Tests/HeadlessPlayerTests.swift
+++ b/ios/core/Tests/HeadlessPlayerTests.swift
@@ -39,7 +39,8 @@ class HeadlessPlayerTests: XCTestCase {
 
     func testUpdateHook() {
         let player = HeadlessPlayerImpl(plugins: [])
-        /// this func only exists because the compiler thinks XCTAssertThrowsError throws when it does not
+        /// this func only exists because the compiler thinks XCTAssertThrowsError throws
+        /// when it does not
         func checkUnregisteredAssetDecodeFails(_ assetJsValue: JSValue) {
             XCTAssertThrowsError(try player.assetRegistry.decode(assetJsValue))
         }

--- a/ios/core/Tests/HeadlessPlayerTests.swift
+++ b/ios/core/Tests/HeadlessPlayerTests.swift
@@ -200,7 +200,7 @@ class HeadlessPlayerTests: XCTestCase {
                 "native-only-plugin"
             }
 
-            func apply<P: HeadlessPlayer>(player _: P) {
+            func apply(player _: some HeadlessPlayer) {
                 onApply()
             }
         }

--- a/ios/core/Tests/HeadlessPlayerTests.swift
+++ b/ios/core/Tests/HeadlessPlayerTests.swift
@@ -7,11 +7,11 @@
 //
 
 import Foundation
-import XCTest
 import JavaScriptCore
 @testable import PlayerUI
 @testable import PlayerUIInternalTestUtilities
 @testable import PlayerUITestUtilitiesCore
+import XCTest
 
 class HeadlessPlayerTests: XCTestCase {
     func testViewId() {
@@ -22,7 +22,7 @@ class HeadlessPlayerTests: XCTestCase {
                 XCTAssertEqual(viewController.currentView?.id, "action")
             }
         }
-        player.start(flow: FlowData.COUNTER) { _ in}
+        player.start(flow: FlowData.COUNTER) { _ in }
     }
 
     // func testApplyTo() {
@@ -39,7 +39,7 @@ class HeadlessPlayerTests: XCTestCase {
 
     func testUpdateHook() {
         let player = HeadlessPlayerImpl(plugins: [])
-        // this func only exists because the compiler thinks XCTAssertThrowsError throws when it does not
+        /// this func only exists because the compiler thinks XCTAssertThrowsError throws when it does not
         func checkUnregisteredAssetDecodeFails(_ assetJsValue: JSValue) {
             XCTAssertThrowsError(try player.assetRegistry.decode(assetJsValue))
         }
@@ -49,11 +49,11 @@ class HeadlessPlayerTests: XCTestCase {
             }
         }
 
-        player.start(flow: FlowData.COUNTER) { (result) in
+        player.start(flow: FlowData.COUNTER) { result in
             switch result {
-            case .success(let result):
+            case let .success(result):
                 print(result)
-            case .failure(let error):
+            case let .failure(error):
                 print(error.localizedDescription)
             }
         }
@@ -63,16 +63,16 @@ class HeadlessPlayerTests: XCTestCase {
         let player = HeadlessPlayerImpl(plugins: [])
         let inProgress = expectation(description: "inProgress state")
         let completed = expectation(description: "completed state")
-        player.hooks?.state.tap({ (newState) in
+        player.hooks?.state.tap { newState in
             if (newState as? InProgressState) != nil {
                 inProgress.fulfill()
             }
             if (newState as? CompletedState) != nil {
                 completed.fulfill()
             }
-        })
+        }
 
-        player.start(flow: FlowData.COUNTER, completion: {_ in})
+        player.start(flow: FlowData.COUNTER, completion: { _ in })
         do {
             try (player.state as? InProgressState)?.controllers?.flow.transition(with: "NEXT")
         } catch {
@@ -86,17 +86,18 @@ class HeadlessPlayerTests: XCTestCase {
         let player = HeadlessPlayerImpl(plugins: [])
         let inProgress = expectation(description: "inProgress state")
         let completed = expectation(description: "completed state")
-        player.hooks?.state.tap({ (newState) in
+        player.hooks?.state.tap { newState in
             if (newState as? InProgressState) != nil {
                 inProgress.fulfill()
             }
             if (newState as? ErrorState) != nil {
                 completed.fulfill()
             }
-        })
+        }
 
-        player.start(flow: FlowData.COUNTER, completion: {_ in})
-        (player.state as? InProgressState)?.fail(PlayerError.unknownResponse(DecodingError.baseAssetNotDecodable))
+        player.start(flow: FlowData.COUNTER, completion: { _ in })
+        (player.state as? InProgressState)?
+            .fail(PlayerError.unknownResponse(DecodingError.baseAssetNotDecodable))
 
         wait(for: [inProgress, completed], timeout: 5)
     }
@@ -105,17 +106,18 @@ class HeadlessPlayerTests: XCTestCase {
         let player = HeadlessPlayerImpl(plugins: [])
         let inProgress = expectation(description: "inProgress state")
         let completed = expectation(description: "completed state")
-        player.hooks?.state.tap({ (newState) in
+        player.hooks?.state.tap { newState in
             if (newState as? InProgressState) != nil {
                 inProgress.fulfill()
             }
             if (newState as? ErrorState) != nil {
                 completed.fulfill()
             }
-        })
+        }
 
-        player.start(flow: FlowData.COUNTER, completion: {_ in})
-        (player.state as? InProgressState)?.fail(PlayerError.unknownResponse(PlayerError.jsConversionFailure))
+        player.start(flow: FlowData.COUNTER, completion: { _ in })
+        (player.state as? InProgressState)?
+            .fail(PlayerError.unknownResponse(PlayerError.jsConversionFailure))
 
         wait(for: [inProgress, completed], timeout: 5)
     }
@@ -123,13 +125,13 @@ class HeadlessPlayerTests: XCTestCase {
     func testTransition() {
         let player = HeadlessPlayerImpl(plugins: [])
         XCTAssertNotNil(player.state as? NotStartedState)
-        player.hooks?.dataController.tap({ dataController in
+        player.hooks?.dataController.tap { dataController in
             dataController.set(transaction: ["count": 5])
-        })
+        }
 
-        player.start(flow: FlowData.COUNTER) { (result) in
+        player.start(flow: FlowData.COUNTER) { result in
             switch result {
-            case .success(let result):
+            case let .success(result):
                 print(result)
                 XCTAssertNotNil(player.state as? CompletedState)
                 XCTAssertEqual(result.endState?.outcome, "done")
@@ -142,7 +144,7 @@ class HeadlessPlayerTests: XCTestCase {
                 XCTAssertEqual(result.flow.id, "counter-flow")
                 XCTAssertEqual(result.flow.data?["count"] as? Int, 0)
                 XCTAssertEqual(result.data["count"] as? Int, 5)
-            case .failure(let error):
+            case let .failure(error):
                 print(error.localizedDescription)
                 XCTFail("flow should have succeeded")
             }
@@ -159,9 +161,10 @@ class HeadlessPlayerTests: XCTestCase {
     func testPlayerControllers() {
         let player = HeadlessPlayerImpl(plugins: [])
 
-        player.start(flow: FlowData.COUNTER) { _ in  }
+        player.start(flow: FlowData.COUNTER) { _ in }
         XCTAssertNotNil(player.state as? InProgressState)
-        guard let state = player.state as? InProgressState else { return XCTFail("state was not InProgressState") }
+        guard let state = player.state as? InProgressState
+        else { return XCTFail("state was not InProgressState") }
         XCTAssertNotNil(state.controllers)
     }
 
@@ -171,11 +174,11 @@ class HeadlessPlayerTests: XCTestCase {
                 self.init(fileName: "", pluginName: "")
             }
 
-            override func setup(context: JSContext) {}
+            override func setup(context _: JSContext) {}
         }
         let player = HeadlessPlayerImpl(plugins: [])
 
-        player.start(flow: FlowData.COUNTER) { _ in  }
+        player.start(flow: FlowData.COUNTER) { _ in }
 
         let plugin = RegisterMePlugin()
 
@@ -188,9 +191,17 @@ class HeadlessPlayerTests: XCTestCase {
         var applied = false
         class NativeOnlyPlugin: NativePlugin {
             var onApply: () -> Void
-            init(onApply: @escaping () -> Void) { self.onApply = onApply }
-            var pluginName: String { "native-only-plugin" }
-            func apply<P: HeadlessPlayer>(player: P) { onApply() }
+            init(onApply: @escaping () -> Void) {
+                self.onApply = onApply
+            }
+
+            var pluginName: String {
+                "native-only-plugin"
+            }
+
+            func apply<P: HeadlessPlayer>(player _: P) {
+                onApply()
+            }
         }
         let player = HeadlessPlayerImpl(plugins: [])
         player.start(flow: FlowData.COUNTER) { _ in }
@@ -201,15 +212,18 @@ class HeadlessPlayerTests: XCTestCase {
 
     func testEmptyFlowObject() {
         let player = HeadlessPlayerImpl(plugins: [])
-        player.start(flow: "{}") { (result) in
+        player.start(flow: "{}") { result in
             switch result {
-            case .success(let result):
+            case let .success(result):
                 print(result)
                 XCTFail("should have failed")
-            case .failure(let error):
+            case let .failure(error):
                 switch error {
-                case .promiseRejected(let errorState):
-                    XCTAssertEqual(errorState.error.message, "undefined is not an object (evaluating 'this.navigation.BEGIN')")
+                case let .promiseRejected(errorState):
+                    XCTAssertEqual(
+                        errorState.error.message,
+                        "undefined is not an object (evaluating 'this.navigation.BEGIN')"
+                    )
                 default:
                     XCTFail("Should throw PlayerError.promiseRejected")
                 }
@@ -219,12 +233,12 @@ class HeadlessPlayerTests: XCTestCase {
 
     func testEmptyStringFlow() {
         let player = HeadlessPlayerImpl(plugins: [])
-        player.start(flow: "") { (result) in
+        player.start(flow: "") { result in
             switch result {
-            case .success(let result):
+            case let .success(result):
                 print(result)
                 XCTFail("should have failed")
-            case .failure(let error):
+            case let .failure(error):
                 switch error {
                 case .jsConversionFailure: break
                 default:
@@ -236,12 +250,12 @@ class HeadlessPlayerTests: XCTestCase {
 
     func testBadStringFlow() {
         let player = HeadlessPlayerImpl(plugins: [])
-        player.start(flow: ")") { (result) in
+        player.start(flow: ")") { result in
             switch result {
-            case .success(let result):
+            case let .success(result):
                 print(result)
                 XCTFail("Should have failed")
-            case .failure(let error):
+            case let .failure(error):
                 switch error {
                 case .jsConversionFailure:
                     XCTAssertTrue(true)
@@ -254,12 +268,12 @@ class HeadlessPlayerTests: XCTestCase {
     func testStartNoContext() {
         let player = HeadlessPlayerImpl(plugins: [])
         player.jsPlayerReference = nil
-        player.start(flow: "{}") { (result) in
+        player.start(flow: "{}") { result in
             switch result {
-            case .success(let result):
+            case let .success(result):
                 print(result)
                 XCTFail("Should have failed")
-            case .failure(let error):
+            case let .failure(error):
                 switch error {
                 case .jsConversionFailure:
                     XCTAssertTrue(true)
@@ -275,7 +289,7 @@ class HeadlessPlayerTests: XCTestCase {
         let updateExp = expectation(description: "Data Updated")
 
         XCTAssertNotNil(player.state as? NotStartedState)
-        player.hooks?.dataController.tap({ dataController in
+        player.hooks?.dataController.tap { dataController in
             dataController.hooks.onUpdate.tap { updates in
                 XCTAssertEqual(updates.first?.binding.asString(), "count")
                 XCTAssertEqual(updates.first?.oldValue, AnyType.number(data: 0))
@@ -284,75 +298,98 @@ class HeadlessPlayerTests: XCTestCase {
             }
 
             dataController.set(transaction: ["count": 5])
-        })
+        }
 
-        player.start(flow: FlowData.COUNTER) { _ in}
+        player.start(flow: FlowData.COUNTER) { _ in }
         wait(for: [updateExp], timeout: 1)
     }
 
-    func testConstantsController() {
+    func testConstantsController() throws {
         let player = HeadlessPlayerImpl(plugins: [])
-        
-        guard let constantsController = player.constantsController else { return }
-        
+
+        let constantsController = try XCTUnwrap(player.constantsController)
+
         // Basic get/set tests
         let data: Any = [
             "firstname": "john",
             "lastname": "doe",
             "favorite": [
-                "color": "red"
+                "color": "red",
             ],
-            "age": 1
+            "age": 1,
         ]
-        
+
         constantsController.addConstants(data: data, namespace: "constants")
 
-        let firstname: String? = constantsController.getConstants(key: "firstname", namespace: "constants")
+        let firstname: String? = constantsController.getConstants(
+            key: "firstname",
+            namespace: "constants"
+        )
         XCTAssertEqual(firstname, "john")
 
-        let middleName: String? = constantsController.getConstants(key:"middlename", namespace: "constants")
+        let middleName: String? = constantsController.getConstants(
+            key: "middlename",
+            namespace: "constants"
+        )
         XCTAssertNil(middleName)
 
-        let middleNameSafe: String? = constantsController.getConstants(key:"middlename", namespace: "constants", fallback: "A")
+        let middleNameSafe: String? = constantsController.getConstants(
+            key: "middlename",
+            namespace: "constants",
+            fallback: "A"
+        )
         XCTAssertEqual(middleNameSafe, "A")
 
-        let favoriteColor: String? = constantsController.getConstants(key:"favorite.color", namespace: "constants")
+        let favoriteColor: String? = constantsController.getConstants(
+            key: "favorite.color",
+            namespace: "constants"
+        )
         XCTAssertEqual(favoriteColor, "red")
-        
-        let age: Int? = constantsController.getConstants(key:"age", namespace: "constants")
+
+        let age: Int? = constantsController.getConstants(key: "age", namespace: "constants")
         XCTAssertEqual(age, 1)
 
-        let nonExistantNamespace: String? = constantsController.getConstants(key:"test", namespace: "foo")
+        let nonExistantNamespace: String? = constantsController.getConstants(
+            key: "test",
+            namespace: "foo"
+        )
         XCTAssertNil(nonExistantNamespace)
 
-        let nonExistantNamespaceWithFallback: String? = constantsController.getConstants(key:"test", namespace: "foo", fallback: "B")
+        let nonExistantNamespaceWithFallback: String? = constantsController.getConstants(
+            key: "test",
+            namespace: "foo",
+            fallback: "B"
+        )
         XCTAssertEqual(nonExistantNamespaceWithFallback, "B")
-        
+
         // Test and make sure keys override properly
         let newData: Any = [
-           "favorite": [
-             "color": "blue",
-           ],
-        ];
+            "favorite": [
+                "color": "blue",
+            ],
+        ]
 
-        constantsController.addConstants(data: newData, namespace: "constants");
-        
-        let newFavoriteColor: String? = constantsController.getConstants(key: "favorite.color", namespace:"constants")
+        constantsController.addConstants(data: newData, namespace: "constants")
+
+        let newFavoriteColor: String? = constantsController.getConstants(
+            key: "favorite.color",
+            namespace: "constants"
+        )
         XCTAssertEqual(newFavoriteColor, "blue")
     }
-    
-    func testConstantsControllerTempValues() {
+
+    func testConstantsControllerTempValues() throws {
         let player = HeadlessPlayerImpl(plugins: [])
-        
-        guard let constantsController = player.constantsController else { return }
-        
+
+        let constantsController = try XCTUnwrap(player.constantsController)
+
         // Add initial constants
         let data: Any = [
             "firstname": "john",
             "lastname": "doe",
             "favorite": [
-                "color": "red"
-            ]
+                "color": "red",
+            ],
         ]
         constantsController.addConstants(data: data, namespace: "constants")
 
@@ -360,42 +397,58 @@ class HeadlessPlayerTests: XCTestCase {
         let tempData: Any = [
             "firstname": "jane",
             "favorite": [
-                "color": "blue"
-            ]
+                "color": "blue",
+            ],
         ]
-        constantsController.setTemporaryValues(data:tempData, namespace: "constants")
+        constantsController.setTemporaryValues(data: tempData, namespace: "constants")
 
         // Test temporary override
-        let firstnameTemp: String? = constantsController.getConstants(key:"firstname", namespace: "constants")
+        let firstnameTemp: String? = constantsController.getConstants(
+            key: "firstname",
+            namespace: "constants"
+        )
         XCTAssertEqual(firstnameTemp, "jane")
 
-        let favoriteColorTemp: String? = constantsController.getConstants(key: "favorite.color", namespace: "constants")
+        let favoriteColorTemp: String? = constantsController.getConstants(
+            key: "favorite.color",
+            namespace: "constants"
+        )
         XCTAssertEqual(favoriteColorTemp, "blue")
 
         // Test fallback to original values when temporary values are not present
-        let lastnameTemp: String? = constantsController.getConstants(key: "lastname", namespace: "constants")
+        let lastnameTemp: String? = constantsController.getConstants(
+            key: "lastname",
+            namespace: "constants"
+        )
         XCTAssertEqual(lastnameTemp, "doe")
-        
+
         // Reset temp and values should be the same as the original data
-        constantsController.clearTemporaryValues();
-        
-        let firstname: String? = constantsController.getConstants(key:"firstname", namespace: "constants")
+        constantsController.clearTemporaryValues()
+
+        let firstname: String? = constantsController.getConstants(
+            key: "firstname",
+            namespace: "constants"
+        )
         XCTAssertEqual(firstname, "john")
 
-        let favoriteColor: String? = constantsController.getConstants(key: "favorite.color", namespace: "constants")
+        let favoriteColor: String? = constantsController.getConstants(
+            key: "favorite.color",
+            namespace: "constants"
+        )
         XCTAssertEqual(favoriteColor, "red")
 
-        let lastname: String? = constantsController.getConstants(key: "lastname", namespace: "constants")
+        let lastname: String? = constantsController.getConstants(
+            key: "lastname",
+            namespace: "constants"
+        )
         XCTAssertEqual(lastname, "doe")
     }
 }
 
 class FakePlugin: JSBasePlugin, NativePlugin {
-    override func setup(context: JSContext) {
-
-    }
-
     convenience init() {
         self.init(fileName: "", pluginName: "")
     }
+
+    override func setup(context _: JSContext) {}
 }

--- a/ios/core/Tests/HeadlessPlayerTests.swift
+++ b/ios/core/Tests/HeadlessPlayerTests.swift
@@ -39,7 +39,8 @@ class HeadlessPlayerTests: XCTestCase {
 
     func testUpdateHook() {
         let player = HeadlessPlayerImpl(plugins: [])
-        /// this func only exists because the compiler thinks XCTAssertThrowsError throws when it does not
+        /// This func only exists because the compiler thinks XCTAssertThrowsError
+        /// throws when it does not
         func checkUnregisteredAssetDecodeFails(_ assetJsValue: JSValue) {
             XCTAssertThrowsError(try player.assetRegistry.decode(assetJsValue))
         }

--- a/ios/core/Tests/NavigationFlowStateTypeTests.swift
+++ b/ios/core/Tests/NavigationFlowStateTypeTests.swift
@@ -11,7 +11,7 @@ class NavigationFlowStateTypeTests: XCTestCase {
             ("ASYNC_ACTION", .asyncAction),
             ("FLOW", .flow),
             ("EXTERNAL", .external),
-            ("END", .end),
+            ("END", .end)
         ]
 
         for (raw, expected) in cases {

--- a/ios/core/Tests/NavigationFlowStateTypeTests.swift
+++ b/ios/core/Tests/NavigationFlowStateTypeTests.swift
@@ -1,9 +1,8 @@
 import Foundation
-import XCTest
 @testable import PlayerUI
+import XCTest
 
 class NavigationFlowStateTypeTests: XCTestCase {
-
     func testKnownStateTypes() {
         let cases: [(String, NavigationFlowStateType)] = [
             ("VIEW", .view),
@@ -11,7 +10,7 @@ class NavigationFlowStateTypeTests: XCTestCase {
             ("ASYNC_ACTION", .asyncAction),
             ("FLOW", .flow),
             ("EXTERNAL", .external),
-            ("END", .end)
+            ("END", .end),
         ]
 
         for (raw, expected) in cases {

--- a/ios/core/Tests/Types/Core/BindingParserTests.swift
+++ b/ios/core/Tests/Types/Core/BindingParserTests.swift
@@ -1,10 +1,10 @@
-import XCTest
 import JavaScriptCore
 @testable import PlayerUI
+import XCTest
 
 class LocalModelTests: XCTestCase {
-    func testLocalModel() {
-        let context = JSContext()!
+    func testLocalModel() throws {
+        let context = try XCTUnwrap(JSContext())
 
         let model = LocalModel(data: ["foo": "bar"], in: context)
 
@@ -17,8 +17,8 @@ class LocalModelTests: XCTestCase {
 }
 
 class BindingParserTests: XCTestCase {
-    func testBindingParser() {
-        let context = JSContext()!
+    func testBindingParser() throws {
+        let context = try XCTUnwrap(JSContext())
 
         let options = BindingParserOptions(get: { _ in nil })
         let parser = BindingParser(options: options, in: context)
@@ -28,8 +28,8 @@ class BindingParserTests: XCTestCase {
         XCTAssertEqual(["baz", "1", "key"], parser.parse(path: "baz[1].key")?.asArray())
     }
 
-    func testBindingParserThroughModel() {
-        let context = JSContext()!
+    func testBindingParserThroughModel() throws {
+        let context = try XCTUnwrap(JSContext())
 
         let model = LocalModel(data: ["foo": ["baz": "value"], "bar": "baz"], in: context)
 
@@ -39,13 +39,16 @@ class BindingParserTests: XCTestCase {
         XCTAssertEqual(["foo"], parser.parse(path: "foo")?.asArray())
         XCTAssertEqual(["foo", "bar"], parser.parse(path: "foo.bar")?.asArray())
 
-        XCTAssertEqual("value", parser.parse(path: "foo.{{bar}}").map { model.get(binding: $0)?.toString() })
+        XCTAssertEqual(
+            "value",
+            parser.parse(path: "foo.{{bar}}").map { model.get(binding: $0)?.toString() }
+        )
     }
 }
 
 class BindingInstanceTests: XCTestCase {
-    func testSimpleBinding() {
-        let context = JSContext()!
+    func testSimpleBinding() throws {
+        let context = try XCTUnwrap(JSContext())
 
         let binding = BindingInstance(rawBinding: "foo.bar", in: context)
 

--- a/ios/core/Tests/Types/Core/DataControllerTests.swift
+++ b/ios/core/Tests/Types/Core/DataControllerTests.swift
@@ -5,40 +5,13 @@
 //  Created by Koriann South with Augment on 2026-01-22.
 //
 
-import XCTest
 import JavaScriptCore
 @testable import PlayerUI
+import XCTest
 
 class DataControllerTests: XCTestCase {
-    var context: JSContext!
-    var dataController: DataController!
-
-    override func setUp() {
-        super.setUp()
-        context = JSContext()!
-        context.loadCore()
-
-        // Create a DataController with initial data
-        let initialData: [String: Any] = ["user": ["name": "Alice", "age": 30], "count": 5]
-
-        // Create a BindingParser - we need a dummy get function since the DataController creates its own LocalModel
-        let getCallback: @convention(block) (JSValue) -> JSValue? = { _ in nil }
-        let parserValue = context
-            .getClassReference("Player.BindingParser", load: { $0.loadCore() })?
-            .construct(withArguments: [[
-                "get": JSValue(object: getCallback, in: context) as Any
-            ]])
-
-        let dcClass = context.getClassReference("Player.DataController", load: { $0.loadCore() })
-        let dcValue = dcClass?.construct(withArguments: [
-            initialData,
-            [
-                "pathResolver": parserValue as Any
-            ]
-        ])
-
-        dataController = dcValue.map { DataController($0) }
-    }
+    private var context: JSContext!
+    private var dataController: DataController!
 
     func testGetReturnsCorrectValue() {
         XCTAssertEqual(dataController.get(binding: "user.name") as? String, "Alice")
@@ -84,13 +57,45 @@ class DataControllerTests: XCTestCase {
         XCTAssertEqual(readOnly?.get(binding: "user.age") as? Int, 30)
     }
 
-    func testGetModelReturnsPipelinedDataModel() {
+    func testGetModelReturnsPipelinedDataModel() throws {
         let model = dataController.getModel()
 
-        let userName = model?.invokeMethod("get", withArguments: [
-            dataController.value.context.evaluateScript("new Player.BindingParser({ get: () => null }).parse('user.name')")!
+        let userName = try model?.invokeMethod("get", withArguments: [
+            XCTUnwrap(dataController.value
+                .context
+                .evaluateScript(
+                    "new Player.BindingParser({ get: () => null }).parse('user.name')"
+                )),
         ])?.toObject() as? String
 
         XCTAssertEqual(userName, "Alice")
+    }
+
+    override func setUp() {
+        super.setUp()
+        context = JSContext()!
+        context.loadCore()
+
+        // Create a DataController with initial data
+        let initialData: [String: Any] = ["user": ["name": "Alice", "age": 30], "count": 5]
+
+        // Create a BindingParser - we need a dummy get function since the DataController creates
+        // its own LocalModel
+        let getCallback: @convention(block) (JSValue) -> JSValue? = { _ in nil }
+        let parserValue = context
+            .getClassReference("Player.BindingParser", load: { $0.loadCore() })?
+            .construct(withArguments: [[
+                "get": JSValue(object: getCallback, in: context) as Any,
+            ]])
+
+        let dcClass = context.getClassReference("Player.DataController", load: { $0.loadCore() })
+        let dcValue = dcClass?.construct(withArguments: [
+            initialData,
+            [
+                "pathResolver": parserValue as Any,
+            ],
+        ])
+
+        dataController = dcValue.map { DataController($0) }
     }
 }

--- a/ios/core/Tests/Types/Core/ExpressionEvaluatorTests.swift
+++ b/ios/core/Tests/Types/Core/ExpressionEvaluatorTests.swift
@@ -7,11 +7,10 @@
 //
 
 import Foundation
-import XCTest
-
 @testable import PlayerUI
 @testable import PlayerUIInternalTestUtilities
 @testable import PlayerUITestUtilitiesCore
+import XCTest
 
 class ExpressionEvaluatorTests: XCTestCase {
     func testExpressionEvaluator() {
@@ -19,7 +18,8 @@ class ExpressionEvaluatorTests: XCTestCase {
 
         player.start(flow: FlowData.COUNTER, completion: { _ in })
         XCTAssertNotNil(player.state as? InProgressState)
-        guard let state = player.state as? InProgressState else { return XCTFail("state was not InProgressState") }
+        guard let state = player.state as? InProgressState
+        else { return XCTFail("state was not InProgressState") }
         XCTAssertNotNil(state.controllers?.expression.evaluate("{{count}} = 6"))
         XCTAssertNotNil(state.controllers?.expression.evaluate(["{{count}} = 6", "{{count}}"]))
     }

--- a/ios/core/Tests/Types/Core/ModifierTests.swift
+++ b/ios/core/Tests/Types/Core/ModifierTests.swift
@@ -7,11 +7,11 @@
 //
 
 import Foundation
-import XCTest
 @testable import PlayerUI
+import XCTest
 
 class ModifierTests: XCTestCase {
-    // this is really just for coverage because structs dont get public inits for free
+    /// this is really just for coverage because structs dont get public inits for free
     func testModifier() {
         let meta = ModifierMetaData(ref: "ref")
         let mod = Modifier(type: "type", value: "value", name: "name", metaData: meta)
@@ -42,7 +42,12 @@ class ModifierTests: XCTestCase {
     func testDecodeFullMetaDataModifier() throws {
         let data = String.fullMetadata.data(using: .utf8) ?? Data()
         let modifier = try JSONDecoder().decode(Modifier.self, from: data)
-        let metadata = ModifierMetaData(ref: "someref", source: "somesource", mimeType: "somemime", maxLine: 5)
+        let metadata = ModifierMetaData(
+            ref: "someref",
+            source: "somesource",
+            mimeType: "somemime",
+            maxLine: 5
+        )
         XCTAssertEqual(modifier.metaData, metadata)
     }
 

--- a/ios/core/Tests/Types/Core/ReadOnlyDataControllerTests.swift
+++ b/ios/core/Tests/Types/Core/ReadOnlyDataControllerTests.swift
@@ -5,13 +5,19 @@
 //  Created by Koriann South with Augment on 2026-01-22.
 //
 
-import XCTest
 import JavaScriptCore
 @testable import PlayerUI
+import XCTest
 
 class ReadOnlyDataControllerTests: XCTestCase {
-    var context: JSContext!
-    var readOnlyController: ReadOnlyDataController!
+    private var context: JSContext!
+    private var readOnlyController: ReadOnlyDataController!
+
+    func testGetReturnsCorrectValue() {
+        XCTAssertEqual(readOnlyController.get(binding: "product.name") as? String, "Widget")
+        XCTAssertEqual(readOnlyController.get(binding: "product.price") as? Double, 99.99)
+        XCTAssertEqual(readOnlyController.get(binding: "inStock") as? Bool, true)
+    }
 
     override func setUp() {
         super.setUp()
@@ -19,31 +25,29 @@ class ReadOnlyDataControllerTests: XCTestCase {
         context.loadCore()
 
         // Create a DataController and convert to read-only
-        let initialData: [String: Any] = ["product": ["name": "Widget", "price": 99.99], "inStock": true]
+        let initialData: [String: Any] = [
+            "product": ["name": "Widget", "price": 99.99],
+            "inStock": true,
+        ]
 
-        // Create a BindingParser - we need a dummy get function since the DataController creates its own LocalModel
+        // Create a BindingParser - we need a dummy get function since the DataController creates
+        // its own LocalModel
         let getCallback: @convention(block) (JSValue) -> JSValue? = { _ in nil }
         let parserValue = context
             .getClassReference("Player.BindingParser", load: { $0.loadCore() })?
             .construct(withArguments: [[
-                "get": JSValue(object: getCallback, in: context) as Any
+                "get": JSValue(object: getCallback, in: context) as Any,
             ]])
 
         let dcClass = context.getClassReference("Player.DataController", load: { $0.loadCore() })
         let dcValue = dcClass?.construct(withArguments: [
             initialData,
             [
-                "pathResolver": parserValue as Any
-            ]
+                "pathResolver": parserValue as Any,
+            ],
         ])
 
         readOnlyController = dcValue
             .flatMap { DataController($0).makeReadOnly() }
-    }
-
-    func testGetReturnsCorrectValue() {
-        XCTAssertEqual(readOnlyController.get(binding: "product.name") as? String, "Widget")
-        XCTAssertEqual(readOnlyController.get(binding: "product.price") as? Double, 99.99)
-        XCTAssertEqual(readOnlyController.get(binding: "inStock") as? Bool, true)
     }
 }

--- a/ios/core/Tests/Types/Core/StateTests.swift
+++ b/ios/core/Tests/Types/Core/StateTests.swift
@@ -7,13 +7,11 @@
 //
 
 import Foundation
-import XCTest
 import JavaScriptCore
 @testable import PlayerUI
+import XCTest
 
 class StateTests: XCTestCase {
-    let context = JSContext()!
-
     func testCompletedStateCreation() {
         let value = JSValue()
         XCTAssertNil(CompletedState.createInstance(from: value))

--- a/ios/core/Tests/Types/Core/StateTests.swift
+++ b/ios/core/Tests/Types/Core/StateTests.swift
@@ -7,12 +7,12 @@
 //
 
 import Foundation
-import XCTest
 import JavaScriptCore
 @testable import PlayerUI
+import XCTest
 
 class StateTests: XCTestCase {
-    let context = JSContext()!
+    private let context: JSContext = ()!
 
     func testParsesCompletedStateFromJS() {
         // Define a JS value completed state. This may not be what we actually
@@ -37,7 +37,8 @@ class StateTests: XCTestCase {
         let countFromData = completedState?.data["count"] as? Int
         XCTAssertEqual(countFromData, 1)
         let dataController = completedState?.controllers.data
-        let countFromDataController = dataController?.get(binding: .init(stringLiteral: "count")) as? Int
+        let countFromDataController = dataController?
+            .get(binding: .init(stringLiteral: "count")) as? Int
         XCTAssertEqual(countFromDataController, 1)
     }
 }

--- a/ios/core/Tests/Types/Core/StateTests.swift
+++ b/ios/core/Tests/Types/Core/StateTests.swift
@@ -12,7 +12,7 @@ import JavaScriptCore
 import XCTest
 
 class StateTests: XCTestCase {
-    private let context: JSContext = ()!
+    private let context: JSContext = .init()
 
     func testParsesCompletedStateFromJS() {
         // Define a JS value completed state. This may not be what we actually

--- a/ios/core/Tests/Types/Generic/AnyTypeTests.swift
+++ b/ios/core/Tests/Types/Generic/AnyTypeTests.swift
@@ -7,8 +7,8 @@
 //
 
 import Foundation
-import XCTest
 @testable import PlayerUI
+import XCTest
 
 class AnyTypeTests: XCTestCase {
     func testStringData() {
@@ -18,7 +18,7 @@ class AnyTypeTests: XCTestCase {
             let anyType = try? JSONDecoder().decode(AnyType.self, from: data)
         else { return XCTFail("could not decode") }
         switch anyType {
-        case .string(let result):
+        case let .string(result):
             XCTAssertEqual("test", result)
         default:
             XCTFail("data was not string")
@@ -32,7 +32,7 @@ class AnyTypeTests: XCTestCase {
             let anyType = try? JSONDecoder().decode(AnyType.self, from: data)
         else { return XCTFail("could not decode") }
         switch anyType {
-        case .bool(let result):
+        case let .bool(result):
             XCTAssertEqual(true, result)
         default:
             XCTFail("data was not string")
@@ -46,7 +46,7 @@ class AnyTypeTests: XCTestCase {
             let anyType = try? JSONDecoder().decode(AnyType.self, from: data)
         else { return XCTFail("could not decode") }
         switch anyType {
-        case .number(let result):
+        case let .number(result):
             XCTAssertEqual(1, result)
         default:
             XCTFail("data was not string")
@@ -60,7 +60,7 @@ class AnyTypeTests: XCTestCase {
             let anyType = try? JSONDecoder().decode(AnyType.self, from: data)
         else { return XCTFail("could not decode") }
         switch anyType {
-        case .number(let result):
+        case let .number(result):
             XCTAssertEqual(1.5, result)
         default:
             XCTFail("data was not string")
@@ -74,7 +74,7 @@ class AnyTypeTests: XCTestCase {
             let anyType = try? JSONDecoder().decode(AnyType.self, from: data)
         else { return XCTFail("could not decode") }
         switch anyType {
-        case .array(let result):
+        case let .array(result):
             XCTAssertEqual(["test", "data"], result)
         default:
             XCTFail("data was not array")
@@ -88,7 +88,7 @@ class AnyTypeTests: XCTestCase {
             let anyType = try? JSONDecoder().decode(AnyType.self, from: data)
         else { return XCTFail("could not decode") }
         switch anyType {
-        case .numberArray(let result):
+        case let .numberArray(result):
             XCTAssertEqual([1, 2], result)
         default:
             XCTFail("data was not array")
@@ -102,7 +102,7 @@ class AnyTypeTests: XCTestCase {
             let anyType = try? JSONDecoder().decode(AnyType.self, from: data)
         else { return XCTFail("could not decode") }
         switch anyType {
-        case .booleanArray(let result):
+        case let .booleanArray(result):
             XCTAssertEqual([false, true], result)
         default:
             XCTFail("data was not array")
@@ -116,7 +116,7 @@ class AnyTypeTests: XCTestCase {
             let anyType = try? JSONDecoder().decode(AnyType.self, from: data)
         else { return XCTFail("could not decode") }
         switch anyType {
-        case .dictionary(let result):
+        case let .dictionary(result):
             XCTAssertEqual("value", result["key"])
         default:
             XCTFail("data was not dictionary")
@@ -130,7 +130,7 @@ class AnyTypeTests: XCTestCase {
             let anyType = try? JSONDecoder().decode(AnyType.self, from: data)
         else { return XCTFail("could not decode") }
         switch anyType {
-        case .numberDictionary(let result):
+        case let .numberDictionary(result):
             XCTAssertEqual(1, result["key"])
         default:
             XCTFail("data was not dictionary")
@@ -144,21 +144,27 @@ class AnyTypeTests: XCTestCase {
             let anyType = try? JSONDecoder().decode(AnyType.self, from: data)
         else { return XCTFail("could not decode") }
         switch anyType {
-        case .booleanDictionary(let result):
+        case let .booleanDictionary(result):
             XCTAssertEqual(false, result["key"])
         default:
             XCTFail("data was not dictionary")
         }
     }
 
-    func testAnyDictionaryData() {
+    func testAnyDictionaryData() throws {
         let string = "{\"key\":false,\"key2\":1}"
         guard
             let data = string.data(using: .utf8),
-            let anyType = try? AnyTypeDecodingContext(rawData: string.data(using: .utf8)!).inject(to: JSONDecoder()).decode(AnyType.self, from: data)
+            let anyType =
+            try? AnyTypeDecodingContext(rawData: try XCTUnwrap(string.data(using: .utf8)))
+                .inject(to: JSONDecoder())
+                .decode(
+                    AnyType.self,
+                    from: data
+                )
         else { return XCTFail("could not decode") }
         switch anyType {
-        case .anyDictionary(let result):
+        case let .anyDictionary(result):
             XCTAssertEqual(false, result["key"] as? Bool)
             XCTAssertEqual(1, result["key2"] as? Double)
         default:
@@ -166,14 +172,20 @@ class AnyTypeTests: XCTestCase {
         }
     }
 
-    func testAnyArray() {
+    func testAnyArray() throws {
         let string = "[1, true]"
         guard
             let data = string.data(using: .utf8),
-            let anyType = try? AnyTypeDecodingContext(rawData: string.data(using: .utf8)!).inject(to: JSONDecoder()).decode(AnyType.self, from: data)
+            let anyType =
+            try? AnyTypeDecodingContext(rawData: try XCTUnwrap(string.data(using: .utf8)))
+                .inject(to: JSONDecoder())
+                .decode(
+                    AnyType.self,
+                    from: data
+                )
         else { return XCTFail("could not decode") }
         switch anyType {
-        case .anyArray(let result):
+        case let .anyArray(result):
             XCTAssertEqual(1, result[0] as? Int)
             XCTAssertEqual(true, result[1] as? Bool)
         default:
@@ -181,14 +193,20 @@ class AnyTypeTests: XCTestCase {
         }
     }
 
-    func testAnyDictionaryDataWithArray() {
+    func testAnyDictionaryDataWithArray() throws {
         let string = "{\"key2\":1,\"key\":[false]}"
         guard
             let data = string.data(using: .utf8),
-            let anyType = try? AnyTypeDecodingContext(rawData: string.data(using: .utf8)!).inject(to: JSONDecoder()).decode(AnyType.self, from: data)
+            let anyType =
+            try? AnyTypeDecodingContext(rawData: try XCTUnwrap(string.data(using: .utf8)))
+                .inject(to: JSONDecoder())
+                .decode(
+                    AnyType.self,
+                    from: data
+                )
         else { return XCTFail("could not decode") }
         switch anyType {
-        case .anyDictionary(let result):
+        case let .anyDictionary(result):
             XCTAssertEqual(false, (result["key"] as? [Bool])?.first)
             XCTAssertEqual(1, result["key2"] as? Double)
         default:
@@ -196,14 +214,20 @@ class AnyTypeTests: XCTestCase {
         }
     }
 
-    func testAnyDictionaryDataWithDeepNestedTypes() {
+    func testAnyDictionaryDataWithDeepNestedTypes() throws {
         let string = "{\"container\":{\"key2\":1,\"key\":[{\"nestedKey\": \"nestedValue\"}]}}"
         guard
             let data = string.data(using: .utf8),
-            let anyType = try? AnyTypeDecodingContext(rawData: string.data(using: .utf8)!).inject(to: JSONDecoder()).decode(AnyType.self, from: data)
+            let anyType =
+            try? AnyTypeDecodingContext(rawData: try XCTUnwrap(string.data(using: .utf8)))
+                .inject(to: JSONDecoder())
+                .decode(
+                    AnyType.self,
+                    from: data
+                )
         else { return XCTFail("could not decode") }
         switch anyType {
-        case .anyDictionary(let result):
+        case let .anyDictionary(result):
             let container = result["container"] as? [String: Any]
             let nestedArray = container?["key"] as? [Any]
             let nestedDict = nestedArray?.first as? [String: Any]
@@ -250,17 +274,18 @@ class AnyTypeTests: XCTestCase {
         XCTAssertEqual("[\"test\",\"data\"]", doEncode(AnyType.array(data: ["test", "data"])))
         XCTAssertEqual("[1,2]", doEncode(AnyType.numberArray(data: [1, 2])))
         XCTAssertEqual("[false,true]", doEncode(AnyType.booleanArray(data: [false, true])))
-        XCTAssertEqual("{\"a\":false,\"b\":1}", doEncode(AnyType.anyDictionary(data: ["a": false, "b": 1])))
+        XCTAssertEqual(
+            "{\"a\":false,\"b\":1}",
+            doEncode(AnyType.anyDictionary(data: ["a": false, "b": 1]))
+        )
         XCTAssertEqual("[1,\"a\",true]", doEncode(AnyType.anyArray(data: [1, "a", true])))
-        XCTAssertEqual("{\"key\":[{\"nestedKey\":\"nestedValue\"},1,{}],\"key2\":1}", doEncode(AnyType.anyDictionary(data: ["key2": 1, "key": AnyType.anyArray(data: [["nestedKey": "nestedValue"], 1, [:] as Any])])))
-    }
-
-    func doEncode(_ data: AnyType) -> String? {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = .sortedKeys
-        let data = try? encoder.encode(data)
-        guard let data = data else { return nil }
-        return String(data: data, encoding: .utf8)
+        XCTAssertEqual(
+            "{\"key\":[{\"nestedKey\":\"nestedValue\"},1,{}],\"key2\":1}",
+            doEncode(AnyType.anyDictionary(data: [
+                "key2": 1,
+                "key": AnyType.anyArray(data: [["nestedKey": "nestedValue"], 1, [:] as Any]),
+            ]))
+        )
     }
 
     func testCustomEncodable() {
@@ -290,15 +315,36 @@ class AnyTypeTests: XCTestCase {
         XCTAssertEqual(AnyType.number(data: 1), AnyType.number(data: 1))
         XCTAssertEqual(AnyType.number(data: 1.5), AnyType.number(data: 1.5))
         XCTAssertEqual(AnyType.bool(data: false), AnyType.bool(data: false))
-        XCTAssertEqual(AnyType.dictionary(data: ["key": "value"]), AnyType.dictionary(data: ["key": "value"]))
-        XCTAssertEqual(AnyType.numberDictionary(data: ["key": 1]), AnyType.numberDictionary(data: ["key": 1]))
-        XCTAssertEqual(AnyType.numberDictionary(data: ["key": 1.5]), AnyType.numberDictionary(data: ["key": 1.5]))
-        XCTAssertEqual(AnyType.booleanDictionary(data: ["key": false]), AnyType.booleanDictionary(data: ["key": false]))
+        XCTAssertEqual(
+            AnyType.dictionary(data: ["key": "value"]),
+            AnyType.dictionary(data: ["key": "value"])
+        )
+        XCTAssertEqual(
+            AnyType.numberDictionary(data: ["key": 1]),
+            AnyType.numberDictionary(data: ["key": 1])
+        )
+        XCTAssertEqual(
+            AnyType.numberDictionary(data: ["key": 1.5]),
+            AnyType.numberDictionary(data: ["key": 1.5])
+        )
+        XCTAssertEqual(
+            AnyType.booleanDictionary(data: ["key": false]),
+            AnyType.booleanDictionary(data: ["key": false])
+        )
         XCTAssertEqual(AnyType.array(data: ["test", "data"]), AnyType.array(data: ["test", "data"]))
         XCTAssertEqual(AnyType.numberArray(data: [1, 2]), AnyType.numberArray(data: [1, 2]))
-        XCTAssertEqual(AnyType.booleanArray(data: [false, true]), AnyType.booleanArray(data: [false, true]))
-        XCTAssertEqual(AnyType.anyDictionary(data: ["key": false, "key2": 1]), AnyType.anyDictionary(data: ["key": false, "key2": 1]))
-        XCTAssertEqual(AnyType.anyArray(data: [1, "a", true]), AnyType.anyArray(data: [1, "a", true]))
+        XCTAssertEqual(
+            AnyType.booleanArray(data: [false, true]),
+            AnyType.booleanArray(data: [false, true])
+        )
+        XCTAssertEqual(
+            AnyType.anyDictionary(data: ["key": false, "key2": 1]),
+            AnyType.anyDictionary(data: ["key": false, "key2": 1])
+        )
+        XCTAssertEqual(
+            AnyType.anyArray(data: [1, "a", true]),
+            AnyType.anyArray(data: [1, "a", true])
+        )
         XCTAssertNotEqual(AnyType.unknownData, AnyType.string(data: "test"))
         XCTAssertEqual(AnyType.unknownData, AnyType.unknownData)
     }
@@ -307,9 +353,9 @@ class AnyTypeTests: XCTestCase {
         let structure = [
             "object": [
                 "key1": [
-                    5
-                ]
-            ]
+                    5,
+                ],
+            ],
         ]
 
         struct TestCodingKey: CodingKey {
@@ -330,11 +376,19 @@ class AnyTypeTests: XCTestCase {
         let context = AnyTypeDecodingContext(rawData: data)
 
         let object = try context.objectFor(path: [
-            TestCodingKey(stringValue: "object")!,
-            TestCodingKey(stringValue: "key1")!,
-            TestCodingKey(intValue: 0)!
+            XCTUnwrap(TestCodingKey(stringValue: "object")),
+            XCTUnwrap(TestCodingKey(stringValue: "key1")),
+            XCTUnwrap(TestCodingKey(intValue: 0)),
         ])
 
         XCTAssertEqual(object as? Double, 5)
+    }
+
+    private func doEncode(_ data: AnyType) -> String? {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        let data = try? encoder.encode(data)
+        guard let data = data else { return nil }
+        return String(data: data, encoding: .utf8)
     }
 }

--- a/ios/core/Tests/Types/Generic/AnyTypeTests.swift
+++ b/ios/core/Tests/Types/Generic/AnyTypeTests.swift
@@ -7,8 +7,8 @@
 //
 
 import Foundation
-import XCTest
 @testable import PlayerUI
+import XCTest
 
 class AnyTypeTests: XCTestCase {
     func testStringData() {
@@ -18,7 +18,7 @@ class AnyTypeTests: XCTestCase {
             let anyType = try? JSONDecoder().decode(AnyType.self, from: data)
         else { return XCTFail("could not decode") }
         switch anyType {
-        case .string(let result):
+        case let .string(result):
             XCTAssertEqual("test", result)
         default:
             XCTFail("data was not string")
@@ -32,7 +32,7 @@ class AnyTypeTests: XCTestCase {
             let anyType = try? JSONDecoder().decode(AnyType.self, from: data)
         else { return XCTFail("could not decode") }
         switch anyType {
-        case .bool(let result):
+        case let .bool(result):
             XCTAssertEqual(true, result)
         default:
             XCTFail("data was not string")
@@ -46,7 +46,7 @@ class AnyTypeTests: XCTestCase {
             let anyType = try? JSONDecoder().decode(AnyType.self, from: data)
         else { return XCTFail("could not decode") }
         switch anyType {
-        case .number(let result):
+        case let .number(result):
             XCTAssertEqual(1, result)
         default:
             XCTFail("data was not string")
@@ -60,7 +60,7 @@ class AnyTypeTests: XCTestCase {
             let anyType = try? JSONDecoder().decode(AnyType.self, from: data)
         else { return XCTFail("could not decode") }
         switch anyType {
-        case .number(let result):
+        case let .number(result):
             XCTAssertEqual(1.5, result)
         default:
             XCTFail("data was not string")
@@ -74,7 +74,7 @@ class AnyTypeTests: XCTestCase {
             let anyType = try? JSONDecoder().decode(AnyType.self, from: data)
         else { return XCTFail("could not decode") }
         switch anyType {
-        case .array(let result):
+        case let .array(result):
             XCTAssertEqual(["test", "data"], result)
         default:
             XCTFail("data was not array")
@@ -88,7 +88,7 @@ class AnyTypeTests: XCTestCase {
             let anyType = try? JSONDecoder().decode(AnyType.self, from: data)
         else { return XCTFail("could not decode") }
         switch anyType {
-        case .numberArray(let result):
+        case let .numberArray(result):
             XCTAssertEqual([1, 2], result)
         default:
             XCTFail("data was not array")
@@ -102,7 +102,7 @@ class AnyTypeTests: XCTestCase {
             let anyType = try? JSONDecoder().decode(AnyType.self, from: data)
         else { return XCTFail("could not decode") }
         switch anyType {
-        case .booleanArray(let result):
+        case let .booleanArray(result):
             XCTAssertEqual([false, true], result)
         default:
             XCTFail("data was not array")
@@ -116,7 +116,7 @@ class AnyTypeTests: XCTestCase {
             let anyType = try? JSONDecoder().decode(AnyType.self, from: data)
         else { return XCTFail("could not decode") }
         switch anyType {
-        case .dictionary(let result):
+        case let .dictionary(result):
             XCTAssertEqual("value", result["key"])
         default:
             XCTFail("data was not dictionary")
@@ -130,7 +130,7 @@ class AnyTypeTests: XCTestCase {
             let anyType = try? JSONDecoder().decode(AnyType.self, from: data)
         else { return XCTFail("could not decode") }
         switch anyType {
-        case .numberDictionary(let result):
+        case let .numberDictionary(result):
             XCTAssertEqual(1, result["key"])
         default:
             XCTFail("data was not dictionary")
@@ -144,7 +144,7 @@ class AnyTypeTests: XCTestCase {
             let anyType = try? JSONDecoder().decode(AnyType.self, from: data)
         else { return XCTFail("could not decode") }
         switch anyType {
-        case .booleanDictionary(let result):
+        case let .booleanDictionary(result):
             XCTAssertEqual(false, result["key"])
         default:
             XCTFail("data was not dictionary")
@@ -165,7 +165,7 @@ class AnyTypeTests: XCTestCase {
         }
 
         // Should decode to anyDictionary with unknownData for the null value
-        guard case .anyDictionary(let dict) = anyType else {
+        guard case let .anyDictionary(dict) = anyType else {
             return XCTFail("Expected anyDictionary but got \(anyType)")
         }
 
@@ -184,7 +184,7 @@ class AnyTypeTests: XCTestCase {
             .decode(AnyType.self, from: data)
 
         switch anyType {
-        case .anyDictionary(let result):
+        case let .anyDictionary(result):
             XCTAssertEqual("value", result["key"]?.as(String.self))
             XCTAssertEqual(2, result["key2"]?.as(Double.self))
         default:
@@ -205,8 +205,8 @@ class AnyTypeTests: XCTestCase {
         }
     }
 
-    /* Test that an array with values of Any type (i.e. different types) can
-     be decoded. Must use the AnyTypeDecodingContext to decode this. */
+    /// Test that an array with values of Any type (i.e. different types) can
+    /// be decoded. Must use the AnyTypeDecodingContext to decode this.
     func testAnyArrayWithDecodingContext() {
         let string = "[\"hello\", 123, true, {\"nested\": \"value\", \"count\": 42}]"
         guard let data = string.data(using: .utf8)
@@ -217,14 +217,14 @@ class AnyTypeTests: XCTestCase {
             .decode(AnyType.self, from: data)
 
         switch anyType {
-        case .anyArray(let result):
+        case let .anyArray(result):
             XCTAssertEqual(4, result.count)
             XCTAssertEqual("hello", result[0].as(String.self))
             XCTAssertEqual(123, result[1].as(Double.self))
             XCTAssertEqual(true, result[2].as(Bool.self))
 
             // Check nested mixed-type dictionary
-            guard case .anyDictionary(let nestedDict) = result[3] else {
+            guard case let .anyDictionary(nestedDict) = result[3] else {
                 return XCTFail("Expected anyDictionary at index 3. Instead found \(result[3])")
             }
             XCTAssertEqual("value", nestedDict["nested"]?.as(String.self))
@@ -270,17 +270,29 @@ class AnyTypeTests: XCTestCase {
         XCTAssertEqual("[\"test\",\"data\"]", doEncode(AnyType.array(data: ["test", "data"])))
         XCTAssertEqual("[1,2]", doEncode(AnyType.numberArray(data: [1, 2])))
         XCTAssertEqual("[false,true]", doEncode(AnyType.booleanArray(data: [false, true])))
-        XCTAssertEqual("{\"a\":false,\"b\":1}", doEncode(AnyType.anyDictionary(data: ["a": .bool(data: false), "b": .number(data: 1)])))
-        XCTAssertEqual("[1,\"a\",true]", doEncode(AnyType.anyArray(data: [.number(data: 1), .string(data: "a"), .bool(data: true)])))
-        XCTAssertEqual("{\"key\":[{\"nestedKey\":\"nestedValue\"},true,{}],\"key2\":1}", doEncode(AnyType.anyDictionary(data: ["key2": .number(data: 1), "key": .anyArray(data: [.anyDictionary(data: ["nestedKey": .string(data: "nestedValue")]), .bool(data: true), .anyDictionary(data: [:])])])))
-    }
-
-    func doEncode(_ data: AnyType) -> String? {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = .sortedKeys
-        let data = try? encoder.encode(data)
-        guard let data = data else { return nil }
-        return String(data: data, encoding: .utf8)
+        XCTAssertEqual(
+            "{\"a\":false,\"b\":1}",
+            doEncode(AnyType.anyDictionary(data: ["a": .bool(data: false), "b": .number(data: 1)]))
+        )
+        XCTAssertEqual(
+            "[1,\"a\",true]",
+            doEncode(AnyType.anyArray(data: [
+                .number(data: 1),
+                .string(data: "a"),
+                .bool(data: true),
+            ]))
+        )
+        XCTAssertEqual(
+            "{\"key\":[{\"nestedKey\":\"nestedValue\"},true,{}],\"key2\":1}",
+            doEncode(AnyType.anyDictionary(data: [
+                "key2": .number(data: 1),
+                "key": .anyArray(data: [
+                    .anyDictionary(data: ["nestedKey": .string(data: "nestedValue")]),
+                    .bool(data: true),
+                    .anyDictionary(data: [:]),
+                ]),
+            ]))
+        )
     }
 
     func testCustomEncodable() {
@@ -304,8 +316,16 @@ class AnyTypeTests: XCTestCase {
         XCTAssertNotEqual(AnyType.array(data: ["test", "data"]).hashValue, 0)
         XCTAssertNotEqual(AnyType.numberArray(data: [1, 2]).hashValue, 0)
         XCTAssertNotEqual(AnyType.booleanArray(data: [false, true]).hashValue, 0)
-        XCTAssertNotEqual(AnyType.anyDictionary(data: ["key": .bool(data: false), "key2": .number(data: 1)]).hashValue, 0)
-        XCTAssertNotEqual(AnyType.anyArray(data: [.number(data: 1), .string(data: "a"), .bool(data: true)]).hashValue, 0)
+        XCTAssertNotEqual(
+            AnyType.anyDictionary(data: ["key": .bool(data: false), "key2": .number(data: 1)])
+                .hashValue,
+            0
+        )
+        XCTAssertNotEqual(
+            AnyType.anyArray(data: [.number(data: 1), .string(data: "a"), .bool(data: true)])
+                .hashValue,
+            0
+        )
         XCTAssertNotEqual(AnyType.unknownData.hashValue, 0)
     }
 
@@ -314,15 +334,36 @@ class AnyTypeTests: XCTestCase {
         XCTAssertEqual(AnyType.number(data: 1), AnyType.number(data: 1))
         XCTAssertEqual(AnyType.number(data: 1.5), AnyType.number(data: 1.5))
         XCTAssertEqual(AnyType.bool(data: false), AnyType.bool(data: false))
-        XCTAssertEqual(AnyType.dictionary(data: ["key": "value"]), AnyType.dictionary(data: ["key": "value"]))
-        XCTAssertEqual(AnyType.numberDictionary(data: ["key": 1]), AnyType.numberDictionary(data: ["key": 1]))
-        XCTAssertEqual(AnyType.numberDictionary(data: ["key": 1.5]), AnyType.numberDictionary(data: ["key": 1.5]))
-        XCTAssertEqual(AnyType.booleanDictionary(data: ["key": false]), AnyType.booleanDictionary(data: ["key": false]))
+        XCTAssertEqual(
+            AnyType.dictionary(data: ["key": "value"]),
+            AnyType.dictionary(data: ["key": "value"])
+        )
+        XCTAssertEqual(
+            AnyType.numberDictionary(data: ["key": 1]),
+            AnyType.numberDictionary(data: ["key": 1])
+        )
+        XCTAssertEqual(
+            AnyType.numberDictionary(data: ["key": 1.5]),
+            AnyType.numberDictionary(data: ["key": 1.5])
+        )
+        XCTAssertEqual(
+            AnyType.booleanDictionary(data: ["key": false]),
+            AnyType.booleanDictionary(data: ["key": false])
+        )
         XCTAssertEqual(AnyType.array(data: ["test", "data"]), AnyType.array(data: ["test", "data"]))
         XCTAssertEqual(AnyType.numberArray(data: [1, 2]), AnyType.numberArray(data: [1, 2]))
-        XCTAssertEqual(AnyType.booleanArray(data: [false, true]), AnyType.booleanArray(data: [false, true]))
-        XCTAssertEqual(AnyType.anyDictionary(data: ["key": .bool(data: false), "key2": .number(data: 1)]), AnyType.anyDictionary(data: ["key": .bool(data: false), "key2": .number(data: 1)]))
-        XCTAssertEqual(AnyType.anyArray(data: [.number(data: 1), .string(data: "a"), .bool(data: true)]), AnyType.anyArray(data: [.number(data: 1), .string(data: "a"), .bool(data: true)]))
+        XCTAssertEqual(
+            AnyType.booleanArray(data: [false, true]),
+            AnyType.booleanArray(data: [false, true])
+        )
+        XCTAssertEqual(
+            AnyType.anyDictionary(data: ["key": .bool(data: false), "key2": .number(data: 1)]),
+            AnyType.anyDictionary(data: ["key": .bool(data: false), "key2": .number(data: 1)])
+        )
+        XCTAssertEqual(
+            AnyType.anyArray(data: [.number(data: 1), .string(data: "a"), .bool(data: true)]),
+            AnyType.anyArray(data: [.number(data: 1), .string(data: "a"), .bool(data: true)])
+        )
         XCTAssertNotEqual(AnyType.unknownData, AnyType.string(data: "test"))
         XCTAssertEqual(AnyType.unknownData, AnyType.unknownData)
     }
@@ -331,9 +372,9 @@ class AnyTypeTests: XCTestCase {
         let structure = [
             "object": [
                 "key1": [
-                    5
-                ]
-            ]
+                    5,
+                ],
+            ],
         ]
 
         struct TestCodingKey: CodingKey {
@@ -354,9 +395,9 @@ class AnyTypeTests: XCTestCase {
         let context = AnyTypeDecodingContext(rawData: data)
 
         let anyType = try context.decode(path: [
-            TestCodingKey(stringValue: "object")!,
-            TestCodingKey(stringValue: "key1")!,
-            TestCodingKey(intValue: 0)!
+            XCTUnwrap(TestCodingKey(stringValue: "object")),
+            XCTUnwrap(TestCodingKey(stringValue: "key1")),
+            XCTUnwrap(TestCodingKey(intValue: 0)),
         ])
 
         XCTAssertEqual(anyType.as(Double.self), 5)
@@ -423,7 +464,7 @@ class AnyTypeTests: XCTestCase {
         // Test as(_:) with recursive AnyType collections
         let anyDict = AnyType.anyDictionary(data: [
             "title": .string(data: "Test"),
-            "count": .number(data: 5)
+            "count": .number(data: 5),
         ])
         let dict: [String: AnyType]? = anyDict.as([String: AnyType].self)
         XCTAssertNotNil(dict)
@@ -431,7 +472,7 @@ class AnyTypeTests: XCTestCase {
 
         let anyArr = AnyType.anyArray(data: [
             .string(data: "test"),
-            .number(data: 42)
+            .number(data: 42),
         ])
         let arr: [AnyType]? = anyArr.as([AnyType].self)
         XCTAssertNotNil(arr)
@@ -453,7 +494,7 @@ class AnyTypeTests: XCTestCase {
         let dict = AnyType.dictionary(data: ["title": "Hello"])
         let title = dict["title"]
         XCTAssertNotNil(title)
-        guard case .string(let value) = title else {
+        guard case let .string(value) = title else {
             return XCTFail("Expected string value")
         }
         XCTAssertEqual("Hello", value)
@@ -462,7 +503,7 @@ class AnyTypeTests: XCTestCase {
         let numDict = AnyType.numberDictionary(data: ["count": 42])
         let count = numDict["count"]
         XCTAssertNotNil(count)
-        guard case .number(let numValue) = count else {
+        guard case let .number(numValue) = count else {
             return XCTFail("Expected number value")
         }
         XCTAssertEqual(42, numValue)
@@ -471,7 +512,7 @@ class AnyTypeTests: XCTestCase {
         let boolDict = AnyType.booleanDictionary(data: ["active": true])
         let active = boolDict["active"]
         XCTAssertNotNil(active)
-        guard case .bool(let boolValue) = active else {
+        guard case let .bool(boolValue) = active else {
             return XCTFail("Expected bool value")
         }
         XCTAssertEqual(true, boolValue)
@@ -482,20 +523,20 @@ class AnyTypeTests: XCTestCase {
         let anyDict = AnyType.anyDictionary(data: [
             "title": .string(data: "Test"),
             "count": .number(data: 5),
-            "enabled": .bool(data: true)
+            "enabled": .bool(data: true),
         ])
 
-        guard case .string(let titleValue) = anyDict["title"] else {
+        guard case let .string(titleValue) = anyDict["title"] else {
             return XCTFail("Expected string value")
         }
         XCTAssertEqual("Test", titleValue)
 
-        guard case .number(let countValue) = anyDict["count"] else {
+        guard case let .number(countValue) = anyDict["count"] else {
             return XCTFail("Expected number value")
         }
         XCTAssertEqual(5, countValue)
 
-        guard case .bool(let enabledValue) = anyDict["enabled"] else {
+        guard case let .bool(enabledValue) = anyDict["enabled"] else {
             return XCTFail("Expected bool value")
         }
         XCTAssertEqual(true, enabledValue)
@@ -506,7 +547,7 @@ class AnyTypeTests: XCTestCase {
         let dict = AnyType.anyDictionary(data: [
             "title": .string(data: "My Title"),
             "count": .number(data: 42),
-            "active": .bool(data: true)
+            "active": .bool(data: true),
         ])
 
         let title: String? = dict["title"]?.as(String.self)
@@ -542,5 +583,13 @@ class AnyTypeTests: XCTestCase {
 
         let anyDict = AnyType.anyDictionary(data: ["key": .string(data: "value")])
         XCTAssertNil(anyDict["nonexistent"])
+    }
+
+    private func doEncode(_ data: AnyType) -> String? {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        let data = try? encoder.encode(data)
+        guard let data = data else { return nil }
+        return String(data: data, encoding: .utf8)
     }
 }

--- a/ios/core/Tests/Types/Generic/AnyTypeTests.swift
+++ b/ios/core/Tests/Types/Generic/AnyTypeTests.swift
@@ -589,7 +589,7 @@ class AnyTypeTests: XCTestCase {
         let encoder = JSONEncoder()
         encoder.outputFormatting = .sortedKeys
         let data = try? encoder.encode(data)
-        guard let data = data else { return nil }
+        guard let data else { return nil }
         return String(data: data, encoding: .utf8)
     }
 }

--- a/ios/core/Tests/Types/Generic/DebugValueTests.swift
+++ b/ios/core/Tests/Types/Generic/DebugValueTests.swift
@@ -7,9 +7,9 @@
 //
 
 import Foundation
-import XCTest
 import JavaScriptCore
 @testable import PlayerUI
+import XCTest
 
 class DebugValueTests: XCTestCase {
     func testDebugValue() {

--- a/ios/core/Tests/Types/HooksTests.swift
+++ b/ios/core/Tests/Types/HooksTests.swift
@@ -6,75 +6,70 @@
 //
 
 import Foundation
-import XCTest
 import JavaScriptCore
 @testable import PlayerUI
 @testable import PlayerUIInternalTestUtilities
 @testable import PlayerUITestUtilitiesCore
+import XCTest
 
 private struct ErrorWithAnyMetadata: ErrorWithMetadata {
-    public var message: String
-    public var type: ErrorTypes
-    public var severity: ErrorSeverity?
-    public var metadata: [String: Any]?
-    public var jsDescription: String { message }
+    var message: String
+    var type: ErrorTypes
+    var severity: ErrorSeverity?
+    var metadata: [String: Any]?
+
+    var jsDescription: String {
+        message
+    }
 }
 
 class HooksTests: XCTestCase {
-    var player: HeadlessPlayerImpl!
-    
-    override func setUp() {
-        super.setUp()
-        player = HeadlessPlayerImpl(plugins: [])
-    }
-    
-    override func tearDown() {
-        player = nil
-        super.tearDown()
-    }
-    
+    private var player: HeadlessPlayerImpl!
+
     // MARK: - Hook2 Return Value Behavior
-    
+
     func testHook2ReturnValueIsIgnoredForNonBailHooks() {
-        // Track whether each handler is called (proving JS ignores the first handler's return value)
+        // Track whether each handler is called (proving JS ignores the first handler's return
+        // value)
         var firstHandlerCallCount = 0
         var secondHandlerCallCount = 0
-        
+
         let bothHandlersCalled = expectation(description: "Both handlers called at least once")
-        
+
         player.hooks?.flowController.tap { flowController in
             flowController.hooks.flow.tap { flow in
                 // First handler - returns true (attempting to bail)
-                flow.hooks.transition.tap { oldState, newState -> Bool in
+                flow.hooks.transition.tap { _, _ -> Bool in
                     firstHandlerCallCount += 1
-                    
+
                     // Fulfill once both handlers have been called at least once
                     if secondHandlerCallCount > 0 {
                         bothHandlersCalled.fulfill()
                     }
-                    
-                    return true  // Returning true, but JS IGNORES it (not a bail hook!)
+
+                    return true // Returning true, but JS IGNORES it (not a bail hook!)
                 }
-                
+
                 // Second handler - SHOULD be called despite first returning true
-                flow.hooks.transition.tap { oldState, newState -> Bool in
+                flow.hooks.transition.tap { _, _ -> Bool in
                     secondHandlerCallCount += 1
-                    
+
                     // Fulfill once both handlers have been called at least once
                     if firstHandlerCallCount > 0 {
                         bothHandlersCalled.fulfill()
                     }
-                    
+
                     return false
                 }
             }
         }
-        
-        // Allow expectation to be fulfilled multiple times (transitions happen during start AND manual transition)
+
+        // Allow expectation to be fulfilled multiple times (transitions happen during start AND
+        // manual transition)
         bothHandlersCalled.assertForOverFulfill = false
-        
+
         player.start(flow: FlowData.COUNTER) { _ in }
-        
+
         // Trigger a transition
         if let inProgressState = player.state as? InProgressState {
             do {
@@ -83,107 +78,125 @@ class HooksTests: XCTestCase {
                 XCTFail("Transition failed: \(error)")
             }
         }
-        
+
         // Verify: BOTH handlers were called (proves JS ignored the true return value)
         wait(for: [bothHandlersCalled], timeout: 2)
-        
+
         // Verify both handlers were actually called
-        XCTAssertGreaterThan(firstHandlerCallCount, 0, "First handler should be called at least once")
-        XCTAssertGreaterThan(secondHandlerCallCount, 0, "Second handler should be called despite first returning true")
-        
+        XCTAssertGreaterThan(
+            firstHandlerCallCount,
+            0,
+            "First handler should be called at least once"
+        )
+        XCTAssertGreaterThan(
+            secondHandlerCallCount,
+            0,
+            "Second handler should be called despite first returning true"
+        )
+
         // Verify: Despite returning true, the transition completed normally
         if let inProgressState = player.state as? InProgressState {
             XCTAssertNotNil(inProgressState.controllers?.flow.current?.currentState,
-                           "Flow should have transitioned successfully - return value was ignored by JS")
+                            "Flow should have transitioned successfully - return value was ignored by JS")
         }
     }
-    
+
     // MARK: - BailHook Return Value Behavior
-    
+
     func testBailHookReturnsTrueStopsSubsequentHandlers() {
         let firstHandlerCalled = expectation(description: "First handler called")
         let secondHandlerCalled = expectation(description: "Second handler called")
         secondHandlerCalled.isInverted = true // Should NOT be called
-        
+
         guard let playerHooks = player.hooks else {
             return XCTFail("Player hooks is undefined. Test cannot run")
         }
-        
+
         playerHooks.errorController.tap { errorController in
             // First handler - returns true to bail
             errorController.hooks.onError.tap { errorInfo -> Bool? in
                 XCTAssertEqual(errorInfo.type, .network)
                 firstHandlerCalled.fulfill()
-                return true  // BAIL - should prevent second handler from being called
+                return true // BAIL - should prevent second handler from being called
             }
-            
+
             // Second handler - should NOT be called due to bail
-            errorController.hooks.onError.tap { errorInfo -> Bool? in
+            errorController.hooks.onError.tap { _ -> Bool? in
                 secondHandlerCalled.fulfill()
                 return nil
             }
         }
-        
-        playerHooks.state.tap { state in
+
+        playerHooks.state.tap { _ in
             guard let inProgressState = self.player.state as? InProgressState else {
                 return
             }
-            
+
             guard let errorController = inProgressState.controllers?.error else {
                 return XCTFail("Error controller not found on in-progress state")
             }
-            
+
             // Capture error to trigger the hooks
             errorController.captureError(
                 error: ErrorWithAnyMetadata(message: "Error", type: .network, severity: .fatal)
             )
-            
+
             // Verify error was captured
             let currentError = errorController.getCurrentError()
             XCTAssertNotNil(currentError)
-            
+
             // Check that errorState was NOT set in data model (bail prevented it)
             guard let dataController = inProgressState.controllers?.data else {
                 return XCTFail("Data controller needs to be defined")
             }
-            
+
             let errorState = dataController.get(binding: "errorState")
             // errorState should be nil because bail prevented it from being set
             XCTAssertTrue(errorState == nil || (errorState as? NSNull) != nil)
         }
-        
+
         player.start(flow: FlowData.COUNTER) { _ in }
-        
+
         wait(for: [firstHandlerCalled, secondHandlerCalled], timeout: 2)
     }
-    
+
     func testBailHookReturnsNilContinuesToNextHandler() {
         let firstHandlerCalled = expectation(description: "First handler called")
         let secondHandlerCalled = expectation(description: "Second handler called")
-        
+
         player.hooks?.errorController.tap { errorController in
             // First handler - returns nil to continue
             errorController.hooks.onError.tap { errorInfo -> Bool? in
                 XCTAssertEqual(errorInfo.type, .data)
                 firstHandlerCalled.fulfill()
-                return nil  // Continue to next handler
+                return nil // Continue to next handler
             }
-            
+
             // Second handler - should be called
             errorController.hooks.onError.tap { errorInfo -> Bool? in
                 XCTAssertEqual(errorInfo.type, .data)
                 secondHandlerCalled.fulfill()
                 return nil
             }
-            
+
             // Capture error to trigger the hooks
             errorController.captureError(
                 error: ErrorWithAnyMetadata(message: "Error", type: .data, severity: .error)
             )
         }
-        
+
         player.start(flow: FlowData.COUNTER) { _ in }
-        
+
         wait(for: [firstHandlerCalled, secondHandlerCalled], timeout: 2)
+    }
+
+    override func setUp() {
+        super.setUp()
+        player = HeadlessPlayerImpl(plugins: [])
+    }
+
+    override func tearDown() {
+        player = nil
+        super.tearDown()
     }
 }

--- a/ios/core/Tests/utilities/ErrorUtilitiesTests.swift
+++ b/ios/core/Tests/utilities/ErrorUtilitiesTests.swift
@@ -5,13 +5,11 @@
 //  Created by bcallaghan  on 5/27/21.
 //
 
-import XCTest
 @testable import PlayerUI
+import XCTest
 
 class ErrorUtilitiesTestCase: XCTestCase {
-
     func testDecodingErrors() {
-
         struct Foo: Codable {
             var aaa: String
             var bar: Bar
@@ -22,7 +20,7 @@ class ErrorUtilitiesTestCase: XCTestCase {
         }
 
         let decoder = JSONDecoder()
-        let decodeFoo = { (jsonString: String) throws -> Void in
+        let decodeFoo = { (jsonString: String) throws in
             guard let data = jsonString.data(using: .utf8) else {
                 return XCTFail("could not get dat")
             }
@@ -35,7 +33,10 @@ class ErrorUtilitiesTestCase: XCTestCase {
             XCTFail("DecodingError expected")
         } catch {
             let message = error.playerDescription
-            XCTAssertEqual(message, "Expected to decode Int but found a string instead. (coding path bar.bbb)")
+            XCTAssertEqual(
+                message,
+                "Expected to decode Int but found a string instead. (coding path bar.bbb)"
+            )
         }
 
         // keyNotFound

--- a/ios/core/Tests/utilities/JSLoggerTests.swift
+++ b/ios/core/Tests/utilities/JSLoggerTests.swift
@@ -7,11 +7,10 @@
 //
 
 import Foundation
-import XCTest
-
 @testable import PlayerUI
 @testable import PlayerUIInternalTestUtilities
 @testable import PlayerUITestUtilitiesCore
+import XCTest
 
 class JSLoggerTests: XCTestCase {
     func testJSLogger() {
@@ -44,7 +43,7 @@ class JSLoggerTests: XCTestCase {
             errorExpect.fulfill()
         }
 
-        player.start(flow: FlowData.COUNTER, completion: {_ in})
+        player.start(flow: FlowData.COUNTER, completion: { _ in })
         let state = player.state as? InProgressState
         state?.logger?.trace("Message")
         state?.logger?.debug("Message")

--- a/ios/core/Tests/utilities/JSUtilitiesTests.swift
+++ b/ios/core/Tests/utilities/JSUtilitiesTests.swift
@@ -8,27 +8,30 @@
 
 import Foundation
 import JavaScriptCore
-import XCTest
 @testable import PlayerUI
 import PlayerUILogger
+import XCTest
 
 class JSUtilitiesTests: XCTestCase {
-    func testPolyfill() {
-        let context = JSContext()!
+    func testPolyfill() throws {
+        let context = try XCTUnwrap(JSContext())
         JSUtilities.polyfill(context)
         let expection = XCTestExpectation(description: "setTimeout called")
 
         let function: @convention(block) () -> Void = {
             expection.fulfill()
         }
-        context.objectForKeyedSubscript("setTimeout")?.call(withArguments: [JSValue(object: function, in: context) as Any, 1])
+        context.objectForKeyedSubscript("setTimeout")?.call(withArguments: [
+            JSValue(object: function, in: context) as Any,
+            1,
+        ])
         wait(for: [expection], timeout: 2)
     }
 
-    func testPromiseSucceeds() {
-        let context = JSContext()!
+    func testPromiseSucceeds() throws {
+        let context = try XCTUnwrap(JSContext())
 
-        let promise = JSUtilities.createPromise(context: context) { (resolve, _) in
+        let promise = JSUtilities.createPromise(context: context) { resolve, _ in
             resolve()
         }
 
@@ -43,10 +46,10 @@ class JSUtilitiesTests: XCTestCase {
         wait(for: [thenExpect], timeout: 1)
     }
 
-    func testPromiseFails() {
-        let context = JSContext()!
+    func testPromiseFails() throws {
+        let context = try XCTUnwrap(JSContext())
 
-        let promise = JSUtilities.createPromise(context: context) { (_, reject) in
+        let promise = JSUtilities.createPromise(context: context) { _, reject in
             reject()
         }
 
@@ -63,13 +66,16 @@ class JSUtilitiesTests: XCTestCase {
         }
 
         let catchHandler = JSValue(object: catchFn, in: context)
-        promise?.invokeMethod("then", withArguments: [thenHandler as Any])?.invokeMethod("catch", withArguments: [catchHandler as Any])
+        promise?.invokeMethod("then", withArguments: [thenHandler as Any])?.invokeMethod(
+            "catch",
+            withArguments: [catchHandler as Any]
+        )
 
         wait(for: [catchExpect], timeout: 1)
     }
 
     func testJsonData() throws {
-        let context = JSContext()!
+        let context = try XCTUnwrap(JSContext())
 
         let obj = context.evaluateScript("({a: 1})")
 
@@ -101,16 +107,18 @@ class JSUtilitiesTests: XCTestCase {
     }
 
     func testDecodeLogsTruncatedPreviewForSmallPayload() throws {
-        let context = JSContext()!
-        let value = context.evaluateScript("({id: 'test', type: 'text'})")!
+        let context = try XCTUnwrap(JSContext())
+        let value = try XCTUnwrap(context.evaluateScript("({id: 'test', type: 'text'})"))
 
         let logger = TapableLogger()
         logger.logLevel = .trace
 
         var loggedMessage: String?
-        logger.hooks.trace.tap(name: "test") { messages in
-            loggedMessage = messages.compactMap { $0 as? String }.joined()
-        }
+        logger.hooks
+            .trace
+            .tap(name: "test") { messages in
+                loggedMessage = messages.compactMap { $0 as? String }.joined()
+            }
 
         let decoder = JSONDecoder()
         decoder.setLogger(logger)
@@ -129,18 +137,20 @@ class JSUtilitiesTests: XCTestCase {
     }
 
     func testDecodeLogsTruncatedPreviewForLargePayload() throws {
-        let context = JSContext()!
+        let context = try XCTUnwrap(JSContext())
         // Generate a JSON object larger than 500 bytes
         let script = "({id: 'test', type: 'text', value: '\(String(repeating: "x", count: 600))'})"
-        let value = context.evaluateScript(script)!
+        let value = try XCTUnwrap(context.evaluateScript(script))
 
         let logger = TapableLogger()
         logger.logLevel = .trace
 
         var loggedMessage: String?
-        logger.hooks.trace.tap(name: "test") { messages in
-            loggedMessage = messages.compactMap { $0 as? String }.joined()
-        }
+        logger.hooks
+            .trace
+            .tap(name: "test") { messages in
+                loggedMessage = messages.compactMap { $0 as? String }.joined()
+            }
 
         let decoder = JSONDecoder()
         decoder.setLogger(logger)

--- a/ios/core/Tests/utilities/JSValueExtensionsTests.swift
+++ b/ios/core/Tests/utilities/JSValueExtensionsTests.swift
@@ -5,44 +5,46 @@
 //  Created by Zhao Xia Wu on 2024-01-22.
 //
 
-
 import Foundation
-import XCTest
 import JavaScriptCore
 @testable import PlayerUI
 @testable import PlayerUIInternalTestUtilities
 @testable import PlayerUITestUtilitiesCore
+import XCTest
 
 class JSValueExtensionsTests: XCTestCase {
-    let context: JSContext = JSContext()
-    func testTryCatchWrapperReturningError() {
+    private let context: JSContext = .init()
 
-        let functionReturningError = self.context
+    func testTryCatchWrapperReturningError() {
+        let functionReturningError = context
             .evaluateScript("""
-                             (() => {
-                                throw new Error("Fail")
-                             })
-                           """)
+              (() => {
+                 throw new Error("Fail")
+              })
+            """)
 
         do {
-            let _ = try functionReturningError?.tryCatch(args: [] as [String])
-        } catch let error {
-            XCTAssertEqual(error as? JSValueError, JSValueError.thrownFromJS(message: "Error: Fail"))
+            _ = try functionReturningError?.tryCatch(args: [] as [String])
+        } catch {
+            XCTAssertEqual(
+                error as? JSValueError,
+                JSValueError.thrownFromJS(message: "Error: Fail")
+            )
         }
     }
 
     func testTryCatchWrapperReturningNumber() {
-        let functionReturningInt = self.context
+        let functionReturningInt = context
             .evaluateScript("""
-                            (() => {
-                               return 1
-                            })
-                           """)
+             (() => {
+                return 1
+             })
+            """)
 
         do {
             let result = try functionReturningInt?.tryCatch(args: [] as [String])
             XCTAssertEqual(result?.toInt32(), 1)
-        } catch let error {
+        } catch {
             XCTFail("Should have returned Int but failed with \(error)")
         }
     }
@@ -54,12 +56,20 @@ class JSValueExtensionsTests: XCTestCase {
 
         player.hooks?.viewController.tap { viewController in
             viewController.hooks.view.tap { view in
-                view.hooks.onUpdate.tap { value in
+                view.hooks.onUpdate.tap { _ in
                     guard view.id == "view-2" else {
                         do {
-                            try (player.state as? InProgressState)?.controllers?.flow.transition(with: "NEXT")
-                        } catch let error {
-                            XCTAssertEqual(error as? JSValueError, JSValueError.thrownFromJS(message: "Error: Transitioning while ongoing transition from VIEW_1 is in progress is not supported"))
+                            try (player.state as? InProgressState)?.controllers?
+                                .flow
+                                .transition(with: "NEXT")
+                        } catch {
+                            XCTAssertEqual(
+                                error as? JSValueError,
+                                JSValueError
+                                    .thrownFromJS(
+                                        message: "Error: Transitioning while ongoing transition from VIEW_1 is in progress is not supported"
+                                    )
+                            )
                             expectation.fulfill()
                         }
 
@@ -69,7 +79,7 @@ class JSValueExtensionsTests: XCTestCase {
             }
         }
 
-        player.start(flow: FlowData.MULTIPAGE, completion: {_ in})
+        player.start(flow: FlowData.MULTIPAGE, completion: { _ in })
         wait(for: [expectation], timeout: 1)
     }
 }

--- a/ios/core/Tests/utilities/JSValueExtensionsTests.swift
+++ b/ios/core/Tests/utilities/JSValueExtensionsTests.swift
@@ -5,103 +5,109 @@
 //  Created by Zhao Xia Wu on 2024-01-22.
 //
 
-
 import Foundation
-import XCTest
 import JavaScriptCore
 @testable import PlayerUI
 @testable import PlayerUIInternalTestUtilities
 @testable import PlayerUITestUtilitiesCore
+import XCTest
 
 class JSValueExtensionsTests: XCTestCase {
-    let context: JSContext = JSContext()
+    private let context: JSContext = .init()
+
     /// Test case for base JS Errors
     func testTryCatchThrowsSimpleError() {
-
-        let functionReturningError = self.context
+        let functionReturningError = context
             .evaluateScript("""
-                             (() => {
-                                throw new Error("Fail")
-                             })
-                           """)
+              (() => {
+                 throw new Error("Fail")
+              })
+            """)
 
-        XCTAssertThrowsError(try functionReturningError?.callWithErrorHandling(args: [] as [String]), "", { error in
+        XCTAssertThrowsError(
+            try functionReturningError?.callWithErrorHandling(args: [] as [String]),
+            ""
+        ) { error in
             guard let jsValueError = error as? JSValueError else {
                 XCTFail("Should throw a JSValueError")
                 return
             }
-            
+
             XCTAssertFalse(jsValueError.isErrorWithMetadata)
             XCTAssertEqual(jsValueError.message, "Fail")
-        })
+        }
     }
-    
+
     /// Test case for errors thrown with error controller metadata. Check that metadata is preserved
     func testTryCatchThrowsErrorWithMetadata() {
-
-        let functionReturningError = self.context
+        let functionReturningError = context
             .evaluateScript("""
-                             (() => {
-                                const error = new Error("Fail")
-                                error.type = "Error Type"
-                                error.severity = "error"
-                                error.metadata = {
-                                  property: "value"
-                                }
-                                throw error
-                             })
-                           """)
+              (() => {
+                 const error = new Error("Fail")
+                 error.type = "Error Type"
+                 error.severity = "error"
+                 error.metadata = {
+                   property: "value"
+                 }
+                 throw error
+              })
+            """)
 
-        XCTAssertThrowsError(try functionReturningError?.callWithErrorHandling(args: [] as [String]), "", { error in
+        XCTAssertThrowsError(
+            try functionReturningError?.callWithErrorHandling(args: [] as [String]),
+            ""
+        ) { error in
             guard let jsValueError = error as? JSValueError else {
                 XCTFail("Should throw a JSValueError")
                 return
             }
-            
+
             XCTAssertEqual(jsValueError.message, "Fail")
             XCTAssertEqual(jsValueError.type, .unknown("Error Type"))
             XCTAssertEqual(jsValueError.severity, ErrorSeverity.error)
             XCTAssertNotNil(jsValueError.metadata)
             XCTAssertEqual(jsValueError.metadata?["property"] as? String, "value")
             XCTAssertTrue(jsValueError.isErrorWithMetadata)
-        })
+        }
     }
-    
+
     /// Test case for non-Errror throws in JS. Need to ensure we still throw something
     func testTryCatchThrowsUnknownError() {
-
-        let functionReturningError = self.context
+        let functionReturningError = context
             .evaluateScript("""
-                             (() => {
-                                throw false
-                             })
-                           """)
+              (() => {
+                 throw false
+              })
+            """)
 
-        XCTAssertThrowsError(try functionReturningError?.callWithErrorHandling(args: [] as [String]), "", { error in
+        XCTAssertThrowsError(
+            try functionReturningError?.callWithErrorHandling(args: [] as [String]),
+            ""
+        ) { error in
             guard let jsValueError = error as? JSValueError else {
                 XCTFail("Should throw a JSValueError")
                 return
             }
-            
+
             XCTAssertTrue(jsValueError.originalJSError.isBoolean)
             XCTAssertFalse(jsValueError.originalJSError.toBool())
             XCTAssertEqual(jsValueError.message, "Unknown JS Error")
             XCTAssertFalse(jsValueError.isErrorWithMetadata)
-        })
+        }
     }
 
     func testTryCatchWrapperReturningNumber() {
-        let functionReturningInt = self.context
+        let functionReturningInt = context
             .evaluateScript("""
-                            (() => {
-                               return 1
-                            })
-                           """)
+             (() => {
+                return 1
+             })
+            """)
 
         do {
             let result = try functionReturningInt?.callWithErrorHandling(args: [] as [String])
             XCTAssertEqual(result?.toInt32(), 1)
-        } catch let error {
+        } catch {
             XCTFail("Should have returned Int but failed with \(error)")
         }
     }
@@ -113,17 +119,22 @@ class JSValueExtensionsTests: XCTestCase {
 
         player.hooks?.viewController.tap { viewController in
             viewController.hooks.view.tap { view in
-                view.hooks.onUpdate.tap { value in
+                view.hooks.onUpdate.tap { _ in
                     guard view.id == "view-2" else {
                         do {
-                            try (player.state as? InProgressState)?.controllers?.flow.transition(with: "NEXT")
-                        } catch let error {
+                            try (player.state as? InProgressState)?.controllers?
+                                .flow
+                                .transition(with: "NEXT")
+                        } catch {
                             guard let jsValueError = error as? JSValueError else {
                                 XCTFail("Should throw a JSValueError")
                                 return
                             }
-                            
-                            XCTAssertEqual(jsValueError.message, "Transitioning while ongoing transition from VIEW_1 is in progress is not supported")
+
+                            XCTAssertEqual(
+                                jsValueError.message,
+                                "Transitioning while ongoing transition from VIEW_1 is in progress is not supported"
+                            )
                             XCTAssertFalse(jsValueError.isErrorWithMetadata)
                             expectation.fulfill()
                         }
@@ -134,7 +145,7 @@ class JSValueExtensionsTests: XCTestCase {
             }
         }
 
-        player.start(flow: FlowData.MULTIPAGE, completion: {_ in})
+        player.start(flow: FlowData.MULTIPAGE, completion: { _ in })
         wait(for: [expectation], timeout: 1)
     }
 }

--- a/ios/demo/Sources/App.swift
+++ b/ios/demo/Sources/App.swift
@@ -1,21 +1,20 @@
-import SwiftUI
 import PlayerUI
-import PlayerUILogger
-import PlayerUISwiftUI
-import PlayerUIReferenceAssets
-
 import PlayerUIBaseBeaconPlugin
 import PlayerUIBeaconPlugin
 import PlayerUICommonExpressionsPlugin
 import PlayerUICommonTypesPlugin
 import PlayerUIExpressionPlugin
 import PlayerUIExternalActionPlugin
+import PlayerUILogger
 import PlayerUIMetricsPlugin
 import PlayerUIPrintLoggerPlugin
 import PlayerUIPubSubPlugin
+import PlayerUIReferenceAssets
+import PlayerUISwiftUI
 import PlayerUISwiftUIPendingTransactionPlugin
 import PlayerUITransitionPlugin
 import PlayerUITypesProviderPlugin
+import SwiftUI
 
 @main
 struct BazelApp: App {
@@ -29,15 +28,6 @@ struct BazelApp: App {
 }
 
 struct MainView: View {
-    @State var result: Result<CompletedState, PlayerError>? = nil
-
-    var showAlert: Binding<Bool> {
-        Binding(get: { result != nil }) { newValue in
-            guard !newValue else { return }
-            result = nil
-        }
-    }
-
     let plugins: [NativePlugin] = [
         PrintLoggerPlugin(level: .trace),
         ReferenceAssetsPlugin(),
@@ -57,8 +47,11 @@ struct MainView: View {
         TypesProviderPlugin(types: [], validators: [], formats: []),
         TransitionPlugin(popTransition: .pop),
         BeaconPlugin<DefaultBeacon> { print(String(describing: $0)) },
-        SwiftUIPendingTransactionPlugin<PendingTransactionPhases>()
+        SwiftUIPendingTransactionPlugin<PendingTransactionPhases>(),
     ]
+
+    @State var result: Result<CompletedState, PlayerError>?
+
     var body: some View {
         SegmentControlView(
             plugins: plugins,
@@ -68,21 +61,28 @@ struct MainView: View {
         )
         .navigationBarTitleDisplayMode(.inline)
         .alert(isPresented: showAlert, content: {
-            return Alert(
+            Alert(
                 title: Text("Flow Finished"),
                 message: Text(result?.message ?? "No Result"),
                 dismissButton: .default(Text("Done"))
             )
         })
     }
+
+    var showAlert: Binding<Bool> {
+        Binding(get: { result != nil }) { newValue in
+            guard !newValue else { return }
+            result = nil
+        }
+    }
 }
 
 extension Result where Success == CompletedState, Failure == PlayerError {
     var message: String {
         switch self {
-        case .success(let success):
+        case let .success(success):
             return success.endState?.outcome ?? "No Outcome"
-        case .failure(let failure):
+        case let .failure(failure):
             guard case let .promiseRejected(error) = failure else {
                 return failure.playerDescription
             }

--- a/ios/demo/Sources/App.swift
+++ b/ios/demo/Sources/App.swift
@@ -70,6 +70,7 @@ struct MainView: View {
     }
 
     var showAlert: Binding<Bool> {
+        // swiftlint:disable:next multiple_closures_with_trailing_closure
         Binding(get: { result != nil }) { newValue in
             guard !newValue else { return }
             result = nil

--- a/ios/demo/Sources/App.swift
+++ b/ios/demo/Sources/App.swift
@@ -1,19 +1,18 @@
-import SwiftUI
 import PlayerUI
-import PlayerUILogger
-import PlayerUISwiftUI
-import PlayerUIReferenceAssets
-
 import PlayerUIBaseBeaconPlugin
 import PlayerUIBeaconPlugin
 import PlayerUIExpressionPlugin
 import PlayerUIExternalStatePlugin
+import PlayerUILogger
 import PlayerUIMetricsPlugin
 import PlayerUIPrintLoggerPlugin
 import PlayerUIPubSubPlugin
+import PlayerUIReferenceAssets
+import PlayerUISwiftUI
 import PlayerUISwiftUIPendingTransactionPlugin
 import PlayerUITransitionPlugin
 import PlayerUITypesProviderPlugin
+import SwiftUI
 
 @main
 struct BazelApp: App {
@@ -27,7 +26,24 @@ struct BazelApp: App {
 }
 
 struct MainView: View {
-    @State var result: Result<CompletedState, PlayerError>? = nil
+    @State var result: Result<CompletedState, PlayerError>?
+
+    var body: some View {
+        SegmentControlView(
+            plugins: plugins,
+            assetSections: MockFlows.assetSections,
+            pluginSections: MockFlows.pluginSections,
+            result: $result
+        )
+        .navigationBarTitleDisplayMode(.inline)
+        .alert(isPresented: showAlert, content: {
+            Alert(
+                title: Text("Flow Finished"),
+                message: Text(result?.message ?? "No Result"),
+                dismissButton: .default(Text("Done"))
+            )
+        })
+    }
 
     var showAlert: Binding<Bool> {
         Binding(get: { result != nil }) { newValue in
@@ -58,35 +74,18 @@ struct MainView: View {
                     handlerFunction: { _, _, _ in
                         print("MainView External State triggered")
                     }
-                )
-            ])
+                ),
+            ]),
         ]
-    }
-
-    var body: some View {
-        SegmentControlView(
-            plugins: plugins,
-            assetSections: MockFlows.assetSections,
-            pluginSections: MockFlows.pluginSections,
-            result: $result
-        )
-        .navigationBarTitleDisplayMode(.inline)
-        .alert(isPresented: showAlert, content: {
-            return Alert(
-                title: Text("Flow Finished"),
-                message: Text(result?.message ?? "No Result"),
-                dismissButton: .default(Text("Done"))
-            )
-        })
     }
 }
 
 extension Result where Success == CompletedState, Failure == PlayerError {
     var message: String {
         switch self {
-        case .success(let success):
+        case let .success(success):
             return success.endState?.outcome ?? "No Outcome"
-        case .failure(let failure):
+        case let .failure(failure):
             guard case let .promiseRejected(error) = failure else {
                 return failure.playerDescription
             }

--- a/ios/demo/Sources/App.swift
+++ b/ios/demo/Sources/App.swift
@@ -46,10 +46,10 @@ struct MainView: View {
     }
 
     var showAlert: Binding<Bool> {
-        Binding(get: { result != nil }) { newValue in
+        Binding(get: { result != nil }, set: { newValue in
             guard !newValue else { return }
             result = nil
-        }
+        })
     }
 
     private var plugins: [NativePlugin] {

--- a/ios/demo/Sources/FlowManagerView.swift
+++ b/ios/demo/Sources/FlowManagerView.swift
@@ -74,6 +74,7 @@ public struct FlowManagerView: View {
                         }
                     )
 
+                    // swiftlint:disable:next multiple_closures_with_trailing_closure
                     Button(action: { complete = true }) {
                         Text("Terminate Flow")
                     }

--- a/ios/demo/Sources/FlowManagerView.swift
+++ b/ios/demo/Sources/FlowManagerView.swift
@@ -5,20 +5,19 @@
 //  Created by Zhao Xia Wu on 2023-11-01.
 //
 
-import SwiftUI
 import PlayerUI
-import PlayerUISwiftUI
-import PlayerUIReferenceAssets
-import PlayerUIMetricsPlugin
 import PlayerUIExternalActionViewModifierPlugin
+import PlayerUIMetricsPlugin
+import PlayerUIReferenceAssets
+import PlayerUISwiftUI
+import SwiftUI
 
-/**
- SwiftUI View to wrap the `ManagedPlayer` and handle the result
- for use in UI testing
- */
+/// SwiftUI View to wrap the `ManagedPlayer` and handle the result
+/// for use in UI testing
 public struct FlowManagerView: View {
     let flowSequence: [String]
     let navTitle: String
+
     @State private var complete = false
 
     public var body: some View {
@@ -26,36 +25,37 @@ public struct FlowManagerView: View {
             if complete {
                 VStack {
                     Text("Flow Completed").font(.title)
-                    Button(action: {complete = false}, label: { Text("Start Over " )})
+                    Button(action: { complete = false }, label: { Text("Start Over ") })
                 }
             } else {
                 VStack {
                     ManagedPlayer(
                         plugins: [
                             ReferenceAssetsPlugin(),
-                            MetricsPlugin { (render, _, flow) in
-                                print("Render: \(render?.duration ?? 0 )ms | Request \(flow?.flow.requestTime ?? 0)ms")
+                            MetricsPlugin { render, _, flow in
+                                print(
+                                    "Render: \(render?.duration ?? 0)ms | Request \(flow?.flow.requestTime ?? 0)ms"
+                                )
                             },
-                            ExternalActionViewModifierPlugin<ExternalStateSheetModifier> { (state, _, transition) in
-
-                                return AnyView(
+                            ExternalActionViewModifierPlugin<ExternalStateSheetModifier> { _, _, transition in
+                                AnyView(
                                     Text("External State")
                                         .onDisappear {
                                             transition("Next")
                                         }
                                 )
-                            }
+                            },
                         ],
                         flowManager: ConstantFlowManager(flowSequence),
                         onComplete: { _ in
                             complete = true
                         },
-                        fallback: { (context) in
+                        fallback: { context in
                             VStack {
                                 Text(context.error.localizedDescription)
 
                                 switch context.error as? PlayerError {
-                                case .promiseRejected(error: let errorState) :
+                                case let .promiseRejected(error: errorState):
                                     Text(errorState.error)
                                 default:
                                     EmptyView()

--- a/ios/demo/Sources/FlowManagerView.swift
+++ b/ios/demo/Sources/FlowManagerView.swift
@@ -4,20 +4,19 @@
 //  Created by Zhao Xia Wu on 2023-11-01.
 //
 
-import SwiftUI
 import PlayerUI
-import PlayerUISwiftUI
-import PlayerUIReferenceAssets
-import PlayerUIMetricsPlugin
 import PlayerUIExternalStateViewModifierPlugin
+import PlayerUIMetricsPlugin
+import PlayerUIReferenceAssets
+import PlayerUISwiftUI
+import SwiftUI
 
-/**
- SwiftUI View to wrap the `ManagedPlayer` and handle the result
- for use in UI testing
- */
+/// SwiftUI View to wrap the `ManagedPlayer` and handle the result
+/// for use in UI testing
 public struct FlowManagerView: View {
     let flowSequence: [String]
     let navTitle: String
+
     @State private var complete = false
 
     public var body: some View {
@@ -25,7 +24,7 @@ public struct FlowManagerView: View {
             if complete {
                 VStack {
                     Text("Flow Completed").font(.title)
-                    Button(action: {complete = false}, label: { Text("Start Over " )})
+                    Button(action: { complete = false }, label: { Text("Start Over ") })
                 }
             } else {
                 VStack {
@@ -35,12 +34,12 @@ public struct FlowManagerView: View {
                         onComplete: { _ in
                             complete = true
                         },
-                        fallback: { (context) in
+                        fallback: { context in
                             VStack {
                                 Text(context.error.localizedDescription)
 
                                 switch context.error as? PlayerError {
-                                case .promiseRejected(error: let errorState) :
+                                case let .promiseRejected(error: errorState):
                                     Text(errorState.error.message)
                                 default:
                                     EmptyView()
@@ -70,14 +69,16 @@ public struct FlowManagerView: View {
     private var plugins: [NativePlugin] {
         [
             ReferenceAssetsPlugin(),
-            MetricsPlugin { (render, _, flow) in
-                print("Render: \(render?.duration ?? 0 )ms | Request \(flow?.flow.requestTime ?? 0)ms")
+            MetricsPlugin { render, _, flow in
+                print(
+                    "Render: \(render?.duration ?? 0)ms | Request \(flow?.flow.requestTime ?? 0)ms"
+                )
             },
             ExternalStateViewModifierPlugin<ExternalStateSheetModifier>(handlers: [
                 .init(
                     ref: "test-1",
                     handlerFunction: { _, _, transition in
-                        return AnyView(
+                        AnyView(
                             Text("External State")
                                 .onAppear {
                                     print("Managed Player External State triggered")
@@ -87,8 +88,8 @@ public struct FlowManagerView: View {
                                 }
                         )
                     }
-                )
-            ])
+                ),
+            ]),
         ]
     }
 }

--- a/ios/demo/Sources/FlowManagerView.swift
+++ b/ios/demo/Sources/FlowManagerView.swift
@@ -58,9 +58,9 @@ public struct FlowManagerView: View {
                         }
                     )
 
-                    Button(action: { complete = true }) {
+                    Button(action: { complete = true }, label: {
                         Text("Terminate Flow")
-                    }
+                    })
                 }
             }
         }.navigationBarTitle(Text(navTitle))

--- a/ios/demo/Sources/MockFlows.swift
+++ b/ios/demo/Sources/MockFlows.swift
@@ -1,1405 +1,1457 @@
 // swiftlint:disable all
 import PlayerUITestUtilitiesCore
 
-public struct MockFlows {
+public enum MockFlows {
+    public static let assetSections: [FlowLoader.FlowSection] = [
+        (title: "action", flows: [
+            (name: "counter", flow: MockFlows.actionCounter),
+            (name: "transition to end", flow: MockFlows.actionTransitionToEnd),
+            (name: "basic", flow: MockFlows.actionBasic),
+            (name: "navigation", flow: MockFlows.actionNavigation),
+        ]),
+        (title: "collection", flows: [
+            (name: "basic", flow: MockFlows.collectionBasic),
+        ]),
+        (title: "image", flows: [
+            (name: "basic", flow: MockFlows.imageBasic),
+            (name: "with accessibility", flow: MockFlows.imageWithAccessibility),
+            (name: "with caption", flow: MockFlows.imageWithCaption),
+            (name: "with placeholder", flow: MockFlows.imageWithPlaceholder),
+        ]),
+        (title: "info", flows: [
+            (name: "footer", flow: MockFlows.infoFooter),
+            (name: "dynamic flow", flow: MockFlows.infoDynamicFlow),
+            (name: "basic", flow: MockFlows.infoBasic),
+            (name: "modal flow", flow: MockFlows.infoModalFlow),
+        ]),
+        (title: "input", flows: [
+            (name: "transition", flow: MockFlows.inputTransition),
+            (name: "basic", flow: MockFlows.inputBasic),
+            (name: "validation", flow: MockFlows.inputValidation),
+        ]),
+        (title: "text", flows: [
+            (name: "basic", flow: MockFlows.textBasic),
+            (name: "with link", flow: MockFlows.textWithLink),
+        ]),
+        (title: "chat message", flows: [
+            (name: "basic", flow: MockFlows.chatMessageBasic),
+            (name: "chat-ui", flow: MockFlows.chatUi),
+        ]),
+    ]
+
+    public static let pluginSections: [FlowLoader.FlowSection] = [
+        (title: "beacon", flows: [
+            (name: "action", flow: MockFlows.beaconAction),
+        ]),
+        (title: "external-action", flows: [
+            (name: "external-action", flow: MockFlows.externalAction),
+        ]),
+        (title: "pubsub", flows: [
+            (name: "pub sub basic", flow: MockFlows.pubSubBasic),
+        ]),
+
+        (title: "pending-transaction", flows: [
+            (name: "input asset pending transaction", flow: MockFlows.inputAssetPendingTransaction),
+        ]),
+    ]
+
     static let actionCounter: String = """
-{
-  "id": "generated-flow",
-  "views": [
     {
-      "id": "action",
-      "type": "action",
-      "exp": "{{count}} = {{count}} + 1",
-      "label": {
-        "asset": {
-          "id": "action-label",
-          "type": "text",
-          "value": "Clicked {{count}} times"
-        }
-      }
-    }
-  ],
-  "data": {
-    "count": 0
-  },
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "action",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  }
-}
-"""
-static let actionTransitionToEnd: String = """
-{
-  "id": "generated-flow",
-  "views": [
-    {
-      "id": "collection",
-      "type": "collection",
-      "values": [
+      "id": "generated-flow",
+      "views": [
         {
-          "asset": {
-            "id": "action-good",
-            "type": "action",
-            "value": "Next",
-            "label": {
-              "asset": {
-                "id": "action-good-label",
-                "type": "text",
-                "value": "End the flow (success)"
-              }
-            }
-          }
-        },
-        {
-          "asset": {
-            "id": "action-bad",
-            "type": "action",
-            "exp": "{{foo.bar..}",
-            "label": {
-              "asset": {
-                "id": "action-bad-label",
-                "type": "text",
-                "value": "End the flow (error)"
-              }
-            }
-          }
-        }
-      ]
-    }
-  ],
-  "data": {},
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "collection",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  }
-}
-"""
-static let actionBasic: String = """
-{
-  "id": "generated-flow",
-  "views": [
-    {
-      "id": "action",
-      "type": "action",
-      "exp": "{{count}} = {{count}} + 1",
-      "label": {
-        "asset": {
-          "id": "action-label",
-          "type": "text",
-          "value": "Count: {{count}}"
-        }
-      }
-    }
-  ],
-  "data": {
-    "count": 0
-  },
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "action",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  }
-}
-"""
-static let actionNavigation: String = """
-{
-  "id": "action-navigation-flow",
-  "views": [
-    {
-      "id": "view-1",
-      "type": "collection",
-      "label": {
-        "asset": {
-          "id": "title",
-          "type": "text",
-          "value": "View 1"
-        }
-      },
-      "values": [
-        {
-          "asset": {
-            "id": "action-prev",
-            "type": "action",
-            "value": "Prev",
-            "label": {
-              "asset": {
-                "id": "action-prev-id",
-                "type": "text",
-                "value": "Go Back Without Icon"
-              }
-            },
-            "metaData": {
-              "role": ""
-            }
-          }
-        },
-        {
-          "asset": {
-            "id": "action-prev-without-icon",
-            "type": "action",
-            "value": "Prev",
-            "label": {
-              "asset": {
-                "id": "action-prev-id-without-icon",
-                "type": "text",
-                "value": "Go Back With Role"
-              }
-            },
-            "metaData": {
-              "role": "back"
-            }
-          }
-        },
-        {
-          "asset": {
-            "id": "action-next",
-            "type": "action",
-            "value": "Next",
-            "label": {
-              "asset": {
-                "id": "action-next-id",
-                "type": "text",
-                "value": "Next"
-              }
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "view-2",
-      "type": "collection",
-      "label": {
-        "asset": {
-          "id": "title",
-          "type": "text",
-          "value": "View 2"
-        }
-      },
-      "values": [
-        {
-          "asset": {
-            "id": "action-prev",
-            "type": "action",
-            "value": "Prev",
-            "label": {
-              "asset": {
-                "id": "action-prev-id",
-                "type": "text",
-                "value": "Go Back"
-              }
-            }
-          }
-        },
-        {
-          "asset": {
-            "id": "action-next",
-            "type": "action",
-            "value": "Next",
-            "label": {
-              "asset": {
-                "id": "action-next-id",
-                "type": "text",
-                "value": "End"
-              }
-            }
-          }
-        }
-      ]
-    }
-  ],
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "view-1",
-        "transitions": {
-          "Next": "VIEW_2",
-          "Prev": "END"
-        }
-      },
-      "VIEW_2": {
-        "state_type": "VIEW",
-        "ref": "view-2",
-        "transitions": {
-          "Next": "END",
-          "Prev": "VIEW_1"
-        }
-      },
-      "END": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  },
-  "data": {}
-}
-"""
-static let collectionBasic: String = """
-{
-  "id": "generated-flow",
-  "views": [
-    {
-      "id": "view-1",
-      "type": "collection",
-      "label": {
-        "asset": {
-          "id": "title",
-          "type": "text",
-          "value": "Collections are used to group assets."
-        }
-      },
-      "values": [
-        {
-          "asset": {
-            "id": "text-1",
-            "type": "text",
-            "value": "This is the first item in the collection"
-          }
-        },
-        {
-          "asset": {
-            "id": "text-2",
-            "type": "text",
-            "value": "This is the second item in the collection"
-          }
-        }
-      ]
-    }
-  ],
-  "data": {},
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "view-1",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  }
-}
-"""
-static let imageBasic: String = """
-{
-  "id": "generated-flow",
-  "views": [
-    {
-      "id": "image-1",
-      "type": "image",
-      "metaData": {
-        "ref": "https://raw.githubusercontent.com/player-ui/player/refs/tags/0.14.1/docs/site/src/assets/logo/logo-light-large.png"
-      }
-    }
-  ],
-  "data": {},
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "image-1",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  }
-}
-"""
-static let imageWithAccessibility: String = """
-{
-  "id": "generated-flow",
-  "views": [
-    {
-      "id": "image-1",
-      "type": "image",
-      "metaData": {
-        "ref": "https://raw.githubusercontent.com/player-ui/player/refs/tags/0.14.1/docs/site/src/assets/logo/logo-light-large.png",
-        "accessibility": "This is accessibility text for an image"
-      },
-      "placeholder": "This is placeholder text for an image"
-    }
-  ],
-  "data": {},
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "image-1",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  }
-}
-"""
-static let imageWithCaption: String = """
-{
-  "id": "generated-flow",
-  "views": [
-    {
-      "id": "image-1",
-      "type": "image",
-      "metaData": {
-        "ref": "https://raw.githubusercontent.com/player-ui/player/refs/tags/0.14.1/docs/site/src/assets/logo/logo-light-large.png"
-      },
-      "caption": {
-        "asset": {
-          "id": "image-caption",
-          "type": "text",
-          "value": "Image caption"
-        }
-      }
-    }
-  ],
-  "data": {},
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "image-1",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  }
-}
-"""
-static let imageWithPlaceholder: String = """
-{
-  "id": "generated-flow",
-  "views": [
-    {
-      "id": "image-1",
-      "type": "image",
-      "metaData": {
-        "ref": "https://raw.githubusercontent.com/player-ui/player/refs/tags/0.14.1/docs/site/src/assets/logo/logo-light-large.png"
-      },
-      "placeholder": "This is placeholder text for an image"
-    }
-  ],
-  "data": {},
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "image-1",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  }
-}
-"""
-static let infoFooter: String = """
-{
-  "id": "generated-flow",
-  "views": [
-    {
-      "id": "info-view",
-      "type": "info",
-      "title": {
-        "asset": {
-          "id": "info-title",
-          "type": "text",
-          "value": "View Title"
-        }
-      },
-      "actions": [
-        {
-          "asset": {
-            "id": "next-action",
-            "value": "Next",
-            "type": "action",
-            "label": {
-              "asset": {
-                "id": "next-action-label",
-                "type": "text",
-                "value": "Continue"
-              }
+          "id": "action",
+          "type": "action",
+          "exp": "{{count}} = {{count}} + 1",
+          "label": {
+            "asset": {
+              "id": "action-label",
+              "type": "text",
+              "value": "Clicked {{count}} times"
             }
           }
         }
       ],
-      "footer": {
-        "asset": {
-          "id": "info-footer",
-          "type": "text",
-          "value": "Footer text"
+      "data": {
+        "count": 0
+      },
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "action",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
         }
       }
     }
-  ],
-  "data": {},
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "info-view",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  }
-}
-"""
-static let infoDynamicFlow: String = """
-{
-  "id": "modal-flow",
-  "views": [
+    """
+    static let actionTransitionToEnd: String = """
     {
-      "id": "view-1",
-      "type": "info",
-      "title": {
-        "asset": {
-          "id": "view-title",
-          "type": "text",
-          "value": "View 1"
-        }
-      },
-      "actions": [
+      "id": "generated-flow",
+      "views": [
         {
-          "asset": {
-            "id": "action-1",
-            "type": "action",
-            "value": "Next",
-            "label": {
-              "asset": {
-                "id": "action-1-label",
-                "type": "text",
-                "value": "Next"
-              }
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "view-2",
-      "type": "info",
-      "title": {
-        "asset": {
-          "id": "view-title",
-          "type": "text",
-          "value": "View 2"
-        }
-      },
-      "actions": [
-        {
-          "asset": {
-            "id": "action-1",
-            "type": "action",
-            "value": "Next",
-            "label": {
-              "asset": {
-                "id": "action-1-label",
-                "type": "text",
-                "value": "Next"
-              }
-            }
-          }
-        },
-        {
-          "asset": {
-            "id": "action-2",
-            "type": "action",
-            "value": "Dismiss",
-            "label": {
-              "asset": {
-                "id": "action-1-label",
-                "type": "text",
-                "value": "Dismiss"
-              }
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "view-3",
-      "type": "info",
-      "title": {
-        "asset": {
-          "id": "view-3-title",
-          "type": "text",
-          "value": "View 3"
-        }
-      },
-      "actions": [
-        {
-          "asset": {
-            "id": "action-3",
-            "type": "action",
-            "value": "Next",
-            "label": {
-              "asset": {
-                "id": "action-3-label",
-                "type": "text",
-                "value": "Next"
-              }
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "view-4",
-      "type": "info",
-      "title": {
-        "asset": {
-          "id": "view-4-title",
-          "type": "text",
-          "value": "View 4"
-        }
-      },
-      "actions": [
-        {
-          "asset": {
-            "id": "action-4",
-            "type": "action",
-            "value": "Next",
-            "label": {
-              "asset": {
-                "id": "action-4-label",
-                "type": "text",
-                "value": "Next"
-              }
-            }
-          }
-        }
-      ]
-    }
-  ],
-  "data": {
-    "viewRef": "VIEW_3"
-  },
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "view-1",
-        "transitions": {
-          "*": "VIEW_2"
-        }
-      },
-      "VIEW_2": {
-        "state_type": "VIEW",
-        "ref": "view-2",
-        "attributes": {
-          "stacked": true
-        },
-        "transitions": {
-          "Next": "{{viewRef}}",
-          "Dismiss": "VIEW_1"
-        }
-      },
-      "VIEW_3": {
-        "state_type": "VIEW",
-        "ref": "view-3",
-        "transitions": {
-          "*": "VIEW_1"
-        }
-      },
-      "VIEW_4": {
-        "state_type": "VIEW",
-        "ref": "view-4",
-        "transitions": {
-          "*": "VIEW_1"
-        }
-      }
-    }
-  }
-}
-"""
-static let infoBasic: String = """
-{
-  "id": "generated-flow",
-  "views": [
-    {
-      "id": "info-view",
-      "type": "info",
-      "title": {
-        "asset": {
-          "id": "info-title",
-          "type": "text",
-          "value": "View Title"
-        }
-      },
-      "actions": [
-        {
-          "asset": {
-            "id": "next-action",
-            "value": "Next",
-            "type": "action",
-            "label": {
-              "asset": {
-                "id": "next-action-label",
-                "type": "text",
-                "value": "Continue"
-              }
-            }
-          }
-        },
-        {
-          "asset": {
-            "id": "prev-action",
-            "value": "Prev",
-            "type": "action",
-            "label": {
-              "asset": {
-                "id": "next-action-label",
-                "type": "text",
-                "value": "Back"
-              }
-            }
-          }
-        }
-      ]
-    }
-  ],
-  "data": {},
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "info-view",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  }
-}
-"""
-static let infoModalFlow: String = """
-{
-  "id": "modal-flow",
-  "views": [
-    {
-      "id": "view-1",
-      "type": "info",
-      "title": {
-        "asset": {
-          "id": "view-title",
-          "type": "text",
-          "value": "View 1"
-        }
-      },
-      "actions": [
-        {
-          "asset": {
-            "id": "action-1",
-            "type": "action",
-            "value": "Next",
-            "label": {
-              "asset": {
-                "id": "action-1-label",
-                "type": "text",
-                "value": "Next"
-              }
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "view-2",
-      "type": "info",
-      "title": {
-        "asset": {
-          "id": "view-title",
-          "type": "text",
-          "value": "View 2"
-        }
-      },
-      "actions": [
-        {
-          "asset": {
-            "id": "action-1",
-            "type": "action",
-            "value": "Next",
-            "label": {
-              "asset": {
-                "id": "action-1-label",
-                "type": "text",
-                "value": "Next"
-              }
-            }
-          }
-        },
-        {
-          "asset": {
-            "id": "action-2",
-            "type": "action",
-            "value": "Dismiss",
-            "label": {
-              "asset": {
-                "id": "action-1-label",
-                "type": "text",
-                "value": "Dismiss"
-              }
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "view-3",
-      "type": "info",
-      "title": {
-        "asset": {
-          "id": "view-3-title",
-          "type": "text",
-          "value": "View 3"
-        }
-      },
-      "actions": [
-        {
-          "asset": {
-            "id": "action-3",
-            "type": "action",
-            "value": "Next",
-            "label": {
-              "asset": {
-                "id": "action-3-label",
-                "type": "text",
-                "value": "Next"
-              }
-            }
-          }
-        }
-      ]
-    }
-  ],
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "view-1",
-        "transitions": {
-          "*": "VIEW_2"
-        }
-      },
-      "VIEW_2": {
-        "state_type": "VIEW",
-        "ref": "view-2",
-        "attributes": {
-          "stacked": true
-        },
-        "transitions": {
-          "Next": "VIEW_3",
-          "Dismiss": "VIEW_1"
-        }
-      },
-      "VIEW_3": {
-        "state_type": "VIEW",
-        "ref": "view-3",
-        "transitions": {
-          "*": "VIEW_1"
-        }
-      }
-    }
-  }
-}
-"""
-static let inputTransition: String = """
-{
-  "id": "generated-flow",
-  "views": [
-    {
-      "id": "input-validation",
-      "type": "info",
-      "title": {
-        "asset": {
-          "id": "title",
-          "type": "text",
-          "value": "Some validations can prevent users from advancing"
-        }
-      },
-      "primaryInfo": {
-        "asset": {
-          "id": "primaryInfo",
+          "id": "collection",
           "type": "collection",
           "values": [
             {
               "asset": {
-                "id": "input-1",
-                "type": "input",
+                "id": "action-good",
+                "type": "action",
+                "value": "Next",
                 "label": {
                   "asset": {
-                    "id": "input-1-label",
+                    "id": "action-good-label",
                     "type": "text",
-                    "value": "Input with validation and formatting"
+                    "value": "End the flow (success)"
                   }
-                },
-                "note": {
+                }
+              }
+            },
+            {
+              "asset": {
+                "id": "action-bad",
+                "type": "action",
+                "exp": "{{foo.bar..}",
+                "label": {
                   "asset": {
-                    "id": "input-1-note",
+                    "id": "action-bad-label",
                     "type": "text",
-                    "value": "It expects a positive integer"
+                    "value": "End the flow (error)"
                   }
-                },
-                "binding": "foo.bar"
+                }
               }
             }
           ]
         }
-      },
-      "actions": [
+      ],
+      "data": {},
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "collection",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      }
+    }
+    """
+    static let actionBasic: String = """
+    {
+      "id": "generated-flow",
+      "views": [
         {
-          "asset": {
-            "id": "next-action",
-            "value": "Next",
-            "type": "action",
-            "label": {
-              "asset": {
-                "id": "next-action-label",
-                "type": "text",
-                "value": "Continue"
-              }
+          "id": "action",
+          "type": "action",
+          "exp": "{{count}} = {{count}} + 1",
+          "label": {
+            "asset": {
+              "id": "action-label",
+              "type": "text",
+              "value": "Count: {{count}}"
             }
           }
         }
-      ]
-    }
-  ],
-  "data": {},
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "input-validation",
-        "transitions": {
-          "*": "END_Done"
-        }
+      ],
+      "data": {
+        "count": 0
       },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  },
-  "schema": {
-    "ROOT": {
-      "foo": {
-        "type": "FooType"
-      }
-    },
-    "FooType": {
-      "bar": {
-        "type": "IntegerPosType",
-        "validation": [
-          {
-            "type": "required"
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "action",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
           }
-        ]
+        }
       }
     }
-  }
-}
-"""
-static let inputBasic: String = """
-{
-  "id": "generated-flow",
-  "views": [
+    """
+    static let actionNavigation: String = """
     {
-      "id": "input",
-      "type": "input",
-      "binding": "foo.bar",
-      "label": {
-        "asset": {
-          "id": "input-label",
-          "type": "text",
-          "value": "This is an input"
-        }
-      },
-      "note": {
-        "asset": {
-          "id": "input-note",
-          "type": "text",
-          "value": "This is a note"
-        }
-      }
-    }
-  ],
-  "data": {},
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "input",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  }
-}
-"""
-static let inputValidation: String = """
-{
-  "id": "generated-flow",
-  "views": [
-    {
-      "id": "input-1",
-      "type": "input",
-      "label": {
-        "asset": {
-          "id": "input-1-label",
-          "type": "text",
-          "value": "Input with validation and formatting"
-        }
-      },
-      "note": {
-        "asset": {
-          "id": "input-1-note",
-          "type": "text",
-          "value": "It expects a positive integer"
-        }
-      },
-      "binding": "foo.bar"
-    }
-  ],
-  "data": {},
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "input-1",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  },
-  "schema": {
-    "ROOT": {
-      "foo": {
-        "type": "FooType"
-      }
-    },
-    "FooType": {
-      "bar": {
-        "type": "IntegerPosType",
-        "validation": [
-          {
-            "type": "required"
-          }
-        ]
-      }
-    }
-  }
-}
-"""
-static let textBasic: String = """
-{
-  "id": "generated-flow",
-  "views": [
-    {
-      "id": "view-1",
-      "type": "collection",
-      "values": [
+      "id": "action-navigation-flow",
+      "views": [
         {
-          "asset": {
-            "id": "text-1",
-            "type": "text",
-            "value": "This is some text."
-          }
+          "id": "view-1",
+          "type": "collection",
+          "label": {
+            "asset": {
+              "id": "title",
+              "type": "text",
+              "value": "View 1"
+            }
+          },
+          "values": [
+            {
+              "asset": {
+                "id": "action-prev",
+                "type": "action",
+                "value": "Prev",
+                "label": {
+                  "asset": {
+                    "id": "action-prev-id",
+                    "type": "text",
+                    "value": "Go Back Without Icon"
+                  }
+                },
+                "metaData": {
+                  "role": ""
+                }
+              }
+            },
+            {
+              "asset": {
+                "id": "action-prev-without-icon",
+                "type": "action",
+                "value": "Prev",
+                "label": {
+                  "asset": {
+                    "id": "action-prev-id-without-icon",
+                    "type": "text",
+                    "value": "Go Back With Role"
+                  }
+                },
+                "metaData": {
+                  "role": "back"
+                }
+              }
+            },
+            {
+              "asset": {
+                "id": "action-next",
+                "type": "action",
+                "value": "Next",
+                "label": {
+                  "asset": {
+                    "id": "action-next-id",
+                    "type": "text",
+                    "value": "Next"
+                  }
+                }
+              }
+            }
+          ]
         },
         {
-          "asset": {
-            "id": "text-2",
-            "type": "text",
-            "value": "This is some text that is a link",
-            "modifiers": [
-              {
-                "type": "link",
-                "metaData": {
-                  "ref": "https://intuit.com"
+          "id": "view-2",
+          "type": "collection",
+          "label": {
+            "asset": {
+              "id": "title",
+              "type": "text",
+              "value": "View 2"
+            }
+          },
+          "values": [
+            {
+              "asset": {
+                "id": "action-prev",
+                "type": "action",
+                "value": "Prev",
+                "label": {
+                  "asset": {
+                    "id": "action-prev-id",
+                    "type": "text",
+                    "value": "Go Back"
+                  }
                 }
+              }
+            },
+            {
+              "asset": {
+                "id": "action-next",
+                "type": "action",
+                "value": "Next",
+                "label": {
+                  "asset": {
+                    "id": "action-next-id",
+                    "type": "text",
+                    "value": "End"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "view-1",
+            "transitions": {
+              "Next": "VIEW_2",
+              "Prev": "END"
+            }
+          },
+          "VIEW_2": {
+            "state_type": "VIEW",
+            "ref": "view-2",
+            "transitions": {
+              "Next": "END",
+              "Prev": "VIEW_1"
+            }
+          },
+          "END": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      },
+      "data": {}
+    }
+    """
+    static let collectionBasic: String = """
+    {
+      "id": "generated-flow",
+      "views": [
+        {
+          "id": "view-1",
+          "type": "collection",
+          "label": {
+            "asset": {
+              "id": "title",
+              "type": "text",
+              "value": "Collections are used to group assets."
+            }
+          },
+          "values": [
+            {
+              "asset": {
+                "id": "text-1",
+                "type": "text",
+                "value": "This is the first item in the collection"
+              }
+            },
+            {
+              "asset": {
+                "id": "text-2",
+                "type": "text",
+                "value": "This is the second item in the collection"
+              }
+            }
+          ]
+        }
+      ],
+      "data": {},
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "view-1",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      }
+    }
+    """
+    static let imageBasic: String = """
+    {
+      "id": "generated-flow",
+      "views": [
+        {
+          "id": "image-1",
+          "type": "image",
+          "metaData": {
+            "ref": "https://raw.githubusercontent.com/player-ui/player/refs/tags/0.14.1/docs/site/src/assets/logo/logo-light-large.png"
+          }
+        }
+      ],
+      "data": {},
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "image-1",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      }
+    }
+    """
+    static let imageWithAccessibility: String = """
+    {
+      "id": "generated-flow",
+      "views": [
+        {
+          "id": "image-1",
+          "type": "image",
+          "metaData": {
+            "ref": "https://raw.githubusercontent.com/player-ui/player/refs/tags/0.14.1/docs/site/src/assets/logo/logo-light-large.png",
+            "accessibility": "This is accessibility text for an image"
+          },
+          "placeholder": "This is placeholder text for an image"
+        }
+      ],
+      "data": {},
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "image-1",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      }
+    }
+    """
+    static let imageWithCaption: String = """
+    {
+      "id": "generated-flow",
+      "views": [
+        {
+          "id": "image-1",
+          "type": "image",
+          "metaData": {
+            "ref": "https://raw.githubusercontent.com/player-ui/player/refs/tags/0.14.1/docs/site/src/assets/logo/logo-light-large.png"
+          },
+          "caption": {
+            "asset": {
+              "id": "image-caption",
+              "type": "text",
+              "value": "Image caption"
+            }
+          }
+        }
+      ],
+      "data": {},
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "image-1",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      }
+    }
+    """
+    static let imageWithPlaceholder: String = """
+    {
+      "id": "generated-flow",
+      "views": [
+        {
+          "id": "image-1",
+          "type": "image",
+          "metaData": {
+            "ref": "https://raw.githubusercontent.com/player-ui/player/refs/tags/0.14.1/docs/site/src/assets/logo/logo-light-large.png"
+          },
+          "placeholder": "This is placeholder text for an image"
+        }
+      ],
+      "data": {},
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "image-1",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      }
+    }
+    """
+    static let infoFooter: String = """
+    {
+      "id": "generated-flow",
+      "views": [
+        {
+          "id": "info-view",
+          "type": "info",
+          "title": {
+            "asset": {
+              "id": "info-title",
+              "type": "text",
+              "value": "View Title"
+            }
+          },
+          "actions": [
+            {
+              "asset": {
+                "id": "next-action",
+                "value": "Next",
+                "type": "action",
+                "label": {
+                  "asset": {
+                    "id": "next-action-label",
+                    "type": "text",
+                    "value": "Continue"
+                  }
+                }
+              }
+            }
+          ],
+          "footer": {
+            "asset": {
+              "id": "info-footer",
+              "type": "text",
+              "value": "Footer text"
+            }
+          }
+        }
+      ],
+      "data": {},
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "info-view",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      }
+    }
+    """
+    static let infoDynamicFlow: String = """
+    {
+      "id": "modal-flow",
+      "views": [
+        {
+          "id": "view-1",
+          "type": "info",
+          "title": {
+            "asset": {
+              "id": "view-title",
+              "type": "text",
+              "value": "View 1"
+            }
+          },
+          "actions": [
+            {
+              "asset": {
+                "id": "action-1",
+                "type": "action",
+                "value": "Next",
+                "label": {
+                  "asset": {
+                    "id": "action-1-label",
+                    "type": "text",
+                    "value": "Next"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "view-2",
+          "type": "info",
+          "title": {
+            "asset": {
+              "id": "view-title",
+              "type": "text",
+              "value": "View 2"
+            }
+          },
+          "actions": [
+            {
+              "asset": {
+                "id": "action-1",
+                "type": "action",
+                "value": "Next",
+                "label": {
+                  "asset": {
+                    "id": "action-1-label",
+                    "type": "text",
+                    "value": "Next"
+                  }
+                }
+              }
+            },
+            {
+              "asset": {
+                "id": "action-2",
+                "type": "action",
+                "value": "Dismiss",
+                "label": {
+                  "asset": {
+                    "id": "action-1-label",
+                    "type": "text",
+                    "value": "Dismiss"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "view-3",
+          "type": "info",
+          "title": {
+            "asset": {
+              "id": "view-3-title",
+              "type": "text",
+              "value": "View 3"
+            }
+          },
+          "actions": [
+            {
+              "asset": {
+                "id": "action-3",
+                "type": "action",
+                "value": "Next",
+                "label": {
+                  "asset": {
+                    "id": "action-3-label",
+                    "type": "text",
+                    "value": "Next"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "view-4",
+          "type": "info",
+          "title": {
+            "asset": {
+              "id": "view-4-title",
+              "type": "text",
+              "value": "View 4"
+            }
+          },
+          "actions": [
+            {
+              "asset": {
+                "id": "action-4",
+                "type": "action",
+                "value": "Next",
+                "label": {
+                  "asset": {
+                    "id": "action-4-label",
+                    "type": "text",
+                    "value": "Next"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "data": {
+        "viewRef": "VIEW_3"
+      },
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "view-1",
+            "transitions": {
+              "*": "VIEW_2"
+            }
+          },
+          "VIEW_2": {
+            "state_type": "VIEW",
+            "ref": "view-2",
+            "attributes": {
+              "stacked": true
+            },
+            "transitions": {
+              "Next": "{{viewRef}}",
+              "Dismiss": "VIEW_1"
+            }
+          },
+          "VIEW_3": {
+            "state_type": "VIEW",
+            "ref": "view-3",
+            "transitions": {
+              "*": "VIEW_1"
+            }
+          },
+          "VIEW_4": {
+            "state_type": "VIEW",
+            "ref": "view-4",
+            "transitions": {
+              "*": "VIEW_1"
+            }
+          }
+        }
+      }
+    }
+    """
+    static let infoBasic: String = """
+    {
+      "id": "generated-flow",
+      "views": [
+        {
+          "id": "info-view",
+          "type": "info",
+          "title": {
+            "asset": {
+              "id": "info-title",
+              "type": "text",
+              "value": "View Title"
+            }
+          },
+          "actions": [
+            {
+              "asset": {
+                "id": "next-action",
+                "value": "Next",
+                "type": "action",
+                "label": {
+                  "asset": {
+                    "id": "next-action-label",
+                    "type": "text",
+                    "value": "Continue"
+                  }
+                }
+              }
+            },
+            {
+              "asset": {
+                "id": "prev-action",
+                "value": "Prev",
+                "type": "action",
+                "label": {
+                  "asset": {
+                    "id": "next-action-label",
+                    "type": "text",
+                    "value": "Back"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "data": {},
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "info-view",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      }
+    }
+    """
+    static let infoModalFlow: String = """
+    {
+      "id": "modal-flow",
+      "views": [
+        {
+          "id": "view-1",
+          "type": "info",
+          "title": {
+            "asset": {
+              "id": "view-title",
+              "type": "text",
+              "value": "View 1"
+            }
+          },
+          "actions": [
+            {
+              "asset": {
+                "id": "action-1",
+                "type": "action",
+                "value": "Next",
+                "label": {
+                  "asset": {
+                    "id": "action-1-label",
+                    "type": "text",
+                    "value": "Next"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "view-2",
+          "type": "info",
+          "title": {
+            "asset": {
+              "id": "view-title",
+              "type": "text",
+              "value": "View 2"
+            }
+          },
+          "actions": [
+            {
+              "asset": {
+                "id": "action-1",
+                "type": "action",
+                "value": "Next",
+                "label": {
+                  "asset": {
+                    "id": "action-1-label",
+                    "type": "text",
+                    "value": "Next"
+                  }
+                }
+              }
+            },
+            {
+              "asset": {
+                "id": "action-2",
+                "type": "action",
+                "value": "Dismiss",
+                "label": {
+                  "asset": {
+                    "id": "action-1-label",
+                    "type": "text",
+                    "value": "Dismiss"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "view-3",
+          "type": "info",
+          "title": {
+            "asset": {
+              "id": "view-3-title",
+              "type": "text",
+              "value": "View 3"
+            }
+          },
+          "actions": [
+            {
+              "asset": {
+                "id": "action-3",
+                "type": "action",
+                "value": "Next",
+                "label": {
+                  "asset": {
+                    "id": "action-3-label",
+                    "type": "text",
+                    "value": "Next"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "view-1",
+            "transitions": {
+              "*": "VIEW_2"
+            }
+          },
+          "VIEW_2": {
+            "state_type": "VIEW",
+            "ref": "view-2",
+            "attributes": {
+              "stacked": true
+            },
+            "transitions": {
+              "Next": "VIEW_3",
+              "Dismiss": "VIEW_1"
+            }
+          },
+          "VIEW_3": {
+            "state_type": "VIEW",
+            "ref": "view-3",
+            "transitions": {
+              "*": "VIEW_1"
+            }
+          }
+        }
+      }
+    }
+    """
+    static let inputTransition: String = """
+    {
+      "id": "generated-flow",
+      "views": [
+        {
+          "id": "input-validation",
+          "type": "info",
+          "title": {
+            "asset": {
+              "id": "title",
+              "type": "text",
+              "value": "Some validations can prevent users from advancing"
+            }
+          },
+          "primaryInfo": {
+            "asset": {
+              "id": "primaryInfo",
+              "type": "collection",
+              "values": [
+                {
+                  "asset": {
+                    "id": "input-1",
+                    "type": "input",
+                    "label": {
+                      "asset": {
+                        "id": "input-1-label",
+                        "type": "text",
+                        "value": "Input with validation and formatting"
+                      }
+                    },
+                    "note": {
+                      "asset": {
+                        "id": "input-1-note",
+                        "type": "text",
+                        "value": "It expects a positive integer"
+                      }
+                    },
+                    "binding": "foo.bar"
+                  }
+                }
+              ]
+            }
+          },
+          "actions": [
+            {
+              "asset": {
+                "id": "next-action",
+                "value": "Next",
+                "type": "action",
+                "label": {
+                  "asset": {
+                    "id": "next-action-label",
+                    "type": "text",
+                    "value": "Continue"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "data": {},
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "input-validation",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      },
+      "schema": {
+        "ROOT": {
+          "foo": {
+            "type": "FooType"
+          }
+        },
+        "FooType": {
+          "bar": {
+            "type": "IntegerPosType",
+            "validation": [
+              {
+                "type": "required"
               }
             ]
           }
         }
-      ]
-    }
-  ],
-  "data": {},
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "view-1",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
       }
     }
-  }
-}
-"""
-static let textWithLink: String = """
-{
-  "id": "generated-flow",
-  "views": [
+    """
+    static let inputBasic: String = """
     {
-      "id": "text",
-      "type": "text",
-      "value": "A Link",
-      "modifiers": [
+      "id": "generated-flow",
+      "views": [
         {
-          "type": "link",
-          "metaData": {
-            "mime-type": "text/html",
-            "ref": "http://www.intuit.com"
+          "id": "input",
+          "type": "input",
+          "binding": "foo.bar",
+          "label": {
+            "asset": {
+              "id": "input-label",
+              "type": "text",
+              "value": "This is an input"
+            }
+          },
+          "note": {
+            "asset": {
+              "id": "input-note",
+              "type": "text",
+              "value": "This is a note"
+            }
           }
         }
-      ]
-    }
-  ],
-  "data": {},
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "text",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  }
-}
-"""
-static let beaconAction: String = """
-{
-  "id": "generated-flow",
-  "views": [
-    {
-      "id": "action",
-      "type": "action",
-      "exp": [
-        "{{count}} = {{count}} + 1",
-        "beacon('action', 'some-data')"
       ],
-      "metaData": {
-        "beacon": "Click count: {{count}}"
-      },
-      "label": {
-        "asset": {
-          "id": "action-label-text",
-          "type": "text",
-          "value": "Clicked {{count}} times"
-        }
-      }
-    }
-  ],
-  "data": {
-    "count": 0
-  },
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "action",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  }
-}
-"""
-static let externalAction: String = """
-{
-  "id": "test-flow",
-  "data": {
-    "transitionValue": "Next"
-  },
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "EXT_1",
-      "EXT_1": {
-        "state_type": "EXTERNAL",
-        "ref": "test-1",
-        "transitions": {
-          "Next": "END_FWD",
-          "Prev": "END_BCK"
-        }
-      },
-      "END_FWD": {
-        "state_type": "END",
-        "outcome": "FWD"
-      },
-      "END_BCK": {
-        "state_type": "END",
-        "outcome": "BCK"
-      }
-    }
-  }
-}
-"""
-static let pubSubBasic: String = """
-{
-  "id": "generated-flow",
-  "views": [
-    {
-      "id": "action",
-      "type": "action",
-      "exp": "@[ publish('some-event', 'event published message') ]@",
-      "label": {
-        "asset": {
-          "id": "action-label",
-          "type": "text",
-          "value": "Clicked to publish event"
-        }
-      }
-    }
-  ],
-  "data": {
-    "count": 0
-  },
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "action",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  }
-}
-"""
-
-    
-static let inputAssetPendingTransaction: String = """
-{
-  "id": "input-validation-flow",
-  "views": [
-    {
-      "id": "view-1",
-      "type": "collection",
-      "values": [
-        {
-          "asset": {
-            "id": "input-required",
-            "type": "input",
-            "binding": "foo.requiredInput",
-            "label": {
-              "asset": {
-                "id": "input-required-label",
-                "type": "text",
-                "value": "This input is required and must be greater than 0"
-              }
+      "data": {},
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "input",
+            "transitions": {
+              "*": "END_Done"
             }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      }
+    }
+    """
+    static let inputValidation: String = """
+    {
+      "id": "generated-flow",
+      "views": [
+        {
+          "id": "input-1",
+          "type": "input",
+          "label": {
+            "asset": {
+              "id": "input-1-label",
+              "type": "text",
+              "value": "Input with validation and formatting"
+            }
+          },
+          "note": {
+            "asset": {
+              "id": "input-1-note",
+              "type": "text",
+              "value": "It expects a positive integer"
+            }
+          },
+          "binding": "foo.bar"
+        }
+      ],
+      "data": {},
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "input-1",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      },
+      "schema": {
+        "ROOT": {
+          "foo": {
+            "type": "FooType"
           }
         },
-        {
-          "asset": {
-            "id": "action-1",
-            "type": "action",
-            "value": "Next",
-            "label": {
-              "asset": {
-                "id": "action-1-label",
-                "type": "text",
-                "value": "Continue"
+        "FooType": {
+          "bar": {
+            "type": "IntegerPosType",
+            "validation": [
+              {
+                "type": "required"
               }
+            ]
+          }
+        }
+      }
+    }
+    """
+    static let textBasic: String = """
+    {
+      "id": "generated-flow",
+      "views": [
+        {
+          "id": "view-1",
+          "type": "collection",
+          "values": [
+            {
+              "asset": {
+                "id": "text-1",
+                "type": "text",
+                "value": "This is some text."
+              }
+            },
+            {
+              "asset": {
+                "id": "text-2",
+                "type": "text",
+                "value": "This is some text that is a link",
+                "modifiers": [
+                  {
+                    "type": "link",
+                    "metaData": {
+                      "ref": "https://intuit.com"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "data": {},
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "view-1",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      }
+    }
+    """
+    static let textWithLink: String = """
+    {
+      "id": "generated-flow",
+      "views": [
+        {
+          "id": "text",
+          "type": "text",
+          "value": "A Link",
+          "modifiers": [
+            {
+              "type": "link",
+              "metaData": {
+                "mime-type": "text/html",
+                "ref": "http://www.intuit.com"
+              }
+            }
+          ]
+        }
+      ],
+      "data": {},
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "text",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      }
+    }
+    """
+    static let beaconAction: String = """
+    {
+      "id": "generated-flow",
+      "views": [
+        {
+          "id": "action",
+          "type": "action",
+          "exp": [
+            "{{count}} = {{count}} + 1",
+            "beacon('action', 'some-data')"
+          ],
+          "metaData": {
+            "beacon": "Click count: {{count}}"
+          },
+          "label": {
+            "asset": {
+              "id": "action-label-text",
+              "type": "text",
+              "value": "Clicked {{count}} times"
             }
           }
         }
-      ]
-    },
-    {
-      "id": "view-2",
-      "type": "info",
-      "title": {
-        "asset": {
-          "id": "view-2-title",
-          "type": "text",
-          "value": "You made it!"
-        }
-      }
-    }
-  ],
-  "schema": {
-    "ROOT": {
-      "foo": {
-        "type": "FooType"
-      }
-    },
-    "FooType": {
-      "requiredInput": {
-        "type": "IntegerPosType",
-        "validation": [
-          {
-            "type": "required"
+      ],
+      "data": {
+        "count": 0
+      },
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "action",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
           }
-        ]
+        }
       }
     }
-  },
-  "data": {},
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "view-1",
-        "transitions": {
-          "*": "VIEW_2"
-        }
+    """
+    static let externalAction: String = """
+    {
+      "id": "test-flow",
+      "data": {
+        "transitionValue": "Next"
       },
-      "VIEW_2": {
-        "state_type": "VIEW",
-        "ref": "view-2",
-        "transitions": {
-          "*": "END_Done"
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "EXT_1",
+          "EXT_1": {
+            "state_type": "EXTERNAL",
+            "ref": "test-1",
+            "transitions": {
+              "Next": "END_FWD",
+              "Prev": "END_BCK"
+            }
+          },
+          "END_FWD": {
+            "state_type": "END",
+            "outcome": "FWD"
+          },
+          "END_BCK": {
+            "state_type": "END",
+            "outcome": "BCK"
+          }
         }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
       }
     }
-  }
-}
-"""
-    
-static let chatMessageBasic: String = """
+    """
+    static let pubSubBasic: String = """
+    {
+      "id": "generated-flow",
+      "views": [
+        {
+          "id": "action",
+          "type": "action",
+          "exp": "@[ publish('some-event', 'event published message') ]@",
+          "label": {
+            "asset": {
+              "id": "action-label",
+              "type": "text",
+              "value": "Clicked to publish event"
+            }
+          }
+        }
+      ],
+      "data": {
+        "count": 0
+      },
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "action",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      }
+    }
+    """
+
+    static let inputAssetPendingTransaction: String = """
+    {
+      "id": "input-validation-flow",
+      "views": [
+        {
+          "id": "view-1",
+          "type": "collection",
+          "values": [
+            {
+              "asset": {
+                "id": "input-required",
+                "type": "input",
+                "binding": "foo.requiredInput",
+                "label": {
+                  "asset": {
+                    "id": "input-required-label",
+                    "type": "text",
+                    "value": "This input is required and must be greater than 0"
+                  }
+                }
+              }
+            },
+            {
+              "asset": {
+                "id": "action-1",
+                "type": "action",
+                "value": "Next",
+                "label": {
+                  "asset": {
+                    "id": "action-1-label",
+                    "type": "text",
+                    "value": "Continue"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "view-2",
+          "type": "info",
+          "title": {
+            "asset": {
+              "id": "view-2-title",
+              "type": "text",
+              "value": "You made it!"
+            }
+          }
+        }
+      ],
+      "schema": {
+        "ROOT": {
+          "foo": {
+            "type": "FooType"
+          }
+        },
+        "FooType": {
+          "requiredInput": {
+            "type": "IntegerPosType",
+            "validation": [
+              {
+                "type": "required"
+              }
+            ]
+          }
+        }
+      },
+      "data": {},
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "view-1",
+            "transitions": {
+              "*": "VIEW_2"
+            }
+          },
+          "VIEW_2": {
+            "state_type": "VIEW",
+            "ref": "view-2",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      }
+    }
+    """
+
+    static let chatMessageBasic: String = """
     {
       "id": "chat",
       "views": [
@@ -1437,182 +1489,129 @@ static let chatMessageBasic: String = """
     """
 
     static let chatUi: String = """
-{
-  "id": "chat-ui",
-  "data": {
-    "content": ""
-  },
-  "views": [
     {
-      "id": "root",
-      "type": "collection",
-      "values": [
-        {
-          "asset": {
-            "id": "chat-demo",
-            "type": "chat-message",
-            "value": {
-              "asset": {
-                "id": "values-0-value",
-                "type": "text",
-                "value": "Start chatting now!"
-              }
-            }
-          }
-        },
-        {
-          "asset": {
-            "id": "input",
-            "type": "input",
-            "binding": "content"
-          }
-        },
-        {
-          "asset": {
-            "id": "values-2",
-            "type": "action",
-            "exp": "send({{content}})",
-            "label": {
-              "asset": {
-                "id": "values-2-label",
-                "type": "text",
-                "value": " Send "
-              }
-            }
-          }
-        }
-      ]
-    }
-  ],
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "root",
-        "transitions": {
-          "*": "END_Done"
-        }
+      "id": "chat-ui",
+      "data": {
+        "content": ""
       },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "DONE"
+      "views": [
+        {
+          "id": "root",
+          "type": "collection",
+          "values": [
+            {
+              "asset": {
+                "id": "chat-demo",
+                "type": "chat-message",
+                "value": {
+                  "asset": {
+                    "id": "values-0-value",
+                    "type": "text",
+                    "value": "Start chatting now!"
+                  }
+                }
+              }
+            },
+            {
+              "asset": {
+                "id": "input",
+                "type": "input",
+                "binding": "content"
+              }
+            },
+            {
+              "asset": {
+                "id": "values-2",
+                "type": "action",
+                "exp": "send({{content}})",
+                "label": {
+                  "asset": {
+                    "id": "values-2-label",
+                    "type": "text",
+                    "value": " Send "
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "root",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "DONE"
+          }
+        }
       }
     }
-  }
-}
-"""
+    """
 
     static let endStateReproFlow: String = """
-{
-  "id": "end-state-repro-flow-1",
-  "views": [
     {
-      "id": "view-1",
-      "type": "collection",
-      "label": {
-        "asset": {
-          "id": "title",
-          "type": "text",
-          "value": "Flow 1 - Click End to complete this flow"
-        }
-      },
-      "values": [
+      "id": "end-state-repro-flow-1",
+      "views": [
         {
-          "asset": {
-            "id": "action-end",
-            "type": "action",
-            "value": "End",
-            "label": {
+          "id": "view-1",
+          "type": "collection",
+          "label": {
+            "asset": {
+              "id": "title",
+              "type": "text",
+              "value": "Flow 1 - Click End to complete this flow"
+            }
+          },
+          "values": [
+            {
               "asset": {
-                "id": "action-end-label",
-                "type": "text",
-                "value": "End Flow 1 (loads Flow 2 next)"
+                "id": "action-end",
+                "type": "action",
+                "value": "End",
+                "label": {
+                  "asset": {
+                    "id": "action-end-label",
+                    "type": "text",
+                    "value": "End Flow 1 (loads Flow 2 next)"
+                  }
+                }
               }
             }
+          ]
+        }
+      ],
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "ACTION_1",
+          "ACTION_1": {
+            "state_type": "ACTION",
+            "exp": "{{foo}} = 1",
+            "transitions": {
+              "*": "VIEW_1"
+            }
+          },
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "view-1",
+            "transitions": {
+              "End": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
           }
         }
-      ]
-    }
-  ],
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "ACTION_1",
-      "ACTION_1": {
-        "state_type": "ACTION",
-        "exp": "{{foo}} = 1",
-        "transitions": {
-          "*": "VIEW_1"
-        }
-      },
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "view-1",
-        "transitions": {
-          "End": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
       }
     }
-  }
-}
-"""
-
-    public static let assetSections: [FlowLoader.FlowSection] = [
-        (title: "action", flows: [
-            (name: "counter", flow: MockFlows.actionCounter),
-            (name: "transition to end", flow: MockFlows.actionTransitionToEnd),
-            (name: "basic", flow: MockFlows.actionBasic),
-            (name: "navigation", flow: MockFlows.actionNavigation)
-        ]),
-        (title: "collection", flows: [
-            (name: "basic", flow: MockFlows.collectionBasic)
-        ]),
-        (title: "image", flows: [
-            (name: "basic", flow: MockFlows.imageBasic),
-            (name: "with accessibility", flow: MockFlows.imageWithAccessibility),
-            (name: "with caption", flow: MockFlows.imageWithCaption),
-            (name: "with placeholder", flow: MockFlows.imageWithPlaceholder)
-        ]),
-        (title: "info", flows: [
-            (name: "footer", flow: MockFlows.infoFooter),
-            (name: "dynamic flow", flow: MockFlows.infoDynamicFlow),
-            (name: "basic", flow: MockFlows.infoBasic),
-            (name: "modal flow", flow: MockFlows.infoModalFlow)
-        ]),
-        (title: "input", flows: [
-            (name: "transition", flow: MockFlows.inputTransition),
-            (name: "basic", flow: MockFlows.inputBasic),
-            (name: "validation", flow: MockFlows.inputValidation)
-        ]),
-        (title: "text", flows: [
-            (name: "basic", flow: MockFlows.textBasic),
-            (name: "with link", flow: MockFlows.textWithLink)
-        ]),
-        (title: "chat message", flows: [
-            (name: "basic", flow: MockFlows.chatMessageBasic),
-            (name: "chat-ui", flow: MockFlows.chatUi),
-        ])
-    ]
-
-    public static let pluginSections: [FlowLoader.FlowSection] = [
-              (title: "beacon", flows: [
-            (name: "action", flow: MockFlows.beaconAction)
-        ]),
-        (title: "external-action", flows: [
-            (name: "external-action", flow: MockFlows.externalAction)
-        ]),
-        (title: "pubsub", flows: [
-            (name: "pub sub basic", flow: MockFlows.pubSubBasic)
-        ])
-      ,
-      (title: "pending-transaction", flows: [
-        (name: "input asset pending transaction", flow: MockFlows.inputAssetPendingTransaction)
-        ])
-      ]
+    """
 }

--- a/ios/demo/Sources/MockFlows.swift
+++ b/ios/demo/Sources/MockFlows.swift
@@ -1,1405 +1,1457 @@
 // swiftlint:disable all
 import PlayerUITestUtilitiesCore
 
-public struct MockFlows {
+public enum MockFlows {
+    public static let assetSections: [FlowLoader.FlowSection] = [
+        (title: "action", flows: [
+            (name: "counter", flow: MockFlows.actionCounter),
+            (name: "transition to end", flow: MockFlows.actionTransitionToEnd),
+            (name: "basic", flow: MockFlows.actionBasic),
+            (name: "navigation", flow: MockFlows.actionNavigation),
+        ]),
+        (title: "collection", flows: [
+            (name: "basic", flow: MockFlows.collectionBasic),
+        ]),
+        (title: "image", flows: [
+            (name: "basic", flow: MockFlows.imageBasic),
+            (name: "with accessibility", flow: MockFlows.imageWithAccessibility),
+            (name: "with caption", flow: MockFlows.imageWithCaption),
+            (name: "with placeholder", flow: MockFlows.imageWithPlaceholder),
+        ]),
+        (title: "info", flows: [
+            (name: "footer", flow: MockFlows.infoFooter),
+            (name: "dynamic flow", flow: MockFlows.infoDynamicFlow),
+            (name: "basic", flow: MockFlows.infoBasic),
+            (name: "modal flow", flow: MockFlows.infoModalFlow),
+        ]),
+        (title: "input", flows: [
+            (name: "transition", flow: MockFlows.inputTransition),
+            (name: "basic", flow: MockFlows.inputBasic),
+            (name: "validation", flow: MockFlows.inputValidation),
+        ]),
+        (title: "text", flows: [
+            (name: "basic", flow: MockFlows.textBasic),
+            (name: "with link", flow: MockFlows.textWithLink),
+        ]),
+        (title: "chat message", flows: [
+            (name: "basic", flow: MockFlows.chatMessageBasic),
+            (name: "chat-ui", flow: MockFlows.chatUi),
+        ]),
+    ]
+
+    public static let pluginSections: [FlowLoader.FlowSection] = [
+        (title: "beacon", flows: [
+            (name: "action", flow: MockFlows.beaconAction),
+        ]),
+        (title: "external-state", flows: [
+            (name: "external-state", flow: MockFlows.externalState),
+        ]),
+        (title: "pubsub", flows: [
+            (name: "pub sub basic", flow: MockFlows.pubSubBasic),
+        ]),
+
+        (title: "pending-transaction", flows: [
+            (name: "input asset pending transaction", flow: MockFlows.inputAssetPendingTransaction),
+        ]),
+    ]
+
     static let actionCounter: String = """
-{
-  "id": "generated-flow",
-  "views": [
     {
-      "id": "action",
-      "type": "action",
-      "exp": "{{count}} = {{count}} + 1",
-      "label": {
-        "asset": {
-          "id": "action-label",
-          "type": "text",
-          "value": "Clicked {{count}} times"
-        }
-      }
-    }
-  ],
-  "data": {
-    "count": 0
-  },
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "action",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  }
-}
-"""
-static let actionTransitionToEnd: String = """
-{
-  "id": "generated-flow",
-  "views": [
-    {
-      "id": "collection",
-      "type": "collection",
-      "values": [
+      "id": "generated-flow",
+      "views": [
         {
-          "asset": {
-            "id": "action-good",
-            "type": "action",
-            "value": "Next",
-            "label": {
-              "asset": {
-                "id": "action-good-label",
-                "type": "text",
-                "value": "End the flow (success)"
-              }
-            }
-          }
-        },
-        {
-          "asset": {
-            "id": "action-bad",
-            "type": "action",
-            "exp": "{{foo.bar..}",
-            "label": {
-              "asset": {
-                "id": "action-bad-label",
-                "type": "text",
-                "value": "End the flow (error)"
-              }
-            }
-          }
-        }
-      ]
-    }
-  ],
-  "data": {},
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "collection",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  }
-}
-"""
-static let actionBasic: String = """
-{
-  "id": "generated-flow",
-  "views": [
-    {
-      "id": "action",
-      "type": "action",
-      "exp": "{{count}} = {{count}} + 1",
-      "label": {
-        "asset": {
-          "id": "action-label",
-          "type": "text",
-          "value": "Count: {{count}}"
-        }
-      }
-    }
-  ],
-  "data": {
-    "count": 0
-  },
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "action",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  }
-}
-"""
-static let actionNavigation: String = """
-{
-  "id": "action-navigation-flow",
-  "views": [
-    {
-      "id": "view-1",
-      "type": "collection",
-      "label": {
-        "asset": {
-          "id": "title",
-          "type": "text",
-          "value": "View 1"
-        }
-      },
-      "values": [
-        {
-          "asset": {
-            "id": "action-prev",
-            "type": "action",
-            "value": "Prev",
-            "label": {
-              "asset": {
-                "id": "action-prev-id",
-                "type": "text",
-                "value": "Go Back Without Icon"
-              }
-            },
-            "metaData": {
-              "role": ""
-            }
-          }
-        },
-        {
-          "asset": {
-            "id": "action-prev-without-icon",
-            "type": "action",
-            "value": "Prev",
-            "label": {
-              "asset": {
-                "id": "action-prev-id-without-icon",
-                "type": "text",
-                "value": "Go Back With Role"
-              }
-            },
-            "metaData": {
-              "role": "back"
-            }
-          }
-        },
-        {
-          "asset": {
-            "id": "action-next",
-            "type": "action",
-            "value": "Next",
-            "label": {
-              "asset": {
-                "id": "action-next-id",
-                "type": "text",
-                "value": "Next"
-              }
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "view-2",
-      "type": "collection",
-      "label": {
-        "asset": {
-          "id": "title",
-          "type": "text",
-          "value": "View 2"
-        }
-      },
-      "values": [
-        {
-          "asset": {
-            "id": "action-prev",
-            "type": "action",
-            "value": "Prev",
-            "label": {
-              "asset": {
-                "id": "action-prev-id",
-                "type": "text",
-                "value": "Go Back"
-              }
-            }
-          }
-        },
-        {
-          "asset": {
-            "id": "action-next",
-            "type": "action",
-            "value": "Next",
-            "label": {
-              "asset": {
-                "id": "action-next-id",
-                "type": "text",
-                "value": "End"
-              }
-            }
-          }
-        }
-      ]
-    }
-  ],
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "view-1",
-        "transitions": {
-          "Next": "VIEW_2",
-          "Prev": "END"
-        }
-      },
-      "VIEW_2": {
-        "state_type": "VIEW",
-        "ref": "view-2",
-        "transitions": {
-          "Next": "END",
-          "Prev": "VIEW_1"
-        }
-      },
-      "END": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  },
-  "data": {}
-}
-"""
-static let collectionBasic: String = """
-{
-  "id": "generated-flow",
-  "views": [
-    {
-      "id": "view-1",
-      "type": "collection",
-      "label": {
-        "asset": {
-          "id": "title",
-          "type": "text",
-          "value": "Collections are used to group assets."
-        }
-      },
-      "values": [
-        {
-          "asset": {
-            "id": "text-1",
-            "type": "text",
-            "value": "This is the first item in the collection"
-          }
-        },
-        {
-          "asset": {
-            "id": "text-2",
-            "type": "text",
-            "value": "This is the second item in the collection"
-          }
-        }
-      ]
-    }
-  ],
-  "data": {},
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "view-1",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  }
-}
-"""
-static let imageBasic: String = """
-{
-  "id": "generated-flow",
-  "views": [
-    {
-      "id": "image-1",
-      "type": "image",
-      "metaData": {
-        "ref": "https://raw.githubusercontent.com/player-ui/player/refs/tags/0.14.1/docs/site/src/assets/logo/logo-light-large.png"
-      }
-    }
-  ],
-  "data": {},
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "image-1",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  }
-}
-"""
-static let imageWithAccessibility: String = """
-{
-  "id": "generated-flow",
-  "views": [
-    {
-      "id": "image-1",
-      "type": "image",
-      "metaData": {
-        "ref": "https://raw.githubusercontent.com/player-ui/player/refs/tags/0.14.1/docs/site/src/assets/logo/logo-light-large.png",
-        "accessibility": "This is accessibility text for an image"
-      },
-      "placeholder": "This is placeholder text for an image"
-    }
-  ],
-  "data": {},
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "image-1",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  }
-}
-"""
-static let imageWithCaption: String = """
-{
-  "id": "generated-flow",
-  "views": [
-    {
-      "id": "image-1",
-      "type": "image",
-      "metaData": {
-        "ref": "https://raw.githubusercontent.com/player-ui/player/refs/tags/0.14.1/docs/site/src/assets/logo/logo-light-large.png"
-      },
-      "caption": {
-        "asset": {
-          "id": "image-caption",
-          "type": "text",
-          "value": "Image caption"
-        }
-      }
-    }
-  ],
-  "data": {},
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "image-1",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  }
-}
-"""
-static let imageWithPlaceholder: String = """
-{
-  "id": "generated-flow",
-  "views": [
-    {
-      "id": "image-1",
-      "type": "image",
-      "metaData": {
-        "ref": "https://raw.githubusercontent.com/player-ui/player/refs/tags/0.14.1/docs/site/src/assets/logo/logo-light-large.png"
-      },
-      "placeholder": "This is placeholder text for an image"
-    }
-  ],
-  "data": {},
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "image-1",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  }
-}
-"""
-static let infoFooter: String = """
-{
-  "id": "generated-flow",
-  "views": [
-    {
-      "id": "info-view",
-      "type": "info",
-      "title": {
-        "asset": {
-          "id": "info-title",
-          "type": "text",
-          "value": "View Title"
-        }
-      },
-      "actions": [
-        {
-          "asset": {
-            "id": "next-action",
-            "value": "Next",
-            "type": "action",
-            "label": {
-              "asset": {
-                "id": "next-action-label",
-                "type": "text",
-                "value": "Continue"
-              }
+          "id": "action",
+          "type": "action",
+          "exp": "{{count}} = {{count}} + 1",
+          "label": {
+            "asset": {
+              "id": "action-label",
+              "type": "text",
+              "value": "Clicked {{count}} times"
             }
           }
         }
       ],
-      "footer": {
-        "asset": {
-          "id": "info-footer",
-          "type": "text",
-          "value": "Footer text"
+      "data": {
+        "count": 0
+      },
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "action",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
         }
       }
     }
-  ],
-  "data": {},
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "info-view",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  }
-}
-"""
-static let infoDynamicFlow: String = """
-{
-  "id": "modal-flow",
-  "views": [
+    """
+    static let actionTransitionToEnd: String = """
     {
-      "id": "view-1",
-      "type": "info",
-      "title": {
-        "asset": {
-          "id": "view-title",
-          "type": "text",
-          "value": "View 1"
-        }
-      },
-      "actions": [
+      "id": "generated-flow",
+      "views": [
         {
-          "asset": {
-            "id": "action-1",
-            "type": "action",
-            "value": "Next",
-            "label": {
-              "asset": {
-                "id": "action-1-label",
-                "type": "text",
-                "value": "Next"
-              }
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "view-2",
-      "type": "info",
-      "title": {
-        "asset": {
-          "id": "view-title",
-          "type": "text",
-          "value": "View 2"
-        }
-      },
-      "actions": [
-        {
-          "asset": {
-            "id": "action-1",
-            "type": "action",
-            "value": "Next",
-            "label": {
-              "asset": {
-                "id": "action-1-label",
-                "type": "text",
-                "value": "Next"
-              }
-            }
-          }
-        },
-        {
-          "asset": {
-            "id": "action-2",
-            "type": "action",
-            "value": "Dismiss",
-            "label": {
-              "asset": {
-                "id": "action-1-label",
-                "type": "text",
-                "value": "Dismiss"
-              }
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "view-3",
-      "type": "info",
-      "title": {
-        "asset": {
-          "id": "view-3-title",
-          "type": "text",
-          "value": "View 3"
-        }
-      },
-      "actions": [
-        {
-          "asset": {
-            "id": "action-3",
-            "type": "action",
-            "value": "Next",
-            "label": {
-              "asset": {
-                "id": "action-3-label",
-                "type": "text",
-                "value": "Next"
-              }
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "view-4",
-      "type": "info",
-      "title": {
-        "asset": {
-          "id": "view-4-title",
-          "type": "text",
-          "value": "View 4"
-        }
-      },
-      "actions": [
-        {
-          "asset": {
-            "id": "action-4",
-            "type": "action",
-            "value": "Next",
-            "label": {
-              "asset": {
-                "id": "action-4-label",
-                "type": "text",
-                "value": "Next"
-              }
-            }
-          }
-        }
-      ]
-    }
-  ],
-  "data": {
-    "viewRef": "VIEW_3"
-  },
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "view-1",
-        "transitions": {
-          "*": "VIEW_2"
-        }
-      },
-      "VIEW_2": {
-        "state_type": "VIEW",
-        "ref": "view-2",
-        "attributes": {
-          "stacked": true
-        },
-        "transitions": {
-          "Next": "{{viewRef}}",
-          "Dismiss": "VIEW_1"
-        }
-      },
-      "VIEW_3": {
-        "state_type": "VIEW",
-        "ref": "view-3",
-        "transitions": {
-          "*": "VIEW_1"
-        }
-      },
-      "VIEW_4": {
-        "state_type": "VIEW",
-        "ref": "view-4",
-        "transitions": {
-          "*": "VIEW_1"
-        }
-      }
-    }
-  }
-}
-"""
-static let infoBasic: String = """
-{
-  "id": "generated-flow",
-  "views": [
-    {
-      "id": "info-view",
-      "type": "info",
-      "title": {
-        "asset": {
-          "id": "info-title",
-          "type": "text",
-          "value": "View Title"
-        }
-      },
-      "actions": [
-        {
-          "asset": {
-            "id": "next-action",
-            "value": "Next",
-            "type": "action",
-            "label": {
-              "asset": {
-                "id": "next-action-label",
-                "type": "text",
-                "value": "Continue"
-              }
-            }
-          }
-        },
-        {
-          "asset": {
-            "id": "prev-action",
-            "value": "Prev",
-            "type": "action",
-            "label": {
-              "asset": {
-                "id": "next-action-label",
-                "type": "text",
-                "value": "Back"
-              }
-            }
-          }
-        }
-      ]
-    }
-  ],
-  "data": {},
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "info-view",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  }
-}
-"""
-static let infoModalFlow: String = """
-{
-  "id": "modal-flow",
-  "views": [
-    {
-      "id": "view-1",
-      "type": "info",
-      "title": {
-        "asset": {
-          "id": "view-title",
-          "type": "text",
-          "value": "View 1"
-        }
-      },
-      "actions": [
-        {
-          "asset": {
-            "id": "action-1",
-            "type": "action",
-            "value": "Next",
-            "label": {
-              "asset": {
-                "id": "action-1-label",
-                "type": "text",
-                "value": "Next"
-              }
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "view-2",
-      "type": "info",
-      "title": {
-        "asset": {
-          "id": "view-title",
-          "type": "text",
-          "value": "View 2"
-        }
-      },
-      "actions": [
-        {
-          "asset": {
-            "id": "action-1",
-            "type": "action",
-            "value": "Next",
-            "label": {
-              "asset": {
-                "id": "action-1-label",
-                "type": "text",
-                "value": "Next"
-              }
-            }
-          }
-        },
-        {
-          "asset": {
-            "id": "action-2",
-            "type": "action",
-            "value": "Dismiss",
-            "label": {
-              "asset": {
-                "id": "action-1-label",
-                "type": "text",
-                "value": "Dismiss"
-              }
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "view-3",
-      "type": "info",
-      "title": {
-        "asset": {
-          "id": "view-3-title",
-          "type": "text",
-          "value": "View 3"
-        }
-      },
-      "actions": [
-        {
-          "asset": {
-            "id": "action-3",
-            "type": "action",
-            "value": "Next",
-            "label": {
-              "asset": {
-                "id": "action-3-label",
-                "type": "text",
-                "value": "Next"
-              }
-            }
-          }
-        }
-      ]
-    }
-  ],
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "view-1",
-        "transitions": {
-          "*": "VIEW_2"
-        }
-      },
-      "VIEW_2": {
-        "state_type": "VIEW",
-        "ref": "view-2",
-        "attributes": {
-          "stacked": true
-        },
-        "transitions": {
-          "Next": "VIEW_3",
-          "Dismiss": "VIEW_1"
-        }
-      },
-      "VIEW_3": {
-        "state_type": "VIEW",
-        "ref": "view-3",
-        "transitions": {
-          "*": "VIEW_1"
-        }
-      }
-    }
-  }
-}
-"""
-static let inputTransition: String = """
-{
-  "id": "generated-flow",
-  "views": [
-    {
-      "id": "input-validation",
-      "type": "info",
-      "title": {
-        "asset": {
-          "id": "title",
-          "type": "text",
-          "value": "Some validations can prevent users from advancing"
-        }
-      },
-      "primaryInfo": {
-        "asset": {
-          "id": "primaryInfo",
+          "id": "collection",
           "type": "collection",
           "values": [
             {
               "asset": {
-                "id": "input-1",
-                "type": "input",
+                "id": "action-good",
+                "type": "action",
+                "value": "Next",
                 "label": {
                   "asset": {
-                    "id": "input-1-label",
+                    "id": "action-good-label",
                     "type": "text",
-                    "value": "Input with validation and formatting"
+                    "value": "End the flow (success)"
                   }
-                },
-                "note": {
+                }
+              }
+            },
+            {
+              "asset": {
+                "id": "action-bad",
+                "type": "action",
+                "exp": "{{foo.bar..}",
+                "label": {
                   "asset": {
-                    "id": "input-1-note",
+                    "id": "action-bad-label",
                     "type": "text",
-                    "value": "It expects a positive integer"
+                    "value": "End the flow (error)"
                   }
-                },
-                "binding": "foo.bar"
+                }
               }
             }
           ]
         }
-      },
-      "actions": [
+      ],
+      "data": {},
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "collection",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      }
+    }
+    """
+    static let actionBasic: String = """
+    {
+      "id": "generated-flow",
+      "views": [
         {
-          "asset": {
-            "id": "next-action",
-            "value": "Next",
-            "type": "action",
-            "label": {
-              "asset": {
-                "id": "next-action-label",
-                "type": "text",
-                "value": "Continue"
-              }
+          "id": "action",
+          "type": "action",
+          "exp": "{{count}} = {{count}} + 1",
+          "label": {
+            "asset": {
+              "id": "action-label",
+              "type": "text",
+              "value": "Count: {{count}}"
             }
           }
         }
-      ]
-    }
-  ],
-  "data": {},
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "input-validation",
-        "transitions": {
-          "*": "END_Done"
-        }
+      ],
+      "data": {
+        "count": 0
       },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  },
-  "schema": {
-    "ROOT": {
-      "foo": {
-        "type": "FooType"
-      }
-    },
-    "FooType": {
-      "bar": {
-        "type": "IntegerPosType",
-        "validation": [
-          {
-            "type": "required"
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "action",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
           }
-        ]
+        }
       }
     }
-  }
-}
-"""
-static let inputBasic: String = """
-{
-  "id": "generated-flow",
-  "views": [
+    """
+    static let actionNavigation: String = """
     {
-      "id": "input",
-      "type": "input",
-      "binding": "foo.bar",
-      "label": {
-        "asset": {
-          "id": "input-label",
-          "type": "text",
-          "value": "This is an input"
-        }
-      },
-      "note": {
-        "asset": {
-          "id": "input-note",
-          "type": "text",
-          "value": "This is a note"
-        }
-      }
-    }
-  ],
-  "data": {},
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "input",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  }
-}
-"""
-static let inputValidation: String = """
-{
-  "id": "generated-flow",
-  "views": [
-    {
-      "id": "input-1",
-      "type": "input",
-      "label": {
-        "asset": {
-          "id": "input-1-label",
-          "type": "text",
-          "value": "Input with validation and formatting"
-        }
-      },
-      "note": {
-        "asset": {
-          "id": "input-1-note",
-          "type": "text",
-          "value": "It expects a positive integer"
-        }
-      },
-      "binding": "foo.bar"
-    }
-  ],
-  "data": {},
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "input-1",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  },
-  "schema": {
-    "ROOT": {
-      "foo": {
-        "type": "FooType"
-      }
-    },
-    "FooType": {
-      "bar": {
-        "type": "IntegerPosType",
-        "validation": [
-          {
-            "type": "required"
-          }
-        ]
-      }
-    }
-  }
-}
-"""
-static let textBasic: String = """
-{
-  "id": "generated-flow",
-  "views": [
-    {
-      "id": "view-1",
-      "type": "collection",
-      "values": [
+      "id": "action-navigation-flow",
+      "views": [
         {
-          "asset": {
-            "id": "text-1",
-            "type": "text",
-            "value": "This is some text."
-          }
+          "id": "view-1",
+          "type": "collection",
+          "label": {
+            "asset": {
+              "id": "title",
+              "type": "text",
+              "value": "View 1"
+            }
+          },
+          "values": [
+            {
+              "asset": {
+                "id": "action-prev",
+                "type": "action",
+                "value": "Prev",
+                "label": {
+                  "asset": {
+                    "id": "action-prev-id",
+                    "type": "text",
+                    "value": "Go Back Without Icon"
+                  }
+                },
+                "metaData": {
+                  "role": ""
+                }
+              }
+            },
+            {
+              "asset": {
+                "id": "action-prev-without-icon",
+                "type": "action",
+                "value": "Prev",
+                "label": {
+                  "asset": {
+                    "id": "action-prev-id-without-icon",
+                    "type": "text",
+                    "value": "Go Back With Role"
+                  }
+                },
+                "metaData": {
+                  "role": "back"
+                }
+              }
+            },
+            {
+              "asset": {
+                "id": "action-next",
+                "type": "action",
+                "value": "Next",
+                "label": {
+                  "asset": {
+                    "id": "action-next-id",
+                    "type": "text",
+                    "value": "Next"
+                  }
+                }
+              }
+            }
+          ]
         },
         {
-          "asset": {
-            "id": "text-2",
-            "type": "text",
-            "value": "This is some text that is a link",
-            "modifiers": [
-              {
-                "type": "link",
-                "metaData": {
-                  "ref": "https://intuit.com"
+          "id": "view-2",
+          "type": "collection",
+          "label": {
+            "asset": {
+              "id": "title",
+              "type": "text",
+              "value": "View 2"
+            }
+          },
+          "values": [
+            {
+              "asset": {
+                "id": "action-prev",
+                "type": "action",
+                "value": "Prev",
+                "label": {
+                  "asset": {
+                    "id": "action-prev-id",
+                    "type": "text",
+                    "value": "Go Back"
+                  }
                 }
+              }
+            },
+            {
+              "asset": {
+                "id": "action-next",
+                "type": "action",
+                "value": "Next",
+                "label": {
+                  "asset": {
+                    "id": "action-next-id",
+                    "type": "text",
+                    "value": "End"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "view-1",
+            "transitions": {
+              "Next": "VIEW_2",
+              "Prev": "END"
+            }
+          },
+          "VIEW_2": {
+            "state_type": "VIEW",
+            "ref": "view-2",
+            "transitions": {
+              "Next": "END",
+              "Prev": "VIEW_1"
+            }
+          },
+          "END": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      },
+      "data": {}
+    }
+    """
+    static let collectionBasic: String = """
+    {
+      "id": "generated-flow",
+      "views": [
+        {
+          "id": "view-1",
+          "type": "collection",
+          "label": {
+            "asset": {
+              "id": "title",
+              "type": "text",
+              "value": "Collections are used to group assets."
+            }
+          },
+          "values": [
+            {
+              "asset": {
+                "id": "text-1",
+                "type": "text",
+                "value": "This is the first item in the collection"
+              }
+            },
+            {
+              "asset": {
+                "id": "text-2",
+                "type": "text",
+                "value": "This is the second item in the collection"
+              }
+            }
+          ]
+        }
+      ],
+      "data": {},
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "view-1",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      }
+    }
+    """
+    static let imageBasic: String = """
+    {
+      "id": "generated-flow",
+      "views": [
+        {
+          "id": "image-1",
+          "type": "image",
+          "metaData": {
+            "ref": "https://raw.githubusercontent.com/player-ui/player/refs/tags/0.14.1/docs/site/src/assets/logo/logo-light-large.png"
+          }
+        }
+      ],
+      "data": {},
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "image-1",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      }
+    }
+    """
+    static let imageWithAccessibility: String = """
+    {
+      "id": "generated-flow",
+      "views": [
+        {
+          "id": "image-1",
+          "type": "image",
+          "metaData": {
+            "ref": "https://raw.githubusercontent.com/player-ui/player/refs/tags/0.14.1/docs/site/src/assets/logo/logo-light-large.png",
+            "accessibility": "This is accessibility text for an image"
+          },
+          "placeholder": "This is placeholder text for an image"
+        }
+      ],
+      "data": {},
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "image-1",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      }
+    }
+    """
+    static let imageWithCaption: String = """
+    {
+      "id": "generated-flow",
+      "views": [
+        {
+          "id": "image-1",
+          "type": "image",
+          "metaData": {
+            "ref": "https://raw.githubusercontent.com/player-ui/player/refs/tags/0.14.1/docs/site/src/assets/logo/logo-light-large.png"
+          },
+          "caption": {
+            "asset": {
+              "id": "image-caption",
+              "type": "text",
+              "value": "Image caption"
+            }
+          }
+        }
+      ],
+      "data": {},
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "image-1",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      }
+    }
+    """
+    static let imageWithPlaceholder: String = """
+    {
+      "id": "generated-flow",
+      "views": [
+        {
+          "id": "image-1",
+          "type": "image",
+          "metaData": {
+            "ref": "https://raw.githubusercontent.com/player-ui/player/refs/tags/0.14.1/docs/site/src/assets/logo/logo-light-large.png"
+          },
+          "placeholder": "This is placeholder text for an image"
+        }
+      ],
+      "data": {},
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "image-1",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      }
+    }
+    """
+    static let infoFooter: String = """
+    {
+      "id": "generated-flow",
+      "views": [
+        {
+          "id": "info-view",
+          "type": "info",
+          "title": {
+            "asset": {
+              "id": "info-title",
+              "type": "text",
+              "value": "View Title"
+            }
+          },
+          "actions": [
+            {
+              "asset": {
+                "id": "next-action",
+                "value": "Next",
+                "type": "action",
+                "label": {
+                  "asset": {
+                    "id": "next-action-label",
+                    "type": "text",
+                    "value": "Continue"
+                  }
+                }
+              }
+            }
+          ],
+          "footer": {
+            "asset": {
+              "id": "info-footer",
+              "type": "text",
+              "value": "Footer text"
+            }
+          }
+        }
+      ],
+      "data": {},
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "info-view",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      }
+    }
+    """
+    static let infoDynamicFlow: String = """
+    {
+      "id": "modal-flow",
+      "views": [
+        {
+          "id": "view-1",
+          "type": "info",
+          "title": {
+            "asset": {
+              "id": "view-title",
+              "type": "text",
+              "value": "View 1"
+            }
+          },
+          "actions": [
+            {
+              "asset": {
+                "id": "action-1",
+                "type": "action",
+                "value": "Next",
+                "label": {
+                  "asset": {
+                    "id": "action-1-label",
+                    "type": "text",
+                    "value": "Next"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "view-2",
+          "type": "info",
+          "title": {
+            "asset": {
+              "id": "view-title",
+              "type": "text",
+              "value": "View 2"
+            }
+          },
+          "actions": [
+            {
+              "asset": {
+                "id": "action-1",
+                "type": "action",
+                "value": "Next",
+                "label": {
+                  "asset": {
+                    "id": "action-1-label",
+                    "type": "text",
+                    "value": "Next"
+                  }
+                }
+              }
+            },
+            {
+              "asset": {
+                "id": "action-2",
+                "type": "action",
+                "value": "Dismiss",
+                "label": {
+                  "asset": {
+                    "id": "action-1-label",
+                    "type": "text",
+                    "value": "Dismiss"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "view-3",
+          "type": "info",
+          "title": {
+            "asset": {
+              "id": "view-3-title",
+              "type": "text",
+              "value": "View 3"
+            }
+          },
+          "actions": [
+            {
+              "asset": {
+                "id": "action-3",
+                "type": "action",
+                "value": "Next",
+                "label": {
+                  "asset": {
+                    "id": "action-3-label",
+                    "type": "text",
+                    "value": "Next"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "view-4",
+          "type": "info",
+          "title": {
+            "asset": {
+              "id": "view-4-title",
+              "type": "text",
+              "value": "View 4"
+            }
+          },
+          "actions": [
+            {
+              "asset": {
+                "id": "action-4",
+                "type": "action",
+                "value": "Next",
+                "label": {
+                  "asset": {
+                    "id": "action-4-label",
+                    "type": "text",
+                    "value": "Next"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "data": {
+        "viewRef": "VIEW_3"
+      },
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "view-1",
+            "transitions": {
+              "*": "VIEW_2"
+            }
+          },
+          "VIEW_2": {
+            "state_type": "VIEW",
+            "ref": "view-2",
+            "attributes": {
+              "stacked": true
+            },
+            "transitions": {
+              "Next": "{{viewRef}}",
+              "Dismiss": "VIEW_1"
+            }
+          },
+          "VIEW_3": {
+            "state_type": "VIEW",
+            "ref": "view-3",
+            "transitions": {
+              "*": "VIEW_1"
+            }
+          },
+          "VIEW_4": {
+            "state_type": "VIEW",
+            "ref": "view-4",
+            "transitions": {
+              "*": "VIEW_1"
+            }
+          }
+        }
+      }
+    }
+    """
+    static let infoBasic: String = """
+    {
+      "id": "generated-flow",
+      "views": [
+        {
+          "id": "info-view",
+          "type": "info",
+          "title": {
+            "asset": {
+              "id": "info-title",
+              "type": "text",
+              "value": "View Title"
+            }
+          },
+          "actions": [
+            {
+              "asset": {
+                "id": "next-action",
+                "value": "Next",
+                "type": "action",
+                "label": {
+                  "asset": {
+                    "id": "next-action-label",
+                    "type": "text",
+                    "value": "Continue"
+                  }
+                }
+              }
+            },
+            {
+              "asset": {
+                "id": "prev-action",
+                "value": "Prev",
+                "type": "action",
+                "label": {
+                  "asset": {
+                    "id": "next-action-label",
+                    "type": "text",
+                    "value": "Back"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "data": {},
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "info-view",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      }
+    }
+    """
+    static let infoModalFlow: String = """
+    {
+      "id": "modal-flow",
+      "views": [
+        {
+          "id": "view-1",
+          "type": "info",
+          "title": {
+            "asset": {
+              "id": "view-title",
+              "type": "text",
+              "value": "View 1"
+            }
+          },
+          "actions": [
+            {
+              "asset": {
+                "id": "action-1",
+                "type": "action",
+                "value": "Next",
+                "label": {
+                  "asset": {
+                    "id": "action-1-label",
+                    "type": "text",
+                    "value": "Next"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "view-2",
+          "type": "info",
+          "title": {
+            "asset": {
+              "id": "view-title",
+              "type": "text",
+              "value": "View 2"
+            }
+          },
+          "actions": [
+            {
+              "asset": {
+                "id": "action-1",
+                "type": "action",
+                "value": "Next",
+                "label": {
+                  "asset": {
+                    "id": "action-1-label",
+                    "type": "text",
+                    "value": "Next"
+                  }
+                }
+              }
+            },
+            {
+              "asset": {
+                "id": "action-2",
+                "type": "action",
+                "value": "Dismiss",
+                "label": {
+                  "asset": {
+                    "id": "action-1-label",
+                    "type": "text",
+                    "value": "Dismiss"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "view-3",
+          "type": "info",
+          "title": {
+            "asset": {
+              "id": "view-3-title",
+              "type": "text",
+              "value": "View 3"
+            }
+          },
+          "actions": [
+            {
+              "asset": {
+                "id": "action-3",
+                "type": "action",
+                "value": "Next",
+                "label": {
+                  "asset": {
+                    "id": "action-3-label",
+                    "type": "text",
+                    "value": "Next"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "view-1",
+            "transitions": {
+              "*": "VIEW_2"
+            }
+          },
+          "VIEW_2": {
+            "state_type": "VIEW",
+            "ref": "view-2",
+            "attributes": {
+              "stacked": true
+            },
+            "transitions": {
+              "Next": "VIEW_3",
+              "Dismiss": "VIEW_1"
+            }
+          },
+          "VIEW_3": {
+            "state_type": "VIEW",
+            "ref": "view-3",
+            "transitions": {
+              "*": "VIEW_1"
+            }
+          }
+        }
+      }
+    }
+    """
+    static let inputTransition: String = """
+    {
+      "id": "generated-flow",
+      "views": [
+        {
+          "id": "input-validation",
+          "type": "info",
+          "title": {
+            "asset": {
+              "id": "title",
+              "type": "text",
+              "value": "Some validations can prevent users from advancing"
+            }
+          },
+          "primaryInfo": {
+            "asset": {
+              "id": "primaryInfo",
+              "type": "collection",
+              "values": [
+                {
+                  "asset": {
+                    "id": "input-1",
+                    "type": "input",
+                    "label": {
+                      "asset": {
+                        "id": "input-1-label",
+                        "type": "text",
+                        "value": "Input with validation and formatting"
+                      }
+                    },
+                    "note": {
+                      "asset": {
+                        "id": "input-1-note",
+                        "type": "text",
+                        "value": "It expects a positive integer"
+                      }
+                    },
+                    "binding": "foo.bar"
+                  }
+                }
+              ]
+            }
+          },
+          "actions": [
+            {
+              "asset": {
+                "id": "next-action",
+                "value": "Next",
+                "type": "action",
+                "label": {
+                  "asset": {
+                    "id": "next-action-label",
+                    "type": "text",
+                    "value": "Continue"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "data": {},
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "input-validation",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      },
+      "schema": {
+        "ROOT": {
+          "foo": {
+            "type": "FooType"
+          }
+        },
+        "FooType": {
+          "bar": {
+            "type": "IntegerPosType",
+            "validation": [
+              {
+                "type": "required"
               }
             ]
           }
         }
-      ]
-    }
-  ],
-  "data": {},
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "view-1",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
       }
     }
-  }
-}
-"""
-static let textWithLink: String = """
-{
-  "id": "generated-flow",
-  "views": [
+    """
+    static let inputBasic: String = """
     {
-      "id": "text",
-      "type": "text",
-      "value": "A Link",
-      "modifiers": [
+      "id": "generated-flow",
+      "views": [
         {
-          "type": "link",
-          "metaData": {
-            "mime-type": "text/html",
-            "ref": "http://www.intuit.com"
+          "id": "input",
+          "type": "input",
+          "binding": "foo.bar",
+          "label": {
+            "asset": {
+              "id": "input-label",
+              "type": "text",
+              "value": "This is an input"
+            }
+          },
+          "note": {
+            "asset": {
+              "id": "input-note",
+              "type": "text",
+              "value": "This is a note"
+            }
           }
         }
-      ]
-    }
-  ],
-  "data": {},
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "text",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  }
-}
-"""
-static let beaconAction: String = """
-{
-  "id": "generated-flow",
-  "views": [
-    {
-      "id": "action",
-      "type": "action",
-      "exp": [
-        "{{count}} = {{count}} + 1",
-        "beacon('action', 'some-data')"
       ],
-      "metaData": {
-        "beacon": "Click count: {{count}}"
-      },
-      "label": {
-        "asset": {
-          "id": "action-label-text",
-          "type": "text",
-          "value": "Clicked {{count}} times"
-        }
-      }
-    }
-  ],
-  "data": {
-    "count": 0
-  },
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "action",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  }
-}
-"""
-static let externalState: String = """
-{
-  "id": "test-flow",
-  "data": {
-    "transitionValue": "Next"
-  },
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "EXT_1",
-      "EXT_1": {
-        "state_type": "EXTERNAL",
-        "ref": "test-1",
-        "transitions": {
-          "Next": "END_FWD",
-          "Prev": "END_BCK"
-        }
-      },
-      "END_FWD": {
-        "state_type": "END",
-        "outcome": "FWD"
-      },
-      "END_BCK": {
-        "state_type": "END",
-        "outcome": "BCK"
-      }
-    }
-  }
-}
-"""
-static let pubSubBasic: String = """
-{
-  "id": "generated-flow",
-  "views": [
-    {
-      "id": "action",
-      "type": "action",
-      "exp": "@[ publish('some-event', 'event published message') ]@",
-      "label": {
-        "asset": {
-          "id": "action-label",
-          "type": "text",
-          "value": "Clicked to publish event"
-        }
-      }
-    }
-  ],
-  "data": {
-    "count": 0
-  },
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "action",
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
-      }
-    }
-  }
-}
-"""
-
-    
-static let inputAssetPendingTransaction: String = """
-{
-  "id": "input-validation-flow",
-  "views": [
-    {
-      "id": "view-1",
-      "type": "collection",
-      "values": [
-        {
-          "asset": {
-            "id": "input-required",
-            "type": "input",
-            "binding": "foo.requiredInput",
-            "label": {
-              "asset": {
-                "id": "input-required-label",
-                "type": "text",
-                "value": "This input is required and must be greater than 0"
-              }
+      "data": {},
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "input",
+            "transitions": {
+              "*": "END_Done"
             }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      }
+    }
+    """
+    static let inputValidation: String = """
+    {
+      "id": "generated-flow",
+      "views": [
+        {
+          "id": "input-1",
+          "type": "input",
+          "label": {
+            "asset": {
+              "id": "input-1-label",
+              "type": "text",
+              "value": "Input with validation and formatting"
+            }
+          },
+          "note": {
+            "asset": {
+              "id": "input-1-note",
+              "type": "text",
+              "value": "It expects a positive integer"
+            }
+          },
+          "binding": "foo.bar"
+        }
+      ],
+      "data": {},
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "input-1",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      },
+      "schema": {
+        "ROOT": {
+          "foo": {
+            "type": "FooType"
           }
         },
-        {
-          "asset": {
-            "id": "action-1",
-            "type": "action",
-            "value": "Next",
-            "label": {
-              "asset": {
-                "id": "action-1-label",
-                "type": "text",
-                "value": "Continue"
+        "FooType": {
+          "bar": {
+            "type": "IntegerPosType",
+            "validation": [
+              {
+                "type": "required"
               }
+            ]
+          }
+        }
+      }
+    }
+    """
+    static let textBasic: String = """
+    {
+      "id": "generated-flow",
+      "views": [
+        {
+          "id": "view-1",
+          "type": "collection",
+          "values": [
+            {
+              "asset": {
+                "id": "text-1",
+                "type": "text",
+                "value": "This is some text."
+              }
+            },
+            {
+              "asset": {
+                "id": "text-2",
+                "type": "text",
+                "value": "This is some text that is a link",
+                "modifiers": [
+                  {
+                    "type": "link",
+                    "metaData": {
+                      "ref": "https://intuit.com"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "data": {},
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "view-1",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      }
+    }
+    """
+    static let textWithLink: String = """
+    {
+      "id": "generated-flow",
+      "views": [
+        {
+          "id": "text",
+          "type": "text",
+          "value": "A Link",
+          "modifiers": [
+            {
+              "type": "link",
+              "metaData": {
+                "mime-type": "text/html",
+                "ref": "http://www.intuit.com"
+              }
+            }
+          ]
+        }
+      ],
+      "data": {},
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "text",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      }
+    }
+    """
+    static let beaconAction: String = """
+    {
+      "id": "generated-flow",
+      "views": [
+        {
+          "id": "action",
+          "type": "action",
+          "exp": [
+            "{{count}} = {{count}} + 1",
+            "beacon('action', 'some-data')"
+          ],
+          "metaData": {
+            "beacon": "Click count: {{count}}"
+          },
+          "label": {
+            "asset": {
+              "id": "action-label-text",
+              "type": "text",
+              "value": "Clicked {{count}} times"
             }
           }
         }
-      ]
-    },
-    {
-      "id": "view-2",
-      "type": "info",
-      "title": {
-        "asset": {
-          "id": "view-2-title",
-          "type": "text",
-          "value": "You made it!"
-        }
-      }
-    }
-  ],
-  "schema": {
-    "ROOT": {
-      "foo": {
-        "type": "FooType"
-      }
-    },
-    "FooType": {
-      "requiredInput": {
-        "type": "IntegerPosType",
-        "validation": [
-          {
-            "type": "required"
+      ],
+      "data": {
+        "count": 0
+      },
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "action",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
           }
-        ]
+        }
       }
     }
-  },
-  "data": {},
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "view-1",
-        "transitions": {
-          "*": "VIEW_2"
-        }
+    """
+    static let externalState: String = """
+    {
+      "id": "test-flow",
+      "data": {
+        "transitionValue": "Next"
       },
-      "VIEW_2": {
-        "state_type": "VIEW",
-        "ref": "view-2",
-        "transitions": {
-          "*": "END_Done"
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "EXT_1",
+          "EXT_1": {
+            "state_type": "EXTERNAL",
+            "ref": "test-1",
+            "transitions": {
+              "Next": "END_FWD",
+              "Prev": "END_BCK"
+            }
+          },
+          "END_FWD": {
+            "state_type": "END",
+            "outcome": "FWD"
+          },
+          "END_BCK": {
+            "state_type": "END",
+            "outcome": "BCK"
+          }
         }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
       }
     }
-  }
-}
-"""
-    
-static let chatMessageBasic: String = """
+    """
+    static let pubSubBasic: String = """
+    {
+      "id": "generated-flow",
+      "views": [
+        {
+          "id": "action",
+          "type": "action",
+          "exp": "@[ publish('some-event', 'event published message') ]@",
+          "label": {
+            "asset": {
+              "id": "action-label",
+              "type": "text",
+              "value": "Clicked to publish event"
+            }
+          }
+        }
+      ],
+      "data": {
+        "count": 0
+      },
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "action",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      }
+    }
+    """
+
+    static let inputAssetPendingTransaction: String = """
+    {
+      "id": "input-validation-flow",
+      "views": [
+        {
+          "id": "view-1",
+          "type": "collection",
+          "values": [
+            {
+              "asset": {
+                "id": "input-required",
+                "type": "input",
+                "binding": "foo.requiredInput",
+                "label": {
+                  "asset": {
+                    "id": "input-required-label",
+                    "type": "text",
+                    "value": "This input is required and must be greater than 0"
+                  }
+                }
+              }
+            },
+            {
+              "asset": {
+                "id": "action-1",
+                "type": "action",
+                "value": "Next",
+                "label": {
+                  "asset": {
+                    "id": "action-1-label",
+                    "type": "text",
+                    "value": "Continue"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "view-2",
+          "type": "info",
+          "title": {
+            "asset": {
+              "id": "view-2-title",
+              "type": "text",
+              "value": "You made it!"
+            }
+          }
+        }
+      ],
+      "schema": {
+        "ROOT": {
+          "foo": {
+            "type": "FooType"
+          }
+        },
+        "FooType": {
+          "requiredInput": {
+            "type": "IntegerPosType",
+            "validation": [
+              {
+                "type": "required"
+              }
+            ]
+          }
+        }
+      },
+      "data": {},
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "view-1",
+            "transitions": {
+              "*": "VIEW_2"
+            }
+          },
+          "VIEW_2": {
+            "state_type": "VIEW",
+            "ref": "view-2",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
+        }
+      }
+    }
+    """
+
+    static let chatMessageBasic: String = """
     {
       "id": "chat",
       "views": [
@@ -1437,217 +1489,164 @@ static let chatMessageBasic: String = """
     """
 
     static let chatUi: String = """
-{
-  "id": "chat-ui",
-  "data": {
-    "content": ""
-  },
-  "views": [
     {
-      "id": "chat-view",
-      "type": "collection",
-      "values": [
-        {
-          "asset": {
-            "id": "chat-demo",
-            "type": "chat-message",
-            "value": {
-              "asset": {
-                "id": "chat-view-values-0-value",
-                "type": "text",
-                "value": "Start chatting now!"
-              }
-            }
-          }
-        },
-        {
-          "asset": {
-            "id": "input",
-            "type": "input",
-            "binding": "content"
-          }
-        },
-        {
-          "asset": {
-            "id": "chat-view-values-2",
-            "type": "action",
-            "exp": "send({{content}})",
-            "label": {
-              "asset": {
-                "id": "chat-view-values-2-label",
-                "type": "text",
-                "value": " Send "
-              }
-            }
-          }
-        },
-        {
-          "asset": {
-            "id": "chat-view-values-3",
-            "type": "text",
-            "value": "To demonstrate error recovery mechanisms, the message can be sent in poorly formatted content that will throw during the transform or at render-time of the asset:"
-          }
-        },
-        {
-          "asset": {
-            "id": "chat-view-values-4",
-            "type": "action",
-            "exp": "sendBroken({{content}})",
-            "label": {
-              "asset": {
-                "id": "chat-view-values-4-label",
-                "type": "text",
-                "value": " Send Broken Render Asset "
-              }
-            }
-          }
-        },
-        {
-          "asset": {
-            "id": "chat-view-values-5",
-            "type": "action",
-            "exp": "sendBrokenTransform({{content}})",
-            "label": {
-              "asset": {
-                "id": "chat-view-values-5-label",
-                "type": "text",
-                "value": " Send Broken Transform Asset "
-              }
-            }
-          }
-        }
-      ]
-    }
-  ],
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "chat-view",
-        "transitions": {
-          "*": "END_Done"
-        }
+      "id": "chat-ui",
+      "data": {
+        "content": ""
       },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "DONE"
+      "views": [
+        {
+          "id": "chat-view",
+          "type": "collection",
+          "values": [
+            {
+              "asset": {
+                "id": "chat-demo",
+                "type": "chat-message",
+                "value": {
+                  "asset": {
+                    "id": "chat-view-values-0-value",
+                    "type": "text",
+                    "value": "Start chatting now!"
+                  }
+                }
+              }
+            },
+            {
+              "asset": {
+                "id": "input",
+                "type": "input",
+                "binding": "content"
+              }
+            },
+            {
+              "asset": {
+                "id": "chat-view-values-2",
+                "type": "action",
+                "exp": "send({{content}})",
+                "label": {
+                  "asset": {
+                    "id": "chat-view-values-2-label",
+                    "type": "text",
+                    "value": " Send "
+                  }
+                }
+              }
+            },
+            {
+              "asset": {
+                "id": "chat-view-values-3",
+                "type": "text",
+                "value": "To demonstrate error recovery mechanisms, the message can be sent in poorly formatted content that will throw during the transform or at render-time of the asset:"
+              }
+            },
+            {
+              "asset": {
+                "id": "chat-view-values-4",
+                "type": "action",
+                "exp": "sendBroken({{content}})",
+                "label": {
+                  "asset": {
+                    "id": "chat-view-values-4-label",
+                    "type": "text",
+                    "value": " Send Broken Render Asset "
+                  }
+                }
+              }
+            },
+            {
+              "asset": {
+                "id": "chat-view-values-5",
+                "type": "action",
+                "exp": "sendBrokenTransform({{content}})",
+                "label": {
+                  "asset": {
+                    "id": "chat-view-values-5-label",
+                    "type": "text",
+                    "value": " Send Broken Transform Asset "
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "chat-view",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "DONE"
+          }
+        }
       }
     }
-  }
-}
-"""
+    """
 
     static let endStateReproFlow: String = """
-{
-  "id": "end-state-repro-flow-1",
-  "views": [
     {
-      "id": "view-1",
-      "type": "collection",
-      "label": {
-        "asset": {
-          "id": "title",
-          "type": "text",
-          "value": "Flow 1 - Click End to complete this flow"
-        }
-      },
-      "values": [
+      "id": "end-state-repro-flow-1",
+      "views": [
         {
-          "asset": {
-            "id": "action-end",
-            "type": "action",
-            "value": "End",
-            "label": {
+          "id": "view-1",
+          "type": "collection",
+          "label": {
+            "asset": {
+              "id": "title",
+              "type": "text",
+              "value": "Flow 1 - Click End to complete this flow"
+            }
+          },
+          "values": [
+            {
               "asset": {
-                "id": "action-end-label",
-                "type": "text",
-                "value": "End Flow 1 (loads Flow 2 next)"
+                "id": "action-end",
+                "type": "action",
+                "value": "End",
+                "label": {
+                  "asset": {
+                    "id": "action-end-label",
+                    "type": "text",
+                    "value": "End Flow 1 (loads Flow 2 next)"
+                  }
+                }
               }
             }
+          ]
+        }
+      ],
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "ACTION_1",
+          "ACTION_1": {
+            "state_type": "ACTION",
+            "exp": "{{foo}} = 1",
+            "transitions": {
+              "*": "VIEW_1"
+            }
+          },
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "view-1",
+            "transitions": {
+              "End": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
           }
         }
-      ]
-    }
-  ],
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "ACTION_1",
-      "ACTION_1": {
-        "state_type": "ACTION",
-        "exp": "{{foo}} = 1",
-        "transitions": {
-          "*": "VIEW_1"
-        }
-      },
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "view-1",
-        "transitions": {
-          "End": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
       }
     }
-  }
-}
-"""
-
-    public static let assetSections: [FlowLoader.FlowSection] = [
-        (title: "action", flows: [
-            (name: "counter", flow: MockFlows.actionCounter),
-            (name: "transition to end", flow: MockFlows.actionTransitionToEnd),
-            (name: "basic", flow: MockFlows.actionBasic),
-            (name: "navigation", flow: MockFlows.actionNavigation)
-        ]),
-        (title: "collection", flows: [
-            (name: "basic", flow: MockFlows.collectionBasic)
-        ]),
-        (title: "image", flows: [
-            (name: "basic", flow: MockFlows.imageBasic),
-            (name: "with accessibility", flow: MockFlows.imageWithAccessibility),
-            (name: "with caption", flow: MockFlows.imageWithCaption),
-            (name: "with placeholder", flow: MockFlows.imageWithPlaceholder)
-        ]),
-        (title: "info", flows: [
-            (name: "footer", flow: MockFlows.infoFooter),
-            (name: "dynamic flow", flow: MockFlows.infoDynamicFlow),
-            (name: "basic", flow: MockFlows.infoBasic),
-            (name: "modal flow", flow: MockFlows.infoModalFlow)
-        ]),
-        (title: "input", flows: [
-            (name: "transition", flow: MockFlows.inputTransition),
-            (name: "basic", flow: MockFlows.inputBasic),
-            (name: "validation", flow: MockFlows.inputValidation)
-        ]),
-        (title: "text", flows: [
-            (name: "basic", flow: MockFlows.textBasic),
-            (name: "with link", flow: MockFlows.textWithLink)
-        ]),
-        (title: "chat message", flows: [
-            (name: "basic", flow: MockFlows.chatMessageBasic),
-            (name: "chat-ui", flow: MockFlows.chatUi),
-        ])
-    ]
-
-    public static let pluginSections: [FlowLoader.FlowSection] = [
-              (title: "beacon", flows: [
-            (name: "action", flow: MockFlows.beaconAction)
-        ]),
-        (title: "external-state", flows: [
-            (name: "external-state", flow: MockFlows.externalState)
-        ]),
-        (title: "pubsub", flows: [
-            (name: "pub sub basic", flow: MockFlows.pubSubBasic)
-        ])
-      ,
-      (title: "pending-transaction", flows: [
-        (name: "input asset pending transaction", flow: MockFlows.inputAssetPendingTransaction)
-        ])
-      ]
+    """
 }

--- a/ios/demo/Sources/PluginsAndPlayerCollection.swift
+++ b/ios/demo/Sources/PluginsAndPlayerCollection.swift
@@ -5,47 +5,27 @@
 //  Created by Zhao Xia Wu on 2023-11-09.
 //
 
-import Foundation
-import SwiftUI
 import Combine
+import Foundation
 import PlayerUI
-import PlayerUITestUtilitiesCore
 import PlayerUIBaseBeaconPlugin
 import PlayerUIBeaconPlugin
 import PlayerUIExternalActionPlugin
 import PlayerUIPubSubPlugin
+import PlayerUITestUtilitiesCore
+import SwiftUI
 
-/**
- A SwiftUI View to load flows for Plugin and ManagedPlayer for ease of UITesting
- */
+/// A SwiftUI View to load flows for Plugin and ManagedPlayer for ease of UITesting
 public struct PluginsAndPlayerCollection: View {
     let plugins: [NativePlugin]
     let sections: [FlowLoader.FlowSection]
     let padding: CGFloat
-
-    /**
-     Initializes and loads flows
-     - parameters:
-        - plugins: Plugins to add to Player instance that is created
-        - sections: The `[FlowSection]` to display
-        - padding: Padding around the AssetFlowView
-     */
-    public init(
-        plugins: [NativePlugin],
-        sections: [FlowLoader.FlowSection],
-        padding: CGFloat = 16
-    ) {
-        self.plugins = plugins
-        self.padding = padding
-        self.sections = sections
-    }
 
     @State var beaconAndPubsubInfo = ""
     @State var completionMessage = ""
     @State var alertPresented = false
 
     public var body: some View {
-
         List {
             // Plugin flows
             pluginFlows
@@ -59,30 +39,47 @@ public struct PluginsAndPlayerCollection: View {
                     )
                     .padding(padding)
                 }.accessibility(identifier: "Reuse already loaded flow")
-                
+
                 NavigationLink("Simple Flows") {
-                    FlowManagerView(flowSequence: [.firstFlow, .secondFlow], navTitle: "Simple Flows")
-                        .padding(padding)
+                    FlowManagerView(
+                        flowSequence: [.firstFlow, .secondFlow],
+                        navTitle: "Simple Flows"
+                    )
+                    .padding(padding)
                 }.accessibility(identifier: "Simple Flows")
                 NavigationLink("Error Content Flow") {
-                    FlowManagerView(flowSequence: [.firstFlow, .errorFlow], navTitle: "Error Content Flow")
-                        .padding(padding)
+                    FlowManagerView(
+                        flowSequence: [.firstFlow, .errorFlow],
+                        navTitle: "Error Content Flow"
+                    )
+                    .padding(padding)
                 }.accessibility(identifier: "Error Content Flow")
                 NavigationLink("Error Asset Flow") {
-                    FlowManagerView(flowSequence: [.firstFlow, .assetErrorFlow], navTitle: "Error Asset Flow")
-                        .padding(padding)
+                    FlowManagerView(
+                        flowSequence: [.firstFlow, .assetErrorFlow],
+                        navTitle: "Error Asset Flow"
+                    )
+                    .padding(padding)
                 }.accessibility(identifier: "Error Asset Flow")
 
                 NavigationLink("Multi Action state before multi view flow") {
-                    FlowManagerView(flowSequence: [.firstFlowAction, .secondFlowAction,  .multiViewTransitionFlow, .secondFlow], navTitle: "Multi Action state before multi view flow")
-                        .padding(padding)
+                    FlowManagerView(
+                        flowSequence: [.firstFlowAction, .secondFlowAction,
+                                       .multiViewTransitionFlow,
+                                       .secondFlow],
+                        navTitle: "Multi Action state before multi view flow"
+                    )
+                    .padding(padding)
                 }.accessibility(identifier: "Multi Action state before multi view flow")
 
                 NavigationLink("External Action transition flow") {
-                    FlowManagerView(flowSequence: [.externalActionFlow, .secondFlow], navTitle: "External Action transition flow")
-                        .padding(padding)
+                    FlowManagerView(
+                        flowSequence: [.externalActionFlow, .secondFlow],
+                        navTitle: "External Action transition flow"
+                    )
+                    .padding(padding)
                 }.accessibility(identifier: "External Action transition flow")
-            }  header: {
+            } header: {
                 Text("Managed Player")
             }
         }
@@ -91,25 +88,28 @@ public struct PluginsAndPlayerCollection: View {
     }
 
     var pluginFlows: some View {
-        let pubsubPlugin = PubSubPlugin([("some-event", { (eventName, eventData) in
+        let pubsubPlugin = PubSubPlugin([("some-event", { eventName, eventData in
             $alertPresented.wrappedValue = true
 
             switch eventData {
-            case .string(data: let string):
+            case let .string(data: string):
                 $beaconAndPubsubInfo.wrappedValue += "Published: `\(eventName)` with message: `\(string)` \n"
             default: break
             }
         })])
 
-        let beaconPlugin =  BeaconPlugin<DefaultBeacon> { beaconStruct in
+        let beaconPlugin = BeaconPlugin<DefaultBeacon> { beaconStruct in
             $alertPresented.wrappedValue = true
             let encoder = JSONEncoder()
-            if let data = try? encoder.encode(beaconStruct), let jsonString = String(data: data, encoding: .utf8) {
+            if let data = try? encoder.encode(beaconStruct), let jsonString = String(
+                data: data,
+                encoding: .utf8
+            ) {
                 $beaconAndPubsubInfo.wrappedValue += "Beacon: \(jsonString) \n"
             }
         }
 
-        let externalActionPlugin =  ExternalActionPlugin(handler: { state, options, transition in
+        let externalActionPlugin = ExternalActionPlugin(handler: { state, options, transition in
             guard state.ref == "test-1" else { return transition("Prev") }
             let transitionValue = options.data.get(binding: "transitionValue") as? String
             options.expression.evaluate("{{foo}} = 'bar'")
@@ -120,25 +120,60 @@ public struct PluginsAndPlayerCollection: View {
             Section {
                 ForEach(section.flows, id: \.name) { flow in
                     NavigationLink(flow.name) {
-                        AssetFlowView(flow: flow.flow, plugins: plugins + [externalActionPlugin, beaconPlugin, pubsubPlugin], completion: completion(result:))
-                            .padding(padding)
-                            .navigationBarTitle(Text(flow.name))
-                            .modifier(
-                                AlertViewModifier(
-                                    alertPresented: $alertPresented,
-                                    pubsubEventName: $beaconAndPubsubInfo,
-                                    completionMessage: $completionMessage)
+                        AssetFlowView(
+                            flow: flow.flow,
+                            plugins: plugins + [externalActionPlugin, beaconPlugin, pubsubPlugin],
+                            completion: completion(result:)
+                        )
+                        .padding(padding)
+                        .navigationBarTitle(Text(flow.name))
+                        .modifier(
+                            AlertViewModifier(
+                                alertPresented: $alertPresented,
+                                pubsubEventName: $beaconAndPubsubInfo,
+                                completionMessage: $completionMessage
                             )
-                            .onDisappear {
-                                // clear tracked beacons and pub sub info
-                                $beaconAndPubsubInfo.wrappedValue = ""
-                            }
+                        )
+                        .onDisappear {
+                            // clear tracked beacons and pub sub info
+                            $beaconAndPubsubInfo.wrappedValue = ""
+                        }
                     }
                     .accessibility(identifier: "\(section.title) \(flow.name)")
                 }
             } header: {
                 Text(section.title)
             }
+        }
+    }
+
+    /// Initializes and loads flows
+    /// - parameters:
+    ///   - plugins: Plugins to add to Player instance that is created
+    ///   - sections: The `[FlowSection]` to display
+    ///   - padding: Padding around the AssetFlowView
+    public init(
+        plugins: [NativePlugin],
+        sections: [FlowLoader.FlowSection],
+        padding: CGFloat = 16
+    ) {
+        self.plugins = plugins
+        self.padding = padding
+        self.sections = sections
+    }
+
+    func completion(result: Result<CompletedState, PlayerError>) {
+        $alertPresented.wrappedValue = true
+        switch result {
+        case let .success(result):
+            completionMessage = result.endState?.outcome ?? "No Outcome"
+        case let .failure(error):
+            guard case let .promiseRejected(errorState) = error else {
+                completionMessage = "\(error)"
+                return
+            }
+
+            completionMessage = "\(errorState.error)"
         }
     }
 
@@ -153,27 +188,14 @@ public struct PluginsAndPlayerCollection: View {
                     isPresented: $alertPresented,
                     content: {
                         Alert(
-                            title: (completionMessage != "" ? Text("FlowCompleted") : Text("Info")),
-                            message: Text("Data: \n \($pubsubEventName.wrappedValue) \n Completion: \($completionMessage.wrappedValue)"),
+                            title: completionMessage != "" ? Text("FlowCompleted") : Text("Info"),
+                            message: Text(
+                                "Data: \n \($pubsubEventName.wrappedValue) \n Completion: \($completionMessage.wrappedValue)"
+                            ),
                             dismissButton: .default(Text("OK"))
                         )
                     }
                 )
-        }
-    }
-
-    func completion(result: Result<CompletedState, PlayerError>) {
-        $alertPresented.wrappedValue = true
-        switch result {
-        case .success(let result):
-            completionMessage = result.endState?.outcome ?? "No Outcome"
-        case .failure(let error):
-            guard case let .promiseRejected(errorState) = error else {
-                completionMessage = "\(error)"
-                return
-            }
-
-            completionMessage = "\(errorState.error)"
         }
     }
 }

--- a/ios/demo/Sources/PluginsAndPlayerCollection.swift
+++ b/ios/demo/Sources/PluginsAndPlayerCollection.swift
@@ -190,7 +190,7 @@ public struct PluginsAndPlayerCollection: View {
                         Alert(
                             title: completionMessage != "" ? Text("FlowCompleted") : Text("Info"),
                             message: Text(
-                                "Data: \n \($pubsubEventName.wrappedValue) \n Completion: \($completionMessage.wrappedValue)"
+                                "Data: \n \($pubsubEventName.wrappedValue) \n Completion: \($completionMessage.wrappedValue)" // swiftlint:disable:this line_length
                             ),
                             dismissButton: .default(Text("OK"))
                         )

--- a/ios/demo/Sources/PluginsAndPlayerCollection.swift
+++ b/ios/demo/Sources/PluginsAndPlayerCollection.swift
@@ -201,7 +201,8 @@ public struct PluginsAndPlayerCollection: View {
                         Alert(
                             title: completionMessage != "" ? Text("FlowCompleted") : Text("Info"),
                             message: Text(
-                                "Data: \n \($pubsubEventName.wrappedValue) \n Completion: \($completionMessage.wrappedValue)"
+                                "Data: \n \($pubsubEventName.wrappedValue) \n "
+                                    + "Completion: \($completionMessage.wrappedValue)"
                             ),
                             dismissButton: .default(Text("OK"))
                         )

--- a/ios/demo/Sources/PluginsAndPlayerCollection.swift
+++ b/ios/demo/Sources/PluginsAndPlayerCollection.swift
@@ -5,47 +5,27 @@
 //  Created by Zhao Xia Wu on 2023-11-09.
 //
 
-import Foundation
-import SwiftUI
 import Combine
+import Foundation
 import PlayerUI
-import PlayerUITestUtilitiesCore
 import PlayerUIBaseBeaconPlugin
 import PlayerUIBeaconPlugin
 import PlayerUIExternalStatePlugin
 import PlayerUIPubSubPlugin
+import PlayerUITestUtilitiesCore
+import SwiftUI
 
-/**
- A SwiftUI View to load flows for Plugin and ManagedPlayer for ease of UITesting
- */
+/// A SwiftUI View to load flows for Plugin and ManagedPlayer for ease of UITesting
 public struct PluginsAndPlayerCollection: View {
     let plugins: [NativePlugin]
     let sections: [FlowLoader.FlowSection]
     let padding: CGFloat
-
-    /**
-     Initializes and loads flows
-     - parameters:
-        - plugins: Plugins to add to Player instance that is created
-        - sections: The `[FlowSection]` to display
-        - padding: Padding around the AssetFlowView
-     */
-    public init(
-        plugins: [NativePlugin],
-        sections: [FlowLoader.FlowSection],
-        padding: CGFloat = 16
-    ) {
-        self.plugins = plugins
-        self.padding = padding
-        self.sections = sections
-    }
 
     @State var beaconAndPubsubInfo = ""
     @State var completionMessage = ""
     @State var alertPresented = false
 
     public var body: some View {
-
         List {
             // Plugin flows
             pluginFlows
@@ -61,28 +41,45 @@ public struct PluginsAndPlayerCollection: View {
                 }.accessibility(identifier: "Reuse already loaded flow")
 
                 NavigationLink("Simple Flows") {
-                    FlowManagerView(flowSequence: [.firstFlow, .secondFlow], navTitle: "Simple Flows")
-                        .padding(padding)
+                    FlowManagerView(
+                        flowSequence: [.firstFlow, .secondFlow],
+                        navTitle: "Simple Flows"
+                    )
+                    .padding(padding)
                 }.accessibility(identifier: "Simple Flows")
                 NavigationLink("Error Content Flow") {
-                    FlowManagerView(flowSequence: [.firstFlow, .errorFlow], navTitle: "Error Content Flow")
-                        .padding(padding)
+                    FlowManagerView(
+                        flowSequence: [.firstFlow, .errorFlow],
+                        navTitle: "Error Content Flow"
+                    )
+                    .padding(padding)
                 }.accessibility(identifier: "Error Content Flow")
                 NavigationLink("Error Asset Flow") {
-                    FlowManagerView(flowSequence: [.firstFlow, .assetErrorFlow], navTitle: "Error Asset Flow")
-                        .padding(padding)
+                    FlowManagerView(
+                        flowSequence: [.firstFlow, .assetErrorFlow],
+                        navTitle: "Error Asset Flow"
+                    )
+                    .padding(padding)
                 }.accessibility(identifier: "Error Asset Flow")
 
                 NavigationLink("Multi Action state before multi view flow") {
-                    FlowManagerView(flowSequence: [.firstFlowAction, .secondFlowAction,  .multiViewTransitionFlow, .secondFlow], navTitle: "Multi Action state before multi view flow")
-                        .padding(padding)
+                    FlowManagerView(
+                        flowSequence: [.firstFlowAction, .secondFlowAction,
+                                       .multiViewTransitionFlow,
+                                       .secondFlow],
+                        navTitle: "Multi Action state before multi view flow"
+                    )
+                    .padding(padding)
                 }.accessibility(identifier: "Multi Action state before multi view flow")
 
                 NavigationLink("External State transition flow") {
-                    FlowManagerView(flowSequence: [.externalStateFlow, .secondFlow], navTitle: "External State transition flow")
-                        .padding(padding)
+                    FlowManagerView(
+                        flowSequence: [.externalStateFlow, .secondFlow],
+                        navTitle: "External State transition flow"
+                    )
+                    .padding(padding)
                 }.accessibility(identifier: "External State transition flow")
-            }  header: {
+            } header: {
                 Text("Managed Player")
             }
         }
@@ -106,7 +103,8 @@ public struct PluginsAndPlayerCollection: View {
                             AlertViewModifier(
                                 alertPresented: $alertPresented,
                                 pubsubEventName: $beaconAndPubsubInfo,
-                                completionMessage: $completionMessage)
+                                completionMessage: $completionMessage
+                            )
                         )
                         .onDisappear {
                             // clear tracked beacons and pub sub info
@@ -121,58 +119,26 @@ public struct PluginsAndPlayerCollection: View {
         }
     }
 
-    struct AlertViewModifier: ViewModifier {
-        @Binding var alertPresented: Bool
-        @Binding var pubsubEventName: String
-        @Binding var completionMessage: String
-
-        func body(content: Content) -> some View {
-            content
-                .alert(
-                    isPresented: $alertPresented,
-                    content: {
-                        Alert(
-                            title: (completionMessage != "" ? Text("FlowCompleted") : Text("Info")),
-                            message: Text("Data: \n \($pubsubEventName.wrappedValue) \n Completion: \($completionMessage.wrappedValue)"),
-                            dismissButton: .default(Text("OK"))
-                        )
-                    }
-                )
-        }
-    }
-
-    func completion(result: Result<CompletedState, PlayerError>) {
-        $alertPresented.wrappedValue = true
-        switch result {
-        case .success(let result):
-            completionMessage = result.endState?.outcome ?? "No Outcome"
-        case .failure(let error):
-            guard case let .promiseRejected(errorState) = error else {
-                completionMessage = "\(error)"
-                return
-            }
-
-            completionMessage = "\(errorState.error)"
-        }
-    }
-
     var pubsubPlugin: PubSubPlugin {
-        .init([("some-event", { (eventName, eventData) in
+        .init([("some-event", { eventName, eventData in
             $alertPresented.wrappedValue = true
 
             switch eventData {
-            case .string(data: let string):
+            case let .string(data: string):
                 $beaconAndPubsubInfo.wrappedValue += "Published: `\(eventName)` with message: `\(string)` \n"
             default: break
             }
         })])
     }
 
-    var beaconPlugin : BeaconPlugin<DefaultBeacon> {
+    var beaconPlugin: BeaconPlugin<DefaultBeacon> {
         .init { beaconStruct in
             $alertPresented.wrappedValue = true
             let encoder = JSONEncoder()
-            if let data = try? encoder.encode(beaconStruct), let jsonString = String(data: data, encoding: .utf8) {
+            if let data = try? encoder.encode(beaconStruct), let jsonString = String(
+                data: data,
+                encoding: .utf8
+            ) {
                 $beaconAndPubsubInfo.wrappedValue += "Beacon: \(jsonString) \n"
             }
         }
@@ -188,7 +154,59 @@ public struct PluginsAndPlayerCollection: View {
                     options.expression.evaluate("{{foo}} = 'bar'")
                     transition(transitionValue ?? "Next")
                 }
-            )
+            ),
         ])
+    }
+
+    /// Initializes and loads flows
+    /// - parameters:
+    ///   - plugins: Plugins to add to Player instance that is created
+    ///   - sections: The `[FlowSection]` to display
+    ///   - padding: Padding around the AssetFlowView
+    public init(
+        plugins: [NativePlugin],
+        sections: [FlowLoader.FlowSection],
+        padding: CGFloat = 16
+    ) {
+        self.plugins = plugins
+        self.padding = padding
+        self.sections = sections
+    }
+
+    func completion(result: Result<CompletedState, PlayerError>) {
+        $alertPresented.wrappedValue = true
+        switch result {
+        case let .success(result):
+            completionMessage = result.endState?.outcome ?? "No Outcome"
+        case let .failure(error):
+            guard case let .promiseRejected(errorState) = error else {
+                completionMessage = "\(error)"
+                return
+            }
+
+            completionMessage = "\(errorState.error)"
+        }
+    }
+
+    struct AlertViewModifier: ViewModifier {
+        @Binding var alertPresented: Bool
+        @Binding var pubsubEventName: String
+        @Binding var completionMessage: String
+
+        func body(content: Content) -> some View {
+            content
+                .alert(
+                    isPresented: $alertPresented,
+                    content: {
+                        Alert(
+                            title: completionMessage != "" ? Text("FlowCompleted") : Text("Info"),
+                            message: Text(
+                                "Data: \n \($pubsubEventName.wrappedValue) \n Completion: \($completionMessage.wrappedValue)"
+                            ),
+                            dismissButton: .default(Text("OK"))
+                        )
+                    }
+                )
+        }
     }
 }

--- a/ios/demo/Sources/SegmentControlView.swift
+++ b/ios/demo/Sources/SegmentControlView.swift
@@ -5,48 +5,20 @@
 //  Created by Zhao Xia Wu on 2023-11-08.
 //
 
-import Foundation
-import SwiftUI
 import Combine
+import Foundation
 import PlayerUI
 import PlayerUITestUtilitiesCore
+import SwiftUI
 
-/**
- A SwiftUI View that contains two tabs AssetCollection and PluginsAndPlayer tab for ease of UITesting
- */
+/// A SwiftUI View that contains two tabs AssetCollection and PluginsAndPlayer tab for ease of
+/// UITesting
 public struct SegmentControlView: View {
     let plugins: [NativePlugin]
     let assetSections: [FlowLoader.FlowSection]
     let pluginSections: [FlowLoader.FlowSection]
     let padding: CGFloat
     let result: Binding<Result<CompletedState, PlayerError>?>
-    /**
-     Initializes and loads flows
-     - parameters:
-        - plugins: Plugins to add to Player instance that is created
-        - assetSections: The `[FlowSection]` to display asset flows
-        - pluginSections: The `[FlowSection]` to display plugin flows
-        - padding: Padding around the AssetFlowView ``
-        - completion: A handler for when a flow reaches an end state
-     */
-    public init(
-        plugins: [NativePlugin],
-        assetSections: [FlowLoader.FlowSection],
-        pluginSections: [FlowLoader.FlowSection],
-        padding: CGFloat = 16,
-        result: Binding<Result<CompletedState, PlayerError>?>
-    ) {
-        self.plugins = plugins
-        self.assetSections = assetSections
-        self.pluginSections = pluginSections
-        self.padding = padding
-        self.result = result
-    }
-
-    enum HeaderSelection: String, CaseIterable {
-        case flows = "Asset Flows"
-        case pluginsAndPlayer = "Plugins + Managed Player"
-    }
 
     @State var segmentationSelection: HeaderSelection = .flows
 
@@ -79,7 +51,7 @@ public struct SegmentControlView: View {
     }
 
     var flowsListSection: some View {
-        return AssetCollection(
+        AssetCollection(
             plugins: plugins,
             sections: assetSections,
             padding: padding,
@@ -89,12 +61,38 @@ public struct SegmentControlView: View {
         .navigationBarTitle(Text("Flows"))
         .alert(isPresented: $doneFlow, content: {
             Alert(title: Text("FlowFinished"),
-                    message: Text("Outcome: \(outcome)"),
-                    dismissButton: .default(Text("OK")))
+                  message: Text("Outcome: \(outcome)"),
+                  dismissButton: .default(Text("OK")))
         })
     }
 
     var playerListSection: some View {
-        return PluginsAndPlayerCollection(plugins: plugins, sections: pluginSections)
+        PluginsAndPlayerCollection(plugins: plugins, sections: pluginSections)
+    }
+
+    /// Initializes and loads flows
+    /// - parameters:
+    ///   - plugins: Plugins to add to Player instance that is created
+    ///   - assetSections: The `[FlowSection]` to display asset flows
+    ///   - pluginSections: The `[FlowSection]` to display plugin flows
+    ///   - padding: Padding around the AssetFlowView ``
+    ///   - completion: A handler for when a flow reaches an end state
+    public init(
+        plugins: [NativePlugin],
+        assetSections: [FlowLoader.FlowSection],
+        pluginSections: [FlowLoader.FlowSection],
+        padding: CGFloat = 16,
+        result: Binding<Result<CompletedState, PlayerError>?>
+    ) {
+        self.plugins = plugins
+        self.assetSections = assetSections
+        self.pluginSections = pluginSections
+        self.padding = padding
+        self.result = result
+    }
+
+    enum HeaderSelection: String, CaseIterable {
+        case flows = "Asset Flows"
+        case pluginsAndPlayer = "Plugins + Managed Player"
     }
 }

--- a/ios/demo/Sources/String+Extensions.swift
+++ b/ios/demo/Sources/String+Extensions.swift
@@ -7,39 +7,39 @@
 
 import Foundation
 
-// mocks for managed player flows
+/// mocks for managed player flows
 extension String {
     static let externalActionFlow = """
-        {
-          "id": "test-flow",
-          "data": {
-            "transitionValue": "Next"
+    {
+      "id": "test-flow",
+      "data": {
+        "transitionValue": "Next"
+      },
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "EXT_1",
+          "EXT_1": {
+            "state_type": "EXTERNAL",
+            "ref": "test-1",
+            "transitions": {
+              "Next": "END_FWD",
+              "Prev": "END_BCK"
+            },
+            "extraProperty": "extraValue"
           },
-          "navigation": {
-            "BEGIN": "FLOW_1",
-            "FLOW_1": {
-              "startState": "EXT_1",
-              "EXT_1": {
-                "state_type": "EXTERNAL",
-                "ref": "test-1",
-                "transitions": {
-                  "Next": "END_FWD",
-                  "Prev": "END_BCK"
-                },
-                "extraProperty": "extraValue"
-              },
-              "END_FWD": {
-                "state_type": "END",
-                "outcome": "FWD"
-              },
-              "END_BCK": {
-                "state_type": "END",
-                "outcome": "BCK"
-              }
-            }
+          "END_FWD": {
+            "state_type": "END",
+            "outcome": "FWD"
+          },
+          "END_BCK": {
+            "state_type": "END",
+            "outcome": "BCK"
           }
         }
-        """
+      }
+    }
+    """
     static let firstFlow: String =
         """
         {
@@ -79,243 +79,243 @@ extension String {
         """
 
     static let secondFlow: String =
-            """
+        """
+        {
+          "id": "flow_2",
+          "views": [
             {
-              "id": "flow_2",
-              "views": [
-                {
-                  "id": "second_view",
-                  "type": "action",
-                  "value": "flow_2",
-                  "label": {
-                    "asset": {
-                      "id": "next-view-label",
-                      "type": "text",
-                      "value": "End View 2"
-                    }
-                  }
-                }
-              ],
-              "navigation": {
-                "BEGIN": "flow_2",
-                "flow_2": {
-                  "startState": "view_2",
-                  "view_2": {
-                    "state_type": "VIEW",
-                    "ref": "second_view",
-                    "transitions": {
-                      "*": "END_Done"
-                    }
-                  },
-                  "END_Done": {
-                    "state_type": "END",
-                    "outcome": "done"
-                  }
+              "id": "second_view",
+              "type": "action",
+              "value": "flow_2",
+              "label": {
+                "asset": {
+                  "id": "next-view-label",
+                  "type": "text",
+                  "value": "End View 2"
                 }
               }
             }
-            """
+          ],
+          "navigation": {
+            "BEGIN": "flow_2",
+            "flow_2": {
+              "startState": "view_2",
+              "view_2": {
+                "state_type": "VIEW",
+                "ref": "second_view",
+                "transitions": {
+                  "*": "END_Done"
+                }
+              },
+              "END_Done": {
+                "state_type": "END",
+                "outcome": "done"
+              }
+            }
+          }
+        }
+        """
 
     static let multiViewTransitionFlow: String =
-    """
-    {
-      "id": "modal-flow",
-      "views": [
-                  {
-                    "id": "view-1",
+        """
+        {
+          "id": "modal-flow",
+          "views": [
+                      {
+                        "id": "view-1",
+                        "type": "action",
+                        "value": "Next",
+                        "label": {
+                          "asset": {
+                            "id": "action-label",
+                            "type": "text",
+                            "value": "Count: {{count}}"
+                          }
+                        }
+
+            },
+            {
+              "id": "view-2",
+              "type": "info",
+              "title": {
+                "asset": {
+                  "id": "view-title",
+                  "type": "text",
+                  "value": "View 2"
+                }
+              },
+              "actions": [
+                {
+                  "asset": {
+                    "id": "view-2-action-1",
                     "type": "action",
                     "value": "Next",
                     "label": {
                       "asset": {
-                        "id": "action-label",
+                        "id": "action-1-label",
                         "type": "text",
-                        "value": "Count: {{count}}"
+                        "value": "Next"
                       }
                     }
-
-        },
-        {
-          "id": "view-2",
-          "type": "info",
-          "title": {
-            "asset": {
-              "id": "view-title",
-              "type": "text",
-              "value": "View 2"
-            }
-          },
-          "actions": [
-            {
-              "asset": {
-                "id": "view-2-action-1",
-                "type": "action",
-                "value": "Next",
-                "label": {
-                  "asset": {
-                    "id": "action-1-label",
-                    "type": "text",
-                    "value": "Next"
                   }
-                }
-              }
-            },
-            {
-              "asset": {
-                "id": "view-2-action-2",
-                "type": "action",
-                "value": "Dismiss",
-                "label": {
-                  "asset": {
-                    "id": "action-1-label",
-                    "type": "text",
-                    "value": "Dismiss"
-                  }
-                }
-              }
-            }
-          ]
-        },
-        {
-          "id": "view-3",
-          "type": "info",
-          "title": {
-            "asset": {
-              "id": "view-3-title",
-              "type": "text",
-              "value": "View 3"
-            }
-          },
-          "actions": [
-            {
-              "asset": {
-                "id": "view-3-action-1",
-                "type": "action",
-                "value": "Next",
-                "label": {
-                  "asset": {
-                    "id": "action-3-label",
-                    "type": "text",
-                    "value": "Next"
-                  }
-                }
-              }
-            }
-          ]
-        }
-      ],
-      "navigation": {
-        "BEGIN": "FLOW_1",
-        "FLOW_1": {
-          "startState": "VIEW_2",
-                "END_Done": {
-                  "state_type": "END",
-                  "outcome": "done"
                 },
-          "VIEW_1": {
-            "state_type": "VIEW",
-            "ref": "view-1",
-            "transitions": {
-              "*": "VIEW_2"
-            }
-          },
-          "VIEW_2": {
-            "state_type": "VIEW",
-            "ref": "view-2",
-            "attributes": {
-              "stacked": false
+                {
+                  "asset": {
+                    "id": "view-2-action-2",
+                    "type": "action",
+                    "value": "Dismiss",
+                    "label": {
+                      "asset": {
+                        "id": "action-1-label",
+                        "type": "text",
+                        "value": "Dismiss"
+                      }
+                    }
+                  }
+                }
+              ]
             },
-            "transitions": {
-              "Next": "VIEW_3",
-              "Dismiss": "VIEW_1"
+            {
+              "id": "view-3",
+              "type": "info",
+              "title": {
+                "asset": {
+                  "id": "view-3-title",
+                  "type": "text",
+                  "value": "View 3"
+                }
+              },
+              "actions": [
+                {
+                  "asset": {
+                    "id": "view-3-action-1",
+                    "type": "action",
+                    "value": "Next",
+                    "label": {
+                      "asset": {
+                        "id": "action-3-label",
+                        "type": "text",
+                        "value": "Next"
+                      }
+                    }
+                  }
+                }
+              ]
             }
-          },
-          "ACTION_2": {
-             "state_type": "ACTION",
-             "exp": "{{foo}}",
-             "transitions": {
-                "*": "END_Done"
+          ],
+          "navigation": {
+            "BEGIN": "FLOW_1",
+            "FLOW_1": {
+              "startState": "VIEW_2",
+                    "END_Done": {
+                      "state_type": "END",
+                      "outcome": "done"
+                    },
+              "VIEW_1": {
+                "state_type": "VIEW",
+                "ref": "view-1",
+                "transitions": {
+                  "*": "VIEW_2"
+                }
+              },
+              "VIEW_2": {
+                "state_type": "VIEW",
+                "ref": "view-2",
+                "attributes": {
+                  "stacked": false
+                },
+                "transitions": {
+                  "Next": "VIEW_3",
+                  "Dismiss": "VIEW_1"
+                }
+              },
+              "ACTION_2": {
+                 "state_type": "ACTION",
+                 "exp": "{{foo}}",
+                 "transitions": {
+                    "*": "END_Done"
+                  }
+                },
+              "VIEW_3": {
+                "state_type": "VIEW",
+                "ref": "view-3",
+                "transitions": {
+                  "*": "ACTION_2"
+                }
               }
-            },
-          "VIEW_3": {
-            "state_type": "VIEW",
-            "ref": "view-3",
-            "transitions": {
-              "*": "ACTION_2"
             }
           }
         }
-      }
-    }
-    """
+        """
 
     static let errorFlow =
-                """
-                {
-                  "id": "flow_2",
-                  "views": [
-                    {
-                      "id": "second_view",
-                      "type": "action",
-                      "exp": "{{foo.bar..}",
-                      "value": "end",
-                      "label": {
-                        "asset": {
-                          "id": "next-view-label",
-                          "type": "text",
-                          "value": "End View 2"
-                        }
-                      }
-                    }
-                  ],
-                  "navigation": {
-                    "BEGIN": "flow_2",
-                    "flow_2": {
-                      "startState": "view_2",
-                      "view_2": {
-                        "state_type": "VIEW",
-                        "ref": "second_view",
-                        "transitions": {
-                          "*": "END_Done"
-                        }
-                      },
-                      "END_Done": {
-                        "state_type": "END",
-                        "outcome": "done"
-                      }
-                    }
-                  }
+        """
+        {
+          "id": "flow_2",
+          "views": [
+            {
+              "id": "second_view",
+              "type": "action",
+              "exp": "{{foo.bar..}",
+              "value": "end",
+              "label": {
+                "asset": {
+                  "id": "next-view-label",
+                  "type": "text",
+                  "value": "End View 2"
                 }
-                """
+              }
+            }
+          ],
+          "navigation": {
+            "BEGIN": "flow_2",
+            "flow_2": {
+              "startState": "view_2",
+              "view_2": {
+                "state_type": "VIEW",
+                "ref": "second_view",
+                "transitions": {
+                  "*": "END_Done"
+                }
+              },
+              "END_Done": {
+                "state_type": "END",
+                "outcome": "done"
+              }
+            }
+          }
+        }
+        """
 
     static let assetErrorFlow =
-             """
-             {
-               "id": "flow_3",
-               "views": [
-                 {
-                   "id": "third_view",
-                   "type": "error"
-                 }
-               ],
-               "navigation": {
-                 "BEGIN": "flow_3",
-                 "flow_3": {
-                   "startState": "view_3",
-                   "view_3": {
-                     "state_type": "VIEW",
-                     "ref": "third_view",
-                     "transitions": {
-                       "*": "END_Done"
-                     }
-                   },
-                   "END_Done": {
-                     "state_type": "END",
-                     "outcome": "done"
-                   }
-                 }
-               }
-             }
-             """
+        """
+        {
+          "id": "flow_3",
+          "views": [
+            {
+              "id": "third_view",
+              "type": "error"
+            }
+          ],
+          "navigation": {
+            "BEGIN": "flow_3",
+            "flow_3": {
+              "startState": "view_3",
+              "view_3": {
+                "state_type": "VIEW",
+                "ref": "third_view",
+                "transitions": {
+                  "*": "END_Done"
+                }
+              },
+              "END_Done": {
+                "state_type": "END",
+                "outcome": "done"
+              }
+            }
+          }
+        }
+        """
 
     static let firstFlowAction: String =
         """

--- a/ios/demo/Sources/String+Extensions.swift
+++ b/ios/demo/Sources/String+Extensions.swift
@@ -7,39 +7,39 @@
 
 import Foundation
 
-// mocks for managed player flows
+/// mocks for managed player flows
 extension String {
     static let externalStateFlow = """
-        {
-          "id": "test-flow",
-          "data": {
-            "transitionValue": "Next"
+    {
+      "id": "test-flow",
+      "data": {
+        "transitionValue": "Next"
+      },
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "EXT_1",
+          "EXT_1": {
+            "state_type": "EXTERNAL",
+            "ref": "test-1",
+            "transitions": {
+              "Next": "END_FWD",
+              "Prev": "END_BCK"
+            },
+            "extraProperty": "extraValue"
           },
-          "navigation": {
-            "BEGIN": "FLOW_1",
-            "FLOW_1": {
-              "startState": "EXT_1",
-              "EXT_1": {
-                "state_type": "EXTERNAL",
-                "ref": "test-1",
-                "transitions": {
-                  "Next": "END_FWD",
-                  "Prev": "END_BCK"
-                },
-                "extraProperty": "extraValue"
-              },
-              "END_FWD": {
-                "state_type": "END",
-                "outcome": "FWD"
-              },
-              "END_BCK": {
-                "state_type": "END",
-                "outcome": "BCK"
-              }
-            }
+          "END_FWD": {
+            "state_type": "END",
+            "outcome": "FWD"
+          },
+          "END_BCK": {
+            "state_type": "END",
+            "outcome": "BCK"
           }
         }
-        """
+      }
+    }
+    """
     static let firstFlow: String =
         """
         {
@@ -79,243 +79,243 @@ extension String {
         """
 
     static let secondFlow: String =
-            """
+        """
+        {
+          "id": "flow_2",
+          "views": [
             {
-              "id": "flow_2",
-              "views": [
-                {
-                  "id": "second_view",
-                  "type": "action",
-                  "value": "flow_2",
-                  "label": {
-                    "asset": {
-                      "id": "next-view-label",
-                      "type": "text",
-                      "value": "End View 2"
-                    }
-                  }
-                }
-              ],
-              "navigation": {
-                "BEGIN": "flow_2",
-                "flow_2": {
-                  "startState": "view_2",
-                  "view_2": {
-                    "state_type": "VIEW",
-                    "ref": "second_view",
-                    "transitions": {
-                      "*": "END_Done"
-                    }
-                  },
-                  "END_Done": {
-                    "state_type": "END",
-                    "outcome": "done"
-                  }
+              "id": "second_view",
+              "type": "action",
+              "value": "flow_2",
+              "label": {
+                "asset": {
+                  "id": "next-view-label",
+                  "type": "text",
+                  "value": "End View 2"
                 }
               }
             }
-            """
+          ],
+          "navigation": {
+            "BEGIN": "flow_2",
+            "flow_2": {
+              "startState": "view_2",
+              "view_2": {
+                "state_type": "VIEW",
+                "ref": "second_view",
+                "transitions": {
+                  "*": "END_Done"
+                }
+              },
+              "END_Done": {
+                "state_type": "END",
+                "outcome": "done"
+              }
+            }
+          }
+        }
+        """
 
     static let multiViewTransitionFlow: String =
-    """
-    {
-      "id": "modal-flow",
-      "views": [
-                  {
-                    "id": "view-1",
+        """
+        {
+          "id": "modal-flow",
+          "views": [
+                      {
+                        "id": "view-1",
+                        "type": "action",
+                        "value": "Next",
+                        "label": {
+                          "asset": {
+                            "id": "action-label",
+                            "type": "text",
+                            "value": "Count: {{count}}"
+                          }
+                        }
+
+            },
+            {
+              "id": "view-2",
+              "type": "info",
+              "title": {
+                "asset": {
+                  "id": "view-title",
+                  "type": "text",
+                  "value": "View 2"
+                }
+              },
+              "actions": [
+                {
+                  "asset": {
+                    "id": "view-2-action-1",
                     "type": "action",
                     "value": "Next",
                     "label": {
                       "asset": {
-                        "id": "action-label",
+                        "id": "action-1-label",
                         "type": "text",
-                        "value": "Count: {{count}}"
+                        "value": "Next"
                       }
                     }
-
-        },
-        {
-          "id": "view-2",
-          "type": "info",
-          "title": {
-            "asset": {
-              "id": "view-title",
-              "type": "text",
-              "value": "View 2"
-            }
-          },
-          "actions": [
-            {
-              "asset": {
-                "id": "view-2-action-1",
-                "type": "action",
-                "value": "Next",
-                "label": {
-                  "asset": {
-                    "id": "action-1-label",
-                    "type": "text",
-                    "value": "Next"
                   }
-                }
-              }
-            },
-            {
-              "asset": {
-                "id": "view-2-action-2",
-                "type": "action",
-                "value": "Dismiss",
-                "label": {
-                  "asset": {
-                    "id": "action-1-label",
-                    "type": "text",
-                    "value": "Dismiss"
-                  }
-                }
-              }
-            }
-          ]
-        },
-        {
-          "id": "view-3",
-          "type": "info",
-          "title": {
-            "asset": {
-              "id": "view-3-title",
-              "type": "text",
-              "value": "View 3"
-            }
-          },
-          "actions": [
-            {
-              "asset": {
-                "id": "view-3-action-1",
-                "type": "action",
-                "value": "Next",
-                "label": {
-                  "asset": {
-                    "id": "action-3-label",
-                    "type": "text",
-                    "value": "Next"
-                  }
-                }
-              }
-            }
-          ]
-        }
-      ],
-      "navigation": {
-        "BEGIN": "FLOW_1",
-        "FLOW_1": {
-          "startState": "VIEW_2",
-                "END_Done": {
-                  "state_type": "END",
-                  "outcome": "done"
                 },
-          "VIEW_1": {
-            "state_type": "VIEW",
-            "ref": "view-1",
-            "transitions": {
-              "*": "VIEW_2"
-            }
-          },
-          "VIEW_2": {
-            "state_type": "VIEW",
-            "ref": "view-2",
-            "attributes": {
-              "stacked": false
+                {
+                  "asset": {
+                    "id": "view-2-action-2",
+                    "type": "action",
+                    "value": "Dismiss",
+                    "label": {
+                      "asset": {
+                        "id": "action-1-label",
+                        "type": "text",
+                        "value": "Dismiss"
+                      }
+                    }
+                  }
+                }
+              ]
             },
-            "transitions": {
-              "Next": "VIEW_3",
-              "Dismiss": "VIEW_1"
+            {
+              "id": "view-3",
+              "type": "info",
+              "title": {
+                "asset": {
+                  "id": "view-3-title",
+                  "type": "text",
+                  "value": "View 3"
+                }
+              },
+              "actions": [
+                {
+                  "asset": {
+                    "id": "view-3-action-1",
+                    "type": "action",
+                    "value": "Next",
+                    "label": {
+                      "asset": {
+                        "id": "action-3-label",
+                        "type": "text",
+                        "value": "Next"
+                      }
+                    }
+                  }
+                }
+              ]
             }
-          },
-          "ACTION_2": {
-             "state_type": "ACTION",
-             "exp": "{{foo}}",
-             "transitions": {
-                "*": "END_Done"
+          ],
+          "navigation": {
+            "BEGIN": "FLOW_1",
+            "FLOW_1": {
+              "startState": "VIEW_2",
+                    "END_Done": {
+                      "state_type": "END",
+                      "outcome": "done"
+                    },
+              "VIEW_1": {
+                "state_type": "VIEW",
+                "ref": "view-1",
+                "transitions": {
+                  "*": "VIEW_2"
+                }
+              },
+              "VIEW_2": {
+                "state_type": "VIEW",
+                "ref": "view-2",
+                "attributes": {
+                  "stacked": false
+                },
+                "transitions": {
+                  "Next": "VIEW_3",
+                  "Dismiss": "VIEW_1"
+                }
+              },
+              "ACTION_2": {
+                 "state_type": "ACTION",
+                 "exp": "{{foo}}",
+                 "transitions": {
+                    "*": "END_Done"
+                  }
+                },
+              "VIEW_3": {
+                "state_type": "VIEW",
+                "ref": "view-3",
+                "transitions": {
+                  "*": "ACTION_2"
+                }
               }
-            },
-          "VIEW_3": {
-            "state_type": "VIEW",
-            "ref": "view-3",
-            "transitions": {
-              "*": "ACTION_2"
             }
           }
         }
-      }
-    }
-    """
+        """
 
     static let errorFlow =
-                """
-                {
-                  "id": "flow_2",
-                  "views": [
-                    {
-                      "id": "second_view",
-                      "type": "action",
-                      "exp": "{{foo.bar..}",
-                      "value": "end",
-                      "label": {
-                        "asset": {
-                          "id": "next-view-label",
-                          "type": "text",
-                          "value": "End View 2"
-                        }
-                      }
-                    }
-                  ],
-                  "navigation": {
-                    "BEGIN": "flow_2",
-                    "flow_2": {
-                      "startState": "view_2",
-                      "view_2": {
-                        "state_type": "VIEW",
-                        "ref": "second_view",
-                        "transitions": {
-                          "*": "END_Done"
-                        }
-                      },
-                      "END_Done": {
-                        "state_type": "END",
-                        "outcome": "done"
-                      }
-                    }
-                  }
+        """
+        {
+          "id": "flow_2",
+          "views": [
+            {
+              "id": "second_view",
+              "type": "action",
+              "exp": "{{foo.bar..}",
+              "value": "end",
+              "label": {
+                "asset": {
+                  "id": "next-view-label",
+                  "type": "text",
+                  "value": "End View 2"
                 }
-                """
+              }
+            }
+          ],
+          "navigation": {
+            "BEGIN": "flow_2",
+            "flow_2": {
+              "startState": "view_2",
+              "view_2": {
+                "state_type": "VIEW",
+                "ref": "second_view",
+                "transitions": {
+                  "*": "END_Done"
+                }
+              },
+              "END_Done": {
+                "state_type": "END",
+                "outcome": "done"
+              }
+            }
+          }
+        }
+        """
 
     static let assetErrorFlow =
-             """
-             {
-               "id": "flow_3",
-               "views": [
-                 {
-                   "id": "third_view",
-                   "type": "error"
-                 }
-               ],
-               "navigation": {
-                 "BEGIN": "flow_3",
-                 "flow_3": {
-                   "startState": "view_3",
-                   "view_3": {
-                     "state_type": "VIEW",
-                     "ref": "third_view",
-                     "transitions": {
-                       "*": "END_Done"
-                     }
-                   },
-                   "END_Done": {
-                     "state_type": "END",
-                     "outcome": "done"
-                   }
-                 }
-               }
-             }
-             """
+        """
+        {
+          "id": "flow_3",
+          "views": [
+            {
+              "id": "third_view",
+              "type": "error"
+            }
+          ],
+          "navigation": {
+            "BEGIN": "flow_3",
+            "flow_3": {
+              "startState": "view_3",
+              "view_3": {
+                "state_type": "VIEW",
+                "ref": "third_view",
+                "transitions": {
+                  "*": "END_Done"
+                }
+              },
+              "END_Done": {
+                "state_type": "END",
+                "outcome": "done"
+              }
+            }
+          }
+        }
+        """
 
     static let firstFlowAction: String =
         """

--- a/ios/internal-test-utils/Sources/FlowData.swift
+++ b/ios/internal-test-utils/Sources/FlowData.swift
@@ -1,187 +1,140 @@
-public struct FlowData {
-
-    static let flowAction: String =
-        """
-                        {
-                          "id": "flow_2",
-                          "views": [
-                            {
-                              "id": "second_view",
-                              "type": "action",
-                              "exp": "{{foo.bar..}",
-                              "value": "end",
-                              "label": {
-                                "asset": {
-                                  "id": "next-view-label",
-                                  "type": "text",
-                                  "value": "End View 2"
-                                }
-                              }
-                            }
-                          ],
-                          "navigation": {
-                            "BEGIN": "flow_2",
-                            "flow_2": {
-                              "startState": "ACTION_2",
-                              "view_2": {
-                                "state_type": "VIEW",
-                                "ref": "second_view",
-                                "transitions": {
-                                  "*": "END_Done"
-                                }
-                              },
-                                     "ACTION_2": {
-                                       "state_type": "ACTION",
-                                       "exp": "{{foo}}",
-                                       "transitions": {
-                                         "*": "END_Done"
-                                       }
-                                     },
-                              "END_Done": {
-                                "state_type": "END",
-                                "outcome": "done"
-                              }
-                            }
-                          }
-                        }
-        """
-
+public enum FlowData {
     public static let COUNTER: String = """
-{
-  "id": "counter-flow",
-  "views": [
     {
-      "id": "action",
-      "type": "action",
-      "exp": "{{count}} = {{count}} + 1",
-      "label": {
-        "asset": {
-          "id": "action-label",
-          "type": "text",
-          "value": "Clicked {{count}} times"
+      "id": "counter-flow",
+      "views": [
+        {
+          "id": "action",
+          "type": "action",
+          "exp": "{{count}} = {{count}} + 1",
+          "label": {
+            "asset": {
+              "id": "action-label",
+              "type": "text",
+              "value": "Clicked {{count}} times"
+            }
+          }
         }
-      }
-    }
-  ],
-  "data": {
-    "count": 0
-  },
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "VIEW_1",
-      "VIEW_1": {
-        "state_type": "VIEW",
-        "ref": "action",
-        "transitions": {
-          "*": "END_Done"
-        },
-        "attributes": { "test": "value" }
+      ],
+      "data": {
+        "count": 0
       },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done",
-        "param": {
-          "someKey": "someValue"
-        },
-        "extraKey": "extraValue",
-        "extraObject": {
-          "someInt": 1
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "VIEW_1",
+          "VIEW_1": {
+            "state_type": "VIEW",
+            "ref": "action",
+            "transitions": {
+              "*": "END_Done"
+            },
+            "attributes": { "test": "value" }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done",
+            "param": {
+              "someKey": "someValue"
+            },
+            "extraKey": "extraValue",
+            "extraObject": {
+              "someInt": 1
+            }
+          }
         }
       }
     }
-  }
-}
-"""
+    """
 
     public static let externalFlow: String = """
-{
-  "id": "counter-flow",
-  "views": [],
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "EXTERNAL_1",
-      "EXTERNAL_1": {
-        "state_type": "EXTERNAL",
-        "ref": "action",
-        "transitions": {
-          "*": "END_Done"
+    {
+      "id": "counter-flow",
+      "views": [],
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "EXTERNAL_1",
+          "EXTERNAL_1": {
+            "state_type": "EXTERNAL",
+            "ref": "action",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done"
+          }
         }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done"
       }
     }
-  }
-}
-"""
+    """
 
     public static let actionFlow: String = """
-{
-  "id": "counter-flow",
-  "views": [],
-  "data": {
-    "count": 0
-  },
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "ACTION_1",
-      "ACTION_1": {
-        "state_type": "ACTION",
-        "exp": "{{foo}}",
-        "transitions": {
-          "*": "END_Done"
-        }
+    {
+      "id": "counter-flow",
+      "views": [],
+      "data": {
+        "count": 0
       },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done",
-        "param": {
-          "someKey": "someValue"
-        },
-        "extraKey": "extraValue",
-        "extraObject": {
-          "someInt": 1
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "ACTION_1",
+          "ACTION_1": {
+            "state_type": "ACTION",
+            "exp": "{{foo}}",
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done",
+            "param": {
+              "someKey": "someValue"
+            },
+            "extraKey": "extraValue",
+            "extraObject": {
+              "someInt": 1
+            }
+          }
         }
       }
     }
-  }
-}
-"""
+    """
     public static let actionMultiExpFlow: String = """
-{
-  "id": "counter-flow",
-  "views": [],
-  "navigation": {
-    "BEGIN": "FLOW_1",
-    "FLOW_1": {
-      "startState": "ACTION_1",
-      "ACTION_1": {
-        "state_type": "ACTION",
-        "exp": ["{{foo}}", "{{bar}}"],
-        "transitions": {
-          "*": "END_Done"
-        }
-      },
-      "END_Done": {
-        "state_type": "END",
-        "outcome": "done",
-        "param": {
-          "someKey": "someValue"
-        },
-        "extraKey": "extraValue",
-        "extraObject": {
-          "someInt": 1
+    {
+      "id": "counter-flow",
+      "views": [],
+      "navigation": {
+        "BEGIN": "FLOW_1",
+        "FLOW_1": {
+          "startState": "ACTION_1",
+          "ACTION_1": {
+            "state_type": "ACTION",
+            "exp": ["{{foo}}", "{{bar}}"],
+            "transitions": {
+              "*": "END_Done"
+            }
+          },
+          "END_Done": {
+            "state_type": "END",
+            "outcome": "done",
+            "param": {
+              "someKey": "someValue"
+            },
+            "extraKey": "extraValue",
+            "extraObject": {
+              "someInt": 1
+            }
+          }
         }
       }
     }
-  }
-}
-"""
-  public static let MULTIPAGE: String = """
+    """
+    public static let MULTIPAGE: String = """
     {
       "id": "transition-between-pages",
       "views": [
@@ -233,4 +186,50 @@ public struct FlowData {
     }
 
     """
+
+    static let flowAction: String =
+        """
+                        {
+                          "id": "flow_2",
+                          "views": [
+                            {
+                              "id": "second_view",
+                              "type": "action",
+                              "exp": "{{foo.bar..}",
+                              "value": "end",
+                              "label": {
+                                "asset": {
+                                  "id": "next-view-label",
+                                  "type": "text",
+                                  "value": "End View 2"
+                                }
+                              }
+                            }
+                          ],
+                          "navigation": {
+                            "BEGIN": "flow_2",
+                            "flow_2": {
+                              "startState": "ACTION_2",
+                              "view_2": {
+                                "state_type": "VIEW",
+                                "ref": "second_view",
+                                "transitions": {
+                                  "*": "END_Done"
+                                }
+                              },
+                                     "ACTION_2": {
+                                       "state_type": "ACTION",
+                                       "exp": "{{foo}}",
+                                       "transitions": {
+                                         "*": "END_Done"
+                                       }
+                                     },
+                              "END_Done": {
+                                "state_type": "END",
+                                "outcome": "done"
+                              }
+                            }
+                          }
+                        }
+        """
 }

--- a/ios/internal-test-utils/Sources/TestDecoder.swift
+++ b/ios/internal-test-utils/Sources/TestDecoder.swift
@@ -1,13 +1,14 @@
 class TestDecoder: Decoder {
-    init() {
-        self.codingPath = []
-        self.userInfo = [:]
-    }
     var codingPath: [CodingKey]
 
     var userInfo: [CodingUserInfoKey: Any]
 
-    func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key: CodingKey {
+    init() {
+        codingPath = []
+        userInfo = [:]
+    }
+
+    func container<Key: CodingKey>(keyedBy _: Key.Type) throws -> KeyedDecodingContainer<Key> {
         fatalError("Not Implemented")
     }
 

--- a/ios/logger/Sources/LogLevel.swift
+++ b/ios/logger/Sources/LogLevel.swift
@@ -7,14 +7,8 @@
 
 import Foundation
 
-/**
- The different levels of logging
- */
+/// The different levels of logging
 public enum LogLevel: Int, CustomStringConvertible, Comparable, CaseIterable {
-    public static func < (lhs: LogLevel, rhs: LogLevel) -> Bool {
-        lhs.rawValue < rhs.rawValue
-    }
-
     /// Log all log statements
     case trace
 
@@ -32,22 +26,26 @@ public enum LogLevel: Int, CustomStringConvertible, Comparable, CaseIterable {
 
     public var description: String {
         switch self {
-        case .trace:    return "trace"
-        case .debug:    return "debug"
-        case .info:     return " info"
-        case .warning:  return " WARN"
-        case .error:    return "ERROR"
+        case .trace: return "trace"
+        case .debug: return "debug"
+        case .info: return " info"
+        case .warning: return " WARN"
+        case .error: return "ERROR"
         }
+    }
+
+    public static func < (lhs: LogLevel, rhs: LogLevel) -> Bool {
+        lhs.rawValue < rhs.rawValue
     }
 }
 
 extension LogLevel {
-    /**
-     Determines if a log message should proceed given the current log level
-     - parameters:
-        - currentLevel: The level to compare against to see if this instance should log
-     - returns:
-        Whether or not the message should log
-     */
-    func shouldLog(currentLevel: LogLevel) -> Bool { self >= currentLevel }
+    /// Determines if a log message should proceed given the current log level
+    /// - parameters:
+    ///   - currentLevel: The level to compare against to see if this instance should log
+    /// - returns:
+    ///   Whether or not the message should log
+    func shouldLog(currentLevel: LogLevel) -> Bool {
+        self >= currentLevel
+    }
 }

--- a/ios/logger/Sources/LogLevel.swift
+++ b/ios/logger/Sources/LogLevel.swift
@@ -26,11 +26,11 @@ public enum LogLevel: Int, CustomStringConvertible, Comparable, CaseIterable {
 
     public var description: String {
         switch self {
-        case .trace: return "trace"
-        case .debug: return "debug"
-        case .info: return " info"
-        case .warning: return " WARN"
-        case .error: return "ERROR"
+        case .trace: "trace"
+        case .debug: "debug"
+        case .info: " info"
+        case .warning: " WARN"
+        case .error: "ERROR"
         }
     }
 

--- a/ios/logger/Sources/TapableLogger.swift
+++ b/ios/logger/Sources/TapableLogger.swift
@@ -1,19 +1,15 @@
 import JavaScriptCore
 import SwiftHooks
 
-/**
- A Logger that has hooks to tap into the lifecycle
- */
+/// A Logger that has hooks to tap into the lifecycle
 public class TapableLogger {
     /// The minimum level of messages to log
     public var logLevel: LogLevel = .error
 
     /// Hooks to tap into the lifecycle
-    public let hooks = LoggerHooks()
+    public let hooks: LoggerHooks = .init()
 
-    /**
-     Creates a new TapableLogger
-     */
+    /// Creates a new TapableLogger
     public init() {
         hooks.convertJSValue.tap(name: "TapableLogger") { [weak self] value in
             guard let converted = self?.convertJSValue(value) else { return .skip }
@@ -21,83 +17,63 @@ public class TapableLogger {
         }
     }
 
-    /**
-     Logs a `trace` level message
-     - parameters:
-        - message: The message(s) to log
-     */
+    /// Logs a `trace` level message
+    /// - parameters:
+    ///   - message: The message(s) to log
     public func t(_ messages: Any...) {
         log(level: .trace, messages: messages)
     }
 
-    /**
-     Logs a `debug` level message
-     - parameters:
-        - message: The message(s) to log
-     */
+    /// Logs a `debug` level message
+    /// - parameters:
+    ///   - message: The message(s) to log
     public func d(_ messages: Any...) {
         log(level: .debug, messages: messages)
     }
 
-    /**
-     Logs an `info` level message
-     - parameters:
-        - message: The message(s) to log
-     */
+    /// Logs an `info` level message
+    /// - parameters:
+    ///   - message: The message(s) to log
     public func i(_ messages: Any...) {
         log(level: .info, messages: messages)
     }
 
-    /**
-     Logs a `warning` level message
-     - parameters:
-        - message: The message(s) to log
-     */
+    /// Logs a `warning` level message
+    /// - parameters:
+    ///   - message: The message(s) to log
     public func w(_ messages: Any...) {
         log(level: .warning, messages: messages)
     }
 
-    /**
-     Logs an `error` level message
-     - parameters:
-     - error: An error object to log
-     */
+    /// Logs an `error` level message
+    /// - parameters:
+    /// - error: An error object to log
     public func e(_ error: Error) {
         guard LogLevel.error.shouldLog(currentLevel: logLevel) else { return }
         hooks.error.call((nil, error))
     }
 
-    /**
-     Logs an `error` level message
-     - parameters:
-     - message: The message(s) to log
-     - error: An associated error object
-     */
+    /// Logs an `error` level message
+    /// - parameters:
+    /// - message: The message(s) to log
+    /// - error: An associated error object
     public func e(_ messages: Any..., er error: Error) {
         guard LogLevel.error.shouldLog(currentLevel: logLevel) else { return }
-            hooks.error.call((messages, error))
+        hooks.error.call((messages, error))
     }
 
-    /**
-     Logs an `error` level message
-     - parameters:
-     - message: The message(s) to log
-     */
+    /// Logs an `error` level message
+    /// - parameters:
+    /// - message: The message(s) to log
     public func e(_ messages: Any...) {
         log(level: .error, messages: messages)
     }
 
-    /// Function signature for log messages from the JS layer
-    public typealias JSLogFunction = @convention(block) (JSValue) -> Void
-
-    /**
-     Creates a log function that can be used in JavaScriptCore
-     - parameters:
-        - level: The log level to create the function for
-     - returns: A `JSLogFunction` to be used in JavaScriptCore
-     */
+    /// Creates a log function that can be used in JavaScriptCore
+    /// - parameters:
+    ///   - level: The log level to create the function for
+    /// - returns: A `JSLogFunction` to be used in JavaScriptCore
     public func getJSLogFor(level: LogLevel, _ context: JSContext) -> JSValue {
-
         // function generator that takes varadic parameters and forwards the arguments into an array
         guard let restWrapper = context.evaluateScript("(fn) => (...args) => fn(args)") else {
             return JSValue()
@@ -114,8 +90,7 @@ public class TapableLogger {
         return restWrapper.call(withArguments: [jsCallback as Any])
     }
 
-
-    internal func log(level: LogLevel, messages: [Any]) {
+    func log(level: LogLevel, messages: [Any]) {
         guard level.shouldLog(currentLevel: logLevel) else { return }
 
         switch level {
@@ -127,14 +102,13 @@ public class TapableLogger {
         }
     }
 
-    // other methods remain unchanged
-    /**
-     A default implementation to use for converting `JSValue` to `[Any]` when logging from JavaScriptCore
-     - parameters:
-        - value: The JSValue to convert
-     - returns: An array of Any
-     */
-    internal func convertJSValue(_ value: JSValue) -> [Any]? {
+    /// other methods remain unchanged
+    /// A default implementation to use for converting `JSValue` to `[Any]` when logging from
+    /// JavaScriptCore
+    /// - parameters:
+    ///   - value: The JSValue to convert
+    /// - returns: An array of Any
+    func convertJSValue(_ value: JSValue) -> [Any]? {
         guard
             !value.isUndefined
         else { return nil }
@@ -142,29 +116,30 @@ public class TapableLogger {
         // return as aAray if JSValue can be converted to array otherwise return object in an Array
         return value.isArray ? value.toArray() : [value.toObject() as Any]
     }
+
+    /// Function signature for log messages from the JS layer
+    public typealias JSLogFunction = @convention(block) (JSValue) -> Void
 }
 
-/**
- Hooks to allow tapping into logger lifecycle
- */
+/// Hooks to allow tapping into logger lifecycle
 public class LoggerHooks {
-    public typealias ErrorMessage = (message: [Any]?, error: Error?)
-
     /// Called for trace level messages
-    public let trace = SyncHook<[Any]>()
+    public let trace: SyncHook<[Any]> = .init()
 
     /// Called for debug level messages
-    public let debug = SyncHook<[Any]>()
+    public let debug: SyncHook<[Any]> = .init()
 
     /// Called for info level messages
-    public let info = SyncHook<[Any]>()
+    public let info: SyncHook<[Any]> = .init()
 
     /// Called for warning level messages
-    public let warn = SyncHook<[Any]>()
+    public let warn: SyncHook<[Any]> = .init()
 
     /// Called for error level messages
-    public let error = SyncHook<ErrorMessage>()
+    public let error: SyncHook<ErrorMessage> = .init()
 
     /// Called to convert a JSValue from the core player into `[Any]` before logging
-    public let convertJSValue = SyncBailHook<JSValue, [Any]>()
+    public let convertJSValue: SyncBailHook<JSValue, [Any]> = .init()
+
+    public typealias ErrorMessage = (message: [Any]?, error: Error?)
 }

--- a/ios/logger/Tests/LogLevelTests.swift
+++ b/ios/logger/Tests/LogLevelTests.swift
@@ -7,8 +7,8 @@
 //
 
 import Foundation
-import XCTest
 @testable import PlayerUILogger
+import XCTest
 
 class LogLevelTests: XCTestCase {
     func testShouldLog() {

--- a/ios/logger/Tests/TapableLoggerTests.swift
+++ b/ios/logger/Tests/TapableLoggerTests.swift
@@ -7,40 +7,44 @@
 //
 
 import Foundation
-import XCTest
 import JavaScriptCore
-import SwiftHooks
 @testable import PlayerUILogger
+import SwiftHooks
+import XCTest
 
 class TapableLoggerTests: XCTestCase {
-    func testJSConversion() {
-        let context = JSContext()!
+    func testJSConversion() throws {
+        let context = try XCTUnwrap(JSContext())
 
         let logger = TapableLogger()
 
-        let undef = context.evaluateScript("(undefined)")!
+        let undef = try XCTUnwrap(context.evaluateScript("(undefined)"))
 
-        let string = context.evaluateScript("('a')")!
+        let string = try XCTUnwrap(context.evaluateScript("('a')"))
 
-        let number = context.evaluateScript("(1)")!
+        let number = try XCTUnwrap(context.evaluateScript("(1)"))
 
-        let array = context.evaluateScript("(['a', 'b'])")!
+        let array = try XCTUnwrap(context.evaluateScript("(['a', 'b'])"))
 
-        let object = context.evaluateScript("({a: 1})")!
+        let object = try XCTUnwrap(context.evaluateScript("({a: 1})"))
 
-        let arrayOfObjectAndStrings = context.evaluateScript("(['message 1', {a: 1}, 'message 2'])")!
+        let arrayOfObjectAndStrings = try XCTUnwrap(context
+            .evaluateScript("(['message 1', {a: 1}, 'message 2'])"))
 
         XCTAssertNil(logger.convertJSValue(undef))
 
         XCTAssertEqual(logger.convertJSValue(string) as? [String], ["a"])
 
-        XCTAssertEqual(logger.convertJSValue(number) as? [Int] , [1])
+        XCTAssertEqual(logger.convertJSValue(number) as? [Int], [1])
 
-        XCTAssertEqual(logger.convertJSValue(array) as? [String] , ["a","b"])
+        XCTAssertEqual(logger.convertJSValue(array) as? [String], ["a", "b"])
 
-        XCTAssertEqual(logger.convertJSValue(object) as? [[String: Int]] , [["a":1]])
+        XCTAssertEqual(logger.convertJSValue(object) as? [[String: Int]], [["a": 1]])
 
-        XCTAssertEqual(logger.convertJSValue(arrayOfObjectAndStrings) as? [AnyHashable], ["message 1", ["a":1], "message 2"])
+        XCTAssertEqual(
+            logger.convertJSValue(arrayOfObjectAndStrings) as? [AnyHashable],
+            ["message 1", ["a": 1], "message 2"]
+        )
     }
 
     func testMessage() {
@@ -48,7 +52,7 @@ class TapableLoggerTests: XCTestCase {
         logger.logLevel = .info
 
         let logExpect = expectation(description: "Prefixed message logged")
-        logger.hooks.info.tap(name: "test") { (message) in
+        logger.hooks.info.tap(name: "test") { message in
             XCTAssertEqual("Message", (message as? [String])?.first)
             logExpect.fulfill()
         }
@@ -58,9 +62,6 @@ class TapableLoggerTests: XCTestCase {
         wait(for: [logExpect], timeout: 1)
     }
 
-    enum TestError: Error {
-        case errored
-    }
     func testLogHooks() {
         let logger = TapableLogger()
         logger.logLevel = .trace
@@ -98,6 +99,14 @@ class TapableLoggerTests: XCTestCase {
         logger.e(TestError.errored)
         logger.e("Message", er: TestError.errored)
 
-        wait(for: [traceExpect, debugExpect, infoExpect, warningExpect, errorExpect, errorMsgExpect, errorMsgAndErrorType], timeout: 1)
+        wait(
+            for: [traceExpect, debugExpect, infoExpect, warningExpect, errorExpect, errorMsgExpect,
+                  errorMsgAndErrorType],
+            timeout: 1
+        )
+    }
+
+    enum TestError: Error {
+        case errored
     }
 }

--- a/ios/swiftui/Sources/ManagedPlayer/ConstantFlowManager.swift
+++ b/ios/swiftui/Sources/ManagedPlayer/ConstantFlowManager.swift
@@ -5,50 +5,46 @@
 //  Created by Harris Borawski on 4/5/21.
 //
 
-import Foundation
 import Combine
+import Foundation
 
 #if SWIFT_PACKAGE
-import PlayerUI
+    import PlayerUI
 #endif
 
-/**
- A `FlowManager` implementation that advances through an array of flows on each
- successful flow completion with a variable delay for flow loading
- */
+/// A `FlowManager` implementation that advances through an array of flows on each
+/// successful flow completion with a variable delay for flow loading
 public class ConstantFlowManager: FlowManager {
     private var elements: [String]
     private var index = 0
     private var delay: TimeInterval
 
     private var previous: CompletedState?
-    /**
-     Creates a `ConstantFlowManager`
-     - parameters:
-        - elements: The full flow strings to use as flows in order
-        - delay: The time to delay when loading the next flow in the array, to show the loading screen
-     */
+
+    /// Creates a `ConstantFlowManager`
+    /// - parameters:
+    ///   - elements: The full flow strings to use as flows in order
+    ///   - delay: The time to delay when loading the next flow in the array, to show the loading
+    /// screen
     public init(_ elements: [String] = [], delay: TimeInterval = 1) {
         self.elements = elements
         self.delay = delay
     }
 
-    /**
-     Uses the result of the current flow to fetch the next flow, updating the publisher
-     - parameters:
-        - result: The result of the current flow
-     */
+    /// Uses the result of the current flow to fetch the next flow, updating the publisher
+    /// - parameters:
+    ///   - result: The result of the current flow
     public func next(_ result: CompletedState?) async throws -> NextState {
         if result == nil {
             index = 0
         } else if result?.flow.id != previous?.flow.id {
-            self.index += 1
+            index += 1
         }
 
         defer { self.previous = result }
         try await Task.sleep(nanoseconds: 1_000_000_000 * UInt64(delay))
-        if self.index < self.elements.count {
-            return .flow(self.elements[self.index])
+        if index < elements.count {
+            return .flow(elements[index])
         } else {
             return .finished
         }

--- a/ios/swiftui/Sources/ManagedPlayer/ConstantFlowManager.swift
+++ b/ios/swiftui/Sources/ManagedPlayer/ConstantFlowManager.swift
@@ -5,48 +5,43 @@
 //  Created by Harris Borawski on 4/5/21.
 //
 
-import Foundation
 import Combine
-
+import Foundation
 import PlayerUI
 
-/**
- A `FlowManager` implementation that advances through an array of flows on each
- successful flow completion with a variable delay for flow loading
- */
+/// A `FlowManager` implementation that advances through an array of flows on each
+/// successful flow completion with a variable delay for flow loading
 public class ConstantFlowManager: FlowManager {
     private var elements: [String]
     private var index = 0
     private var delay: TimeInterval
 
     private var previous: CompletedState?
-    /**
-     Creates a `ConstantFlowManager`
-     - parameters:
-        - elements: The full flow strings to use as flows in order
-        - delay: The time to delay when loading the next flow in the array, to show the loading screen
-     */
+
+    /// Creates a `ConstantFlowManager`
+    /// - parameters:
+    ///   - elements: The full flow strings to use as flows in order
+    ///   - delay: The time to delay when loading the next flow in the array, to show the loading
+    /// screen
     public init(_ elements: [String] = [], delay: TimeInterval = 1) {
         self.elements = elements
         self.delay = delay
     }
 
-    /**
-     Uses the result of the current flow to fetch the next flow, updating the publisher
-     - parameters:
-        - result: The result of the current flow
-     */
+    /// Uses the result of the current flow to fetch the next flow, updating the publisher
+    /// - parameters:
+    ///   - result: The result of the current flow
     public func next(result: CompletedState?) async throws -> String? {
         if result == nil {
             index = 0
         } else if result?.flow.id != previous?.flow.id {
-            self.index += 1
+            index += 1
         }
 
         defer { self.previous = result }
         try await Task.sleep(nanoseconds: 1_000_000_000 * UInt64(delay))
-        if self.index < self.elements.count {
-            return self.elements[self.index]
+        if index < elements.count {
+            return elements[index]
         } else {
             return nil
         }

--- a/ios/swiftui/Sources/ManagedPlayer/FlowManager.swift
+++ b/ios/swiftui/Sources/ManagedPlayer/FlowManager.swift
@@ -5,11 +5,11 @@
 //  Created by Harris Borawski on 3/26/21.
 //
 
-import Foundation
 import Combine
+import Foundation
 
 #if SWIFT_PACKAGE
-import PlayerUI
+    import PlayerUI
 #endif
 
 /// A state object to return from a FlowManager to advance
@@ -18,33 +18,25 @@ public enum NextState {
     case finished
 }
 
-/**
- A protocol declaring the required properties for a FlowManager
- that is used with the `ManagedPlayer` to orchestrate advancing between
- multiple flows from some data source
- */
+/// A protocol declaring the required properties for a FlowManager
+/// that is used with the `ManagedPlayer` to orchestrate advancing between
+/// multiple flows from some data source
 public protocol FlowManager {
-    /**
-     A function called to fetch the next flow
-     `CompletedState` will be `nil` if it is asking for the first state
-     - parameters:
-        - state: The `CompletedState` from the previous flow if there was one
-    */
+    /// A function called to fetch the next flow
+    /// `CompletedState` will be `nil` if it is asking for the first state
+    /// - parameters:
+    ///    - state: The `CompletedState` from the previous flow if there was one
     func next(_: CompletedState?) async throws -> NextState
 
-    /**
-     Called when the `ManagedPlayer` is being removed from the view tree
-     if there is a flow in progress, `state` will be non-nil, if `ManagedPlayer` is loading
-     a flow, or in an error state, `state` will be nil
-     - parameters:
-        - state: The InProgressState for the current flow
-     */
+    /// Called when the `ManagedPlayer` is being removed from the view tree
+    /// if there is a flow in progress, `state` will be non-nil, if `ManagedPlayer` is loading
+    /// a flow, or in an error state, `state` will be nil
+    /// - parameters:
+    ///   - state: The InProgressState for the current flow
     func terminate(state: InProgressState?)
 }
 
-/**
- Default Implementation for `terminate(player:)`
- */
+/// Default Implementation for `terminate(player:)`
 public extension FlowManager {
-    func terminate(state: InProgressState?) {}
+    func terminate(state _: InProgressState?) {}
 }

--- a/ios/swiftui/Sources/ManagedPlayer/FlowManager.swift
+++ b/ios/swiftui/Sources/ManagedPlayer/FlowManager.swift
@@ -5,38 +5,29 @@
 //  Created by Harris Borawski on 3/26/21.
 //
 
-import Foundation
 import Combine
-
+import Foundation
 import PlayerUI
 
-/**
- A protocol declaring the required properties for a FlowManager
- that is used with the `ManagedPlayer` to orchestrate advancing between
- multiple flows from some data source
- */
+/// A protocol declaring the required properties for a FlowManager
+/// that is used with the `ManagedPlayer` to orchestrate advancing between
+/// multiple flows from some data source
 public protocol FlowManager {
-    /**
-     A function called to fetch the next flow. If the flow is complete, return `nil`.
-     `CompletedState` will be `nil` if it is asking for the first state
-     - parameters:
-        - result: The `CompletedState` from the previous flow if there was one
-    */
+    /// A function called to fetch the next flow. If the flow is complete, return `nil`.
+    /// `CompletedState` will be `nil` if it is asking for the first state
+    /// - parameters:
+    ///    - result: The `CompletedState` from the previous flow if there was one
     func next(result: CompletedState?) async throws -> String?
 
-    /**
-     Called when the `ManagedPlayer` is being removed from the view tree
-     if there is a flow in progress, `state` will be non-nil, if `ManagedPlayer` is loading
-     a flow, or in an error state, `state` will be nil
-     - parameters:
-        - state: The InProgressState for the current flow
-     */
+    /// Called when the `ManagedPlayer` is being removed from the view tree
+    /// if there is a flow in progress, `state` will be non-nil, if `ManagedPlayer` is loading
+    /// a flow, or in an error state, `state` will be nil
+    /// - parameters:
+    ///   - state: The InProgressState for the current flow
     func terminate(state: InProgressState?)
 }
 
-/**
- Default Implementation for `terminate(player:)`
- */
+/// Default Implementation for `terminate(player:)`
 public extension FlowManager {
-    func terminate(state: InProgressState?) {}
+    func terminate(state _: InProgressState?) {}
 }

--- a/ios/swiftui/Sources/ManagedPlayer/ManagedPlayer.swift
+++ b/ios/swiftui/Sources/ManagedPlayer/ManagedPlayer.swift
@@ -5,49 +5,55 @@
 //  Created by Harris Borawski on 3/26/21.
 //
 
-import Foundation
-import SwiftUI
 import Combine
+import Foundation
 import JavaScriptCore
+import SwiftUI
 
 #if SWIFT_PACKAGE
-import PlayerUI
+    import PlayerUI
 #endif
 
-/**
- An error type for errors from `ManagedPlayer`
- */
+/// An error type for errors from `ManagedPlayer`
 public enum ManagedPlayerError: Error {
     /// An error if the flow was received from the `FlowManager` but was empty
     case emptyFlow
 }
 
-/**
- A wrapper around the `SwiftUIPlayer` that uses a `FlowManager` to proceed through multi-flow experiences
- */
+/// A wrapper around the `SwiftUIPlayer` that uses a `FlowManager` to proceed through multi-flow
+/// experiences
 public struct ManagedPlayer<Loading: View, Fallback: View>: View {
+    /// For ViewInspector testing
+    let inspection: Inspection<Self> = .init()
+
     private var plugins: [NativePlugin]
     private var flowManager: FlowManager?
-    @ObservedObject private var context: SwiftUIPlayer.Context
-
     private var loading: () -> Loading
     private var fallback: (ManagedPlayerErrorContext) -> Fallback
     private var viewModel: ManagedPlayerViewModel
 
     private var handleScroll: Bool
 
-    // For ViewInspector testing
-    internal let inspection = Inspection<Self>()
+    @ObservedObject private var context: SwiftUIPlayer.Context
 
-    /**
-     Creates a `ManagedPlayer`
-     - parameters:
-        - plugins: The plugins to use for the `SwiftUIPlayer`
-        - viewModel: The `ManagedPlayerViewModel` to use for fetching flows
-        - handleScroll: Whether or not the `ManagedPlayer` should wrap content in a `ScrollView`
-        - onError: A handler for when the `SwiftUIPlayer` encounters an error
-        - loading: A closure providing a `View` to display while the `FlowManager` fetches flows
-     */
+    public var body: some View {
+        ManagedPlayer14(
+            viewModel: viewModel,
+            plugins: plugins,
+            context: context,
+            handleScroll: handleScroll,
+            fallback: fallback,
+            loading: loading
+        ).onReceive(inspection.notice) { inspection.visit(self, $0) }
+    }
+
+    /// Creates a `ManagedPlayer`
+    /// - parameters:
+    ///   - plugins: The plugins to use for the `SwiftUIPlayer`
+    ///   - viewModel: The `ManagedPlayerViewModel` to use for fetching flows
+    ///   - handleScroll: Whether or not the `ManagedPlayer` should wrap content in a `ScrollView`
+    ///   - onError: A handler for when the `SwiftUIPlayer` encounters an error
+    ///   - loading: A closure providing a `View` to display while the `FlowManager` fetches flows
     public init(
         plugins: [NativePlugin],
         context: SwiftUIPlayer.Context = .sharedManaged,
@@ -65,16 +71,15 @@ public struct ManagedPlayer<Loading: View, Fallback: View>: View {
         plugins.apply(viewModel)
     }
 
-    /**
-     Creates a `ManagedPlayer`
-     - parameters:
-        - plugins: The plugins to use for the `SwiftUIPlayer`
-        - flowManager: The `FlowManager` to use for fetching flows
-        - handleScroll: Whether or not the `ManagedPlayer` should wrap content in a `ScrollView`
-        - onComplete: A handler for when the `FlowManager` signals that it has no more flows to fetch
-        - onError: A handler for when the `SwiftUIPlayer` encounters an error
-        - loading: A closure providing a `View` to display while the `FlowManager` fetches flows
-     */
+    /// Creates a `ManagedPlayer`
+    /// - parameters:
+    ///   - plugins: The plugins to use for the `SwiftUIPlayer`
+    ///   - flowManager: The `FlowManager` to use for fetching flows
+    ///   - handleScroll: Whether or not the `ManagedPlayer` should wrap content in a `ScrollView`
+    ///   - onComplete: A handler for when the `FlowManager` signals that it has no more flows to
+    /// fetch
+    ///   - onError: A handler for when the `SwiftUIPlayer` encounters an error
+    ///   - loading: A closure providing a `View` to display while the `FlowManager` fetches flows
     public init(
         plugins: [NativePlugin],
         flowManager: FlowManager,
@@ -93,45 +98,51 @@ public struct ManagedPlayer<Loading: View, Fallback: View>: View {
             loading: loading
         )
     }
-
-    public var body: some View {
-        ManagedPlayer14(
-            viewModel: viewModel,
-            plugins: plugins,
-            context: context,
-            handleScroll: handleScroll,
-            fallback: fallback,
-            loading: loading
-        ).onReceive(inspection.notice) { self.inspection.visit(self, $0) }
-    }
 }
-/**
- A managed version of the `SwiftUIPlayer` that uses a provided `FlowManager` to orchestrate
- loading Player through multiple flows, and showing a loading view in between flows
- */
-internal struct ManagedPlayer14<Loading: View, Fallback: View>: View {
-    @StateObject private var viewModel: ManagedPlayerViewModel
 
+/// A managed version of the `SwiftUIPlayer` that uses a provided `FlowManager` to orchestrate
+/// loading Player through multiple flows, and showing a loading view in between flows
+struct ManagedPlayer14<Loading: View, Fallback: View>: View {
     private var plugins: [NativePlugin]
-    @ObservedObject private var context: SwiftUIPlayer.Context
-
-    @State private var inViewState = false
-
     private var loading: () -> Loading
     private var fallback: (ManagedPlayerErrorContext) -> Fallback
 
     private var handleScroll: Bool
 
-    /**
-     Creates a `ManagedPlayer`
-     - parameters:
-        - viewModel: The `ManagedPlayerViewModel` to use for fetching flows
-        - plugins: The plugins to use for the `SwiftUIPlayer`
-        - handleScroll: Whether or not the `ManagedPlayer` should wrap content in a `ScrollView`
-        - onError: A handler for when the `SwiftUIPlayer` encounters an error
-        - loading: A closure providing a `View` to display while the `FlowManager` fetches flows
-     */
-    public init(
+    @StateObject private var viewModel: ManagedPlayerViewModel
+
+    @ObservedObject private var context: SwiftUIPlayer.Context
+
+    @State private var inViewState = false
+
+    var body: some View {
+        bodyContent(viewModel.stateTransition.call() ?? .identity)
+            .onDisappear {
+                context.unload()
+            }
+    }
+
+    var scrollPlugin: [NativePlugin] {
+        guard
+            plugins.filter({ $0 is ScrollPlugin }).isEmpty,
+            handleScroll
+        else { return [] }
+        return [ScrollPlugin()]
+    }
+
+    private var isViewLoaded: Bool {
+        guard case .loaded = viewModel.loadingState else { return false }
+        return inViewState
+    }
+
+    /// Creates a `ManagedPlayer`
+    /// - parameters:
+    ///   - viewModel: The `ManagedPlayerViewModel` to use for fetching flows
+    ///   - plugins: The plugins to use for the `SwiftUIPlayer`
+    ///   - handleScroll: Whether or not the `ManagedPlayer` should wrap content in a `ScrollView`
+    ///   - onError: A handler for when the `SwiftUIPlayer` encounters an error
+    ///   - loading: A closure providing a `View` to display while the `FlowManager` fetches flows
+    init(
         viewModel: ManagedPlayerViewModel,
         plugins: [NativePlugin],
         context: SwiftUIPlayer.Context = .sharedManaged,
@@ -141,22 +152,21 @@ internal struct ManagedPlayer14<Loading: View, Fallback: View>: View {
     ) {
         _viewModel = StateObject(wrappedValue: viewModel)
         self.plugins = plugins
-        self._context = ObservedObject(initialValue: context)
+        _context = ObservedObject(initialValue: context)
         self.loading = loading
         self.fallback = fallback
         self.handleScroll = handleScroll
     }
 
-    public var body: some View {
-        bodyContent(viewModel.stateTransition.call() ?? .identity)
-            .onDisappear {
-                context.unload()
-            }
-    }
-
-    private var isViewLoaded: Bool {
-        guard case .loaded = viewModel.loadingState else { return false }
-        return inViewState
+    func makePlayerView(flow: String) -> some View {
+        SwiftUIPlayer(
+            flow: flow,
+            plugins: plugins + [viewModel] + scrollPlugin +
+                [ToggleInViewPlugin(isViewLoaded: $inViewState)],
+            result: $viewModel.result,
+            context: context,
+            unloadOnDisappear: false
+        )
     }
 
     private func bodyContent(_ transitionInfo: PlayerViewTransition) -> some View {
@@ -168,29 +178,38 @@ internal struct ManagedPlayer14<Loading: View, Fallback: View>: View {
                         context.unload()
                         Task { await viewModel.next() }
                     }
-                case .retry(let prevResult):
+                case let .retry(prevResult):
                     Color.clear.onAppear {
                         context.unload()
                         Task { await viewModel.next(prevResult) }
                     }
-                case .failed(let error):
-                    fallback(ManagedPlayerErrorContext(error: error, retry: viewModel.retry, reset: viewModel.reset)).onAppear { context.unload() }
-                case .loading, .loaded:
-                    /// to prevent alternative between loaded and loading state when flows reach multiple non VIEW states after another causing flickering of the loading spinner, change the opacity to show either the loading view or the player view
+                case let .failed(error):
+                    fallback(ManagedPlayerErrorContext(
+                        error: error,
+                        retry: viewModel.retry,
+                        reset: viewModel.reset
+                    )).onAppear { context.unload() }
+                case .loaded, .loading:
+                    // to prevent alternative between loaded and loading state when flows reach
+                    // multiple non VIEW states after another causing flickering of the loading
+                    // spinner, change the opacity to show either the loading view or the player
+                    // view
                     ZStack {
-                        // use isViewLoaded to determine when the loader is shown instead of checking for .loading case
+                        // use isViewLoaded to determine when the loader is shown instead of
+                        // checking for .loading case
                         loading().opacity(isViewLoaded ? 0 : 1)
-                        
-                        if case .loaded(let flow) = viewModel.loadingState {
+
+                        if case let .loaded(flow) = viewModel.loadingState {
                             makePlayerView(flow: flow).opacity(isViewLoaded ? 1 : 0)
                         }
                     }
                     .onChange(of: viewModel.loadingState) { newState in
                         if case .loading = newState {
-                            context.logger.d("loadingState changed to .loading - calling context.unload()")
+                            context.logger
+                                .d("loadingState changed to .loading - calling context.unload()")
                             // only call unload if were in loading state
                             context.unload()
-                        } else if case .loaded(let flow) = newState {
+                        } else if case let .loaded(flow) = newState {
                             context.logger.d("loadingState changed to .loaded")
                         }
                     }
@@ -199,65 +218,47 @@ internal struct ManagedPlayer14<Loading: View, Fallback: View>: View {
         }
         .animation(transitionInfo.animationCurve, value: viewModel.loadingState)
     }
-
-    func makePlayerView(flow: String) -> some View {
-        SwiftUIPlayer(
-            flow: flow,
-            plugins: plugins + [viewModel] + scrollPlugin + [ToggleInViewPlugin(isViewLoaded: self.$inViewState)],
-            result: $viewModel.result,
-            context: context,
-            unloadOnDisappear: false
-        )
-    }
-
-    var scrollPlugin: [NativePlugin] {
-        guard
-            plugins.filter({ $0 as? ScrollPlugin != nil }).count == 0,
-            handleScroll
-        else { return [] }
-        return [ScrollPlugin()]
-    }
 }
 
-/// A plugin for the passed into the SwiftUIPlayer for determining when a view has been loaded based on the binding passed in
+/// A plugin for the passed into the SwiftUIPlayer for determining when a view has been loaded based
+/// on the binding passed in
 /// updates that binding to false once the view disappears
-fileprivate class ToggleInViewPlugin: NativePlugin {
+private class ToggleInViewPlugin: NativePlugin {
+    var pluginName: String = "ToggleInViewPlugin"
 
-    @Binding public var isViewLoaded: Bool
+    @Binding var isViewLoaded: Bool
 
-    public init(isViewLoaded: Binding<Bool>) {
-        self._isViewLoaded = isViewLoaded
+    init(isViewLoaded: Binding<Bool>) {
+        _isViewLoaded = isViewLoaded
     }
 
-   public var pluginName: String = "ToggleInViewPlugin"
-
-   public func apply<P>(player: P) where P: HeadlessPlayer {
+    func apply<P: HeadlessPlayer>(player: P) {
         guard let player = player as? SwiftUIPlayer else { return }
 
-       player.hooks?.flowController.tap { flowController in
+        player.hooks?.flowController.tap { flowController in
             flowController.hooks.flow.tap { flow in
                 flow.hooks.transition.tap { [weak self] _, newState in
-                    // set isViewLoaded back to false to show loading spinner when we transition to non view
+                    // set isViewLoaded back to false to show loading spinner when we transition to
+                    // non view
                     if (newState.value as? NavigationFlowViewState) == nil {
                         DispatchQueue.main.async {
-                          self?.$isViewLoaded.wrappedValue = false
+                            self?.$isViewLoaded.wrappedValue = false
                         }
-
                     }
                 }
             }
         }
 
-       // ensures we only set isViewLoaded to true once a view has been loaded
-        player.hooks?.viewController.tap({ (viewController) in
-            viewController.hooks.view.tap { (view) in
-                view.hooks.onUpdate.tap { [weak self] val in
+        // ensures we only set isViewLoaded to true once a view has been loaded
+        player.hooks?.viewController.tap { viewController in
+            viewController.hooks.view.tap { view in
+                view.hooks.onUpdate.tap { [weak self] _ in
                     DispatchQueue.main.async {
                         self?.$isViewLoaded.wrappedValue = true
                     }
                 }
             }
-        })
+        }
     }
 }
 
@@ -274,7 +275,9 @@ public extension SwiftUIPlayer.Context {
 }
 
 private extension JSContext {
-    static var sharedManaged: JSContext! { JSContext(virtualMachine: .playerShared) }
+    static var sharedManaged: JSContext! {
+        JSContext(virtualMachine: .playerShared)
+    }
 }
 
 private extension JSVirtualMachine {
@@ -287,26 +290,22 @@ public typealias ManagedPlayerRetry = () -> Void
 /// A function for resetting the `FlowManager`
 public typealias ManagedPlayerReset = () -> Void
 
-/**
- The context for constructing a fallback component when there is an error in the `FlowManager`
- */
+/// The context for constructing a fallback component when there is an error in the `FlowManager`
 public struct ManagedPlayerErrorContext {
     /// The Error that occurred
     public var error: Error
     /// A function for retrying the previous flow load (recalls `next` with the same CompletedState)
     public var retry: ManagedPlayerRetry
 
-    /// A function for resetting the `FlowManager` (calls `next` with `nil` to fetch the first flow again)
+    /// A function for resetting the `FlowManager` (calls `next` with `nil` to fetch the first flow
+    /// again)
     public var reset: ManagedPlayerReset
 }
 
-/**
- A helper for ViewInspector
- */
-internal final class Inspection<V> where V: View {
-
-    let notice = PassthroughSubject<UInt, Never>()
-    var callbacks = [UInt: (V) -> Void]()
+/// A helper for ViewInspector
+final class Inspection<V: View> {
+    let notice: PassthroughSubject<UInt, Never> = .init()
+    var callbacks: [UInt: (V) -> Void] = [:]
 
     func visit(_ view: V, _ line: UInt) {
         if let callback = callbacks.removeValue(forKey: line) {

--- a/ios/swiftui/Sources/ManagedPlayer/ManagedPlayer.swift
+++ b/ios/swiftui/Sources/ManagedPlayer/ManagedPlayer.swift
@@ -5,12 +5,11 @@
 //  Created by Harris Borawski on 3/26/21.
 //
 
-import Foundation
-import SwiftUI
 import Combine
+import Foundation
 import JavaScriptCore
-
 import PlayerUI
+import SwiftUI
 
 /// An error type for errors from `ManagedPlayer`
 public enum ManagedPlayerError: Error {
@@ -18,20 +17,32 @@ public enum ManagedPlayerError: Error {
     case emptyFlow
 }
 
-/// A wrapper around the `SwiftUIPlayer` that uses a `FlowManager` to proceed through multi-flow experiences
+/// A wrapper around the `SwiftUIPlayer` that uses a `FlowManager` to proceed through multi-flow
+/// experiences
 public struct ManagedPlayer<Loading: View, Fallback: View>: View {
+    /// For ViewInspector testing
+    let inspection: Inspection<Self> = .init()
+
     private var plugins: [NativePlugin]
     private var flowManager: FlowManager?
-    @ObservedObject private var context: SwiftUIPlayer.Context
-
     private var loading: () -> Loading
     private var fallback: (ManagedPlayerErrorContext) -> Fallback
     private var viewModel: ManagedPlayerViewModel
 
     private var handleScroll: Bool
 
-    // For ViewInspector testing
-    internal let inspection = Inspection<Self>()
+    @ObservedObject private var context: SwiftUIPlayer.Context
+
+    public var body: some View {
+        ManagedPlayer14(
+            viewModel: viewModel,
+            plugins: plugins,
+            context: context,
+            handleScroll: handleScroll,
+            fallback: fallback,
+            loading: loading
+        ).onReceive(inspection.notice) { inspection.visit(self, $0) }
+    }
 
     /// Creates a `ManagedPlayer`
     /// - parameters:
@@ -62,8 +73,10 @@ public struct ManagedPlayer<Loading: View, Fallback: View>: View {
     ///    - plugins: The plugins to use for the `SwiftUIPlayer`
     ///    - flowManager: The `FlowManager` to use for fetching flows
     ///    - handleScroll: Whether or not the `ManagedPlayer` should wrap content in a `ScrollView`
-    ///    - onComplete: A handler for when the `FlowManager` signals that it has no more flows to fetch
-    ///    - onStartedFlow: A handler for when a flow is started, passed the flow `String` that was used to start it
+    ///    - onComplete: A handler for when the `FlowManager` signals that it has no more flows to
+    /// fetch
+    ///    - onStartedFlow: A handler for when a flow is started, passed the flow `String` that was
+    /// used to start it
     ///    - onError: A handler for when the `SwiftUIPlayer` encounters an error
     ///    - loading: A closure providing a `View` to display while the `FlowManager` fetches flows
     public init(
@@ -79,38 +92,52 @@ public struct ManagedPlayer<Loading: View, Fallback: View>: View {
         self.init(
             plugins: plugins,
             context: context,
-            viewModel: ManagedPlayerViewModel(manager: flowManager, onComplete: onComplete, onStartedFlow: onStartedFlow),
+            viewModel: ManagedPlayerViewModel(
+                manager: flowManager,
+                onComplete: onComplete,
+                onStartedFlow: onStartedFlow
+            ),
             handleScroll: handleScroll,
             fallback: fallback,
             loading: loading
         )
     }
-
-    public var body: some View {
-        ManagedPlayer14(
-            viewModel: viewModel,
-            plugins: plugins,
-            context: context,
-            handleScroll: handleScroll,
-            fallback: fallback,
-            loading: loading
-        ).onReceive(inspection.notice) { self.inspection.visit(self, $0) }
-    }
 }
+
 /// A managed version of the `SwiftUIPlayer` that uses a provided `FlowManager` to orchestrate
 /// loading Player through multiple flows, and showing a loading view in between flows
-internal struct ManagedPlayer14<Loading: View, Fallback: View>: View {
-    @StateObject private var viewModel: ManagedPlayerViewModel
-
+struct ManagedPlayer14<Loading: View, Fallback: View>: View {
     private var plugins: [NativePlugin]
-    @ObservedObject private var context: SwiftUIPlayer.Context
-
-    @State private var inViewState = false
-
     private var loading: () -> Loading
     private var fallback: (ManagedPlayerErrorContext) -> Fallback
 
     private var handleScroll: Bool
+
+    @StateObject private var viewModel: ManagedPlayerViewModel
+
+    @ObservedObject private var context: SwiftUIPlayer.Context
+
+    @State private var inViewState = false
+
+    var body: some View {
+        bodyContent(viewModel.stateTransition.call() ?? .identity)
+            .onDisappear {
+                context.clearExceptionHandler()
+            }
+    }
+
+    var scrollPlugin: [NativePlugin] {
+        guard
+            plugins.filter({ $0 is ScrollPlugin }).isEmpty,
+            handleScroll
+        else { return [] }
+        return [ScrollPlugin()]
+    }
+
+    private var isViewLoaded: Bool {
+        guard case .loaded = viewModel.loadingState else { return false }
+        return inViewState
+    }
 
     /// Creates a `ManagedPlayer`
     /// - parameters:
@@ -119,7 +146,7 @@ internal struct ManagedPlayer14<Loading: View, Fallback: View>: View {
     ///    - handleScroll: Whether or not the `ManagedPlayer` should wrap content in a `ScrollView`
     ///    - onError: A handler for when the `SwiftUIPlayer` encounters an error
     ///    - loading: A closure providing a `View` to display while the `FlowManager` fetches flows
-    public init(
+    init(
         viewModel: ManagedPlayerViewModel,
         plugins: [NativePlugin],
         context: SwiftUIPlayer.Context = .sharedManaged,
@@ -129,22 +156,21 @@ internal struct ManagedPlayer14<Loading: View, Fallback: View>: View {
     ) {
         _viewModel = StateObject(wrappedValue: viewModel)
         self.plugins = plugins
-        self._context = ObservedObject(initialValue: context)
+        _context = ObservedObject(initialValue: context)
         self.loading = loading
         self.fallback = fallback
         self.handleScroll = handleScroll
     }
 
-    public var body: some View {
-        bodyContent(viewModel.stateTransition.call() ?? .identity)
-            .onDisappear {
-                context.clearExceptionHandler()
-            }
-    }
-
-    private var isViewLoaded: Bool {
-        guard case .loaded = viewModel.loadingState else { return false }
-        return inViewState
+    func makePlayerView(flow: String) -> some View {
+        SwiftUIPlayer(
+            flow: flow,
+            plugins: plugins + [viewModel] + scrollPlugin +
+                [ToggleInViewPlugin(isViewLoaded: $inViewState)],
+            result: $viewModel.result,
+            context: context,
+            unloadOnDisappear: false
+        )
     }
 
     private func bodyContent(_ transitionInfo: PlayerViewTransition) -> some View {
@@ -156,29 +182,38 @@ internal struct ManagedPlayer14<Loading: View, Fallback: View>: View {
                         context.unload()
                         Task { await viewModel.next() }
                     }
-                case .retry(let prevResult):
+                case let .retry(prevResult):
                     Color.clear.onAppear {
                         context.unload()
                         Task { await viewModel.next(prevResult) }
                     }
-                case .failed(let error):
-                    fallback(ManagedPlayerErrorContext(error: error, retry: viewModel.retry, reset: viewModel.reset)).onAppear { context.unload() }
-                case .loading, .loaded:
-                    /// to prevent alternative between loaded and loading state when flows reach multiple non VIEW states after another causing flickering of the loading spinner, change the opacity to show either the loading view or the player view
+                case let .failed(error):
+                    fallback(ManagedPlayerErrorContext(
+                        error: error,
+                        retry: viewModel.retry,
+                        reset: viewModel.reset
+                    )).onAppear { context.unload() }
+                case .loaded, .loading:
+                    // to prevent alternative between loaded and loading state when flows reach
+                    // multiple non VIEW states after another causing flickering of the loading
+                    // spinner, change the opacity to show either the loading view or the player
+                    // view
                     ZStack {
-                        // use isViewLoaded to determine when the loader is shown instead of checking for .loading case
+                        // use isViewLoaded to determine when the loader is shown instead of
+                        // checking for .loading case
                         loading().opacity(isViewLoaded ? 0 : 1)
-                        
-                        if case .loaded(let flow) = viewModel.loadingState {
+
+                        if case let .loaded(flow) = viewModel.loadingState {
                             makePlayerView(flow: flow).opacity(isViewLoaded ? 1 : 0)
                         }
                     }
                     .onChange(of: viewModel.loadingState) { newState in
                         if case .loading = newState {
-                            context.logger.d("loadingState changed to .loading - calling context.unload()")
+                            context.logger
+                                .d("loadingState changed to .loading - calling context.unload()")
                             // only call unload if were in loading state
                             context.unload()
-                        } else if case .loaded(_) = newState {
+                        } else if case .loaded = newState {
                             context.logger.d("loadingState changed to .loaded")
                         }
                     }
@@ -187,65 +222,47 @@ internal struct ManagedPlayer14<Loading: View, Fallback: View>: View {
         }
         .animation(transitionInfo.animationCurve, value: viewModel.loadingState)
     }
-
-    func makePlayerView(flow: String) -> some View {
-        SwiftUIPlayer(
-            flow: flow,
-            plugins: plugins + [viewModel] + scrollPlugin + [ToggleInViewPlugin(isViewLoaded: self.$inViewState)],
-            result: $viewModel.result,
-            context: context,
-            unloadOnDisappear: false
-        )
-    }
-
-    var scrollPlugin: [NativePlugin] {
-        guard
-            plugins.filter({ $0 as? ScrollPlugin != nil }).count == 0,
-            handleScroll
-        else { return [] }
-        return [ScrollPlugin()]
-    }
 }
 
-/// A plugin for the passed into the SwiftUIPlayer for determining when a view has been loaded based on the binding passed in
+/// A plugin for the passed into the SwiftUIPlayer for determining when a view has been loaded based
+/// on the binding passed in
 /// updates that binding to false once the view disappears
-fileprivate class ToggleInViewPlugin: NativePlugin {
+private class ToggleInViewPlugin: NativePlugin {
+    var pluginName: String = "ToggleInViewPlugin"
 
-    @Binding public var isViewLoaded: Bool
+    @Binding var isViewLoaded: Bool
 
-    public init(isViewLoaded: Binding<Bool>) {
-        self._isViewLoaded = isViewLoaded
+    init(isViewLoaded: Binding<Bool>) {
+        _isViewLoaded = isViewLoaded
     }
 
-   public var pluginName: String = "ToggleInViewPlugin"
-
-   public func apply<P>(player: P) where P: HeadlessPlayer {
+    func apply<P: HeadlessPlayer>(player: P) {
         guard let player = player as? SwiftUIPlayer else { return }
 
-       player.hooks?.flowController.tap { flowController in
+        player.hooks?.flowController.tap { flowController in
             flowController.hooks.flow.tap { flow in
                 flow.hooks.transition.tap { [weak self] _, newState in
-                    // set isViewLoaded back to false to show loading spinner when we transition to non view
+                    // set isViewLoaded back to false to show loading spinner when we transition to
+                    // non view
                     if (newState.value as? NavigationFlowViewState) == nil {
                         DispatchQueue.main.async {
-                          self?.$isViewLoaded.wrappedValue = false
+                            self?.$isViewLoaded.wrappedValue = false
                         }
-
                     }
                 }
             }
         }
 
-       // ensures we only set isViewLoaded to true once a view has been loaded
-        player.hooks?.viewController.tap({ (viewController) in
-            viewController.hooks.view.tap { (view) in
-                view.hooks.onUpdate.tap { [weak self] val in
+        // ensures we only set isViewLoaded to true once a view has been loaded
+        player.hooks?.viewController.tap { viewController in
+            viewController.hooks.view.tap { view in
+                view.hooks.onUpdate.tap { [weak self] _ in
                     DispatchQueue.main.async {
                         self?.$isViewLoaded.wrappedValue = true
                     }
                 }
             }
-        })
+        }
     }
 }
 
@@ -262,7 +279,9 @@ public extension SwiftUIPlayer.Context {
 }
 
 private extension JSContext {
-    static var sharedManaged: JSContext! { JSContext(virtualMachine: .playerShared) }
+    static var sharedManaged: JSContext! {
+        JSContext(virtualMachine: .playerShared)
+    }
 }
 
 private extension JSVirtualMachine {
@@ -282,17 +301,17 @@ public struct ManagedPlayerErrorContext {
     /// A function for retrying the previous flow load (recalls `next` with the same CompletedState)
     public var retry: ManagedPlayerRetry
 
-    /// A function for resetting the `FlowManager` (calls `next` with `nil` to fetch the first flow again)
+    /// A function for resetting the `FlowManager` (calls `next` with `nil` to fetch the first flow
+    /// again)
     public var reset: ManagedPlayerReset
 }
 
 /// A helper for ViewInspector.
 /// Marked `@unchecked Sendable` to satisfy `InspectionEmissary` conformance;
 /// this class is only used in test targets and is always accessed from the main thread.
-internal final class Inspection<V>: @unchecked Sendable where V: View {
-
-    let notice = PassthroughSubject<UInt, Never>()
-    var callbacks = [UInt: (V) -> Void]()
+final class Inspection<V: View>: @unchecked Sendable {
+    let notice: PassthroughSubject<UInt, Never> = .init()
+    var callbacks: [UInt: (V) -> Void] = [:]
 
     func visit(_ view: V, _ line: UInt) {
         if let callback = callbacks.removeValue(forKey: line) {

--- a/ios/swiftui/Sources/ManagedPlayer/ManagedPlayer.swift
+++ b/ios/swiftui/Sources/ManagedPlayer/ManagedPlayer.swift
@@ -236,7 +236,7 @@ private class ToggleInViewPlugin: NativePlugin {
         _isViewLoaded = isViewLoaded
     }
 
-    func apply<P: HeadlessPlayer>(player: P) {
+    func apply(player: some HeadlessPlayer) {
         guard let player = player as? SwiftUIPlayer else { return }
 
         player.hooks?.flowController.tap { flowController in
@@ -266,7 +266,7 @@ private class ToggleInViewPlugin: NativePlugin {
     }
 }
 
-private extension Collection where Element == NativePlugin {
+private extension Collection<NativePlugin> {
     func apply(_ model: ManagedPlayerViewModel) {
         compactMap { $0 as? ManagedPlayerPlugin }.forEach { $0.apply(model) }
     }

--- a/ios/swiftui/Sources/ManagedPlayer/ManagedPlayerViewModel.swift
+++ b/ios/swiftui/Sources/ManagedPlayer/ManagedPlayerViewModel.swift
@@ -5,63 +5,28 @@
 //  Created by Harris Borawski on 3/26/21.
 //
 
-import Foundation
 import Combine
+import Foundation
 import SwiftHooks
 
 #if SWIFT_PACKAGE
-import PlayerUI
+    import PlayerUI
 #endif
 
 /// A plugin used by the ManagedPlayer.
 ///
-/// When a ManagedPlayer is instantiated it will call `apply(_:)` on all managed player plugins it is
+/// When a ManagedPlayer is instantiated it will call `apply(_:)` on all managed player plugins it
+/// is
 /// provided.
 public protocol ManagedPlayerPlugin {
     /// Called by the ManagedPlayer upon instantiation.
     func apply(_ model: ManagedPlayerViewModel)
 }
 
-/**
- A ViewModel for the `ManagedPlayer` that orchestrates the use of the `FlowManager`
- passed to it
- */
+/// A ViewModel for the `ManagedPlayer` that orchestrates the use of the `FlowManager`
+/// passed to it
 public class ManagedPlayerViewModel: ObservableObject, NativePlugin {
     public var pluginName: String = "ManagedPlayerViewModel"
-
-    /**
-     The state of loading flows
-     */
-    public enum LoadingState: Equatable {
-        public static func == (lhs: Self, rhs: Self) -> Bool {
-            switch (lhs, rhs) {
-            case (.idle, .idle):                                        return true
-            case (.loading, .loading):                                  return true
-            case (.loaded(let lll), .loaded(let rrr)) where lll == rrr: return true
-            case (.retry(let lll), .retry(let rrr)) where lll === rrr:  return true
-            default:                                                    return false
-            }
-        }
-
-        var isLoaded: Bool {
-            guard case .loaded = self else { return false }
-            return true
-        }
-
-        /// Player has been constructed but not yet fetching
-        case idle
-        /// An error occurred and a retry can be attempted
-        case retry(CompletedState)
-        /// Loading the next flow
-        case loading
-        /// The flow failed with an error
-        case failed(Error)
-        /// Flow was successfully loaded
-        case loaded(String)
-    }
-
-    /// The Loading State for `ManagedPlayer`
-    @Published private(set) var loadingState: LoadingState = .idle
 
     /// The current flow to run in the `SwiftUIPlayer`
     @Published public var flow: String?
@@ -70,16 +35,16 @@ public class ManagedPlayerViewModel: ObservableObject, NativePlugin {
     @Published public var result: Result<CompletedState, PlayerError>?
 
     /// Provide Transition Animation information for load state transitions in managed flows
-    public let stateTransition = SyncBailHook<Void, PlayerViewTransition>()
+    public let stateTransition: SyncBailHook<Void, PlayerViewTransition> = .init()
 
     /// A function to get the delay for view transitions
     public var getDelay: (() -> Double?)?
 
-    /// Logger instance from current player
-    private var logger: JSLogger?
+    /// The Loading State for `ManagedPlayer`
+    @Published private(set) var loadingState: LoadingState = .idle
 
     /// The current state of the current player
-    internal var currentState: InProgressState?
+    var currentState: InProgressState?
 
     /// The last completed state
     private var prevResult: CompletedState?
@@ -91,15 +56,14 @@ public class ManagedPlayerViewModel: ObservableObject, NativePlugin {
     /// The `FlowManager` that is used for this instance
     private var manager: FlowManager
 
-    private var bag = Set<AnyCancellable>()
+    private var bag: Set<AnyCancellable> = []
 
-    /**
-     Creates a new `ManagedPlayerViewModel`
-     - parameters:
-        - manager: The `FlowManager` to use for fetching flows
-        - onComplete: A handler for when the `FlowManager` signals that it has no more flows to fetch
-        - onError: A handler for when the `SwiftUIPlayer` encounters an error
-     */
+    /// Creates a new `ManagedPlayerViewModel`
+    /// - parameters:
+    ///   - manager: The `FlowManager` to use for fetching flows
+    ///   - onComplete: A handler for when the `FlowManager` signals that it has no more flows to
+    /// fetch
+    ///   - onError: A handler for when the `SwiftUIPlayer` encounters an error
     public init(
         manager: FlowManager,
         onComplete: @escaping (CompletedState) -> Void
@@ -108,28 +72,49 @@ public class ManagedPlayerViewModel: ObservableObject, NativePlugin {
         self.onComplete = onComplete
 
         $result.sink { [weak self] result in
-            guard let result = result else { return }
+            guard let result else { return }
             self?.handleResult(result)
-        }.store(in: &bag)
+        }
+        .store(in: &bag)
     }
 
-    public func apply<P>(player: P) where P: HeadlessPlayer {
-        player.hooks?.state.tap({ [weak self] (state) in
+    deinit {
+        manager.terminate(state: currentState)
+        bag.forEach { $0.cancel() }
+    }
+
+    public func apply<P: HeadlessPlayer>(player: P) {
+        player.hooks?.state.tap { [weak self] state in
             guard let inProgress = state as? InProgressState else {
                 self?.currentState = nil
                 return
             }
             self?.currentState = inProgress
-        })
+        }
+    }
+
+    /// Resets and starts the multi-flow experience from the beginning
+    public func reset() {
+        prevResult = nil
+        loadingState = .idle
+    }
+
+    /// Refetches the last loaded flow
+    public func retry() {
+        if let prev = prevResult {
+            loadingState = .retry(prev)
+        } else {
+            loadingState = .idle
+        }
     }
 
     func handleResult(_ result: Result<CompletedState, PlayerError>) {
         switch result {
-        case .success(let completed):
-            self.prevResult = completed
+        case let .success(completed):
+            prevResult = completed
             Task { [weak self] in await self?.next(completed) }
-        case .failure(let error):
-            self.loadingState = .failed(error)
+        case let .failure(error):
+            loadingState = .failed(error)
         }
     }
 
@@ -150,7 +135,7 @@ public class ManagedPlayerViewModel: ObservableObject, NativePlugin {
     func handleNextState(_ state: NextState) {
         prevState = state
         switch state {
-        case .flow(let flow):
+        case let .flow(flow):
             if !flow.isEmpty {
                 self.flow = flow
                 loadingState = .loaded(flow)
@@ -163,27 +148,32 @@ public class ManagedPlayerViewModel: ObservableObject, NativePlugin {
         }
     }
 
-    /**
-     Resets and starts the multi-flow experience from the beginning
-     */
-    public func reset() {
-        prevResult = nil
-        loadingState = .idle
-    }
+    /// The state of loading flows
+    public enum LoadingState: Equatable {
+        /// Player has been constructed but not yet fetching
+        case idle
+        /// An error occurred and a retry can be attempted
+        case retry(CompletedState)
+        /// Loading the next flow
+        case loading
+        /// The flow failed with an error
+        case failed(Error)
+        /// Flow was successfully loaded
+        case loaded(String)
 
-    /**
-     Refetches the last loaded flow
-     */
-    public func retry() {
-        if let prev = prevResult {
-            loadingState = .retry(prev)
-        } else {
-            loadingState = .idle
+        var isLoaded: Bool {
+            guard case .loaded = self else { return false }
+            return true
         }
-    }
 
-    deinit {
-        manager.terminate(state: currentState)
-        bag.forEach { $0.cancel() }
+        public static func == (lhs: Self, rhs: Self) -> Bool {
+            switch (lhs, rhs) {
+            case (.idle, .idle): return true
+            case (.loading, .loading): return true
+            case let (.loaded(lll), .loaded(rrr)) where lll == rrr: return true
+            case let (.retry(lll), .retry(rrr)) where lll === rrr: return true
+            default: return false
+            }
+        }
     }
 }

--- a/ios/swiftui/Sources/ManagedPlayer/ManagedPlayerViewModel.swift
+++ b/ios/swiftui/Sources/ManagedPlayer/ManagedPlayerViewModel.swift
@@ -84,7 +84,7 @@ public class ManagedPlayerViewModel: ObservableObject, NativePlugin {
         bag.forEach { $0.cancel() }
     }
 
-    public func apply<P: HeadlessPlayer>(player: P) {
+    public func apply(player: some HeadlessPlayer) {
         player.hooks?.state.tap { [weak self] state in
             guard let inProgress = state as? InProgressState else {
                 self?.currentState = nil
@@ -170,11 +170,11 @@ public class ManagedPlayerViewModel: ObservableObject, NativePlugin {
 
         public static func == (lhs: Self, rhs: Self) -> Bool {
             switch (lhs, rhs) {
-            case (.idle, .idle): return true
-            case (.loading, .loading): return true
-            case let (.loaded(lll), .loaded(rrr)) where lll == rrr: return true
-            case let (.retry(lll), .retry(rrr)) where lll === rrr: return true
-            default: return false
+            case (.idle, .idle): true
+            case (.loading, .loading): true
+            case let (.loaded(lll), .loaded(rrr)) where lll == rrr: true
+            case let (.retry(lll), .retry(rrr)) where lll === rrr: true
+            default: false
             }
         }
     }

--- a/ios/swiftui/Sources/ManagedPlayer/ManagedPlayerViewModel.swift
+++ b/ios/swiftui/Sources/ManagedPlayer/ManagedPlayerViewModel.swift
@@ -5,61 +5,25 @@
 //  Created by Harris Borawski on 3/26/21.
 //
 
-import Foundation
 import Combine
-import SwiftHooks
-
+import Foundation
 import PlayerUI
+import SwiftHooks
 
 /// A plugin used by the ManagedPlayer.
 ///
-/// When a ManagedPlayer is instantiated it will call `apply(_:)` on all managed player plugins it is
+/// When a ManagedPlayer is instantiated it will call `apply(_:)` on all managed player plugins it
+/// is
 /// provided.
 public protocol ManagedPlayerPlugin {
     /// Called by the ManagedPlayer upon instantiation.
     func apply(_ model: ManagedPlayerViewModel)
 }
 
-/**
- A ViewModel for the `ManagedPlayer` that orchestrates the use of the `FlowManager`
- passed to it
- */
+/// A ViewModel for the `ManagedPlayer` that orchestrates the use of the `FlowManager`
+/// passed to it
 public class ManagedPlayerViewModel: ObservableObject, NativePlugin {
     public var pluginName: String = "ManagedPlayerViewModel"
-
-    /**
-     The state of loading flows
-     */
-    public enum LoadingState: Equatable {
-        public static func == (lhs: Self, rhs: Self) -> Bool {
-            switch (lhs, rhs) {
-            case (.idle, .idle):                                        return true
-            case (.loading, .loading):                                  return true
-            case (.loaded(let lll), .loaded(let rrr)) where lll == rrr: return true
-            case (.retry(let lll), .retry(let rrr)) where lll === rrr:  return true
-            default:                                                    return false
-            }
-        }
-
-        var isLoaded: Bool {
-            guard case .loaded = self else { return false }
-            return true
-        }
-
-        /// Player has been constructed but not yet fetching
-        case idle
-        /// An error occurred and a retry can be attempted
-        case retry(CompletedState)
-        /// Loading the next flow
-        case loading
-        /// The flow failed with an error
-        case failed(Error)
-        /// Flow was successfully loaded
-        case loaded(String)
-    }
-
-    /// The Loading State for `ManagedPlayer`
-    @Published private(set) var loadingState: LoadingState = .idle
 
     /// The current flow to run in the `SwiftUIPlayer`
     @Published public var flow: String?
@@ -68,16 +32,16 @@ public class ManagedPlayerViewModel: ObservableObject, NativePlugin {
     @Published public var result: Result<CompletedState, PlayerError>?
 
     /// Provide Transition Animation information for load state transitions in managed flows
-    public let stateTransition = SyncBailHook<Void, PlayerViewTransition>()
+    public let stateTransition: SyncBailHook<Void, PlayerViewTransition> = .init()
 
     /// A function to get the delay for view transitions
     public var getDelay: (() -> Double?)?
 
-    /// Logger instance from current player
-    private var logger: JSLogger?
+    /// The Loading State for `ManagedPlayer`
+    @Published private(set) var loadingState: LoadingState = .idle
 
     /// The current state of the current player
-    internal var currentState: InProgressState?
+    var currentState: InProgressState?
 
     /// The last completed state
     private var prevResult: CompletedState?
@@ -89,16 +53,16 @@ public class ManagedPlayerViewModel: ObservableObject, NativePlugin {
     /// The `FlowManager` that is used for this instance
     private var manager: FlowManager
 
-    private var bag = Set<AnyCancellable>()
+    private var bag: Set<AnyCancellable> = []
 
-    /**
-     Creates a new `ManagedPlayerViewModel`
-     - parameters:
-        - manager: The `FlowManager` to use for fetching flows
-        - onComplete: A handler for when the `FlowManager` signals that it has no more flows to fetch
-        - onStartedFlow: A handler for when a flow is started, passed the flow `String` that was used to start it
-        - onError: A handler for when the `SwiftUIPlayer` encounters an error
-     */
+    /// Creates a new `ManagedPlayerViewModel`
+    /// - parameters:
+    ///   - manager: The `FlowManager` to use for fetching flows
+    ///   - onComplete: A handler for when the `FlowManager` signals that it has no more flows to
+    /// fetch
+    ///   - onStartedFlow: A handler for when a flow is started, passed the flow `String` that was
+    /// used to start it
+    ///   - onError: A handler for when the `SwiftUIPlayer` encounters an error
     public init(
         manager: FlowManager,
         onComplete: @escaping (CompletedState) -> Void,
@@ -109,28 +73,49 @@ public class ManagedPlayerViewModel: ObservableObject, NativePlugin {
         self.onStartedFlow = onStartedFlow
 
         $result.sink { [weak self] result in
-            guard let result = result else { return }
+            guard let result else { return }
             self?.handleResult(result)
-        }.store(in: &bag)
+        }
+        .store(in: &bag)
     }
 
-    public func apply<P>(player: P) where P: HeadlessPlayer {
-        player.hooks?.state.tap({ [weak self] (state) in
+    deinit {
+        manager.terminate(state: currentState)
+        bag.forEach { $0.cancel() }
+    }
+
+    public func apply<P: HeadlessPlayer>(player: P) {
+        player.hooks?.state.tap { [weak self] state in
             guard let inProgress = state as? InProgressState else {
                 self?.currentState = nil
                 return
             }
             self?.currentState = inProgress
-        })
+        }
+    }
+
+    /// Resets and starts the multi-flow experience from the beginning
+    public func reset() {
+        prevResult = nil
+        loadingState = .idle
+    }
+
+    /// Refetches the last loaded flow
+    public func retry() {
+        if let prev = prevResult {
+            loadingState = .retry(prev)
+        } else {
+            loadingState = .idle
+        }
     }
 
     func handleResult(_ result: Result<CompletedState, PlayerError>) {
         switch result {
-        case .success(let completed):
-            self.prevResult = completed
+        case let .success(completed):
+            prevResult = completed
             Task { [weak self] in await self?.next(completed) }
-        case .failure(let error):
-            self.loadingState = .failed(error)
+        case let .failure(error):
+            loadingState = .failed(error)
         }
     }
 
@@ -165,27 +150,32 @@ public class ManagedPlayerViewModel: ObservableObject, NativePlugin {
         }
     }
 
-    /**
-     Resets and starts the multi-flow experience from the beginning
-     */
-    public func reset() {
-        prevResult = nil
-        loadingState = .idle
-    }
+    /// The state of loading flows
+    public enum LoadingState: Equatable {
+        /// Player has been constructed but not yet fetching
+        case idle
+        /// An error occurred and a retry can be attempted
+        case retry(CompletedState)
+        /// Loading the next flow
+        case loading
+        /// The flow failed with an error
+        case failed(Error)
+        /// Flow was successfully loaded
+        case loaded(String)
 
-    /**
-     Refetches the last loaded flow
-     */
-    public func retry() {
-        if let prev = prevResult {
-            loadingState = .retry(prev)
-        } else {
-            loadingState = .idle
+        var isLoaded: Bool {
+            guard case .loaded = self else { return false }
+            return true
         }
-    }
 
-    deinit {
-        manager.terminate(state: currentState)
-        bag.forEach { $0.cancel() }
+        public static func == (lhs: Self, rhs: Self) -> Bool {
+            switch (lhs, rhs) {
+            case (.idle, .idle): return true
+            case (.loading, .loading): return true
+            case let (.loaded(lll), .loaded(rrr)) where lll == rrr: return true
+            case let (.retry(lll), .retry(rrr)) where lll === rrr: return true
+            default: return false
+            }
+        }
     }
 }

--- a/ios/swiftui/Sources/ManagedPlayer/ScrollPlugin.swift
+++ b/ios/swiftui/Sources/ManagedPlayer/ScrollPlugin.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 #if SWIFT_PACKAGE
-import PlayerUI
+    import PlayerUI
 #endif
 
 /// A plugin to wrap player content in a scrollview
@@ -16,14 +16,14 @@ public class ScrollPlugin: NativePlugin {
     /// Wraps SwiftUIPlayer content in `ScrollView`
     /// - Parameter edgesIgnoringSafeArea: Edges to ignore for the safe area
     public init(edgesIgnoringSafeArea: Edge.Set = []) {
-        self.ignoredEdges = edgesIgnoringSafeArea
+        ignoredEdges = edgesIgnoringSafeArea
     }
 
-    public func apply<P>(player: P) where P: HeadlessPlayer {
+    public func apply<P: HeadlessPlayer>(player: P) {
         guard let player = player as? SwiftUIPlayer else { return }
-        let ignoredEdges = self.ignoredEdges
+        let ignoredEdges = ignoredEdges
         player.hooks?.view.tap(name: pluginName) { view in
-            return AnyView(
+            AnyView(
                 ScrollViewReader { proxy in
                     ScrollView {
                         view.scrollToProxy(proxy)
@@ -38,7 +38,9 @@ public class ScrollPlugin: NativePlugin {
 
 struct MeasureToEnvironment: ViewModifier {
     let path: WritableKeyPath<EnvironmentValues, CGSize>
+
     @State var size: CGSize = .zero
+
     func body(content: Content) -> some View {
         content
             .background(
@@ -46,7 +48,6 @@ struct MeasureToEnvironment: ViewModifier {
                     Color.clear
                         .onAppear { size = proxy.size }
                         .onChange(of: proxy.size, perform: { size = $0 })
-
                 }
             )
             .environment(path, size)

--- a/ios/swiftui/Sources/ManagedPlayer/ScrollPlugin.swift
+++ b/ios/swiftui/Sources/ManagedPlayer/ScrollPlugin.swift
@@ -1,6 +1,5 @@
-import SwiftUI
-
 import PlayerUI
+import SwiftUI
 
 /// A plugin to wrap player content in a scrollview
 /// and provide `EnvironmentValues` for
@@ -14,14 +13,14 @@ public class ScrollPlugin: NativePlugin {
     /// Wraps SwiftUIPlayer content in `ScrollView`
     /// - Parameter edgesIgnoringSafeArea: Edges to ignore for the safe area
     public init(edgesIgnoringSafeArea: Edge.Set = []) {
-        self.ignoredEdges = edgesIgnoringSafeArea
+        ignoredEdges = edgesIgnoringSafeArea
     }
 
-    public func apply<P>(player: P) where P: HeadlessPlayer {
+    public func apply<P: HeadlessPlayer>(player: P) {
         guard let player = player as? SwiftUIPlayer else { return }
-        let ignoredEdges = self.ignoredEdges
+        let ignoredEdges = ignoredEdges
         player.hooks?.view.tap(name: pluginName) { view in
-            return AnyView(
+            AnyView(
                 ScrollViewReader { proxy in
                     ScrollView {
                         view.scrollToProxy(proxy)
@@ -36,7 +35,9 @@ public class ScrollPlugin: NativePlugin {
 
 struct MeasureToEnvironment: ViewModifier {
     let path: WritableKeyPath<EnvironmentValues, CGSize>
+
     @State var size: CGSize = .zero
+
     func body(content: Content) -> some View {
         content
             .background(
@@ -44,7 +45,6 @@ struct MeasureToEnvironment: ViewModifier {
                     Color.clear
                         .onAppear { size = proxy.size }
                         .onChange(of: proxy.size, perform: { size = $0 })
-
                 }
             )
             .environment(path, size)

--- a/ios/swiftui/Sources/ManagedPlayer/ScrollPlugin.swift
+++ b/ios/swiftui/Sources/ManagedPlayer/ScrollPlugin.swift
@@ -16,7 +16,7 @@ public class ScrollPlugin: NativePlugin {
         ignoredEdges = edgesIgnoringSafeArea
     }
 
-    public func apply<P: HeadlessPlayer>(player: P) {
+    public func apply(player: some HeadlessPlayer) {
         guard let player = player as? SwiftUIPlayer else { return }
         let ignoredEdges = ignoredEdges
         player.hooks?.view.tap(name: pluginName) { view in

--- a/ios/swiftui/Sources/ManagedPlayer/ScrollToProxy.swift
+++ b/ios/swiftui/Sources/ManagedPlayer/ScrollToProxy.swift
@@ -7,16 +7,18 @@
 
 import SwiftUI
 
-/// Adopters of ScrollToProxy must provide the ability to scroll a view with a specified identifier into the
+/// Adopters of ScrollToProxy must provide the ability to scroll a view with a specified identifier
+/// into the
 /// current viewport.
 ///
-/// A ScrollToProxy can be added to the environment and will be utilized by any contained input assets to
+/// A ScrollToProxy can be added to the environment and will be utilized by any contained input
+/// assets to
 /// ensure they are visible when focused.
 public protocol ScrollToProxy {
-    func scrollTo<Item>(_ item: Item, anchor: UnitPoint?) where Item: Hashable
+    func scrollTo<Item: Hashable>(_ item: Item, anchor: UnitPoint?)
 }
 
-// ScrollViewProxy is only available on 14+
+/// ScrollViewProxy is only available on 14+
 extension ScrollViewProxy: ScrollToProxy {}
 
 public extension View {
@@ -37,7 +39,7 @@ public extension View {
     /// }
     /// ```
     func scrollToProxy(_ scrollTo: ScrollToProxy) -> some View {
-        return environment(\.scrollToProxy, scrollTo)
+        environment(\.scrollToProxy, scrollTo)
     }
 }
 
@@ -48,8 +50,8 @@ public extension EnvironmentValues {
     }
 }
 
-extension ScrollToProxy {
-    public func scrollTo<Item>(_ item: Item) where Item: Hashable {
+public extension ScrollToProxy {
+    func scrollTo<Item: Hashable>(_ item: Item) {
         scrollTo(item, anchor: nil)
     }
 }
@@ -58,6 +60,6 @@ private struct ScrollToEnvironmentKey: EnvironmentKey {
     static let defaultValue: ScrollToProxy = VoidScrollToProxy()
 
     private struct VoidScrollToProxy: ScrollToProxy {
-        func scrollTo<Item>(_ item: Item, anchor: UnitPoint?) where Item: Hashable {}
+        func scrollTo<Item: Hashable>(_: Item, anchor _: UnitPoint?) {}
     }
 }

--- a/ios/swiftui/Sources/ManagedPlayer/ScrollToProxy.swift
+++ b/ios/swiftui/Sources/ManagedPlayer/ScrollToProxy.swift
@@ -15,7 +15,7 @@ import SwiftUI
 /// assets to
 /// ensure they are visible when focused.
 public protocol ScrollToProxy {
-    func scrollTo<Item: Hashable>(_ item: Item, anchor: UnitPoint?)
+    func scrollTo(_ item: some Hashable, anchor: UnitPoint?)
 }
 
 /// ScrollViewProxy is only available on 14+
@@ -51,7 +51,7 @@ public extension EnvironmentValues {
 }
 
 public extension ScrollToProxy {
-    func scrollTo<Item: Hashable>(_ item: Item) {
+    func scrollTo(_ item: some Hashable) {
         scrollTo(item, anchor: nil)
     }
 }
@@ -60,6 +60,6 @@ private struct ScrollToEnvironmentKey: EnvironmentKey {
     static let defaultValue: ScrollToProxy = VoidScrollToProxy()
 
     private struct VoidScrollToProxy: ScrollToProxy {
-        func scrollTo<Item: Hashable>(_: Item, anchor _: UnitPoint?) {}
+        func scrollTo(_: some Hashable, anchor _: UnitPoint?) {}
     }
 }

--- a/ios/swiftui/Sources/PlayerViewTransition.swift
+++ b/ios/swiftui/Sources/PlayerViewTransition.swift
@@ -1,0 +1,76 @@
+import Combine
+import SwiftUI
+
+/// Holds information needed for transition animations when a new view in a flow is being shown
+public struct PlayerViewTransition: Equatable {
+    public static let identity: PlayerViewTransition = .init(
+        name: .identity,
+        transition: .identity,
+        animationCurve: .default
+    )
+
+    /// The animation curve to use for the transition
+    public var animationCurve: Animation
+
+    private var _transition: Transition
+
+    /// The transition to show the new view with
+    public var transition: AnyTransition {
+        _transition.transition
+    }
+
+    /// Creates a new `PlayerViewTransition`
+    /// - parameters:
+    ///   - transition: The transition to show the new view with
+    ///   - animationCurve: The animation curve to use for the transition
+    public init(
+        transition: AnyTransition,
+        animationCurve: Animation
+    ) {
+        _transition = .unnamed(transition)
+        self.animationCurve = animationCurve
+    }
+
+    /// Creates a new `PlayerViewTransition`
+    /// - parameters:
+    ///   - transition: The transition to show the new view with
+    ///   - animationCurve: The animation curve to use for the transition
+    public init(
+        name: Name,
+        transition: AnyTransition,
+        animationCurve: Animation
+    ) {
+        _transition = .named(name, transition)
+        self.animationCurve = animationCurve
+    }
+
+    /// Name mostly exists as a way to allow testing of transition hooks.
+    public struct Name: RawRepresentable {
+        public static let identity: Name = .init(rawValue: "identity")
+
+        public let rawValue: String
+
+        public init(rawValue: String) {
+            self.rawValue = rawValue
+        }
+    }
+
+    private enum Transition: Equatable {
+        case named(Name, AnyTransition)
+        case unnamed(AnyTransition)
+
+        var transition: AnyTransition {
+            switch self {
+            case let .named(_, transition): return transition
+            case let .unnamed(transition): return transition
+            }
+        }
+
+        static func == (lhs: Self, rhs: Self) -> Bool {
+            switch (lhs, rhs) {
+            case let (.named(lName, _), .named(rName, _)): return lName == rName
+            default: return false
+            }
+        }
+    }
+}

--- a/ios/swiftui/Sources/PlayerViewTransition.swift
+++ b/ios/swiftui/Sources/PlayerViewTransition.swift
@@ -61,15 +61,15 @@ public struct PlayerViewTransition: Equatable {
 
         var transition: AnyTransition {
             switch self {
-            case let .named(_, transition): return transition
-            case let .unnamed(transition): return transition
+            case let .named(_, transition): transition
+            case let .unnamed(transition): transition
             }
         }
 
         static func == (lhs: Self, rhs: Self) -> Bool {
             switch (lhs, rhs) {
-            case let (.named(lName, _), .named(rName, _)): return lName == rName
-            default: return false
+            case let (.named(lName, _), .named(rName, _)): lName == rName
+            default: false
             }
         }
     }

--- a/ios/swiftui/Sources/SwiftUIPlayer.swift
+++ b/ios/swiftui/Sources/SwiftUIPlayer.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 //
 //  SwiftUIPlayer.swift
 //  PlayerUI
@@ -5,40 +6,130 @@
 //  Created by Harris Borawski on 2/26/21.
 //
 
-import SwiftUI
-import JavaScriptCore
 import Combine
-import SwiftHooks
+import JavaScriptCore
 import PlayerUI
 import PlayerUILogger
+import SwiftHooks
+import SwiftUI
 
-/**
- A `HeadlessPlayer` implementation that renders itself as a SwiftUI View
- */
+/// A `HeadlessPlayer` implementation that renders itself as a SwiftUI View
 public struct SwiftUIPlayer: View, HeadlessPlayer {
-    /// A SwiftUIPlayer Context maintains the current javascript state of Player. This includes providing
+    /// For ViewInspector testing
+    let inspection: Inspection<Self> = .init()
+
+    private let unloadOnDisappear: Bool
+
+    @ObservedObject private var context: Context
+    @Binding private var result: Result<CompletedState, PlayerError>?
+
+    /// The SwiftUI View that is this Player flow
+    public var body: some View {
+        bodyContent
+            .environment(\.inProgressState, (state as? InProgressState))
+            .environment(\.constantsController, constantsController)
+            // forward results from our Context along to our result binding
+            .onReceive(context.$result.debounce(for: 0.1, scheduler: RunLoop.main)) {
+                result = $0
+            }
+            .onReceive(inspection.notice) { inspection.visit(self, $0) }
+            .onDisappear {
+                guard unloadOnDisappear else { return }
+                context.unload()
+            }
+    }
+
+    private var bodyContent: some View {
+        bodyContent(hooks?.transition.call() ?? .identity)
+    }
+
+    /// A reference to the shared logger
+    public var logger: TapableLogger {
+        context.logger
+    }
+
+    /// A read only reference to the platform shared core player value in the `JSContext`
+    public var jsPlayerReference: JSValue? {
+        context.player
+    }
+
+    /// Lifecycle hooks exposed from the platform shared core player
+    public var hooks: SwiftUIPlayerHooks? {
+        context.hooks
+    }
+
+    /// The registry for registering assets to be used for rendering
+    public var assetRegistry: SwiftUIRegistry {
+        context.registry
+    }
+
+    /// Constructs a `SwiftUIPlayer` with the given flow and plugins
+    /// - parameters:
+    ///   - flow: The JSON flow to run
+    ///   - plugins: Any plugins to add to Player
+    ///   - context: An optional JSContext to use for loading platform shared code
+    public init(
+        flow: String,
+        plugins: [NativePlugin],
+        result: Binding<Result<CompletedState, PlayerError>?>,
+        context: Context = .shared,
+        unloadOnDisappear: Bool = true
+    ) {
+        _result = result
+        _context = ObservedObject(initialValue: context)
+        self.unloadOnDisappear = unloadOnDisappear
+        context.load(flow: flow, plugins: plugins, player: self)
+    }
+
+    private func bodyContent(_ transitionInfo: PlayerViewTransition) -> some View {
+        // use a VStack to provide a container for our view transitions to run inside
+        VStack {
+            hooks?.view
+                .call(context.registry.root?.view ?? AnyView(Color.clear))
+                .transition(transitionInfo.transition)
+                .id(context.registry.root?.id)
+        }
+        // only apply our transition animation when the root view is changing
+        .animation(transitionInfo.animationCurve, value: context.registry.root?.id)
+    }
+
+    /// A SwiftUIPlayer Context maintains the current javascript state of Player. This includes
+    /// providing
     /// stable storage for Player JSValue across SwiftUI View updates.
     ///
     public final class Context: ObservableObject {
-        /// A global context that can be managed by a single SwiftUIPlayer at a time. This may be useful
+        /// A global context that can be managed by a single SwiftUIPlayer at a time. This may be
+        /// useful
         /// for fullscreen player views when @StateObject is not available to the host application.
-        public static let shared = Context()
+        public static let shared: Context = .init()
+
+        public let logger: TapableLogger = .init()
+
+        fileprivate(set) var hooks: SwiftUIPlayerHooks?
+
+        fileprivate var player: JSValue?
+        fileprivate let registry: SwiftUIRegistry = .init()
+
+        @Published fileprivate var result: Result<CompletedState, PlayerError>?
 
         private var contextBuilder: () -> JSContext
-        private let partialMatchPlugin = PartialMatchFingerprintPlugin()
-        public let logger = TapableLogger()
+        private let partialMatchPlugin: PartialMatchFingerprintPlugin = .init()
         private var flow: String?
         private var registryWatch: AnyCancellable?
         private var state: BaseFlowState?
 
-        fileprivate var player: JSValue?
-        fileprivate(set) var hooks: SwiftUIPlayerHooks?
-        fileprivate let registry = SwiftUIRegistry()
+        /// Returns true iff there is a non-nil player.
+        public var isLoaded: Bool {
+            player != nil
+        }
 
-        @Published fileprivate var result: Result<CompletedState, PlayerError>?
-
-        /// Returns true iff there is a non-nil player. 
-        public var isLoaded: Bool { player != nil }
+        /// Returns `player` but asserts that it is not nil. Used from methods that should not be
+        /// called
+        /// when we are unloaded.
+        private var expectedPlayer: JSValue? {
+            assert(player != nil, "should have a player value here")
+            return player
+        }
 
         /// Create a new context that generates JSContexts using the supplied contextBuilder.
         public init(contextBuilder: @escaping () -> JSContext = { JSContext() }) {
@@ -50,57 +141,8 @@ public struct SwiftUIPlayer: View, HeadlessPlayer {
             }
         }
 
-        /// Load the supplied flow into this context. If the currently loaded flow is supplied this will do nothing.
-        /// If a new flow is supplied then the javascript environment is created or rebuilt around the new flow.
-        fileprivate func load(flow: String, plugins: [NativePlugin], player: SwiftUIPlayer) {
-            registry.logger = logger
-            guard self.player == nil || flow != self.flow else {
-                logger.d("Reusing already loaded flow")
-                return
-            }
-
-            let context: JSContext = contextBuilder()
-
-            let allPlugins = plugins + [partialMatchPlugin]
-            guard let playerValue = player.setupPlayer(context: context, plugins: allPlugins) else {
-                return logger.e("Failed to load player")
-            }
-
-            let hooks = SwiftUIPlayerHooks(from: playerValue)
-
-            self.player = playerValue
-            self.flow = flow
-            self.hooks = hooks
-            DispatchQueue.main.async { [weak self] in
-                self?.result = nil 
-            }
-
-            for plugin in allPlugins { plugin.apply(player: player) }
-            registry.partialMatchRegistry = partialMatchPlugin
-
-            hooks.viewController.tap { [weak self, weak playerValue] controller in
-                guard let self, let playerValue, self.player == playerValue else { return }
-                self.onViewController(controller)
-            }
-
-            hooks.state.tap { [weak self] newState in
-                self?.state = newState
-            }
-
-            guard !flow.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-                logger.d("Empty flow, not loading")
-                return
-            }
-
-            player.start(flow: flow) { [weak self, weak playerValue] (result) in
-                guard let self, let playerValue, self.player == playerValue else { return }
-                DispatchQueue.main.async { [weak self] in
-                    self?.result = result 
-                }
-            }
-        }
-
-        /// Unload the context. This will release the current javascript player/context and clear the current
+        /// Unload the context. This will release the current javascript player/context and clear
+        /// the current
         /// result. Also breaks cross-runtime retain cycles between Swift closures and the JSContext
         /// by clearing the exceptionHandler and any exported objects on the context.
         public func unload() {
@@ -122,8 +164,8 @@ public struct SwiftUIPlayer: View, HeadlessPlayer {
                 state = nil
             }
             DispatchQueue.main.async { [weak self] in
-                self?.result = nil 
-             }
+                self?.result = nil
+            }
             registry.resetView()
         }
 
@@ -133,18 +175,63 @@ public struct SwiftUIPlayer: View, HeadlessPlayer {
             player?.context.exceptionHandler = nil
         }
 
-        /// Returns `player` but asserts that it is not nil. Used from methods that should not be called
-        /// when we are unloaded.
-        private var expectedPlayer: JSValue? {
-            assert(player != nil, "should have a player value here")
-            return player
+        /// Load the supplied flow into this context. If the currently loaded flow is supplied this
+        /// will do nothing.
+        /// If a new flow is supplied then the javascript environment is created or rebuilt around
+        /// the new flow.
+        fileprivate func load(flow: String, plugins: [NativePlugin], player: SwiftUIPlayer) {
+            registry.logger = logger
+            guard self.player == nil || flow != self.flow else {
+                logger.d("Reusing already loaded flow")
+                return
+            }
+
+            let context: JSContext = contextBuilder()
+
+            let allPlugins = plugins + [partialMatchPlugin]
+            guard let playerValue = player.setupPlayer(context: context, plugins: allPlugins) else {
+                return logger.e("Failed to load player")
+            }
+
+            let hooks = SwiftUIPlayerHooks(from: playerValue)
+
+            self.player = playerValue
+            self.flow = flow
+            self.hooks = hooks
+            DispatchQueue.main.async { [weak self] in
+                self?.result = nil
+            }
+
+            for plugin in allPlugins {
+                plugin.apply(player: player)
+            }
+            registry.partialMatchRegistry = partialMatchPlugin
+
+            hooks.viewController.tap { [weak self, weak playerValue] controller in
+                guard let self, let playerValue, self.player == playerValue else { return }
+                self.onViewController(controller)
+            }
+
+            hooks.state.tap { [weak self] newState in
+                self?.state = newState
+            }
+
+            guard !flow.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                logger.d("Empty flow, not loading")
+                return
+            }
+
+            player.start(flow: flow) { [weak self, weak playerValue] result in
+                guard let self, let playerValue, self.player == playerValue else { return }
+                DispatchQueue.main.async { [weak self] in
+                    self?.result = result
+                }
+            }
         }
 
-        /**
-         Handler for when the ViewController in the core player changes
-         - parameters:
-            - viewController: The new ViewController instance
-         */
+        /// Handler for when the ViewController in the core player changes
+        /// - parameters:
+        ///   - viewController: The new ViewController instance
         private func onViewController(_ viewController: ViewController) {
             viewController.hooks.view.tap { [weak self, weak expectedPlayer] view in
                 guard let self, let expectedPlayer, self.player == expectedPlayer else { return }
@@ -152,25 +239,22 @@ public struct SwiftUIPlayer: View, HeadlessPlayer {
             }
         }
 
-        /**
-         Handler for when the View changes in the ViewController
-         - parameters:
-            - view: The new View in the ViewController
-         */
+        /// Handler for when the View changes in the ViewController
+        /// - parameters:
+        ///   - view: The new View in the ViewController
         private func onView(_ view: PlayerView) {
             view.hooks.onUpdate.tap { [weak self, weak expectedPlayer] value in
                 Task { @MainActor [weak self] in
-                    guard let self, let expectedPlayer, self.player == expectedPlayer else { return }
+                    guard let self, let expectedPlayer,
+                          self.player == expectedPlayer else { return }
                     self.onUpdate(value)
                 }
             }
         }
 
-        /**
-         Handler for when there is an update to the asset tree in the current `PlayerView`
-         - parameters:
-            - value: JSValue that is the root of the resolved asset tree
-         */
+        /// Handler for when there is an update to the asset tree in the current `PlayerView`
+        /// - parameters:
+        ///   - value: JSValue that is the root of the resolved asset tree
         private func onUpdate(_ value: JSValue) {
             JSGarbageCollect(value.context.jsGlobalContextRef)
             do {
@@ -179,75 +263,6 @@ public struct SwiftUIPlayer: View, HeadlessPlayer {
                 (state as? InProgressState)?.fail(PlayerError.unknownResponse(error))
             }
         }
-    }
-
-    @ObservedObject private var context: Context
-    @Binding private var result: Result<CompletedState, PlayerError>?
-    private let unloadOnDisappear: Bool
-    /// A reference to the shared logger
-    public var logger: TapableLogger { context.logger }
-
-    /// A read only reference to the platform shared core player value in the `JSContext`
-    public var jsPlayerReference: JSValue? { context.player }
-
-    /// Lifecycle hooks exposed from the platform shared core player
-    public var hooks: SwiftUIPlayerHooks? { context.hooks }
-
-    /// The registry for registering assets to be used for rendering
-    public var assetRegistry: SwiftUIRegistry { context.registry }
-
-    // For ViewInspector testing
-    internal let inspection = Inspection<Self>()
-
-    /**
-     Constructs a `SwiftUIPlayer` with the given flow and plugins
-     - parameters:
-        - flow: The JSON flow to run
-        - plugins: Any plugins to add to Player
-        - context: An optional JSContext to use for loading platform shared code
-     */
-    public init(
-        flow: String,
-        plugins: [NativePlugin],
-        result: Binding<Result<CompletedState, PlayerError>?>,
-        context: Context = .shared,
-        unloadOnDisappear: Bool = true
-    ) {
-        self._result = result
-        self._context = ObservedObject(initialValue: context)
-        self.unloadOnDisappear = unloadOnDisappear
-        context.load(flow: flow, plugins: plugins, player: self)
-    }
-
-    /// The SwiftUI View that is this Player flow
-    public var body: some View {
-        bodyContent
-            .environment(\.inProgressState, (state as? InProgressState))
-            .environment(\.constantsController, constantsController)
-            // forward results from our Context along to our result binding
-            .onReceive(context.$result.debounce(for: 0.1, scheduler: RunLoop.main)) {
-                self.result = $0
-            }
-            .onReceive(inspection.notice) { self.inspection.visit(self, $0) }
-            .onDisappear {
-                guard unloadOnDisappear else { return }
-                context.unload()
-            }
-    }
-
-    private var bodyContent: some View {
-        bodyContent(hooks?.transition.call() ?? .identity)
-    }
-
-    private func bodyContent(_ transitionInfo: PlayerViewTransition) -> some View {
-        // use a VStack to provide a container for our view transitions to run inside
-        VStack {
-            hooks?.view.call(context.registry.root?.view ?? AnyView(Color.clear))
-                .transition(transitionInfo.transition)
-                .id(context.registry.root?.id)
-        }
-        // only apply our transition animation when the root view is changing
-        .animation(transitionInfo.animationCurve, value: context.registry.root?.id)
     }
 }
 
@@ -260,7 +275,7 @@ struct InProgressStateKey: EnvironmentKey {
 /// EnvironmentKey for storing `constantsController`
 struct ConstantsControllerStateKey: EnvironmentKey {
     /// The default value for `@Environment(\.constantsController)`
-    static var defaultValue: ConstantsController? = nil
+    static var defaultValue: ConstantsController?
 }
 
 public extension EnvironmentValues {
@@ -269,7 +284,7 @@ public extension EnvironmentValues {
         get { self[InProgressStateKey.self] }
         set { self[InProgressStateKey.self] = newValue }
     }
-    
+
     /// The ConstantsController reference of Player
     var constantsController: ConstantsController? {
         get { self[ConstantsControllerStateKey.self] }
@@ -277,16 +292,14 @@ public extension EnvironmentValues {
     }
 }
 
-internal extension SwiftUIPlayer {
+extension SwiftUIPlayer {
     /// For testing, uses a constant result of nil.
     init(flow: String, plugins: [NativePlugin], context: SwiftUIPlayer.Context = .init()) {
         self.init(flow: flow, plugins: plugins, result: .constant(nil), context: context)
     }
 }
 
-/**
- Lifecycle hooks for `SwiftUIPlayer`
- */
+/// Lifecycle hooks for `SwiftUIPlayer`
 public struct SwiftUIPlayerHooks: CoreHooks {
     /// Fired when the FlowController changes
     public var flowController: Hook<FlowController>
@@ -321,54 +334,52 @@ public struct SwiftUIPlayerHooks: CoreHooks {
     }
 }
 
-/**
- Holds information needed for transition animations when a new view in a flow is being shown
- */
+/// Holds information needed for transition animations when a new view in a flow is being shown
 public struct PlayerViewTransition: Equatable {
-    public static let identity = PlayerViewTransition(name: .identity, transition: .identity, animationCurve: .default)
+    public static let identity: PlayerViewTransition = .init(
+        name: .identity,
+        transition: .identity,
+        animationCurve: .default
+    )
 
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs._transition == rhs._transition && lhs.animationCurve == rhs.animationCurve
-    }
-
-    private var _transition: Transition
-    /// The transition to show the new view with
-    public var transition: AnyTransition { _transition.transition }
     /// The animation curve to use for the transition
     public var animationCurve: Animation
 
-    /**
-     Creates a new `PlayerViewTransition`
-     - parameters:
-        - transition: The transition to show the new view with
-        - animationCurve: The animation curve to use for the transition
-     */
+    private var _transition: Transition
+
+    /// The transition to show the new view with
+    public var transition: AnyTransition {
+        _transition.transition
+    }
+
+    /// Creates a new `PlayerViewTransition`
+    /// - parameters:
+    ///   - transition: The transition to show the new view with
+    ///   - animationCurve: The animation curve to use for the transition
     public init(
         transition: AnyTransition,
         animationCurve: Animation
     ) {
-        self._transition = .unnamed(transition)
+        _transition = .unnamed(transition)
         self.animationCurve = animationCurve
     }
 
-    /**
-     Creates a new `PlayerViewTransition`
-     - parameters:
-        - transition: The transition to show the new view with
-        - animationCurve: The animation curve to use for the transition
-     */
+    /// Creates a new `PlayerViewTransition`
+    /// - parameters:
+    ///   - transition: The transition to show the new view with
+    ///   - animationCurve: The animation curve to use for the transition
     public init(
         name: Name,
         transition: AnyTransition,
         animationCurve: Animation
     ) {
-        self._transition = .named(name, transition)
+        _transition = .named(name, transition)
         self.animationCurve = animationCurve
     }
 
     /// Name mostly exists as a way to allow testing of transition hooks.
     public struct Name: RawRepresentable {
-        public static let identity = Name(rawValue: "identity")
+        public static let identity: Name = .init(rawValue: "identity")
 
         public let rawValue: String
 
@@ -378,20 +389,20 @@ public struct PlayerViewTransition: Equatable {
     }
 
     private enum Transition: Equatable {
-        public static func == (lhs: Self, rhs: Self) -> Bool {
-            switch (lhs, rhs) {
-            case (.named(let lName, _), .named(let rName, _)): return lName == rName
-            default:                                           return false
-            }
-        }
-
         case named(Name, AnyTransition)
         case unnamed(AnyTransition)
 
         var transition: AnyTransition {
             switch self {
-            case .named(_, let transition): return transition
-            case .unnamed(let transition):  return transition
+            case let .named(_, transition): return transition
+            case let .unnamed(transition): return transition
+            }
+        }
+
+        static func == (lhs: Self, rhs: Self) -> Bool {
+            switch (lhs, rhs) {
+            case let (.named(lName, _), .named(rName, _)): return lName == rName
+            default: return false
             }
         }
     }

--- a/ios/swiftui/Sources/SwiftUIPlayer.swift
+++ b/ios/swiftui/Sources/SwiftUIPlayer.swift
@@ -215,7 +215,7 @@ public struct SwiftUIPlayer: View, HeadlessPlayer {
 
             hooks.viewController.tap { [weak self, weak playerValue] controller in
                 guard let self, let playerValue, self.player == playerValue else { return }
-                self.onViewController(controller)
+                onViewController(controller)
             }
 
             hooks.state.tap { [weak self] newState in
@@ -240,8 +240,8 @@ public struct SwiftUIPlayer: View, HeadlessPlayer {
         ///   - viewController: The new ViewController instance
         private func onViewController(_ viewController: ViewController) {
             viewController.hooks.view.tap { [weak self, weak expectedPlayer] view in
-                guard let self, let expectedPlayer, self.player == expectedPlayer else { return }
-                self.onView(view)
+                guard let self, let expectedPlayer, player == expectedPlayer else { return }
+                onView(view)
             }
         }
 
@@ -252,8 +252,8 @@ public struct SwiftUIPlayer: View, HeadlessPlayer {
             view.hooks.onUpdate.tap { [weak self, weak expectedPlayer] value in
                 Task { @MainActor [weak self] in
                     guard let self, let expectedPlayer,
-                          self.player == expectedPlayer else { return }
-                    self.onUpdate(value)
+                          player == expectedPlayer else { return }
+                    onUpdate(value)
                 }
             }
         }

--- a/ios/swiftui/Sources/SwiftUIPlayer.swift
+++ b/ios/swiftui/Sources/SwiftUIPlayer.swift
@@ -5,40 +5,135 @@
 //  Created by Harris Borawski on 2/26/21.
 //
 
-import SwiftUI
-import JavaScriptCore
 import Combine
-import SwiftHooks
+import JavaScriptCore
 import PlayerUI
 import PlayerUILogger
+import SwiftHooks
+import SwiftUI
 
-/**
- A `HeadlessPlayer` implementation that renders itself as a SwiftUI View
- */
+/// A `HeadlessPlayer` implementation that renders itself as a SwiftUI View
 public struct SwiftUIPlayer: View, HeadlessPlayer {
-    /// A SwiftUIPlayer Context maintains the current javascript state of Player. This includes providing
+    /// For ViewInspector testing
+    let inspection: Inspection<Self> = .init()
+
+    private let unloadOnDisappear: Bool
+
+    @ObservedObject private var context: Context
+    @Binding private var result: Result<CompletedState, PlayerError>?
+
+    /// The SwiftUI View that is this Player flow
+    public var body: some View {
+        bodyContent
+            .environment(\.inProgressState, (state as? InProgressState))
+            .environment(\.constantsController, constantsController)
+            // forward results from our Context along to our result binding
+            .onReceive(context.$result.debounce(for: 0.1, scheduler: RunLoop.main)) {
+                result = $0
+            }
+            .onReceive(inspection.notice) { inspection.visit(self, $0) }
+            .onDisappear {
+                guard unloadOnDisappear else { return }
+                context.unload()
+            }
+    }
+
+    private var bodyContent: some View {
+        bodyContent(hooks?.transition.call() ?? .identity)
+    }
+
+    /// A reference to the shared logger
+    public var logger: TapableLogger {
+        context.logger
+    }
+
+    /// A read only reference to the platform shared core player value in the `JSContext`
+    public var jsPlayerReference: JSValue? {
+        context.player
+    }
+
+    /// Lifecycle hooks exposed from the platform shared core player
+    public var hooks: SwiftUIPlayerHooks? {
+        context.hooks
+    }
+
+    /// The registry for registering assets to be used for rendering
+    public var assetRegistry: SwiftUIRegistry {
+        context.registry
+    }
+
+    /// Constructs a `SwiftUIPlayer` with the given flow and plugins
+    /// - parameters:
+    ///   - flow: The JSON flow to run
+    ///   - plugins: Any plugins to add to Player
+    ///   - context: An optional JSContext to use for loading platform shared code
+    public init(
+        flow: String,
+        plugins: [NativePlugin],
+        result: Binding<Result<CompletedState, PlayerError>?>,
+        context: Context = .shared,
+        unloadOnDisappear: Bool = true
+    ) {
+        let startTime = Date()
+        _result = result
+        _context = ObservedObject(initialValue: context)
+        self.unloadOnDisappear = unloadOnDisappear
+        context.load(flow: flow, plugins: plugins, player: self)
+
+        // Log the time it took to initialize Player
+        let initTime = Int((Date().timeIntervalSince(startTime) * 1000).rounded())
+        context.logger.i("SwiftUIPlayer initialized in \(initTime) ms.")
+    }
+
+    private func bodyContent(_ transitionInfo: PlayerViewTransition) -> some View {
+        // use a VStack to provide a container for our view transitions to run inside
+        VStack {
+            hooks?.view
+                .call(context.registry.root?.view ?? AnyView(Color.clear))
+                .transition(transitionInfo.transition)
+                .id(context.registry.root?.id)
+        }
+        // only apply our transition animation when the root view is changing
+        .animation(transitionInfo.animationCurve, value: context.registry.root?.id)
+    }
+
+    /// A SwiftUIPlayer Context maintains the current javascript state of Player. This includes
+    /// providing
     /// stable storage for Player JSValue across SwiftUI View updates.
     ///
     public final class Context: ObservableObject {
-        /// A global context that can be managed by a single SwiftUIPlayer at a time. This may be useful
+        /// A global context that can be managed by a single SwiftUIPlayer at a time. This may be
+        /// useful
         /// for fullscreen player views when @StateObject is not available to the host application.
-        public static let shared = Context()
+        public static let shared: Context = .init()
+
+        public let logger: TapableLogger = .init()
+
+        fileprivate(set) var hooks: SwiftUIPlayerHooks?
+
+        fileprivate var player: JSValue?
+        fileprivate let registry: SwiftUIRegistry = .init()
+
+        @Published fileprivate var result: Result<CompletedState, PlayerError>?
 
         private var contextBuilder: () -> JSContext
-        private let partialMatchPlugin = PartialMatchFingerprintPlugin()
-        public let logger = TapableLogger()
+        private let partialMatchPlugin: PartialMatchFingerprintPlugin = .init()
         private var flow: String?
         private var registryWatch: AnyCancellable?
         private var state: BaseFlowState?
 
-        fileprivate var player: JSValue?
-        fileprivate(set) var hooks: SwiftUIPlayerHooks?
-        fileprivate let registry = SwiftUIRegistry()
+        /// Returns true iff there is a non-nil player.
+        public var isLoaded: Bool {
+            player != nil
+        }
 
-        @Published fileprivate var result: Result<CompletedState, PlayerError>?
-
-        /// Returns true iff there is a non-nil player. 
-        public var isLoaded: Bool { player != nil }
+        /// Returns `player` but asserts that it is not nil. Used from methods that should not be
+        /// called
+        /// when we are unloaded.
+        private var expectedPlayer: JSValue? {
+            assert(player != nil, "should have a player value here")
+            return player
+        }
 
         /// Create a new context that generates JSContexts using the supplied contextBuilder.
         public init(contextBuilder: @escaping () -> JSContext = { JSContext() }) {
@@ -50,57 +145,8 @@ public struct SwiftUIPlayer: View, HeadlessPlayer {
             }
         }
 
-        /// Load the supplied flow into this context. If the currently loaded flow is supplied this will do nothing.
-        /// If a new flow is supplied then the javascript environment is created or rebuilt around the new flow.
-        fileprivate func load(flow: String, plugins: [NativePlugin], player: SwiftUIPlayer) {
-            registry.logger = logger
-            guard self.player == nil || flow != self.flow else {
-                logger.d("Reusing already loaded flow")
-                return
-            }
-
-            let context: JSContext = contextBuilder()
-
-            let allPlugins = plugins + [partialMatchPlugin]
-            guard let playerValue = player.setupPlayer(context: context, plugins: allPlugins) else {
-                return logger.e("Failed to load player")
-            }
-
-            let hooks = SwiftUIPlayerHooks(from: playerValue)
-
-            self.player = playerValue
-            self.flow = flow
-            self.hooks = hooks
-            DispatchQueue.main.async { [weak self] in
-                self?.result = nil 
-            }
-
-            for plugin in allPlugins { plugin.apply(player: player) }
-            registry.partialMatchRegistry = partialMatchPlugin
-
-            hooks.viewController.tap { [weak self, weak playerValue] controller in
-                guard let self, let playerValue, self.player == playerValue else { return }
-                self.onViewController(controller)
-            }
-
-            hooks.state.tap { [weak self] newState in
-                self?.state = newState
-            }
-
-            guard !flow.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-                logger.d("Empty flow, not loading")
-                return
-            }
-
-            player.start(flow: flow) { [weak self, weak playerValue] (result) in
-                guard let self, let playerValue, self.player == playerValue else { return }
-                DispatchQueue.main.async { [weak self] in
-                    self?.result = result 
-                }
-            }
-        }
-
-        /// Unload the context. This will release the current javascript player/context and clear the current
+        /// Unload the context. This will release the current javascript player/context and clear
+        /// the current
         /// result. Also breaks cross-runtime retain cycles between Swift closures and the JSContext
         /// by clearing the exceptionHandler and any exported objects on the context.
         public func unload() {
@@ -124,8 +170,8 @@ public struct SwiftUIPlayer: View, HeadlessPlayer {
                 state = nil
             }
             DispatchQueue.main.async { [weak self] in
-                self?.result = nil 
-             }
+                self?.result = nil
+            }
             registry.resetView()
         }
 
@@ -135,18 +181,63 @@ public struct SwiftUIPlayer: View, HeadlessPlayer {
             player?.context.exceptionHandler = nil
         }
 
-        /// Returns `player` but asserts that it is not nil. Used from methods that should not be called
-        /// when we are unloaded.
-        private var expectedPlayer: JSValue? {
-            assert(player != nil, "should have a player value here")
-            return player
+        /// Load the supplied flow into this context. If the currently loaded flow is supplied this
+        /// will do nothing.
+        /// If a new flow is supplied then the javascript environment is created or rebuilt around
+        /// the new flow.
+        fileprivate func load(flow: String, plugins: [NativePlugin], player: SwiftUIPlayer) {
+            registry.logger = logger
+            guard self.player == nil || flow != self.flow else {
+                logger.d("Reusing already loaded flow")
+                return
+            }
+
+            let context: JSContext = contextBuilder()
+
+            let allPlugins = plugins + [partialMatchPlugin]
+            guard let playerValue = player.setupPlayer(context: context, plugins: allPlugins) else {
+                return logger.e("Failed to load player")
+            }
+
+            let hooks = SwiftUIPlayerHooks(from: playerValue)
+
+            self.player = playerValue
+            self.flow = flow
+            self.hooks = hooks
+            DispatchQueue.main.async { [weak self] in
+                self?.result = nil
+            }
+
+            for plugin in allPlugins {
+                plugin.apply(player: player)
+            }
+            registry.partialMatchRegistry = partialMatchPlugin
+
+            hooks.viewController.tap { [weak self, weak playerValue] controller in
+                guard let self, let playerValue, self.player == playerValue else { return }
+                self.onViewController(controller)
+            }
+
+            hooks.state.tap { [weak self] newState in
+                self?.state = newState
+            }
+
+            guard !flow.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                logger.d("Empty flow, not loading")
+                return
+            }
+
+            player.start(flow: flow) { [weak self, weak playerValue] result in
+                guard let self, let playerValue, self.player == playerValue else { return }
+                DispatchQueue.main.async { [weak self] in
+                    self?.result = result
+                }
+            }
         }
 
-        /**
-         Handler for when the ViewController in the core player changes
-         - parameters:
-            - viewController: The new ViewController instance
-         */
+        /// Handler for when the ViewController in the core player changes
+        /// - parameters:
+        ///   - viewController: The new ViewController instance
         private func onViewController(_ viewController: ViewController) {
             viewController.hooks.view.tap { [weak self, weak expectedPlayer] view in
                 guard let self, let expectedPlayer, self.player == expectedPlayer else { return }
@@ -154,25 +245,22 @@ public struct SwiftUIPlayer: View, HeadlessPlayer {
             }
         }
 
-        /**
-         Handler for when the View changes in the ViewController
-         - parameters:
-            - view: The new View in the ViewController
-         */
+        /// Handler for when the View changes in the ViewController
+        /// - parameters:
+        ///   - view: The new View in the ViewController
         private func onView(_ view: PlayerView) {
             view.hooks.onUpdate.tap { [weak self, weak expectedPlayer] value in
                 Task { @MainActor [weak self] in
-                    guard let self, let expectedPlayer, self.player == expectedPlayer else { return }
+                    guard let self, let expectedPlayer,
+                          self.player == expectedPlayer else { return }
                     self.onUpdate(value)
                 }
             }
         }
 
-        /**
-         Handler for when there is an update to the asset tree in the current `PlayerView`
-         - parameters:
-            - value: JSValue that is the root of the resolved asset tree
-         */
+        /// Handler for when there is an update to the asset tree in the current `PlayerView`
+        /// - parameters:
+        ///   - value: JSValue that is the root of the resolved asset tree
         private func onUpdate(_ value: JSValue) {
             JSGarbageCollect(value.context.jsGlobalContextRef)
             do {
@@ -181,80 +269,6 @@ public struct SwiftUIPlayer: View, HeadlessPlayer {
                 (state as? InProgressState)?.controllers?.error.captureError(error: error)
             }
         }
-    }
-
-    @ObservedObject private var context: Context
-    @Binding private var result: Result<CompletedState, PlayerError>?
-    private let unloadOnDisappear: Bool
-    /// A reference to the shared logger
-    public var logger: TapableLogger { context.logger }
-
-    /// A read only reference to the platform shared core player value in the `JSContext`
-    public var jsPlayerReference: JSValue? { context.player }
-
-    /// Lifecycle hooks exposed from the platform shared core player
-    public var hooks: SwiftUIPlayerHooks? { context.hooks }
-
-    /// The registry for registering assets to be used for rendering
-    public var assetRegistry: SwiftUIRegistry { context.registry }
-
-    // For ViewInspector testing
-    internal let inspection = Inspection<Self>()
-
-    /**
-     Constructs a `SwiftUIPlayer` with the given flow and plugins
-     - parameters:
-        - flow: The JSON flow to run
-        - plugins: Any plugins to add to Player
-        - context: An optional JSContext to use for loading platform shared code
-     */
-    public init(
-        flow: String,
-        plugins: [NativePlugin],
-        result: Binding<Result<CompletedState, PlayerError>?>,
-        context: Context = .shared,
-        unloadOnDisappear: Bool = true
-    ) {
-        let startTime = Date()
-        self._result = result
-        self._context = ObservedObject(initialValue: context)
-        self.unloadOnDisappear = unloadOnDisappear
-        context.load(flow: flow, plugins: plugins, player: self)
-
-        // Log the time it took to initialize Player
-        let initTime = Int((Date().timeIntervalSince(startTime) * 1000).rounded())
-        context.logger.i("SwiftUIPlayer initialized in \(initTime) ms.")
-    }
-
-    /// The SwiftUI View that is this Player flow
-    public var body: some View {
-        bodyContent
-            .environment(\.inProgressState, (state as? InProgressState))
-            .environment(\.constantsController, constantsController)
-            // forward results from our Context along to our result binding
-            .onReceive(context.$result.debounce(for: 0.1, scheduler: RunLoop.main)) {
-                self.result = $0
-            }
-            .onReceive(inspection.notice) { self.inspection.visit(self, $0) }
-            .onDisappear {
-                guard unloadOnDisappear else { return }
-                context.unload()
-            }
-    }
-
-    private var bodyContent: some View {
-        bodyContent(hooks?.transition.call() ?? .identity)
-    }
-
-    private func bodyContent(_ transitionInfo: PlayerViewTransition) -> some View {
-        // use a VStack to provide a container for our view transitions to run inside
-        VStack {
-            hooks?.view.call(context.registry.root?.view ?? AnyView(Color.clear))
-                .transition(transitionInfo.transition)
-                .id(context.registry.root?.id)
-        }
-        // only apply our transition animation when the root view is changing
-        .animation(transitionInfo.animationCurve, value: context.registry.root?.id)
     }
 }
 
@@ -267,7 +281,7 @@ struct InProgressStateKey: EnvironmentKey {
 /// EnvironmentKey for storing `constantsController`
 struct ConstantsControllerStateKey: EnvironmentKey {
     /// The default value for `@Environment(\.constantsController)`
-    static var defaultValue: ConstantsController? = nil
+    static var defaultValue: ConstantsController?
 }
 
 public extension EnvironmentValues {
@@ -276,7 +290,7 @@ public extension EnvironmentValues {
         get { self[InProgressStateKey.self] }
         set { self[InProgressStateKey.self] = newValue }
     }
-    
+
     /// The ConstantsController reference of Player
     var constantsController: ConstantsController? {
         get { self[ConstantsControllerStateKey.self] }
@@ -284,16 +298,14 @@ public extension EnvironmentValues {
     }
 }
 
-internal extension SwiftUIPlayer {
+extension SwiftUIPlayer {
     /// For testing, uses a constant result of nil.
     init(flow: String, plugins: [NativePlugin], context: SwiftUIPlayer.Context = .init()) {
         self.init(flow: flow, plugins: plugins, result: .constant(nil), context: context)
     }
 }
 
-/**
- Lifecycle hooks for `SwiftUIPlayer`
- */
+/// Lifecycle hooks for `SwiftUIPlayer`
 public struct SwiftUIPlayerHooks: CoreHooks {
     /// Fired when the FlowController changes
     public var flowController: Hook<FlowController>
@@ -329,82 +341,6 @@ public struct SwiftUIPlayerHooks: CoreHooks {
         view = SyncWaterfallHook<AnyView>()
         transition = SyncBailHook<Void, PlayerViewTransition>()
         onStart = Hook<FlowType>(baseValue: player, name: "onStart")
-    }
-}
-
-/**
- Holds information needed for transition animations when a new view in a flow is being shown
- */
-public struct PlayerViewTransition: Equatable {
-    public static let identity = PlayerViewTransition(name: .identity, transition: .identity, animationCurve: .default)
-
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs._transition == rhs._transition && lhs.animationCurve == rhs.animationCurve
-    }
-
-    private var _transition: Transition
-    /// The transition to show the new view with
-    public var transition: AnyTransition { _transition.transition }
-    /// The animation curve to use for the transition
-    public var animationCurve: Animation
-
-    /**
-     Creates a new `PlayerViewTransition`
-     - parameters:
-        - transition: The transition to show the new view with
-        - animationCurve: The animation curve to use for the transition
-     */
-    public init(
-        transition: AnyTransition,
-        animationCurve: Animation
-    ) {
-        self._transition = .unnamed(transition)
-        self.animationCurve = animationCurve
-    }
-
-    /**
-     Creates a new `PlayerViewTransition`
-     - parameters:
-        - transition: The transition to show the new view with
-        - animationCurve: The animation curve to use for the transition
-     */
-    public init(
-        name: Name,
-        transition: AnyTransition,
-        animationCurve: Animation
-    ) {
-        self._transition = .named(name, transition)
-        self.animationCurve = animationCurve
-    }
-
-    /// Name mostly exists as a way to allow testing of transition hooks.
-    public struct Name: RawRepresentable {
-        public static let identity = Name(rawValue: "identity")
-
-        public let rawValue: String
-
-        public init(rawValue: String) {
-            self.rawValue = rawValue
-        }
-    }
-
-    private enum Transition: Equatable {
-        public static func == (lhs: Self, rhs: Self) -> Bool {
-            switch (lhs, rhs) {
-            case (.named(let lName, _), .named(let rName, _)): return lName == rName
-            default:                                           return false
-            }
-        }
-
-        case named(Name, AnyTransition)
-        case unnamed(AnyTransition)
-
-        var transition: AnyTransition {
-            switch self {
-            case .named(_, let transition): return transition
-            case .unnamed(let transition):  return transition
-            }
-        }
     }
 }
 

--- a/ios/swiftui/Sources/SwiftUIRegistry.swift
+++ b/ios/swiftui/Sources/SwiftUIRegistry.swift
@@ -8,19 +8,30 @@
 import JavaScriptCore
 
 #if SWIFT_PACKAGE
-import PlayerUI
-import PlayerUILogger
+    import PlayerUI
+    import PlayerUILogger
 #endif
 
-/**
- Registry for SwiftUI based `SwiftUIAsset` implementations
- */
+/// Registry for SwiftUI based `SwiftUIAsset` implementations
 public class SwiftUIRegistry: BaseAssetRegistry<WrappedAsset>, ObservableObject {
     /// The Root level asset
     @Published public var root: SwiftUIAsset?
 
     /// Used during decoding to ensure view models are reused
-    private let modelCache = ModelCache()
+    private let modelCache: ModelCache = .init()
+
+    override public init(logger: TapableLogger? = nil) {
+        super.init(logger: logger)
+        decoder.setModelCache(modelCache)
+    }
+
+    /// Decodes the given `JSValue` and updates the @Published root asset
+    /// - parameters:
+    ///   - value: The JSValue that is the root of a resolved Asset tree from the `HeadlessPlayer`
+    public func decode(value: JSValue) throws {
+        // remain on the current `root` if decoding fails
+        root = try decode(value)
+    }
 
     func resetView(releasePartialMatch: Bool = true) {
         root = nil
@@ -29,25 +40,33 @@ public class SwiftUIRegistry: BaseAssetRegistry<WrappedAsset>, ObservableObject 
         }
         modelCache.clear()
     }
-
-    public override init(logger: TapableLogger? = nil) {
-        super.init(logger: logger)
-        decoder.setModelCache(modelCache)
-    }
-
-    /**
-     Decodes the given `JSValue` and updates the @Published root asset
-     - parameters:
-        - value: The JSValue that is the root of a resolved Asset tree from the `HeadlessPlayer`
-     */
-    public func decode(value: JSValue) throws {
-        // remain on the current `root` if decoding fails
-        root = try decode(value)
-    }
 }
 
 /// A key-value store used to hold previously created view models.
 final class ModelCache {
+    private var entries: [Key: Any] = [:]
+
+    func entry<T: AssetViewModel<ModelData>, ModelData>(forKey id: String,
+                                                        codingPath: [CodingKey]) -> T? {
+        assert(Thread.isMainThread)
+        let key = Key(id: id, codingPath: codingPath)
+        return entries[key] as? T
+    }
+
+    func set<T: AssetViewModel<ModelData>, ModelData>(
+        _ entry: T,
+        forKey id: String,
+        codingPath: [CodingKey]
+    ) {
+        assert(Thread.isMainThread)
+        let key = Key(id: id, codingPath: codingPath)
+        entries[key] = entry
+    }
+
+    fileprivate func clear() {
+        entries = [:]
+    }
+
     private struct Key: Hashable {
         private let id: String
         private let codingPath: [CodingPath]
@@ -70,22 +89,6 @@ final class ModelCache {
             self = .int(intValue)
         }
     }
-
-    private var entries: [Key: Any] = [:]
-
-    func entry<T, ModelData>(forKey id: String, codingPath: [CodingKey]) -> T? where T: AssetViewModel<ModelData> {
-        assert(Thread.isMainThread)
-        let key = Key(id: id, codingPath: codingPath)
-        return entries[key] as? T
-    }
-
-    func set<T, ModelData>(_ entry: T, forKey id: String, codingPath: [CodingKey]) where T: AssetViewModel<ModelData> {
-        assert(Thread.isMainThread)
-        let key = Key(id: id, codingPath: codingPath)
-        entries[key] = entry
-    }
-
-    fileprivate func clear() { entries = [:] }
 }
 
 extension Decoder {

--- a/ios/swiftui/Sources/SwiftUIRegistry.swift
+++ b/ios/swiftui/Sources/SwiftUIRegistry.swift
@@ -6,19 +6,29 @@
 //
 
 import JavaScriptCore
-
 import PlayerUI
 import PlayerUILogger
 
-/**
- Registry for SwiftUI based `SwiftUIAsset` implementations
- */
+/// Registry for SwiftUI based `SwiftUIAsset` implementations
 public class SwiftUIRegistry: BaseAssetRegistry<WrappedAsset>, ObservableObject {
     /// The Root level asset
     @Published public var root: SwiftUIAsset?
 
     /// Used during decoding to ensure view models are reused
-    private let modelCache = ModelCache()
+    private let modelCache: ModelCache = .init()
+
+    override public init(logger: TapableLogger? = nil) {
+        super.init(logger: logger)
+        decoder.setModelCache(modelCache)
+    }
+
+    /// Decodes the given `JSValue` and updates the @Published root asset
+    /// - parameters:
+    ///   - value: The JSValue that is the root of a resolved Asset tree from the `HeadlessPlayer`
+    public func decode(value: JSValue) throws {
+        // remain on the current `root` if decoding fails
+        root = try decode(value)
+    }
 
     func resetView(releasePartialMatch: Bool = true) {
         root = nil
@@ -27,25 +37,33 @@ public class SwiftUIRegistry: BaseAssetRegistry<WrappedAsset>, ObservableObject 
         }
         modelCache.clear()
     }
-
-    public override init(logger: TapableLogger? = nil) {
-        super.init(logger: logger)
-        decoder.setModelCache(modelCache)
-    }
-
-    /**
-     Decodes the given `JSValue` and updates the @Published root asset
-     - parameters:
-        - value: The JSValue that is the root of a resolved Asset tree from the `HeadlessPlayer`
-     */
-    public func decode(value: JSValue) throws {
-        // remain on the current `root` if decoding fails
-        root = try decode(value)
-    }
 }
 
 /// A key-value store used to hold previously created view models.
 final class ModelCache {
+    private var entries: [Key: Any] = [:]
+
+    func entry<T: AssetViewModel<ModelData>, ModelData>(forKey id: String,
+                                                        codingPath: [CodingKey]) -> T? {
+        assert(Thread.isMainThread)
+        let key = Key(id: id, codingPath: codingPath)
+        return entries[key] as? T
+    }
+
+    func set<T: AssetViewModel<ModelData>, ModelData>(
+        _ entry: T,
+        forKey id: String,
+        codingPath: [CodingKey]
+    ) {
+        assert(Thread.isMainThread)
+        let key = Key(id: id, codingPath: codingPath)
+        entries[key] = entry
+    }
+
+    fileprivate func clear() {
+        entries = [:]
+    }
+
     private struct Key: Hashable {
         private let id: String
         private let codingPath: [CodingPath]
@@ -68,22 +86,6 @@ final class ModelCache {
             self = .int(intValue)
         }
     }
-
-    private var entries: [Key: Any] = [:]
-
-    func entry<T, ModelData>(forKey id: String, codingPath: [CodingKey]) -> T? where T: AssetViewModel<ModelData> {
-        assert(Thread.isMainThread)
-        let key = Key(id: id, codingPath: codingPath)
-        return entries[key] as? T
-    }
-
-    func set<T, ModelData>(_ entry: T, forKey id: String, codingPath: [CodingKey]) where T: AssetViewModel<ModelData> {
-        assert(Thread.isMainThread)
-        let key = Key(id: id, codingPath: codingPath)
-        entries[key] = entry
-    }
-
-    fileprivate func clear() { entries = [:] }
 }
 
 extension Decoder {

--- a/ios/swiftui/Sources/SwiftUIRegistry.swift
+++ b/ios/swiftui/Sources/SwiftUIRegistry.swift
@@ -50,8 +50,8 @@ final class ModelCache {
         return entries[key] as? T
     }
 
-    func set<T: AssetViewModel<ModelData>, ModelData>(
-        _ entry: T,
+    func set(
+        _ entry: some AssetViewModel<some Any>,
         forKey id: String,
         codingPath: [CodingKey]
     ) {

--- a/ios/swiftui/Sources/extensions/SwiftUI+Decoder+Extensions.swift
+++ b/ios/swiftui/Sources/extensions/SwiftUI+Decoder+Extensions.swift
@@ -1,5 +1,5 @@
 //
-//  Decoder+Extensions.swift
+//  SwiftUI+Decoder+Extensions.swift
 //  PlayerUI
 //
 //  Created by Harris Borawski on 3/2/21.
@@ -8,19 +8,17 @@
 import Foundation
 
 #if SWIFT_PACKAGE
-import PlayerUI
+    import PlayerUI
 #endif
 
 /// A function that decodes a `SwiftUIAsset`
-public typealias DecodeSwiftUIFunction = ((Any) throws -> SwiftUIAsset?)
+public typealias DecodeSwiftUIFunction = (Any) throws -> SwiftUIAsset?
 
 public extension Decoder {
-    /**
-     Retrieves a `DecodeSwiftUIFunction` if the decoder has one
-     - returns: A `DecodeSwiftUIFunction`
-     */
+    /// Retrieves a `DecodeSwiftUIFunction` if the decoder has one
+    /// - returns: A `DecodeSwiftUIFunction`
     func getSUIDecodeFunction() throws -> DecodeSwiftUIFunction {
-        guard let decodeFunction = self.userInfo[self.decodeFunctionKey] as? DecodeSwiftUIFunction else {
+        guard let decodeFunction = userInfo[decodeFunctionKey] as? DecodeSwiftUIFunction else {
             throw DecodingError.decoderNotAnAssetDecoder
         }
         return decodeFunction

--- a/ios/swiftui/Sources/extensions/SwiftUI+Decoder+Extensions.swift
+++ b/ios/swiftui/Sources/extensions/SwiftUI+Decoder+Extensions.swift
@@ -1,24 +1,21 @@
 //
-//  Decoder+Extensions.swift
+//  SwiftUI+Decoder+Extensions.swift
 //  PlayerUI
 //
 //  Created by Harris Borawski on 3/2/21.
 //
 
 import Foundation
-
 import PlayerUI
 
 /// A function that decodes a `SwiftUIAsset`
-public typealias DecodeSwiftUIFunction = ((Any) throws -> SwiftUIAsset?)
+public typealias DecodeSwiftUIFunction = (Any) throws -> SwiftUIAsset?
 
 public extension Decoder {
-    /**
-     Retrieves a `DecodeSwiftUIFunction` if the decoder has one
-     - returns: A `DecodeSwiftUIFunction`
-     */
+    /// Retrieves a `DecodeSwiftUIFunction` if the decoder has one
+    /// - returns: A `DecodeSwiftUIFunction`
     func getSUIDecodeFunction() throws -> DecodeSwiftUIFunction {
-        guard let decodeFunction = self.userInfo[self.decodeFunctionKey] as? DecodeSwiftUIFunction else {
+        guard let decodeFunction = userInfo[decodeFunctionKey] as? DecodeSwiftUIFunction else {
             throw DecodingError.decoderNotAnAssetDecoder
         }
         return decodeFunction

--- a/ios/swiftui/Sources/types/WrappedFunction.swift
+++ b/ios/swiftui/Sources/types/WrappedFunction.swift
@@ -9,17 +9,11 @@ import Foundation
 import JavaScriptCore
 
 #if SWIFT_PACKAGE
-import PlayerUI
+    import PlayerUI
 #endif
 
-/**
- Represents a JS Function that was part of the asset in the JS runtime
- */
+/// Represents a JS Function that was part of the asset in the JS runtime
 public struct WrappedFunction<T>: JSValueBacked, Decodable, Hashable {
-    public static func == (lhs: WrappedFunction<T>, rhs: WrappedFunction<T>) -> Bool {
-        lhs.rawValue == rhs.rawValue
-    }
-
     public let rawValue: JSValue?
 
     public let userInfo: [CodingUserInfoKey: Any]?
@@ -29,48 +23,46 @@ public struct WrappedFunction<T>: JSValueBacked, Decodable, Hashable {
         self.userInfo = userInfo
     }
 
-    public func hash(into hasher: inout Hasher) {
-        return hasher.combine(rawValue)
-    }
-
-    /**
-     Constructs a WrappedFunction from a decoder
-     Since we can't decode JS functions using the JSONDecoder, this does nothing
-     and the JSValue is populated later with reflection
-     */
+    /// Constructs a WrappedFunction from a decoder
+    /// Since we can't decode JS functions using the JSONDecoder, this does nothing
+    /// and the JSValue is populated later with reflection
     public init(from decoder: Decoder) throws {
-        self.init(rawValue: try decoder.getJSValue(), userInfo: decoder.userInfo)
+        try self.init(rawValue: decoder.getJSValue(), userInfo: decoder.userInfo)
     }
 
-    // In Swift 5.2 we can just call the entire object
-    /**
-     Executes the function
-     */
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(rawValue)
+    }
+
+    /// In Swift 5.2 we can just call the entire object
+    /// Executes the function
     public func callAsFunction(_ args: Any...) -> T? {
         guard let jsValue = rawValue else { return nil }
         let val = jsValue.call(withArguments: args)
         return val?.toObject() as? T
     }
 
-    /**
-     Executes the function and returns the customType specified
-     */
-    public func callAsFunction<U>(customType: U.Type, args: Any...) throws -> U? where U: Decodable {
+    /// Executes the function and returns the customType specified
+    public func callAsFunction<U: Decodable>(customType: U.Type, args: Any...) throws -> U? {
         guard let jsValue = rawValue else { throw DecodingError.malformedData }
-        let decodedState = try JSONDecoder().decode(customType, from: jsValue.call(withArguments: args))
-        return decodedState
+        return try JSONDecoder().decode(customType, from: jsValue.call(withArguments: args))
+    }
+
+    public static func == (lhs: WrappedFunction<T>, rhs: WrappedFunction<T>) -> Bool {
+        lhs.rawValue == rhs.rawValue
     }
 }
 
-extension WrappedFunction where T: Decodable {
-    public enum Error: Swift.Error, Equatable {
+public extension WrappedFunction where T: Decodable {
+    enum Error: Swift.Error, Equatable {
         /// There was a failure in the promise from calling a JS function
         case promiseFailed(error: String)
     }
 
-    public func callAsFunctionAsync(args: Any...) async throws -> T {
+    func callAsFunctionAsync(args: Any...) async throws -> T {
         try await withCheckedThrowingContinuation { continuation in
-            guard let jsValue = rawValue else { return continuation.resume(throwing: DecodingError.malformedData) }
+            guard let jsValue = rawValue
+            else { return continuation.resume(throwing: DecodingError.malformedData) }
 
             let promiseHandler: @convention(block) (JSValue) -> Void = {
                 do {
@@ -82,7 +74,8 @@ extension WrappedFunction where T: Decodable {
             }
 
             let errorHandler: @convention(block) (JSValue) -> Void = { error in
-                return continuation.resume(throwing: WrappedFunction.Error.promiseFailed(error: error.toString()))
+                continuation
+                    .resume(throwing: WrappedFunction.Error.promiseFailed(error: error.toString()))
             }
 
             guard
@@ -100,22 +93,20 @@ extension WrappedFunction where T: Decodable {
     }
 }
 
-/**
- Wrapper class to decode model references into strings from the raw JSValue
- */
+/// Wrapper class to decode model references into strings from the raw JSValue
 public struct ModelReference: JSValueBacked, Decodable, Hashable {
     public let rawValue: JSValue?
+
+    /// The string value of this model reference
+    public var stringValue: String? {
+        rawValue?.toString()
+    }
 
     public init(rawValue: JSValue?) {
         self.rawValue = rawValue
     }
 
     public init(from decoder: Decoder) throws {
-        self.init(rawValue: try decoder.getJSValue())
-    }
-
-    /// The string value of this model reference
-    public var stringValue: String? {
-        rawValue?.toString()
+        try self.init(rawValue: decoder.getJSValue())
     }
 }

--- a/ios/swiftui/Sources/types/WrappedFunction.swift
+++ b/ios/swiftui/Sources/types/WrappedFunction.swift
@@ -7,17 +7,10 @@
 
 import Foundation
 import JavaScriptCore
-
 import PlayerUI
 
-/**
- Represents a JS Function that was part of the asset in the JS runtime
- */
+/// Represents a JS Function that was part of the asset in the JS runtime
 public struct WrappedFunction<T>: JSValueBacked, Decodable, Hashable {
-    public static func == (lhs: WrappedFunction<T>, rhs: WrappedFunction<T>) -> Bool {
-        lhs.rawValue == rhs.rawValue
-    }
-
     public let rawValue: JSValue?
 
     public let userInfo: [CodingUserInfoKey: Any]?
@@ -27,48 +20,46 @@ public struct WrappedFunction<T>: JSValueBacked, Decodable, Hashable {
         self.userInfo = userInfo
     }
 
-    public func hash(into hasher: inout Hasher) {
-        return hasher.combine(rawValue)
-    }
-
-    /**
-     Constructs a WrappedFunction from a decoder
-     Since we can't decode JS functions using the JSONDecoder, this does nothing
-     and the JSValue is populated later with reflection
-     */
+    /// Constructs a WrappedFunction from a decoder
+    /// Since we can't decode JS functions using the JSONDecoder, this does nothing
+    /// and the JSValue is populated later with reflection
     public init(from decoder: Decoder) throws {
-        self.init(rawValue: try decoder.getJSValue(), userInfo: decoder.userInfo)
+        try self.init(rawValue: decoder.getJSValue(), userInfo: decoder.userInfo)
     }
 
-    // In Swift 5.2 we can just call the entire object
-    /**
-     Executes the function
-     */
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(rawValue)
+    }
+
+    /// In Swift 5.2 we can just call the entire object
+    /// Executes the function
     public func callAsFunction(_ args: Any...) -> T? {
         guard let jsValue = rawValue else { return nil }
         let val = jsValue.call(withArguments: args)
         return val?.toObject() as? T
     }
 
-    /**
-     Executes the function and returns the customType specified
-     */
-    public func callAsFunction<U>(customType: U.Type, args: Any...) throws -> U? where U: Decodable {
+    /// Executes the function and returns the customType specified
+    public func callAsFunction<U: Decodable>(customType: U.Type, args: Any...) throws -> U? {
         guard let jsValue = rawValue else { throw DecodingError.malformedData }
-        let decodedState = try JSONDecoder().decode(customType, from: jsValue.call(withArguments: args))
-        return decodedState
+        return try JSONDecoder().decode(customType, from: jsValue.call(withArguments: args))
+    }
+
+    public static func == (lhs: WrappedFunction<T>, rhs: WrappedFunction<T>) -> Bool {
+        lhs.rawValue == rhs.rawValue
     }
 }
 
-extension WrappedFunction where T: Decodable {
-    public enum Error: Swift.Error, Equatable {
+public extension WrappedFunction where T: Decodable {
+    enum Error: Swift.Error, Equatable {
         /// There was a failure in the promise from calling a JS function
         case promiseFailed(error: String)
     }
 
-    public func callAsFunctionAsync(args: Any...) async throws -> T {
+    func callAsFunctionAsync(args: Any...) async throws -> T {
         try await withCheckedThrowingContinuation { continuation in
-            guard let jsValue = rawValue else { return continuation.resume(throwing: DecodingError.malformedData) }
+            guard let jsValue = rawValue
+            else { return continuation.resume(throwing: DecodingError.malformedData) }
 
             let promiseHandler: @convention(block) (JSValue) -> Void = {
                 do {
@@ -80,7 +71,8 @@ extension WrappedFunction where T: Decodable {
             }
 
             let errorHandler: @convention(block) (JSValue) -> Void = { error in
-                return continuation.resume(throwing: WrappedFunction.Error.promiseFailed(error: error.toString()))
+                continuation
+                    .resume(throwing: WrappedFunction.Error.promiseFailed(error: error.toString()))
             }
 
             guard
@@ -98,22 +90,20 @@ extension WrappedFunction where T: Decodable {
     }
 }
 
-/**
- Wrapper class to decode model references into strings from the raw JSValue
- */
+/// Wrapper class to decode model references into strings from the raw JSValue
 public struct ModelReference: JSValueBacked, Decodable, Hashable {
     public let rawValue: JSValue?
+
+    /// The string value of this model reference
+    public var stringValue: String? {
+        rawValue?.toString()
+    }
 
     public init(rawValue: JSValue?) {
         self.rawValue = rawValue
     }
 
     public init(from decoder: Decoder) throws {
-        self.init(rawValue: try decoder.getJSValue())
-    }
-
-    /// The string value of this model reference
-    public var stringValue: String? {
-        rawValue?.toString()
+        try self.init(rawValue: decoder.getJSValue())
     }
 }

--- a/ios/swiftui/Sources/types/assets/ControlledAsset.swift
+++ b/ios/swiftui/Sources/types/assets/ControlledAsset.swift
@@ -9,36 +9,36 @@ import Combine
 import SwiftUI
 
 #if SWIFT_PACKAGE
-import PlayerUI
+    import PlayerUI
 #endif
 
 public enum AssetRenderError: Error {
-    // Thrown when the asset fails to decode its data from the JS runtime into its swift data type
+    /// Thrown when the asset fails to decode its data from the JS runtime into its swift data type
     case decodingFailure(innerError: Error, asset: AssetData? = nil, pathToAsset: [AssetData])
 }
 
 extension AssetRenderError: CustomDebugStringConvertible {
     public var debugDescription: String {
         switch self {
-        case .decodingFailure(let innerError, let asset, let pathToAsset):
+        case let .decodingFailure(innerError, asset, pathToAsset):
             return """
-An error occured while decoding an asset.
-Caused by: \(innerError.playerDescription)
-Exception occurred in asset with id '\(asset?.id ?? "UNKNOWN")' of type '\(asset?.type ?? "UNKNOWN")'\(pathToAsset.map({ "\n\tFound in (id: '\($0.id)', type: '\($0.type)')" }).joined())
-"""
+            An error occured while decoding an asset.
+            Caused by: \(innerError.playerDescription)
+            Exception occurred in asset with id '\(asset?.id ?? "UNKNOWN")' of type '\(asset?
+                .type ?? "UNKNOWN")'\(pathToAsset
+                .map { "\n\tFound in (id: '\($0.id)', type: '\($0.type)')" }
+                .joined())
+            """
         }
     }
 }
 
 struct MinimumAssetData: AssetData {
-    public var id: String
-    public var type: String
+    var id: String
+    var type: String
 }
 
-
-/**
- A ViewModel that contains decoded AssetData for an Asset
- */
+/// A ViewModel that contains decoded AssetData for an Asset
 open class AssetViewModel<T: AssetData>: ObservableObject {
     /// The decoded data
     @Published public var data: T
@@ -47,46 +47,45 @@ open class AssetViewModel<T: AssetData>: ObservableObject {
     public var userInfo: [CodingUserInfoKey: Any]
 
     /// Set to store subscriptions in for cancellation
-    public var bag = Set<AnyCancellable>()
+    public var bag: Set<AnyCancellable> = []
 
-    /**
-     Constructs an instance of this ViewModel with the given data
-     - parameters:
-        - data: The data to publish from this ViewModel
-        - userInfo:  Any contextual information set by the user
-     */
+    /// Constructs an instance of this ViewModel with the given data
+    /// - parameters:
+    ///   - data: The data to publish from this ViewModel
+    ///   - userInfo:  Any contextual information set by the user
     public required init(_ data: T, userInfo: [CodingUserInfoKey: Any] = [:]) {
-        self._data = Published(initialValue: data)
+        _data = Published(initialValue: data)
         self.userInfo = userInfo
     }
 }
 
-/**
- An Asset with a default ViewModel
- */
-open class UncontrolledAsset<DataType: AssetData>: ControlledAsset<DataType, AssetViewModel<DataType>> {}
+/// An Asset with a default ViewModel
+open class UncontrolledAsset<DataType: AssetData>: ControlledAsset<
+    DataType,
+    AssetViewModel<DataType>
+> {}
 
-/**
- An Asset with a custom ViewModel that extends the default one to receive data updates
- */
-open class ControlledAsset<DataType: AssetData, ModelType>: SwiftUIAsset where ModelType: AssetViewModel<DataType> {
+/// An Asset with a custom ViewModel that extends the default one to receive data updates
+open class ControlledAsset<DataType: AssetData, ModelType: AssetViewModel<DataType>>: SwiftUIAsset {
     /// The ViewModel associated with this asset
     public let model: ModelType
 
     /// The decoded data associated with this asset
-    override open var valueData: AssetData { model.data }
+    override open var valueData: AssetData {
+        model.data
+    }
 
-    override var modelObject: AnyObject { model }
+    override var modelObject: AnyObject {
+        model
+    }
 
-    /**
-     Constructs a SwiftUIAsset from a decoder
-     - parameters:
-        - from: The decoder to decode from
-     */
+    /// Constructs a SwiftUIAsset from a decoder
+    /// - parameters:
+    ///   - from: The decoder to decode from
     public required init(from decoder: Decoder) throws {
         do {
             let data = try decoder.singleValueContainer().decode(DataType.self)
-            
+
             // When we have a plain old AssetViewModel, not a subclass with custom
             // properties, we want to bypass the model cache altogether.
             //
@@ -101,7 +100,10 @@ open class ControlledAsset<DataType: AssetData, ModelType>: SwiftUIAsset where M
             //
             let needsModelCache = (ModelType.self != AssetViewModel<DataType>.self)
             let modelCache = needsModelCache ? try decoder.getModelCache() : nil
-            if let model: ModelType = modelCache?.entry(forKey: data.id, codingPath: decoder.codingPath) {
+            if let model: ModelType = modelCache?.entry(
+                forKey: data.id,
+                codingPath: decoder.codingPath
+            ) {
                 // we can't safely take advantage of AssetData.isEqual here because
                 // the process of decoding can alter the contents of previously
                 // cached model data (because AssetData can contain reference types)
@@ -110,25 +112,31 @@ open class ControlledAsset<DataType: AssetData, ModelType>: SwiftUIAsset where M
                 model.data = data
                 model.userInfo = decoder.userInfo
             } else {
-                self.model = ModelType(data, userInfo: decoder.userInfo)
+                model = ModelType(data, userInfo: decoder.userInfo)
                 decoder.logger?.t("Creating model for \(data.id)")
                 modelCache?.set(model, forKey: data.id, codingPath: decoder.codingPath)
             }
-            
+
             try super.init(from: decoder)
-        }
-        catch AssetRenderError.decodingFailure(let innerError, let asset, let pathToAsset) {
+        } catch let AssetRenderError.decodingFailure(innerError, asset, pathToAsset) {
             let basicData = try? decoder.singleValueContainer().decode(MinimumAssetData.self)
             var newPath = pathToAsset
             if let basicData {
                 newPath = pathToAsset + [basicData]
             }
-            throw AssetRenderError.decodingFailure(innerError: innerError, asset: asset, pathToAsset: newPath)
-            
-        }
-        catch {
+            throw AssetRenderError.decodingFailure(
+                innerError: innerError,
+                asset: asset,
+                pathToAsset: newPath
+            )
+
+        } catch {
             let basicData = try? decoder.singleValueContainer().decode(MinimumAssetData.self)
-            throw AssetRenderError.decodingFailure(innerError: error, asset: basicData, pathToAsset: [])
+            throw AssetRenderError.decodingFailure(
+                innerError: error,
+                asset: basicData,
+                pathToAsset: []
+            )
         }
     }
 }

--- a/ios/swiftui/Sources/types/assets/ControlledAsset.swift
+++ b/ios/swiftui/Sources/types/assets/ControlledAsset.swift
@@ -26,7 +26,7 @@ extension AssetRenderError: ErrorWithMetadata {
     public var metadata: [String: Any]? {
         switch self {
         case let .decodingFailure(_, asset, _):
-            return ["assetId": asset?.id ?? ""]
+            ["assetId": asset?.id ?? ""]
         }
     }
 
@@ -39,7 +39,7 @@ extension AssetRenderError: CustomDebugStringConvertible {
     public var debugDescription: String {
         switch self {
         case let .decodingFailure(innerError, asset, pathToAsset):
-            return """
+            """
             An error occured while decoding an asset.
             Caused by: \(innerError.playerDescription)
             Exception occurred in asset with id '\(asset?.id ?? "UNKNOWN")' of type '\(asset?

--- a/ios/swiftui/Sources/types/assets/ControlledAsset.swift
+++ b/ios/swiftui/Sources/types/assets/ControlledAsset.swift
@@ -6,50 +6,57 @@
 //
 
 import Combine
+import PlayerUI
 import SwiftUI
 
-import PlayerUI
-
 public enum AssetRenderError: Error {
-    // Thrown when the asset fails to decode its data from the JS runtime into its swift data type
+    /// Thrown when the asset fails to decode its data from the JS runtime into its swift data type
     case decodingFailure(innerError: Error, asset: AssetData? = nil, pathToAsset: [AssetData])
 }
 
 extension AssetRenderError: ErrorWithMetadata {
-    public var type: ErrorTypes { .render }
-    public var severity: ErrorSeverity? { ErrorSeverity.error }
+    public var type: ErrorTypes {
+        .render
+    }
+
+    public var severity: ErrorSeverity? {
+        ErrorSeverity.error
+    }
+
     public var metadata: [String: Any]? {
         switch self {
-        case .decodingFailure(_, let asset, _):
+        case let .decodingFailure(_, asset, _):
             return ["assetId": asset?.id ?? ""]
         }
     }
-    public var jsDescription: String { debugDescription }
+
+    public var jsDescription: String {
+        debugDescription
+    }
 }
 
 extension AssetRenderError: CustomDebugStringConvertible {
     public var debugDescription: String {
         switch self {
-        case .decodingFailure(let innerError, let asset, let pathToAsset):
+        case let .decodingFailure(innerError, asset, pathToAsset):
             return """
-An error occured while decoding an asset.
-Caused by: \(innerError.playerDescription)
-Exception occurred in asset with id '\(asset?.id ?? "UNKNOWN")' of type '\(asset?.type ?? "UNKNOWN")'\(pathToAsset.map({ "\n\tFound in (id: '\($0.id)', type: '\($0.type)')" }).joined())
-"""
+            An error occured while decoding an asset.
+            Caused by: \(innerError.playerDescription)
+            Exception occurred in asset with id '\(asset?.id ?? "UNKNOWN")' of type '\(asset?
+                .type ?? "UNKNOWN")'\(pathToAsset
+                .map { "\n\tFound in (id: '\($0.id)', type: '\($0.type)')" }
+                .joined())
+            """
         }
     }
 }
 
-
 struct MinimumAssetData: AssetData {
-    public var id: String
-    public var type: String
+    var id: String
+    var type: String
 }
 
-
-/**
- A ViewModel that contains decoded AssetData for an Asset
- */
+/// A ViewModel that contains decoded AssetData for an Asset
 open class AssetViewModel<T: AssetData>: ObservableObject {
     /// The decoded data
     @Published public var data: T
@@ -58,46 +65,45 @@ open class AssetViewModel<T: AssetData>: ObservableObject {
     public var userInfo: [CodingUserInfoKey: Any]
 
     /// Set to store subscriptions in for cancellation
-    public var bag = Set<AnyCancellable>()
+    public var bag: Set<AnyCancellable> = []
 
-    /**
-     Constructs an instance of this ViewModel with the given data
-     - parameters:
-        - data: The data to publish from this ViewModel
-        - userInfo:  Any contextual information set by the user
-     */
+    /// Constructs an instance of this ViewModel with the given data
+    /// - parameters:
+    ///   - data: The data to publish from this ViewModel
+    ///   - userInfo:  Any contextual information set by the user
     public required init(_ data: T, userInfo: [CodingUserInfoKey: Any] = [:]) {
-        self._data = Published(initialValue: data)
+        _data = Published(initialValue: data)
         self.userInfo = userInfo
     }
 }
 
-/**
- An Asset with a default ViewModel
- */
-open class UncontrolledAsset<DataType: AssetData>: ControlledAsset<DataType, AssetViewModel<DataType>> {}
+/// An Asset with a default ViewModel
+open class UncontrolledAsset<DataType: AssetData>: ControlledAsset<
+    DataType,
+    AssetViewModel<DataType>
+> {}
 
-/**
- An Asset with a custom ViewModel that extends the default one to receive data updates
- */
-open class ControlledAsset<DataType: AssetData, ModelType>: SwiftUIAsset where ModelType: AssetViewModel<DataType> {
+/// An Asset with a custom ViewModel that extends the default one to receive data updates
+open class ControlledAsset<DataType: AssetData, ModelType: AssetViewModel<DataType>>: SwiftUIAsset {
     /// The ViewModel associated with this asset
     public let model: ModelType
 
     /// The decoded data associated with this asset
-    override open var valueData: AssetData { model.data }
+    override open var valueData: AssetData {
+        model.data
+    }
 
-    override var modelObject: AnyObject { model }
+    override var modelObject: AnyObject {
+        model
+    }
 
-    /**
-     Constructs a SwiftUIAsset from a decoder
-     - parameters:
-        - from: The decoder to decode from
-     */
+    /// Constructs a SwiftUIAsset from a decoder
+    /// - parameters:
+    ///   - from: The decoder to decode from
     public required init(from decoder: Decoder) throws {
         do {
             let data = try decoder.singleValueContainer().decode(DataType.self)
-            
+
             // When we have a plain old AssetViewModel, not a subclass with custom
             // properties, we want to bypass the model cache altogether.
             //
@@ -112,7 +118,10 @@ open class ControlledAsset<DataType: AssetData, ModelType>: SwiftUIAsset where M
             //
             let needsModelCache = (ModelType.self != AssetViewModel<DataType>.self)
             let modelCache = needsModelCache ? try decoder.getModelCache() : nil
-            if let model: ModelType = modelCache?.entry(forKey: data.id, codingPath: decoder.codingPath) {
+            if let model: ModelType = modelCache?.entry(
+                forKey: data.id,
+                codingPath: decoder.codingPath
+            ) {
                 // we can't safely take advantage of AssetData.isEqual here because
                 // the process of decoding can alter the contents of previously
                 // cached model data (because AssetData can contain reference types)
@@ -121,25 +130,31 @@ open class ControlledAsset<DataType: AssetData, ModelType>: SwiftUIAsset where M
                 model.data = data
                 model.userInfo = decoder.userInfo
             } else {
-                self.model = ModelType(data, userInfo: decoder.userInfo)
+                model = ModelType(data, userInfo: decoder.userInfo)
                 decoder.logger?.t("Creating model for \(data.id)")
                 modelCache?.set(model, forKey: data.id, codingPath: decoder.codingPath)
             }
-            
+
             try super.init(from: decoder)
-        }
-        catch AssetRenderError.decodingFailure(let innerError, let asset, let pathToAsset) {
+        } catch let AssetRenderError.decodingFailure(innerError, asset, pathToAsset) {
             let basicData = try? decoder.singleValueContainer().decode(MinimumAssetData.self)
             var newPath = pathToAsset
             if let basicData {
                 newPath = pathToAsset + [basicData]
             }
-            throw AssetRenderError.decodingFailure(innerError: innerError, asset: asset, pathToAsset: newPath)
-            
-        }
-        catch {
+            throw AssetRenderError.decodingFailure(
+                innerError: innerError,
+                asset: asset,
+                pathToAsset: newPath
+            )
+
+        } catch {
             let basicData = try? decoder.singleValueContainer().decode(MinimumAssetData.self)
-            throw AssetRenderError.decodingFailure(innerError: error, asset: basicData, pathToAsset: [])
+            throw AssetRenderError.decodingFailure(
+                innerError: error,
+                asset: basicData,
+                pathToAsset: []
+            )
         }
     }
 }

--- a/ios/swiftui/Sources/types/assets/SwiftUIAsset.swift
+++ b/ios/swiftui/Sources/types/assets/SwiftUIAsset.swift
@@ -9,24 +9,48 @@ import JavaScriptCore
 import SwiftUI
 
 #if SWIFT_PACKAGE
-import PlayerUI
+    import PlayerUI
 #endif
 
-/**
- A base class representing a Player Asset that will be rendering using SwiftUI
- */
+/// A base class representing a Player Asset that will be rendering using SwiftUI
 open class SwiftUIAsset: Decodable, PlayerAsset, Identifiable {
     /// UUID of this Asset for identifying the instance
-    public var uuid = UUID()
+    public var uuid: UUID = .init()
+
+    /// Decoded `Data`
+    public var baseData: Data
+
+    /// Full data decoded by the implementation of this asset
+    open var valueData: AssetData {
+        baseData
+    }
+
+    /// A type erased SwiftUI view to use for rendering this asset
+    open var view: AnyView {
+        AnyView(EmptyView())
+    }
 
     /// id of the asset
-    public var id: String { valueData.id }
+    public var id: String {
+        valueData.id
+    }
 
     /// type of the asset
-    public var type: String { valueData.type }
+    public var type: String {
+        valueData.type
+    }
 
     /// Used for model cache testing
-    var modelObject: AnyObject { self }
+    var modelObject: AnyObject {
+        self
+    }
+
+    /// Decodes an asset to create an instance
+    /// - parameters:
+    ///   - decoder: The decoder to decode from
+    public required init(from decoder: Decoder) throws {
+        baseData = try decoder.singleValueContainer().decode(Data.self)
+    }
 
     /// Default data that an asset will contain
     public struct Data: AssetData, Codable {
@@ -37,22 +61,4 @@ open class SwiftUIAsset: Decodable, PlayerAsset, Identifiable {
         /// MetaData associated with this asset
         public var metaData: MetaData?
     }
-
-    /// Decoded `Data`
-    public var baseData: Data
-
-    /// Full data decoded by the implementation of this asset
-    open var valueData: AssetData { baseData }
-
-    /**
-     Decodes an asset to create an instance
-      - parameters:
-        - decoder: The decoder to decode from
-     */
-    public required init(from decoder: Decoder) throws {
-        baseData = try decoder.singleValueContainer().decode(Data.self)
-    }
-
-    /// A type erased SwiftUI view to use for rendering this asset
-    open var view: AnyView { AnyView(EmptyView()) }
 }

--- a/ios/swiftui/Sources/types/assets/SwiftUIAsset.swift
+++ b/ios/swiftui/Sources/types/assets/SwiftUIAsset.swift
@@ -6,25 +6,48 @@
 //
 
 import JavaScriptCore
+import PlayerUI
 import SwiftUI
 
-import PlayerUI
-
-/**
- A base class representing a Player Asset that will be rendering using SwiftUI
- */
+/// A base class representing a Player Asset that will be rendering using SwiftUI
 open class SwiftUIAsset: Decodable, PlayerAsset, Identifiable {
     /// UUID of this Asset for identifying the instance
-    public var uuid = UUID()
+    public var uuid: UUID = .init()
+
+    /// Decoded `Data`
+    public var baseData: Data
+
+    /// Full data decoded by the implementation of this asset
+    open var valueData: AssetData {
+        baseData
+    }
+
+    /// A type erased SwiftUI view to use for rendering this asset
+    open var view: AnyView {
+        AnyView(EmptyView())
+    }
 
     /// id of the asset
-    public var id: String { valueData.id }
+    public var id: String {
+        valueData.id
+    }
 
     /// type of the asset
-    public var type: String { valueData.type }
+    public var type: String {
+        valueData.type
+    }
 
     /// Used for model cache testing
-    var modelObject: AnyObject { self }
+    var modelObject: AnyObject {
+        self
+    }
+
+    /// Decodes an asset to create an instance
+    /// - parameters:
+    ///   - decoder: The decoder to decode from
+    public required init(from decoder: Decoder) throws {
+        baseData = try decoder.singleValueContainer().decode(Data.self)
+    }
 
     /// Default data that an asset will contain
     public struct Data: AssetData, Codable {
@@ -35,22 +58,4 @@ open class SwiftUIAsset: Decodable, PlayerAsset, Identifiable {
         /// MetaData associated with this asset
         public var metaData: MetaData?
     }
-
-    /// Decoded `Data`
-    public var baseData: Data
-
-    /// Full data decoded by the implementation of this asset
-    open var valueData: AssetData { baseData }
-
-    /**
-     Decodes an asset to create an instance
-      - parameters:
-        - decoder: The decoder to decode from
-     */
-    public required init(from decoder: Decoder) throws {
-        baseData = try decoder.singleValueContainer().decode(Data.self)
-    }
-
-    /// A type erased SwiftUI view to use for rendering this asset
-    open var view: AnyView { AnyView(EmptyView()) }
 }

--- a/ios/swiftui/Sources/types/assets/WrappedAsset.swift
+++ b/ios/swiftui/Sources/types/assets/WrappedAsset.swift
@@ -6,37 +6,32 @@
 //
 
 #if SWIFT_PACKAGE
-import PlayerUI
+    import PlayerUI
 #endif
 
-/**
- Represents the wrapping object that contains a SwiftUIAsset
- The JS Player will return assets in the format
- ```
- { asset: {id, type} }
- ```
- or
- ```
- { id, type }
- ```
- This wrapper decodes either to provide a consistent access mechanism
- */
+/// Represents the wrapping object that contains a SwiftUIAsset
+/// The JS Player will return assets in the format
+/// ```
+/// { asset: {id, type} }
+/// ```
+/// or
+/// ```
+/// { id, type }
+/// ```
+/// This wrapper decodes either to provide a consistent access mechanism
 public typealias WrappedAsset = GenericWrappedAsset<MetaData>
 
-public typealias GenericWrappedAsset<MetaDataType: Decodable&Equatable> = BaseGenericWrappedAsset<MetaDataType, DefaultAdditionalData>
+public typealias GenericWrappedAsset<MetaDataType: Decodable & Equatable> = BaseGenericWrappedAsset<
+    MetaDataType,
+    DefaultAdditionalData
+>
 
 public struct DefaultAdditionalData: Decodable, Equatable {}
 
-public struct BaseGenericWrappedAsset<MetaData, AdditionalData>: Decodable, AssetContainer
-    where MetaData: Decodable&Equatable, AdditionalData: Decodable&Equatable {
-    /// The keys used to decode the wrapper
-    public enum CodingKeys: String, CodingKey {
-        /// Key to decode asset in a wrapper
-        case asset
-        /// Key to decode metadata in a wrapper
-        case metaData
-    }
-
+public struct BaseGenericWrappedAsset<
+    MetaData: Decodable & Equatable,
+    AdditionalData: Decodable & Equatable
+>: Decodable, AssetContainer {
     /// The underlying asset if it decoded
     public var asset: SwiftUIAsset?
 
@@ -46,37 +41,46 @@ public struct BaseGenericWrappedAsset<MetaData, AdditionalData>: Decodable, Asse
     /// Additional data to decode as sibling keys to `asset` or `metaData`
     public var additionalData: AdditionalData?
 
-    /**
-     Constructs an AssetWrapper, this is used as a fallback when decoding fails
-     so the base asset can be used in the tree
-     - parameters:
-        - forAsset: The asset to put into the wrapper
-     */
+    /// Constructs an AssetWrapper, this is used as a fallback when decoding fails
+    /// so the base asset can be used in the tree
+    /// - parameters:
+    ///   - forAsset: The asset to put into the wrapper
     public init(forAsset: SwiftUIAsset) {
-        self.asset = forAsset
+        asset = forAsset
     }
 
-    /**
-     Constructs an AssetWrapper from a decoder instance
-     - parameters:
-        - decoder: The decoder to decode from
-     - throws:
-        Throws an error if the decoder does not contain a DecodeFunction
-     */
+    /// Constructs an AssetWrapper from a decoder instance
+    /// - parameters:
+    ///   - decoder: The decoder to decode from
+    /// - throws:
+    ///   Throws an error if the decoder does not contain a DecodeFunction
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.asset = try container.decodeIfPresent(RegistryDecodeShim<SwiftUIAsset>.self, forKey: .asset)?.asset
-        self.metaData = try container.decodeIfPresent(MetaData.self, forKey: .metaData)
-        self.additionalData = try decoder.singleValueContainer().decode(AdditionalData.self)
+        asset = try container
+            .decodeIfPresent(RegistryDecodeShim<SwiftUIAsset>.self, forKey: .asset)?
+            .asset
+        metaData = try container.decodeIfPresent(MetaData.self, forKey: .metaData)
+        additionalData = try decoder.singleValueContainer().decode(AdditionalData.self)
+    }
+
+    /// The keys used to decode the wrapper
+    public enum CodingKeys: String, CodingKey {
+        /// Key to decode asset in a wrapper
+        case asset
+        /// Key to decode metadata in a wrapper
+        case metaData
     }
 }
 
 // MARK: - Equatable conformance
+
 extension GenericWrappedAsset: Equatable where MetaData: Equatable {
     public static func == (lhs: Self, rhs: Self) -> Bool {
-        let isMetaDataSame   = lhs.metaData == rhs.metaData
+        let isMetaDataSame = lhs.metaData == rhs.metaData
         let areBothAssetsNil = lhs.asset == nil && rhs.asset == nil
-        var areAssetsEqual: Bool { (lhs.asset?.valueData).flatMap { rhs.asset?.valueData.isEqual($0) } ?? false }
+        var areAssetsEqual: Bool {
+            (lhs.asset?.valueData).flatMap { rhs.asset?.valueData.isEqual($0) } ?? false
+        }
         return isMetaDataSame && (areBothAssetsNil || areAssetsEqual)
     }
 }

--- a/ios/swiftui/Sources/types/assets/WrappedAsset.swift
+++ b/ios/swiftui/Sources/types/assets/WrappedAsset.swift
@@ -7,34 +7,29 @@
 
 import PlayerUI
 
-/**
- Represents the wrapping object that contains a SwiftUIAsset
- The JS Player will return assets in the format
- ```
- { asset: {id, type} }
- ```
- or
- ```
- { id, type }
- ```
- This wrapper decodes either to provide a consistent access mechanism
- */
+/// Represents the wrapping object that contains a SwiftUIAsset
+/// The JS Player will return assets in the format
+/// ```
+/// { asset: {id, type} }
+/// ```
+/// or
+/// ```
+/// { id, type }
+/// ```
+/// This wrapper decodes either to provide a consistent access mechanism
 public typealias WrappedAsset = GenericWrappedAsset<MetaData>
 
-public typealias GenericWrappedAsset<MetaDataType: Decodable&Equatable> = BaseGenericWrappedAsset<MetaDataType, DefaultAdditionalData>
+public typealias GenericWrappedAsset<MetaDataType: Decodable & Equatable> = BaseGenericWrappedAsset<
+    MetaDataType,
+    DefaultAdditionalData
+>
 
 public struct DefaultAdditionalData: Decodable, Equatable {}
 
-public struct BaseGenericWrappedAsset<MetaData, AdditionalData>: Decodable, AssetContainer
-    where MetaData: Decodable&Equatable, AdditionalData: Decodable&Equatable {
-    /// The keys used to decode the wrapper
-    public enum CodingKeys: String, CodingKey {
-        /// Key to decode asset in a wrapper
-        case asset
-        /// Key to decode metadata in a wrapper
-        case metaData
-    }
-
+public struct BaseGenericWrappedAsset<
+    MetaData: Decodable & Equatable,
+    AdditionalData: Decodable & Equatable
+>: Decodable, AssetContainer {
     /// The underlying asset if it decoded
     public var asset: SwiftUIAsset?
 
@@ -44,37 +39,46 @@ public struct BaseGenericWrappedAsset<MetaData, AdditionalData>: Decodable, Asse
     /// Additional data to decode as sibling keys to `asset` or `metaData`
     public var additionalData: AdditionalData?
 
-    /**
-     Constructs an AssetWrapper, this is used as a fallback when decoding fails
-     so the base asset can be used in the tree
-     - parameters:
-        - forAsset: The asset to put into the wrapper
-     */
+    /// Constructs an AssetWrapper, this is used as a fallback when decoding fails
+    /// so the base asset can be used in the tree
+    /// - parameters:
+    ///   - forAsset: The asset to put into the wrapper
     public init(forAsset: SwiftUIAsset) {
-        self.asset = forAsset
+        asset = forAsset
     }
 
-    /**
-     Constructs an AssetWrapper from a decoder instance
-     - parameters:
-        - decoder: The decoder to decode from
-     - throws:
-        Throws an error if the decoder does not contain a DecodeFunction
-     */
+    /// Constructs an AssetWrapper from a decoder instance
+    /// - parameters:
+    ///   - decoder: The decoder to decode from
+    /// - throws:
+    ///   Throws an error if the decoder does not contain a DecodeFunction
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.asset = try container.decodeIfPresent(RegistryDecodeShim<SwiftUIAsset>.self, forKey: .asset)?.asset
-        self.metaData = try container.decodeIfPresent(MetaData.self, forKey: .metaData)
-        self.additionalData = try decoder.singleValueContainer().decode(AdditionalData.self)
+        asset = try container
+            .decodeIfPresent(RegistryDecodeShim<SwiftUIAsset>.self, forKey: .asset)?
+            .asset
+        metaData = try container.decodeIfPresent(MetaData.self, forKey: .metaData)
+        additionalData = try decoder.singleValueContainer().decode(AdditionalData.self)
+    }
+
+    /// The keys used to decode the wrapper
+    public enum CodingKeys: String, CodingKey {
+        /// Key to decode asset in a wrapper
+        case asset
+        /// Key to decode metadata in a wrapper
+        case metaData
     }
 }
 
 // MARK: - Equatable conformance
+
 extension GenericWrappedAsset: Equatable where MetaData: Equatable {
     public static func == (lhs: Self, rhs: Self) -> Bool {
-        let isMetaDataSame   = lhs.metaData == rhs.metaData
+        let isMetaDataSame = lhs.metaData == rhs.metaData
         let areBothAssetsNil = lhs.asset == nil && rhs.asset == nil
-        var areAssetsEqual: Bool { (lhs.asset?.valueData).flatMap { rhs.asset?.valueData.isEqual($0) } ?? false }
+        var areAssetsEqual: Bool {
+            (lhs.asset?.valueData).flatMap { rhs.asset?.valueData.isEqual($0) } ?? false
+        }
         return isMetaDataSame && (areBothAssetsNil || areAssetsEqual)
     }
 }

--- a/ios/swiftui/Tests/ManagedPlayer/ManagedPlayerJSContextLifecycleTests.swift
+++ b/ios/swiftui/Tests/ManagedPlayer/ManagedPlayerJSContextLifecycleTests.swift
@@ -1,15 +1,13 @@
-import Foundation
-import XCTest
-import JavaScriptCore
 import Combine
-
+import Foundation
+import JavaScriptCore
 @testable import PlayerUI
-@testable import PlayerUISwiftUI
 @testable import PlayerUIInternalTestUtilities
+@testable import PlayerUISwiftUI
 @testable import PlayerUITestUtilitiesCore
+import XCTest
 
 class ManagedPlayerJSContextLifecycleTests: XCTestCase {
-
     /// Verifies that the old JSContext is properly released when
     /// SwiftUIPlayer.Context loads a new flow after unloading the previous one.
     ///
@@ -54,7 +52,10 @@ class ManagedPlayerJSContextLifecycleTests: XCTestCase {
 
         autoreleasepool {
             let player2 = SwiftUIPlayer(
-                flow: FlowData.COUNTER.replacingOccurrences(of: "counter-flow", with: "counter-flow-2"),
+                flow: FlowData.COUNTER.replacingOccurrences(
+                    of: "counter-flow",
+                    with: "counter-flow-2"
+                ),
                 plugins: [],
                 result: .constant(nil),
                 context: context
@@ -66,7 +67,7 @@ class ManagedPlayerJSContextLifecycleTests: XCTestCase {
         XCTAssertNil(
             weakOldContext,
             "Old JSContext was not deallocated after unload + reload — " +
-            "cross-runtime retain cycle between Swift closures and JSContext"
+                "cross-runtime retain cycle between Swift closures and JSContext"
         )
     }
 
@@ -74,9 +75,9 @@ class ManagedPlayerJSContextLifecycleTests: XCTestCase {
     /// JSContexts across multiple flow loads, simulating the ManagedPlayer
     /// navigation pattern. Each flow load creates a new JSContext on the same VM.
     /// After unload, the previous context should be released.
-    func testSharedVMDoesNotAccumulateContexts() {
-        let vm = JSVirtualMachine()!
-        var createdContexts: [Weak<JSContext>] = []
+    func testSharedVMDoesNotAccumulateContexts() throws {
+        let vm = try XCTUnwrap(JSVirtualMachine())
+        var createdContexts = [Weak<JSContext>]()
 
         let context = SwiftUIPlayer.Context {
             let ctx = JSContext(virtualMachine: vm)!
@@ -84,7 +85,7 @@ class ManagedPlayerJSContextLifecycleTests: XCTestCase {
             return ctx
         }
 
-        for i in 0..<5 {
+        for i in 0 ..< 5 {
             autoreleasepool {
                 let flow = FlowData.COUNTER.replacingOccurrences(
                     of: "counter-flow",
@@ -112,7 +113,7 @@ class ManagedPlayerJSContextLifecycleTests: XCTestCase {
         XCTAssertEqual(
             leakedCount, 0,
             "\(leakedCount) of 5 JSContexts still alive after unload — " +
-            "orphaned contexts accumulating on shared JSVirtualMachine"
+                "orphaned contexts accumulating on shared JSVirtualMachine"
         )
     }
 
@@ -121,7 +122,7 @@ class ManagedPlayerJSContextLifecycleTests: XCTestCase {
     /// the run loop must tick to let those blocks execute and release JSValues.
     private func waitForDeallocation(of object: @escaping () -> AnyObject?, timeout: TimeInterval) {
         let deadline = Date(timeIntervalSinceNow: timeout)
-        while object() != nil && Date() < deadline {
+        while object() != nil, Date() < deadline {
             RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.01))
         }
     }
@@ -129,5 +130,8 @@ class ManagedPlayerJSContextLifecycleTests: XCTestCase {
 
 private class Weak<T: AnyObject> {
     weak var value: T?
-    init(_ value: T) { self.value = value }
+
+    init(_ value: T) {
+        self.value = value
+    }
 }

--- a/ios/swiftui/Tests/ManagedPlayer/ManagedPlayerJSContextLifecycleTests.swift
+++ b/ios/swiftui/Tests/ManagedPlayer/ManagedPlayerJSContextLifecycleTests.swift
@@ -52,8 +52,8 @@ class ManagedPlayerJSContextLifecycleTests: XCTestCase {
 
         autoreleasepool {
             let player2 = SwiftUIPlayer(
-                flow: FlowData.COUNTER.replacing(
-                    "counter-flow",
+                flow: FlowData.COUNTER.replacingOccurrences(
+                    of: "counter-flow",
                     with: "counter-flow-2"
                 ),
                 plugins: [],
@@ -87,8 +87,8 @@ class ManagedPlayerJSContextLifecycleTests: XCTestCase {
 
         for i in 0 ..< 5 {
             autoreleasepool {
-                let flow = FlowData.COUNTER.replacing(
-                    "counter-flow",
+                let flow = FlowData.COUNTER.replacingOccurrences(
+                    of: "counter-flow",
                     with: "counter-flow-\(i)"
                 )
                 let player = SwiftUIPlayer(

--- a/ios/swiftui/Tests/ManagedPlayer/ManagedPlayerJSContextLifecycleTests.swift
+++ b/ios/swiftui/Tests/ManagedPlayer/ManagedPlayerJSContextLifecycleTests.swift
@@ -52,8 +52,8 @@ class ManagedPlayerJSContextLifecycleTests: XCTestCase {
 
         autoreleasepool {
             let player2 = SwiftUIPlayer(
-                flow: FlowData.COUNTER.replacingOccurrences(
-                    of: "counter-flow",
+                flow: FlowData.COUNTER.replacing(
+                    "counter-flow",
                     with: "counter-flow-2"
                 ),
                 plugins: [],
@@ -87,8 +87,8 @@ class ManagedPlayerJSContextLifecycleTests: XCTestCase {
 
         for i in 0 ..< 5 {
             autoreleasepool {
-                let flow = FlowData.COUNTER.replacingOccurrences(
-                    of: "counter-flow",
+                let flow = FlowData.COUNTER.replacing(
+                    "counter-flow",
                     with: "counter-flow-\(i)"
                 )
                 let player = SwiftUIPlayer(

--- a/ios/swiftui/Tests/ManagedPlayer/ManagedPlayerViewModelTests.swift
+++ b/ios/swiftui/Tests/ManagedPlayer/ManagedPlayerViewModelTests.swift
@@ -6,29 +6,33 @@
 //  Copyright © 2021 CocoaPods. All rights reserved.
 //
 
-import Foundation
 import Combine
-import XCTest
+import Foundation
 import JavaScriptCore
-
 @testable import PlayerUI
-@testable import PlayerUISwiftUI
 @testable import PlayerUIInternalTestUtilities
+@testable import PlayerUISwiftUI
 @testable import PlayerUITestUtilitiesCore
+import XCTest
 
 class ManagedPlayerViewModelTests: XCTestCase {
-    let flow1 = FlowData.COUNTER
-    let flow2 = FlowData.COUNTER.replacingOccurrences(of: "counter-flow", with: "counter-flow-2")
+    private let flow1 = FlowData.COUNTER
+    private let flow2 = FlowData.COUNTER.replacingOccurrences(
+        of: "counter-flow",
+        with: "counter-flow-2"
+    )
 
     func testViewModelSuccessFlow() async throws {
         let flowManager = ConstantFlowManager([flow1], delay: 0)
 
         let completed = expectation(description: "Flows Completed")
-        let viewModel = ManagedPlayerViewModel(manager: flowManager, onComplete: {_ in
+        let viewModel = ManagedPlayerViewModel(manager: flowManager, onComplete: { _ in
             completed.fulfill()
         })
 
-        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow1 } action: { await viewModel.next() }
+        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow1 } action: {
+            await viewModel.next()
+        }
 
         let result = """
         {
@@ -42,7 +46,7 @@ class ManagedPlayerViewModelTests: XCTestCase {
 
         let stateObj = JSContext()?.evaluateScript("(\(result))")
 
-        let state = CompletedState.createInstance(from: stateObj)!
+        let state = try XCTUnwrap(CompletedState.createInstance(from: stateObj))
 
         viewModel.result = .success(state)
         await fulfillment(of: [completed], timeout: 2)
@@ -51,10 +55,11 @@ class ManagedPlayerViewModelTests: XCTestCase {
     func testViewModelSuccessMultiFlow() async throws {
         let flowManager = ConstantFlowManager([flow1, flow2], delay: 0)
 
-        let viewModel = ManagedPlayerViewModel(manager: flowManager, onComplete: {_ in})
+        let viewModel = ManagedPlayerViewModel(manager: flowManager, onComplete: { _ in })
 
-
-        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow1 } action: { await viewModel.next() }
+        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow1 } action: {
+            await viewModel.next()
+        }
 
         let result = """
         {
@@ -68,9 +73,11 @@ class ManagedPlayerViewModelTests: XCTestCase {
 
         let stateObj = JSContext()?.evaluateScript("(\(result))")
 
-        let state = CompletedState.createInstance(from: stateObj)!
+        let state = try XCTUnwrap(CompletedState.createInstance(from: stateObj))
 
-        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow2 } action: { viewModel.result = .success(state) }
+        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow2 } action: {
+            viewModel.result = .success(state)
+        }
     }
 
     func testViewModelManagerError() async {
@@ -81,11 +88,11 @@ class ManagedPlayerViewModelTests: XCTestCase {
         }
         let flowManager = ErrorFlowManager()
 
-        let viewModel = ManagedPlayerViewModel(manager: flowManager, onComplete: {_ in })
+        let viewModel = ManagedPlayerViewModel(manager: flowManager, onComplete: { _ in })
 
         await assertPublished(AnyPublisher(viewModel.$loadingState), condition: { state in
             guard
-                case .failed(let error) = state,
+                case let .failed(error) = state,
                 let _ = error as? PlayerError
             else { return false }
 
@@ -100,10 +107,10 @@ class ManagedPlayerViewModelTests: XCTestCase {
     func testViewModelRetry() async throws {
         let flowManager = ConstantFlowManager([flow1, flow2], delay: 0)
 
-        let viewModel = ManagedPlayerViewModel(manager: flowManager, onComplete: {_ in})
+        let viewModel = ManagedPlayerViewModel(manager: flowManager, onComplete: { _ in })
 
         await assertPublished(AnyPublisher(viewModel.$loadingState)) { value in
-            if case .loaded(let flow) = value, flow == self.flow1 {
+            if case let .loaded(flow) = value, flow == self.flow1 {
                 return true
             }
             return false
@@ -123,9 +130,11 @@ class ManagedPlayerViewModelTests: XCTestCase {
 
         let stateObj = JSContext()?.evaluateScript("(\(result))")
 
-        let state = CompletedState.createInstance(from: stateObj)!
+        let state = try XCTUnwrap(CompletedState.createInstance(from: stateObj))
 
-        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow2 } action: { viewModel.result = .success(state) }
+        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow2 } action: {
+            viewModel.result = .success(state)
+        }
 
         await assertPublished(AnyPublisher(viewModel.$loadingState)) { value in
             if case .failed = value {
@@ -145,15 +154,19 @@ class ManagedPlayerViewModelTests: XCTestCase {
             viewModel.retry()
         }
 
-        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow2 } action: { await viewModel.next(state) }
+        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow2 } action: {
+            await viewModel.next(state)
+        }
     }
 
     func testViewModelReset() async throws {
         let flowManager = ConstantFlowManager([flow1, flow2], delay: 0)
 
-        let viewModel = ManagedPlayerViewModel(manager: flowManager, onComplete: {_ in})
+        let viewModel = ManagedPlayerViewModel(manager: flowManager, onComplete: { _ in })
 
-        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow1 } action: { await viewModel.next() }
+        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow1 } action: {
+            await viewModel.next()
+        }
 
         let result = """
         {
@@ -167,9 +180,11 @@ class ManagedPlayerViewModelTests: XCTestCase {
 
         let stateObj = JSContext()?.evaluateScript("(\(result))")
 
-        let state = CompletedState.createInstance(from: stateObj)!
+        let state = try XCTUnwrap(CompletedState.createInstance(from: stateObj))
 
-        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow2 } action: { viewModel.result = .success(state) }
+        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow2 } action: {
+            viewModel.result = .success(state)
+        }
 
         await assertPublished(AnyPublisher(viewModel.$loadingState)) { value in
             if case .failed = value {
@@ -189,18 +204,22 @@ class ManagedPlayerViewModelTests: XCTestCase {
             viewModel.reset()
         }
 
-        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow1 } action: { await viewModel.next() }
+        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow1 } action: {
+            await viewModel.next()
+        }
     }
 
     func testViewModelErrorFlow() async {
         let flowManager = ConstantFlowManager(["flow1"], delay: 0)
 
         let completed = expectation(description: "Flows Completed")
-        let viewModel = ManagedPlayerViewModel(manager: flowManager, onComplete: {_ in})
+        let viewModel = ManagedPlayerViewModel(manager: flowManager, onComplete: { _ in })
 
-        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 != nil } action: { await viewModel.next() }
+        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 != nil } action: {
+            await viewModel.next()
+        }
 
-        let cancellable = viewModel.$loadingState.sink { (loadingState) in
+        let cancellable = viewModel.$loadingState.sink { loadingState in
             guard case .failed = loadingState else { return }
             completed.fulfill()
         }
@@ -224,7 +243,10 @@ class ManagedPlayerViewModelTests: XCTestCase {
             terminated.fulfill()
         }
 
-        var model: ManagedPlayerViewModel? = ManagedPlayerViewModel(manager: manager, onComplete: {_ in})
+        var model: ManagedPlayerViewModel? = ManagedPlayerViewModel(
+            manager: manager,
+            onComplete: { _ in }
+        )
 
         XCTAssertNotNil(model)
         model = nil
@@ -232,7 +254,10 @@ class ManagedPlayerViewModelTests: XCTestCase {
     }
 
     func testStateHook() {
-        let model = ManagedPlayerViewModel(manager: ConstantFlowManager([FlowData.COUNTER]), onComplete: {_ in})
+        let model = ManagedPlayerViewModel(
+            manager: ConstantFlowManager([FlowData.COUNTER]),
+            onComplete: { _ in }
+        )
 
         let player = HeadlessPlayerImpl(plugins: [model])
 
@@ -250,12 +275,15 @@ class ManagedPlayerViewModelTests: XCTestCase {
     }
 
     func testLoadingStateFailureEmptyFlow() {
-        let model = ManagedPlayerViewModel(manager: ConstantFlowManager([FlowData.COUNTER]), onComplete: {_ in})
+        let model = ManagedPlayerViewModel(
+            manager: ConstantFlowManager([FlowData.COUNTER]),
+            onComplete: { _ in }
+        )
 
         model.handleNextState(.flow(""))
 
         switch model.loadingState {
-        case .failed(let error):
+        case let .failed(error):
             XCTAssertEqual(error as? ManagedPlayerError, ManagedPlayerError.emptyFlow)
         default:
             XCTFail("Should Have entered failed state")
@@ -263,11 +291,11 @@ class ManagedPlayerViewModelTests: XCTestCase {
     }
 
     func testRetryIdleState() {
-        let model = ManagedPlayerViewModel(manager: ConstantFlowManager([]), onComplete: {_ in})
+        let model = ManagedPlayerViewModel(manager: ConstantFlowManager([]), onComplete: { _ in })
         model.handleNextState(.flow(FlowData.COUNTER))
 
         switch model.loadingState {
-        case .loaded(let flow):
+        case let .loaded(flow):
             XCTAssertEqual(flow, FlowData.COUNTER)
         default:
             XCTFail("Should have entered loaded state")
@@ -283,33 +311,54 @@ class ManagedPlayerViewModelTests: XCTestCase {
     }
 
     func testNextUpdatesLoadingStateOnMainNoFlows() async throws {
-        let model = ManagedPlayerViewModel(manager: ConstantFlowManager([], delay: 1/60), onComplete: {_ in})
+        let model = ManagedPlayerViewModel(
+            manager: ConstantFlowManager([], delay: 1 / 60),
+            onComplete: { _ in }
+        )
         try await checkNextUpdatesLoadingStateOnMain(model: model, expectedStateChangeCount: 1)
     }
 
     func testNextUpdatesLoadingStateOnMainOneFlow() async throws {
-        let model = ManagedPlayerViewModel(manager: ConstantFlowManager(["abc"], delay: 1/60), onComplete: {_ in})
-        try await checkNextUpdatesLoadingStateOnMain(model: model, nextCallCount: 2, expectedStateChangeCount: 4)
+        let model = ManagedPlayerViewModel(
+            manager: ConstantFlowManager(["abc"], delay: 1 / 60),
+            onComplete: { _ in }
+        )
+        try await checkNextUpdatesLoadingStateOnMain(
+            model: model,
+            nextCallCount: 2,
+            expectedStateChangeCount: 4
+        )
     }
 
     func testNextUpdatesLoadingStateOnMainMultipleFlows() async throws {
-        let model = ManagedPlayerViewModel(manager: ConstantFlowManager(["abc", "def", "ghi"], delay: 1/60), onComplete: {_ in})
-        try await checkNextUpdatesLoadingStateOnMain(model: model, nextCallCount: 3, expectedStateChangeCount: 6)
+        let model = ManagedPlayerViewModel(
+            manager: ConstantFlowManager(["abc", "def", "ghi"], delay: 1 / 60),
+            onComplete: { _ in }
+        )
+        try await checkNextUpdatesLoadingStateOnMain(
+            model: model,
+            nextCallCount: 3,
+            expectedStateChangeCount: 6
+        )
     }
 
     func testThrowingNextUpdatesLoadingStateOnMain() async throws {
-        let model = ManagedPlayerViewModel(manager: ThrowingFlowManager(), onComplete: {_ in})
+        let model = ManagedPlayerViewModel(manager: ThrowingFlowManager(), onComplete: { _ in })
         try await checkNextUpdatesLoadingStateOnMain(model: model, expectedStateChangeCount: 2)
     }
 
-    private func checkNextUpdatesLoadingStateOnMain(model: ManagedPlayerViewModel, nextCallCount: Int = 1, expectedStateChangeCount: Int) async throws {
-        let expect = (0..<expectedStateChangeCount).map {
+    private func checkNextUpdatesLoadingStateOnMain(
+        model: ManagedPlayerViewModel,
+        nextCallCount: Int = 1,
+        expectedStateChangeCount: Int
+    ) async throws {
+        let expect = (0 ..< expectedStateChangeCount).map {
             expectation(description: "\($0)")
         }
         var stateChangeCount = 0
         // the publisher emits immediately, we only care about changes
         // from the `next` call(s) below, drop the first state received
-        let cancellable = model.$loadingState.dropFirst().sink { state in
+        let cancellable = model.$loadingState.dropFirst().sink { _ in
             XCTAssertTrue(Thread.isMainThread)
             XCTAssertTrue(stateChangeCount < expect.count)
             stateChangeCount += 1
@@ -317,7 +366,7 @@ class ManagedPlayerViewModelTests: XCTestCase {
         }
         await withTaskGroup(of: Void.self) { group in
             group.addTask {
-                for _ in (0..<nextCallCount) {
+                for _ in 0 ..< nextCallCount {
                     await model.next()
                 }
             }
@@ -340,22 +389,29 @@ class ManagedPlayerViewModelTests: XCTestCase {
 }
 
 class TerminatingManager: FlowManager {
-    func next(_ result: CompletedState?) async throws -> NextState {
-        return .flow(FlowData.COUNTER)
-    }
     private var terminateFn: (InProgressState?) -> Void
-    init(_ terminate: @escaping (InProgressState?) -> Void ) {
-        self.terminateFn = terminate
+
+    init(_ terminate: @escaping (InProgressState?) -> Void) {
+        terminateFn = terminate
     }
-    public func terminate(state: InProgressState?) {
-        self.terminateFn(state)
+
+    func next(_: CompletedState?) async throws -> NextState {
+        .flow(FlowData.COUNTER)
+    }
+
+    func terminate(state: InProgressState?) {
+        terminateFn(state)
     }
 }
 
-internal extension XCTestCase {
-    func assertPublished<T>(_ publisher: AnyPublisher<T, Never>, condition: @escaping (T) -> Bool, action: () async -> Void) async {
+extension XCTestCase {
+    func assertPublished<T>(
+        _ publisher: AnyPublisher<T, Never>,
+        condition: @escaping (T) -> Bool,
+        action: () async -> Void
+    ) async {
         let expectation = XCTestExpectation(description: "Waiting for publisher to emit value")
-        let cancel = publisher.sink { (value) in
+        let cancel = publisher.sink { value in
             guard condition(value) else { return }
             expectation.fulfill()
         }

--- a/ios/swiftui/Tests/ManagedPlayer/ManagedPlayerViewModelTests.swift
+++ b/ios/swiftui/Tests/ManagedPlayer/ManagedPlayerViewModelTests.swift
@@ -6,29 +6,33 @@
 //  Copyright © 2021 Intuit. All rights reserved.
 //
 
-import Foundation
 import Combine
-import XCTest
+import Foundation
 import JavaScriptCore
-
 @testable import PlayerUI
-@testable import PlayerUISwiftUI
 @testable import PlayerUIInternalTestUtilities
+@testable import PlayerUISwiftUI
 @testable import PlayerUITestUtilitiesCore
+import XCTest
 
 class ManagedPlayerViewModelTests: XCTestCase {
-    let flow1 = FlowData.COUNTER
-    let flow2 = FlowData.COUNTER.replacingOccurrences(of: "counter-flow", with: "counter-flow-2")
+    private let flow1 = FlowData.COUNTER
+    private let flow2 = FlowData.COUNTER.replacingOccurrences(
+        of: "counter-flow",
+        with: "counter-flow-2"
+    )
 
     func testViewModelSuccessFlow() async throws {
         let flowManager = ConstantFlowManager([flow1], delay: 0)
 
         let completed = expectation(description: "Flows Completed")
-        let viewModel = ManagedPlayerViewModel(manager: flowManager, onComplete: {_ in
+        let viewModel = ManagedPlayerViewModel(manager: flowManager, onComplete: { _ in
             completed.fulfill()
         })
 
-        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow1 } action: { await viewModel.next() }
+        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow1 } action: {
+            await viewModel.next()
+        }
 
         let result = """
         {
@@ -42,25 +46,29 @@ class ManagedPlayerViewModelTests: XCTestCase {
 
         let stateObj = JSContext()?.evaluateScript("(\(result))")
 
-        let state = CompletedState.createInstance(from: stateObj)!
+        let state = try XCTUnwrap(CompletedState.createInstance(from: stateObj))
 
         viewModel.result = .success(state)
         await fulfillment(of: [completed], timeout: 2)
     }
 
-    func testViewModelOnStartedFlow() async throws {
+    func testViewModelOnStartedFlow() async {
         let flowManager = ConstantFlowManager([flow1], delay: 0)
 
         let started = expectation(description: "onStartedFlow called")
-        var startedFlows: [String] = []
-        let viewModel = ManagedPlayerViewModel(manager: flowManager, onComplete: {_ in}, onStartedFlow: { flow in
-            startedFlows.append(flow)
-            started.fulfill()
-        })
+        var startedFlows = [String]()
+        let viewModel = ManagedPlayerViewModel(
+            manager: flowManager,
+            onComplete: { _ in },
+            onStartedFlow: { flow in
+                startedFlows.append(flow)
+                started.fulfill()
+            }
+        )
 
         await viewModel.next()
         await fulfillment(of: [started], timeout: 2)
-        XCTAssertEqual(startedFlows, [self.flow1])
+        XCTAssertEqual(startedFlows, [flow1])
     }
 
     func testViewModelOnStartedFlowMultiFlow() async throws {
@@ -68,13 +76,19 @@ class ManagedPlayerViewModelTests: XCTestCase {
 
         let started = expectation(description: "onStartedFlow called for each flow")
         started.expectedFulfillmentCount = 2
-        var startedFlows: [String] = []
-        let viewModel = ManagedPlayerViewModel(manager: flowManager, onComplete: {_ in}, onStartedFlow: { flow in
-            startedFlows.append(flow)
-            started.fulfill()
-        })
+        var startedFlows = [String]()
+        let viewModel = ManagedPlayerViewModel(
+            manager: flowManager,
+            onComplete: { _ in },
+            onStartedFlow: { flow in
+                startedFlows.append(flow)
+                started.fulfill()
+            }
+        )
 
-        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow1 } action: { await viewModel.next() }
+        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow1 } action: {
+            await viewModel.next()
+        }
 
         let result = """
         {
@@ -88,23 +102,29 @@ class ManagedPlayerViewModelTests: XCTestCase {
 
         let stateObj = JSContext()?.evaluateScript("(\(result))")
 
-        let state = CompletedState.createInstance(from: stateObj)!
+        let state = try XCTUnwrap(CompletedState.createInstance(from: stateObj))
 
-        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow2 } action: { viewModel.result = .success(state) }
+        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow2 } action: {
+            viewModel.result = .success(state)
+        }
 
         await fulfillment(of: [started], timeout: 2)
-        XCTAssertEqual(startedFlows, [self.flow1, self.flow2])
+        XCTAssertEqual(startedFlows, [flow1, flow2])
     }
 
     func testViewModelOnStartedFlowNotCalledForEmptyFlow() {
-        var startedFlows: [String] = []
-        let model = ManagedPlayerViewModel(manager: ConstantFlowManager([FlowData.COUNTER]), onComplete: {_ in}, onStartedFlow: { startedFlows.append($0) })
+        var startedFlows = [String]()
+        let model = ManagedPlayerViewModel(
+            manager: ConstantFlowManager([FlowData.COUNTER]),
+            onComplete: { _ in },
+            onStartedFlow: { startedFlows.append($0) }
+        )
 
         model.handleNextFlow("")
 
         XCTAssertTrue(startedFlows.isEmpty)
         switch model.loadingState {
-        case .failed(let error):
+        case let .failed(error):
             XCTAssertEqual(error as? ManagedPlayerError, ManagedPlayerError.emptyFlow)
         default:
             XCTFail("Should Have entered failed state")
@@ -114,10 +134,11 @@ class ManagedPlayerViewModelTests: XCTestCase {
     func testViewModelSuccessMultiFlow() async throws {
         let flowManager = ConstantFlowManager([flow1, flow2], delay: 0)
 
-        let viewModel = ManagedPlayerViewModel(manager: flowManager, onComplete: {_ in})
+        let viewModel = ManagedPlayerViewModel(manager: flowManager, onComplete: { _ in })
 
-
-        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow1 } action: { await viewModel.next() }
+        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow1 } action: {
+            await viewModel.next()
+        }
 
         let result = """
         {
@@ -131,24 +152,26 @@ class ManagedPlayerViewModelTests: XCTestCase {
 
         let stateObj = JSContext()?.evaluateScript("(\(result))")
 
-        let state = CompletedState.createInstance(from: stateObj)!
+        let state = try XCTUnwrap(CompletedState.createInstance(from: stateObj))
 
-        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow2 } action: { viewModel.result = .success(state) }
+        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow2 } action: {
+            viewModel.result = .success(state)
+        }
     }
 
     func testViewModelManagerError() async {
         struct ErrorFlowManager: FlowManager {
-            func next(result: CompletedState?) async throws -> String? {
+            func next(result _: CompletedState?) async throws -> String? {
                 throw PlayerError.jsConversionFailure
             }
         }
         let flowManager = ErrorFlowManager()
 
-        let viewModel = ManagedPlayerViewModel(manager: flowManager, onComplete: {_ in })
+        let viewModel = ManagedPlayerViewModel(manager: flowManager, onComplete: { _ in })
 
         await assertPublished(AnyPublisher(viewModel.$loadingState), condition: { state in
             guard
-                case .failed(let error) = state,
+                case let .failed(error) = state,
                 let _ = error as? PlayerError
             else { return false }
 
@@ -163,10 +186,10 @@ class ManagedPlayerViewModelTests: XCTestCase {
     func testViewModelRetry() async throws {
         let flowManager = ConstantFlowManager([flow1, flow2], delay: 0)
 
-        let viewModel = ManagedPlayerViewModel(manager: flowManager, onComplete: {_ in})
+        let viewModel = ManagedPlayerViewModel(manager: flowManager, onComplete: { _ in })
 
         await assertPublished(AnyPublisher(viewModel.$loadingState)) { value in
-            if case .loaded(let flow) = value, flow == self.flow1 {
+            if case let .loaded(flow) = value, flow == self.flow1 {
                 return true
             }
             return false
@@ -186,9 +209,11 @@ class ManagedPlayerViewModelTests: XCTestCase {
 
         let stateObj = JSContext()?.evaluateScript("(\(result))")
 
-        let state = CompletedState.createInstance(from: stateObj)!
+        let state = try XCTUnwrap(CompletedState.createInstance(from: stateObj))
 
-        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow2 } action: { viewModel.result = .success(state) }
+        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow2 } action: {
+            viewModel.result = .success(state)
+        }
 
         await assertPublished(AnyPublisher(viewModel.$loadingState)) { value in
             if case .failed = value {
@@ -208,15 +233,19 @@ class ManagedPlayerViewModelTests: XCTestCase {
             viewModel.retry()
         }
 
-        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow2 } action: { await viewModel.next(state) }
+        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow2 } action: {
+            await viewModel.next(state)
+        }
     }
 
     func testViewModelReset() async throws {
         let flowManager = ConstantFlowManager([flow1, flow2], delay: 0)
 
-        let viewModel = ManagedPlayerViewModel(manager: flowManager, onComplete: {_ in})
+        let viewModel = ManagedPlayerViewModel(manager: flowManager, onComplete: { _ in })
 
-        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow1 } action: { await viewModel.next() }
+        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow1 } action: {
+            await viewModel.next()
+        }
 
         let result = """
         {
@@ -230,9 +259,11 @@ class ManagedPlayerViewModelTests: XCTestCase {
 
         let stateObj = JSContext()?.evaluateScript("(\(result))")
 
-        let state = CompletedState.createInstance(from: stateObj)!
+        let state = try XCTUnwrap(CompletedState.createInstance(from: stateObj))
 
-        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow2 } action: { viewModel.result = .success(state) }
+        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow2 } action: {
+            viewModel.result = .success(state)
+        }
 
         await assertPublished(AnyPublisher(viewModel.$loadingState)) { value in
             if case .failed = value {
@@ -252,18 +283,22 @@ class ManagedPlayerViewModelTests: XCTestCase {
             viewModel.reset()
         }
 
-        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow1 } action: { await viewModel.next() }
+        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow1 } action: {
+            await viewModel.next()
+        }
     }
 
     func testViewModelErrorFlow() async {
         let flowManager = ConstantFlowManager(["flow1"], delay: 0)
 
         let completed = expectation(description: "Flows Completed")
-        let viewModel = ManagedPlayerViewModel(manager: flowManager, onComplete: {_ in})
+        let viewModel = ManagedPlayerViewModel(manager: flowManager, onComplete: { _ in })
 
-        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 != nil } action: { await viewModel.next() }
+        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 != nil } action: {
+            await viewModel.next()
+        }
 
-        let cancellable = viewModel.$loadingState.sink { (loadingState) in
+        let cancellable = viewModel.$loadingState.sink { loadingState in
             guard case .failed = loadingState else { return }
             completed.fulfill()
         }
@@ -287,7 +322,10 @@ class ManagedPlayerViewModelTests: XCTestCase {
             terminated.fulfill()
         }
 
-        var model: ManagedPlayerViewModel? = ManagedPlayerViewModel(manager: manager, onComplete: {_ in})
+        var model: ManagedPlayerViewModel? = ManagedPlayerViewModel(
+            manager: manager,
+            onComplete: { _ in }
+        )
 
         XCTAssertNotNil(model)
         model = nil
@@ -295,7 +333,10 @@ class ManagedPlayerViewModelTests: XCTestCase {
     }
 
     func testStateHook() {
-        let model = ManagedPlayerViewModel(manager: ConstantFlowManager([FlowData.COUNTER]), onComplete: {_ in})
+        let model = ManagedPlayerViewModel(
+            manager: ConstantFlowManager([FlowData.COUNTER]),
+            onComplete: { _ in }
+        )
 
         let player = HeadlessPlayerImpl(plugins: [model])
 
@@ -313,12 +354,15 @@ class ManagedPlayerViewModelTests: XCTestCase {
     }
 
     func testLoadingStateFailureEmptyFlow() {
-        let model = ManagedPlayerViewModel(manager: ConstantFlowManager([FlowData.COUNTER]), onComplete: {_ in})
+        let model = ManagedPlayerViewModel(
+            manager: ConstantFlowManager([FlowData.COUNTER]),
+            onComplete: { _ in }
+        )
 
         model.handleNextFlow("")
 
         switch model.loadingState {
-        case .failed(let error):
+        case let .failed(error):
             XCTAssertEqual(error as? ManagedPlayerError, ManagedPlayerError.emptyFlow)
         default:
             XCTFail("Should Have entered failed state")
@@ -326,11 +370,11 @@ class ManagedPlayerViewModelTests: XCTestCase {
     }
 
     func testRetryIdleState() {
-        let model = ManagedPlayerViewModel(manager: ConstantFlowManager([]), onComplete: {_ in})
+        let model = ManagedPlayerViewModel(manager: ConstantFlowManager([]), onComplete: { _ in })
         model.handleNextFlow(FlowData.COUNTER)
 
         switch model.loadingState {
-        case .loaded(let flow):
+        case let .loaded(flow):
             XCTAssertEqual(flow, FlowData.COUNTER)
         default:
             XCTFail("Should have entered loaded state")
@@ -346,33 +390,54 @@ class ManagedPlayerViewModelTests: XCTestCase {
     }
 
     func testNextUpdatesLoadingStateOnMainNoFlows() async throws {
-        let model = ManagedPlayerViewModel(manager: ConstantFlowManager([], delay: 1/60), onComplete: {_ in})
+        let model = ManagedPlayerViewModel(
+            manager: ConstantFlowManager([], delay: 1 / 60),
+            onComplete: { _ in }
+        )
         try await checkNextUpdatesLoadingStateOnMain(model: model, expectedStateChangeCount: 1)
     }
 
     func testNextUpdatesLoadingStateOnMainOneFlow() async throws {
-        let model = ManagedPlayerViewModel(manager: ConstantFlowManager(["abc"], delay: 1/60), onComplete: {_ in})
-        try await checkNextUpdatesLoadingStateOnMain(model: model, nextCallCount: 2, expectedStateChangeCount: 4)
+        let model = ManagedPlayerViewModel(
+            manager: ConstantFlowManager(["abc"], delay: 1 / 60),
+            onComplete: { _ in }
+        )
+        try await checkNextUpdatesLoadingStateOnMain(
+            model: model,
+            nextCallCount: 2,
+            expectedStateChangeCount: 4
+        )
     }
 
     func testNextUpdatesLoadingStateOnMainMultipleFlows() async throws {
-        let model = ManagedPlayerViewModel(manager: ConstantFlowManager(["abc", "def", "ghi"], delay: 1/60), onComplete: {_ in})
-        try await checkNextUpdatesLoadingStateOnMain(model: model, nextCallCount: 3, expectedStateChangeCount: 6)
+        let model = ManagedPlayerViewModel(
+            manager: ConstantFlowManager(["abc", "def", "ghi"], delay: 1 / 60),
+            onComplete: { _ in }
+        )
+        try await checkNextUpdatesLoadingStateOnMain(
+            model: model,
+            nextCallCount: 3,
+            expectedStateChangeCount: 6
+        )
     }
 
     func testThrowingNextUpdatesLoadingStateOnMain() async throws {
-        let model = ManagedPlayerViewModel(manager: ThrowingFlowManager(), onComplete: {_ in})
+        let model = ManagedPlayerViewModel(manager: ThrowingFlowManager(), onComplete: { _ in })
         try await checkNextUpdatesLoadingStateOnMain(model: model, expectedStateChangeCount: 2)
     }
 
-    private func checkNextUpdatesLoadingStateOnMain(model: ManagedPlayerViewModel, nextCallCount: Int = 1, expectedStateChangeCount: Int) async throws {
-        let expect = (0..<expectedStateChangeCount).map {
+    private func checkNextUpdatesLoadingStateOnMain(
+        model: ManagedPlayerViewModel,
+        nextCallCount: Int = 1,
+        expectedStateChangeCount: Int
+    ) async throws {
+        let expect = (0 ..< expectedStateChangeCount).map {
             expectation(description: "\($0)")
         }
         var stateChangeCount = 0
         // the publisher emits immediately, we only care about changes
         // from the `next` call(s) below, drop the first state received
-        let cancellable = model.$loadingState.dropFirst().sink { state in
+        let cancellable = model.$loadingState.dropFirst().sink { _ in
             XCTAssertTrue(Thread.isMainThread)
             XCTAssertTrue(stateChangeCount < expect.count)
             stateChangeCount += 1
@@ -380,7 +445,7 @@ class ManagedPlayerViewModelTests: XCTestCase {
         }
         await withTaskGroup(of: Void.self) { group in
             group.addTask {
-                for _ in (0..<nextCallCount) {
+                for _ in 0 ..< nextCallCount {
                     await model.next()
                 }
             }
@@ -392,7 +457,7 @@ class ManagedPlayerViewModelTests: XCTestCase {
     }
 
     private struct ThrowingFlowManager: FlowManager {
-        func next(result: CompletedState?) async throws -> String? {
+        func next(result _: CompletedState?) async throws -> String? {
             throw Errors.failed
         }
 
@@ -403,22 +468,29 @@ class ManagedPlayerViewModelTests: XCTestCase {
 }
 
 class TerminatingManager: FlowManager {
-    func next(result: CompletedState?) async throws -> String? {
-        return FlowData.COUNTER
-    }
     private var terminateFn: (InProgressState?) -> Void
-    init(_ terminate: @escaping (InProgressState?) -> Void ) {
-        self.terminateFn = terminate
+
+    init(_ terminate: @escaping (InProgressState?) -> Void) {
+        terminateFn = terminate
     }
-    public func terminate(state: InProgressState?) {
-        self.terminateFn(state)
+
+    func next(result _: CompletedState?) async throws -> String? {
+        FlowData.COUNTER
+    }
+
+    func terminate(state: InProgressState?) {
+        terminateFn(state)
     }
 }
 
-internal extension XCTestCase {
-    func assertPublished<T>(_ publisher: AnyPublisher<T, Never>, condition: @escaping (T) -> Bool, action: () async -> Void) async {
+extension XCTestCase {
+    func assertPublished<T>(
+        _ publisher: AnyPublisher<T, Never>,
+        condition: @escaping (T) -> Bool,
+        action: () async -> Void
+    ) async {
         let expectation = XCTestExpectation(description: "Waiting for publisher to emit value")
-        let cancel = publisher.sink { (value) in
+        let cancel = publisher.sink { value in
             guard condition(value) else { return }
             expectation.fulfill()
         }

--- a/ios/swiftui/Tests/ManagedPlayer/ManagedPlayerViewModelTests.swift
+++ b/ios/swiftui/Tests/ManagedPlayer/ManagedPlayerViewModelTests.swift
@@ -17,8 +17,8 @@ import XCTest
 
 class ManagedPlayerViewModelTests: XCTestCase {
     private let flow1 = FlowData.COUNTER
-    private let flow2 = FlowData.COUNTER.replacing(
-        "counter-flow",
+    private let flow2 = FlowData.COUNTER.replacingOccurrences(
+        of: "counter-flow",
         with: "counter-flow-2"
     )
 

--- a/ios/swiftui/Tests/ManagedPlayer/ManagedPlayerViewModelTests.swift
+++ b/ios/swiftui/Tests/ManagedPlayer/ManagedPlayerViewModelTests.swift
@@ -17,8 +17,8 @@ import XCTest
 
 class ManagedPlayerViewModelTests: XCTestCase {
     private let flow1 = FlowData.COUNTER
-    private let flow2 = FlowData.COUNTER.replacingOccurrences(
-        of: "counter-flow",
+    private let flow2 = FlowData.COUNTER.replacing(
+        "counter-flow",
         with: "counter-flow-2"
     )
 

--- a/ios/swiftui/Tests/SwiftUIRegistryTests.swift
+++ b/ios/swiftui/Tests/SwiftUIRegistryTests.swift
@@ -6,19 +6,19 @@
 //  Copyright © 2021 CocoaPods. All rights reserved.
 //
 
-import Foundation
-import XCTest
-import JavaScriptCore
 import Combine
-import SwiftUI
+import Foundation
+import JavaScriptCore
 @testable import PlayerUI
-@testable import PlayerUISwiftUI
 @testable import PlayerUILogger
 @testable import PlayerUIReferenceAssets
+@testable import PlayerUISwiftUI
+import SwiftUI
+import XCTest
 
 // swiftlint:disable type_body_length file_length
 class SwiftUIRegistryTests: XCTestCase {
-    let context: JSContext = JSContext()
+    private let context: JSContext = .init()
 
     func testDuplicateRegistration() {
         let operationSkipped = expectation(description: "Skipped duplicate registration")
@@ -26,17 +26,17 @@ class SwiftUIRegistryTests: XCTestCase {
         operationSkipped.expectedFulfillmentCount = 2
         let logger = TapableLogger()
         logger.logLevel = .trace
-        logger.hooks.trace.tap(name: "test", { messages in
+        logger.hooks.trace.tap(name: "test") { messages in
             let message: String = (messages as? [String] ?? []).first ?? ""
-            guard  message.contains("Duplicate Registration skipped for") else { return }
+            guard message.contains("Duplicate Registration skipped for") else { return }
             operationSkipped.fulfill()
-        })
+        }
 
-        logger.hooks.warn.tap(name: "test", { messages in
+        logger.hooks.warn.tap(name: "test") { messages in
             let message: String = (messages as? [String] ?? []).first ?? ""
             guard message.contains("Overriding registration for match") else { return }
             override.fulfill()
-        })
+        }
         let registry = SwiftUIRegistry(logger: logger)
         registry.register(["type": "action"], for: ActionAsset.self)
         XCTAssertEqual(1, registry.registeredAssets.count)
@@ -52,7 +52,8 @@ class SwiftUIRegistryTests: XCTestCase {
     }
 
     func testDecodeWrappedAsset() {
-        let val = context.evaluateScript("({asset: {id: 'someId', type: 'text', value: 'someValue'}})")
+        let val = context
+            .evaluateScript("({asset: {id: 'someId', type: 'text', value: 'someValue'}})")
 
         let partialMatch = PartialMatchFingerprintPlugin()
         partialMatch.context = context
@@ -84,10 +85,14 @@ class SwiftUIRegistryTests: XCTestCase {
         }
 
         class TestNestedAsset: UncontrolledAsset<TestData> {
-            override var view: AnyView { AnyView(EmptyView()) }
+            override var view: AnyView {
+                AnyView(EmptyView())
+            }
         }
         let val = context
-            .evaluateScript("({asset: {id: 'someId', type: 'nested', nested: {asset: {id: 'someOtherId', type: 'text', value: ''}, extra: 'value'}}})")
+            .evaluateScript(
+                "({asset: {id: 'someId', type: 'nested', nested: {asset: {id: 'someOtherId', type: 'text', value: ''}, extra: 'value'}}})"
+            )
 
         let partialMatch = PartialMatchFingerprintPlugin()
         partialMatch.context = context
@@ -103,7 +108,8 @@ class SwiftUIRegistryTests: XCTestCase {
         do {
             let decoded = try registry.decodeWrapper(object)
             XCTAssertEqual(decoded.asset?.id, "someId")
-            guard let asset = decoded.asset as? TestNestedAsset else { return XCTFail("Decoded asset was not TestNestedAsset") }
+            guard let asset = decoded.asset as? TestNestedAsset
+            else { return XCTFail("Decoded asset was not TestNestedAsset") }
             XCTAssertEqual(asset.model.data.nested?.additionalData?.extra, "value")
         } catch {
             XCTFail("unable to decode wrapper")
@@ -111,8 +117,10 @@ class SwiftUIRegistryTests: XCTestCase {
     }
 
     func testWrappedAssetEquivalence() {
-        let asset1 = context.evaluateScript("({asset: {id: 'someId', type: 'text', value: 'someValue'}})")
-        let asset2 = context.evaluateScript("({asset: {id: 'someId', type: 'text', value: 'someOtherValue'}})")
+        let asset1 = context
+            .evaluateScript("({asset: {id: 'someId', type: 'text', value: 'someValue'}})")
+        let asset2 = context
+            .evaluateScript("({asset: {id: 'someId', type: 'text', value: 'someOtherValue'}})")
 
         let partialMatch = PartialMatchFingerprintPlugin()
         partialMatch.context = context
@@ -124,8 +132,8 @@ class SwiftUIRegistryTests: XCTestCase {
         guard
             let object = asset1,
             let object2 = asset2 else {
-                return XCTFail("object should not be nil")
-            }
+            return XCTFail("object should not be nil")
+        }
 
         do {
             let wrapped1 = try registry.decodeWrapper(object)
@@ -167,14 +175,16 @@ class SwiftUIRegistryTests: XCTestCase {
         var set = Set<AnyCancellable>()
 
         let decodedExpectation = expectation(description: "Root Decoded")
-        registry.$root.sink { newVal in
-            if newVal != nil {
-                XCTAssertEqual(newVal?.id, "someId")
-                decodedExpectation.fulfill()
+        registry.$root
+            .sink { newVal in
+                if newVal != nil {
+                    XCTAssertEqual(newVal?.id, "someId")
+                    decodedExpectation.fulfill()
+                }
             }
-        }.store(in: &set)
+            .store(in: &set)
 
-        try registry.decode(value: val!)
+        try registry.decode(value: XCTUnwrap(val))
 
         wait(for: [decodedExpectation], timeout: 1)
     }
@@ -196,17 +206,19 @@ class SwiftUIRegistryTests: XCTestCase {
         var root: AnyObject?
 
         let decodedExpectation = expectation(description: "Root Decoded")
-        registry.$root.sink { newVal in
-            if root == nil, newVal != nil {
-                root = newVal?.modelObject
-            } else if root != nil, newVal != nil {
-                XCTAssertFalse(root === newVal?.modelObject)
-                decodedExpectation.fulfill()
+        registry.$root
+            .sink { newVal in
+                if root == nil, newVal != nil {
+                    root = newVal?.modelObject
+                } else if root != nil, newVal != nil {
+                    XCTAssertFalse(root === newVal?.modelObject)
+                    decodedExpectation.fulfill()
+                }
             }
-        }.store(in: &set)
+            .store(in: &set)
 
-        try registry.decode(value: val!)
-        try registry.decode(value: val!)
+        try registry.decode(value: XCTUnwrap(val))
+        try registry.decode(value: XCTUnwrap(val))
 
         wait(for: [decodedExpectation], timeout: 1)
     }
@@ -218,7 +230,9 @@ class SwiftUIRegistryTests: XCTestCase {
 
         class SwiftUITestAsset: ControlledAsset<TextData, TestModel> {
             /// A type erased view object
-            public override var view: AnyView { AnyView(EmptyView()) }
+            override public var view: AnyView {
+                AnyView(EmptyView())
+            }
         }
 
         let partialMatch = PartialMatchFingerprintPlugin()
@@ -235,24 +249,27 @@ class SwiftUIRegistryTests: XCTestCase {
         var root: AnyObject?
 
         let decodedExpectation = expectation(description: "Root Decoded")
-        registry.$root.sink { newVal in
-            if root == nil, newVal != nil {
-                root = newVal?.modelObject
-            } else if root != nil, newVal != nil {
-                XCTAssertTrue(root === newVal?.modelObject)
-                decodedExpectation.fulfill()
+        registry.$root
+            .sink { newVal in
+                if root == nil, newVal != nil {
+                    root = newVal?.modelObject
+                } else if root != nil, newVal != nil {
+                    XCTAssertTrue(root === newVal?.modelObject)
+                    decodedExpectation.fulfill()
+                }
             }
-        }.store(in: &set)
+            .store(in: &set)
 
-        try registry.decode(value: val!)
-        try registry.decode(value: val!)
+        try registry.decode(value: XCTUnwrap(val))
+        try registry.decode(value: XCTUnwrap(val))
 
         wait(for: [decodedExpectation], timeout: 1)
     }
 
     func testDecodeJSValueReturnsNewAsset() throws {
         let val = context.evaluateScript("({id: 'someId', type: 'text', value: 'someValue'})")
-        let val2 = context.evaluateScript("({id: 'someOtherId', type: 'action', value: 'someValue'})")
+        let val2 = context
+            .evaluateScript("({id: 'someOtherId', type: 'action', value: 'someValue'})")
 
         let partialMatch = PartialMatchFingerprintPlugin()
         partialMatch.context = context
@@ -270,17 +287,19 @@ class SwiftUIRegistryTests: XCTestCase {
         var root: SwiftUIAsset?
 
         let decodedExpectation = expectation(description: "Root Decoded")
-        registry.$root.sink { newVal in
-            if root == nil, newVal != nil {
-                root = newVal
-            } else if root != nil, newVal != nil {
-                XCTAssertNotEqual(root?.uuid, newVal?.uuid)
-                decodedExpectation.fulfill()
+        registry.$root
+            .sink { newVal in
+                if root == nil, newVal != nil {
+                    root = newVal
+                } else if root != nil, newVal != nil {
+                    XCTAssertNotEqual(root?.uuid, newVal?.uuid)
+                    decodedExpectation.fulfill()
+                }
             }
-        }.store(in: &set)
+            .store(in: &set)
 
-        try registry.decode(value: val!)
-        try registry.decode(value: val2!)
+        try registry.decode(value: XCTUnwrap(val))
+        try registry.decode(value: XCTUnwrap(val2))
 
         wait(for: [decodedExpectation], timeout: 1)
     }
@@ -310,18 +329,20 @@ class SwiftUIRegistryTests: XCTestCase {
         var root: AnyObject?
 
         let decodedExpectation = expectation(description: "Root Decoded")
-        registry.$root.sink { newVal in
-            if root == nil, newVal != nil {
-                root = newVal?.modelObject
-            } else if root != nil, newVal != nil {
-                XCTAssertFalse(root === newVal?.modelObject)
-                root = newVal?.modelObject
-                decodedExpectation.fulfill()
+        registry.$root
+            .sink { newVal in
+                if root == nil, newVal != nil {
+                    root = newVal?.modelObject
+                } else if root != nil, newVal != nil {
+                    XCTAssertFalse(root === newVal?.modelObject)
+                    root = newVal?.modelObject
+                    decodedExpectation.fulfill()
+                }
             }
-        }.store(in: &set)
+            .store(in: &set)
 
-        try registry.decode(value: val!)
-        try registry.decode(value: val2!)
+        try registry.decode(value: XCTUnwrap(val))
+        try registry.decode(value: XCTUnwrap(val2))
 
         wait(for: [decodedExpectation], timeout: 1)
 
@@ -331,7 +352,6 @@ class SwiftUIRegistryTests: XCTestCase {
         else { return XCTFail("unable to decode asset") }
 
         XCTAssertEqual(text.model.data.value.stringValue, "value2")
-
     }
 
     func testDecodeJSValueUpdatesNestedArrayData() throws {
@@ -359,18 +379,20 @@ class SwiftUIRegistryTests: XCTestCase {
         var root: AnyObject?
 
         let decodedExpectation = expectation(description: "Root Decoded")
-        registry.$root.sink { newVal in
-            if root == nil, newVal != nil {
-                root = newVal?.modelObject
-            } else if root != nil, newVal != nil {
-                XCTAssertFalse(root === newVal?.modelObject)
-                root = newVal?.modelObject
-                decodedExpectation.fulfill()
+        registry.$root
+            .sink { newVal in
+                if root == nil, newVal != nil {
+                    root = newVal?.modelObject
+                } else if root != nil, newVal != nil {
+                    XCTAssertFalse(root === newVal?.modelObject)
+                    root = newVal?.modelObject
+                    decodedExpectation.fulfill()
+                }
             }
-        }.store(in: &set)
+            .store(in: &set)
 
-        try registry.decode(value: val!)
-        try registry.decode(value: val2!)
+        try registry.decode(value: XCTUnwrap(val))
+        try registry.decode(value: XCTUnwrap(val2))
 
         wait(for: [decodedExpectation], timeout: 1)
 
@@ -438,7 +460,7 @@ class SwiftUIRegistryTests: XCTestCase {
         guard let values = (root as? CollectionAsset)?.model.data.values else {
             return XCTFail("value should not be nil")
         }
-        guard 2 == values.count else {
+        guard values.count == 2 else {
             return XCTFail("incorrect number of values")
         }
         let text1 = values[0]?.asset as? TextAsset
@@ -452,7 +474,7 @@ class SwiftUIRegistryTests: XCTestCase {
         guard let updatedValues = (root as? CollectionAsset)?.model.data.values else {
             return XCTFail("unable to get updated values")
         }
-        guard 2 == updatedValues.count else {
+        guard updatedValues.count == 2 else {
             return XCTFail("incorrect number of updated values")
         }
         let updatedText1 = updatedValues[0]?.asset as? TextAsset
@@ -534,9 +556,7 @@ class SwiftUIRegistryTests: XCTestCase {
 
         let jsValue = context.evaluateScript(jsString)
         XCTAssertNotNil(jsValue)
-        guard let _ = jsValue else {
-            return
-        }
+        _ = try XCTUnwrap(jsValue)
 
         let registry = SwiftUIRegistry(logger: TapableLogger())
         registry.register("collection", asset: CollectionAsset.self)
@@ -561,13 +581,16 @@ class SwiftUIRegistryTests: XCTestCase {
         var root: SwiftUIAsset?
 
         let decodedExpectation = expectation(description: "Root Decoded")
-        registry.$root.dropFirst().sink { newVal in
-            guard newVal != nil else { return }
-            root = newVal
-            decodedExpectation.fulfill()
-        }.store(in: &set)
+        registry.$root
+            .dropFirst()
+            .sink { newVal in
+                guard newVal != nil else { return }
+                root = newVal
+                decodedExpectation.fulfill()
+            }
+            .store(in: &set)
 
-        try registry.decode(value: jsValue!)
+        try registry.decode(value: XCTUnwrap(jsValue))
 
         wait(for: [decodedExpectation], timeout: 1)
 
@@ -577,16 +600,25 @@ class SwiftUIRegistryTests: XCTestCase {
             return XCTFail("incorrect root asset")
         }
 
-        guard let choice = collectionAsset.model.data.values.first.flatMap({ $0?.asset as? SwiftUIChoiceAsset }) else {
+        guard let choice = collectionAsset.model
+            .data
+            .values
+            .first
+            .flatMap({ $0?.asset as? SwiftUIChoiceAsset }) else {
             return XCTFail("incorrect asset for first value")
         }
 
         for choice in choice.model.data.choices {
-            let hasSelectFunction = (choice.select?.rawValue != nil) || (choice.unSelect?.rawValue != nil)
+            let hasSelectFunction = (choice.select?.rawValue != nil) ||
+                (choice.unSelect?.rawValue != nil)
             XCTAssertTrue(hasSelectFunction)
         }
 
-        guard let action = collectionAsset.model.data.values.last.flatMap({ $0?.asset as? ActionAsset }) else {
+        guard let action = collectionAsset.model
+            .data
+            .values
+            .last
+            .flatMap({ $0?.asset as? ActionAsset }) else {
             return XCTFail("incorrect asset for last value")
         }
 

--- a/ios/swiftui/Tests/SwiftUIRegistryTests.swift
+++ b/ios/swiftui/Tests/SwiftUIRegistryTests.swift
@@ -423,8 +423,8 @@ class SwiftUIRegistryTests: XCTestCase {
         }
 
         let updatedJSString = jsString
-            .replacingOccurrences(of: "value1", with: "value3")
-            .replacingOccurrences(of: "value2", with: "value4")
+            .replacing("value1", with: "value3")
+            .replacing("value2", with: "value4")
         guard let updatedJSValue = context.evaluateScript(updatedJSString) else {
             return XCTFail("could not create JSValue")
         }

--- a/ios/swiftui/Tests/SwiftUIRegistryTests.swift
+++ b/ios/swiftui/Tests/SwiftUIRegistryTests.swift
@@ -6,19 +6,19 @@
 //  Copyright © 2021 Intuit. All rights reserved.
 //
 
-import Foundation
-import XCTest
-import JavaScriptCore
 import Combine
-import SwiftUI
+import Foundation
+import JavaScriptCore
 @testable import PlayerUI
-@testable import PlayerUISwiftUI
 @testable import PlayerUILogger
 @testable import PlayerUIReferenceAssets
+@testable import PlayerUISwiftUI
+import SwiftUI
+import XCTest
 
 // swiftlint:disable type_body_length file_length
 class SwiftUIRegistryTests: XCTestCase {
-    let context: JSContext = JSContext()
+    private let context: JSContext = .init()
 
     func testDuplicateRegistration() {
         let operationSkipped = expectation(description: "Skipped duplicate registration")
@@ -26,17 +26,17 @@ class SwiftUIRegistryTests: XCTestCase {
         operationSkipped.expectedFulfillmentCount = 2
         let logger = TapableLogger()
         logger.logLevel = .trace
-        logger.hooks.trace.tap(name: "test", { messages in
+        logger.hooks.trace.tap(name: "test") { messages in
             let message: String = (messages as? [String] ?? []).first ?? ""
-            guard  message.contains("Duplicate Registration skipped for") else { return }
+            guard message.contains("Duplicate Registration skipped for") else { return }
             operationSkipped.fulfill()
-        })
+        }
 
-        logger.hooks.warn.tap(name: "test", { messages in
+        logger.hooks.warn.tap(name: "test") { messages in
             let message: String = (messages as? [String] ?? []).first ?? ""
             guard message.contains("Overriding registration for match") else { return }
             override.fulfill()
-        })
+        }
         let registry = SwiftUIRegistry(logger: logger)
         registry.register(["type": "action"], for: ActionAsset.self)
         XCTAssertEqual(1, registry.registeredAssets.count)
@@ -52,7 +52,8 @@ class SwiftUIRegistryTests: XCTestCase {
     }
 
     func testDecodeWrappedAsset() {
-        let val = context.evaluateScript("({asset: {id: 'someId', type: 'text', value: 'someValue'}})")
+        let val = context
+            .evaluateScript("({asset: {id: 'someId', type: 'text', value: 'someValue'}})")
 
         let partialMatch = PartialMatchFingerprintPlugin()
         partialMatch.context = context
@@ -84,10 +85,14 @@ class SwiftUIRegistryTests: XCTestCase {
         }
 
         class TestNestedAsset: UncontrolledAsset<TestData> {
-            override var view: AnyView { AnyView(EmptyView()) }
+            override var view: AnyView {
+                AnyView(EmptyView())
+            }
         }
         let val = context
-            .evaluateScript("({asset: {id: 'someId', type: 'nested', nested: {asset: {id: 'someOtherId', type: 'text', value: ''}, extra: 'value'}}})")
+            .evaluateScript(
+                "({asset: {id: 'someId', type: 'nested', nested: {asset: {id: 'someOtherId', type: 'text', value: ''}, extra: 'value'}}})"
+            )
 
         let partialMatch = PartialMatchFingerprintPlugin()
         partialMatch.context = context
@@ -103,7 +108,8 @@ class SwiftUIRegistryTests: XCTestCase {
         do {
             let decoded = try registry.decodeWrapper(object)
             XCTAssertEqual(decoded.asset?.id, "someId")
-            guard let asset = decoded.asset as? TestNestedAsset else { return XCTFail("Decoded asset was not TestNestedAsset") }
+            guard let asset = decoded.asset as? TestNestedAsset
+            else { return XCTFail("Decoded asset was not TestNestedAsset") }
             XCTAssertEqual(asset.model.data.nested?.additionalData?.extra, "value")
         } catch {
             XCTFail("unable to decode wrapper")
@@ -111,8 +117,10 @@ class SwiftUIRegistryTests: XCTestCase {
     }
 
     func testWrappedAssetEquivalence() {
-        let asset1 = context.evaluateScript("({asset: {id: 'someId', type: 'text', value: 'someValue'}})")
-        let asset2 = context.evaluateScript("({asset: {id: 'someId', type: 'text', value: 'someOtherValue'}})")
+        let asset1 = context
+            .evaluateScript("({asset: {id: 'someId', type: 'text', value: 'someValue'}})")
+        let asset2 = context
+            .evaluateScript("({asset: {id: 'someId', type: 'text', value: 'someOtherValue'}})")
 
         let partialMatch = PartialMatchFingerprintPlugin()
         partialMatch.context = context
@@ -124,8 +132,8 @@ class SwiftUIRegistryTests: XCTestCase {
         guard
             let object = asset1,
             let object2 = asset2 else {
-                return XCTFail("object should not be nil")
-            }
+            return XCTFail("object should not be nil")
+        }
 
         do {
             let wrapped1 = try registry.decodeWrapper(object)
@@ -167,14 +175,16 @@ class SwiftUIRegistryTests: XCTestCase {
         var set = Set<AnyCancellable>()
 
         let decodedExpectation = expectation(description: "Root Decoded")
-        registry.$root.sink { newVal in
-            if newVal != nil {
-                XCTAssertEqual(newVal?.id, "someId")
-                decodedExpectation.fulfill()
+        registry.$root
+            .sink { newVal in
+                if newVal != nil {
+                    XCTAssertEqual(newVal?.id, "someId")
+                    decodedExpectation.fulfill()
+                }
             }
-        }.store(in: &set)
+            .store(in: &set)
 
-        try registry.decode(value: val!)
+        try registry.decode(value: XCTUnwrap(val))
 
         wait(for: [decodedExpectation], timeout: 1)
     }
@@ -196,17 +206,19 @@ class SwiftUIRegistryTests: XCTestCase {
         var root: AnyObject?
 
         let decodedExpectation = expectation(description: "Root Decoded")
-        registry.$root.sink { newVal in
-            if root == nil, newVal != nil {
-                root = newVal?.modelObject
-            } else if root != nil, newVal != nil {
-                XCTAssertFalse(root === newVal?.modelObject)
-                decodedExpectation.fulfill()
+        registry.$root
+            .sink { newVal in
+                if root == nil, newVal != nil {
+                    root = newVal?.modelObject
+                } else if root != nil, newVal != nil {
+                    XCTAssertFalse(root === newVal?.modelObject)
+                    decodedExpectation.fulfill()
+                }
             }
-        }.store(in: &set)
+            .store(in: &set)
 
-        try registry.decode(value: val!)
-        try registry.decode(value: val!)
+        try registry.decode(value: XCTUnwrap(val))
+        try registry.decode(value: XCTUnwrap(val))
 
         wait(for: [decodedExpectation], timeout: 1)
     }
@@ -218,7 +230,9 @@ class SwiftUIRegistryTests: XCTestCase {
 
         class SwiftUITestAsset: ControlledAsset<TextData, TestModel> {
             /// A type erased view object
-            public override var view: AnyView { AnyView(EmptyView()) }
+            override public var view: AnyView {
+                AnyView(EmptyView())
+            }
         }
 
         let partialMatch = PartialMatchFingerprintPlugin()
@@ -235,24 +249,27 @@ class SwiftUIRegistryTests: XCTestCase {
         var root: AnyObject?
 
         let decodedExpectation = expectation(description: "Root Decoded")
-        registry.$root.sink { newVal in
-            if root == nil, newVal != nil {
-                root = newVal?.modelObject
-            } else if root != nil, newVal != nil {
-                XCTAssertTrue(root === newVal?.modelObject)
-                decodedExpectation.fulfill()
+        registry.$root
+            .sink { newVal in
+                if root == nil, newVal != nil {
+                    root = newVal?.modelObject
+                } else if root != nil, newVal != nil {
+                    XCTAssertTrue(root === newVal?.modelObject)
+                    decodedExpectation.fulfill()
+                }
             }
-        }.store(in: &set)
+            .store(in: &set)
 
-        try registry.decode(value: val!)
-        try registry.decode(value: val!)
+        try registry.decode(value: XCTUnwrap(val))
+        try registry.decode(value: XCTUnwrap(val))
 
         wait(for: [decodedExpectation], timeout: 1)
     }
 
     func testDecodeJSValueReturnsNewAsset() throws {
         let val = context.evaluateScript("({id: 'someId', type: 'text', value: 'someValue'})")
-        let val2 = context.evaluateScript("({id: 'someOtherId', type: 'action', value: 'someValue'})")
+        let val2 = context
+            .evaluateScript("({id: 'someOtherId', type: 'action', value: 'someValue'})")
 
         let partialMatch = PartialMatchFingerprintPlugin()
         partialMatch.context = context
@@ -270,17 +287,19 @@ class SwiftUIRegistryTests: XCTestCase {
         var root: SwiftUIAsset?
 
         let decodedExpectation = expectation(description: "Root Decoded")
-        registry.$root.sink { newVal in
-            if root == nil, newVal != nil {
-                root = newVal
-            } else if root != nil, newVal != nil {
-                XCTAssertNotEqual(root?.uuid, newVal?.uuid)
-                decodedExpectation.fulfill()
+        registry.$root
+            .sink { newVal in
+                if root == nil, newVal != nil {
+                    root = newVal
+                } else if root != nil, newVal != nil {
+                    XCTAssertNotEqual(root?.uuid, newVal?.uuid)
+                    decodedExpectation.fulfill()
+                }
             }
-        }.store(in: &set)
+            .store(in: &set)
 
-        try registry.decode(value: val!)
-        try registry.decode(value: val2!)
+        try registry.decode(value: XCTUnwrap(val))
+        try registry.decode(value: XCTUnwrap(val2))
 
         wait(for: [decodedExpectation], timeout: 1)
     }
@@ -310,18 +329,20 @@ class SwiftUIRegistryTests: XCTestCase {
         var root: AnyObject?
 
         let decodedExpectation = expectation(description: "Root Decoded")
-        registry.$root.sink { newVal in
-            if root == nil, newVal != nil {
-                root = newVal?.modelObject
-            } else if root != nil, newVal != nil {
-                XCTAssertFalse(root === newVal?.modelObject)
-                root = newVal?.modelObject
-                decodedExpectation.fulfill()
+        registry.$root
+            .sink { newVal in
+                if root == nil, newVal != nil {
+                    root = newVal?.modelObject
+                } else if root != nil, newVal != nil {
+                    XCTAssertFalse(root === newVal?.modelObject)
+                    root = newVal?.modelObject
+                    decodedExpectation.fulfill()
+                }
             }
-        }.store(in: &set)
+            .store(in: &set)
 
-        try registry.decode(value: val!)
-        try registry.decode(value: val2!)
+        try registry.decode(value: XCTUnwrap(val))
+        try registry.decode(value: XCTUnwrap(val2))
 
         wait(for: [decodedExpectation], timeout: 1)
 
@@ -331,7 +352,6 @@ class SwiftUIRegistryTests: XCTestCase {
         else { return XCTFail("unable to decode asset") }
 
         XCTAssertEqual(text.model.data.value.stringValue, "value2")
-
     }
 
     func testDecodeJSValueUpdatesNestedArrayData() throws {
@@ -359,18 +379,20 @@ class SwiftUIRegistryTests: XCTestCase {
         var root: AnyObject?
 
         let decodedExpectation = expectation(description: "Root Decoded")
-        registry.$root.sink { newVal in
-            if root == nil, newVal != nil {
-                root = newVal?.modelObject
-            } else if root != nil, newVal != nil {
-                XCTAssertFalse(root === newVal?.modelObject)
-                root = newVal?.modelObject
-                decodedExpectation.fulfill()
+        registry.$root
+            .sink { newVal in
+                if root == nil, newVal != nil {
+                    root = newVal?.modelObject
+                } else if root != nil, newVal != nil {
+                    XCTAssertFalse(root === newVal?.modelObject)
+                    root = newVal?.modelObject
+                    decodedExpectation.fulfill()
+                }
             }
-        }.store(in: &set)
+            .store(in: &set)
 
-        try registry.decode(value: val!)
-        try registry.decode(value: val2!)
+        try registry.decode(value: XCTUnwrap(val))
+        try registry.decode(value: XCTUnwrap(val2))
 
         wait(for: [decodedExpectation], timeout: 1)
 
@@ -438,7 +460,7 @@ class SwiftUIRegistryTests: XCTestCase {
         guard let values = (root as? CollectionAsset)?.model.data.values else {
             return XCTFail("value should not be nil")
         }
-        guard 2 == values.count else {
+        guard values.count == 2 else {
             return XCTFail("incorrect number of values")
         }
         let text1 = values[0]?.asset as? TextAsset
@@ -452,7 +474,7 @@ class SwiftUIRegistryTests: XCTestCase {
         guard let updatedValues = (root as? CollectionAsset)?.model.data.values else {
             return XCTFail("unable to get updated values")
         }
-        guard 2 == updatedValues.count else {
+        guard updatedValues.count == 2 else {
             return XCTFail("incorrect number of updated values")
         }
         let updatedText1 = updatedValues[0]?.asset as? TextAsset
@@ -534,9 +556,7 @@ class SwiftUIRegistryTests: XCTestCase {
 
         let jsValue = context.evaluateScript(jsString)
         XCTAssertNotNil(jsValue)
-        guard let _ = jsValue else {
-            return
-        }
+        _ = try XCTUnwrap(jsValue)
 
         let registry = SwiftUIRegistry(logger: TapableLogger())
         registry.register("collection", asset: CollectionAsset.self)
@@ -561,13 +581,16 @@ class SwiftUIRegistryTests: XCTestCase {
         var root: SwiftUIAsset?
 
         let decodedExpectation = expectation(description: "Root Decoded")
-        registry.$root.dropFirst().sink { newVal in
-            guard newVal != nil else { return }
-            root = newVal
-            decodedExpectation.fulfill()
-        }.store(in: &set)
+        registry.$root
+            .dropFirst()
+            .sink { newVal in
+                guard newVal != nil else { return }
+                root = newVal
+                decodedExpectation.fulfill()
+            }
+            .store(in: &set)
 
-        try registry.decode(value: jsValue!)
+        try registry.decode(value: XCTUnwrap(jsValue))
 
         wait(for: [decodedExpectation], timeout: 1)
 
@@ -577,16 +600,25 @@ class SwiftUIRegistryTests: XCTestCase {
             return XCTFail("incorrect root asset")
         }
 
-        guard let choice = collectionAsset.model.data.values.first.flatMap({ $0?.asset as? SwiftUIChoiceAsset }) else {
+        guard let choice = collectionAsset.model
+            .data
+            .values
+            .first
+            .flatMap({ $0?.asset as? SwiftUIChoiceAsset }) else {
             return XCTFail("incorrect asset for first value")
         }
 
         for choice in choice.model.data.choices {
-            let hasSelectFunction = (choice.select?.rawValue != nil) || (choice.unSelect?.rawValue != nil)
+            let hasSelectFunction = (choice.select?.rawValue != nil) ||
+                (choice.unSelect?.rawValue != nil)
             XCTAssertTrue(hasSelectFunction)
         }
 
-        guard let action = collectionAsset.model.data.values.last.flatMap({ $0?.asset as? ActionAsset }) else {
+        guard let action = collectionAsset.model
+            .data
+            .values
+            .last
+            .flatMap({ $0?.asset as? ActionAsset }) else {
             return XCTFail("incorrect asset for last value")
         }
 

--- a/ios/swiftui/Tests/SwiftUIRegistryTests.swift
+++ b/ios/swiftui/Tests/SwiftUIRegistryTests.swift
@@ -423,8 +423,8 @@ class SwiftUIRegistryTests: XCTestCase {
         }
 
         let updatedJSString = jsString
-            .replacing("value1", with: "value3")
-            .replacing("value2", with: "value4")
+            .replacingOccurrences(of: "value1", with: "value3")
+            .replacingOccurrences(of: "value2", with: "value4")
         guard let updatedJSValue = context.evaluateScript(updatedJSString) else {
             return XCTFail("could not create JSValue")
         }

--- a/ios/swiftui/Tests/extensions/DecoderExtensionsTests.swift
+++ b/ios/swiftui/Tests/extensions/DecoderExtensionsTests.swift
@@ -7,10 +7,10 @@
 //
 
 import Foundation
-import XCTest
 @testable import PlayerUI
-@testable import PlayerUISwiftUI
 @testable import PlayerUIInternalTestUtilities
+@testable import PlayerUISwiftUI
+import XCTest
 
 class DecoderExtensionsTests: XCTestCase {
     func testNotAnAssetDecoderForSUIDecodeFunction() {

--- a/ios/swiftui/Tests/reference-assets/SwiftUIChoiceAsset.swift
+++ b/ios/swiftui/Tests/reference-assets/SwiftUIChoiceAsset.swift
@@ -5,14 +5,12 @@
 //  Created by bcallaghan  on 5/27/21.
 //
 
-import SwiftUI
 import Combine
 import PlayerUI
 import PlayerUISwiftUI
+import SwiftUI
 
-/**
- Data Decoded by Player for `ChoiceAssetData`
- */
+/// Data Decoded by Player for `ChoiceAssetData`
 public struct ChoiceData: AssetData {
     public var id: String
     public var type: String
@@ -28,20 +26,17 @@ public struct ChoiceData: AssetData {
     }
 }
 
-/**
- Wrapper class to tie `ChoiceData` to a SwiftUI `View`
- */
+/// Wrapper class to tie `ChoiceData` to a SwiftUI `View`
 final class SwiftUIChoiceAsset: UncontrolledAsset<ChoiceData> {
-    public override var view: AnyView { AnyView(ChoiceAssetView(model: model)) }
+    override var view: AnyView {
+        AnyView(ChoiceAssetView(model: model))
+    }
 }
 
-/**
- View implementation for `ChoiceAsset`
- */
+/// View implementation for `ChoiceAsset`
 struct ChoiceAssetView: View {
     @ObservedObject var model: AssetViewModel<ChoiceData>
 
-    @ViewBuilder
     var body: some View {
         VStack {
             ForEach(model.data.choices) { choice in

--- a/ios/swiftui/Tests/types/WrappedFunctionTests.swift
+++ b/ios/swiftui/Tests/types/WrappedFunctionTests.swift
@@ -7,32 +7,13 @@
 //
 
 import Foundation
-import XCTest
 import JavaScriptCore
-
 @testable import PlayerUI
 @testable import PlayerUISwiftUI
+import XCTest
 
 class WrappedFunctionTests: XCTestCase {
-    let context: JSContext = JSContext()
-
-    private enum PromiseValues: Decodable, Equatable {
-        case listOfString([String])
-        case listOfCustomStruct([CustomStruct])
-
-        init(from decoder: Decoder) throws {
-            let container = try decoder.singleValueContainer()
-            do {
-                self = .listOfString(try container.decode([String].self))
-            } catch {
-                self = .listOfCustomStruct(try container.decode([CustomStruct].self))
-            }
-        }
-    }
-
-    private struct CustomStruct: Decodable, Equatable, Encodable {
-        var someString: String
-    }
+    private let context: JSContext = .init()
 
     func testWrappedFunction() {
         let called = expectation(description: "Function Called")
@@ -67,19 +48,19 @@ class WrappedFunctionTests: XCTestCase {
     }
 
     func testWrappedFunctionAsyncReturnsInt() async {
-        JSUtilities.polyfill(self.context)
+        JSUtilities.polyfill(context)
 
-        let function = self.context
+        let function = context
             .evaluateScript("""
-                              (() => {
-                                return new Promise((resolve) => {
-                                  setTimeout(
-                                    () => { resolve(1) },
-                                    1000
-                                  )
-                                })
-                              })
-                           """)
+               (() => {
+                 return new Promise((resolve) => {
+                   setTimeout(
+                     () => { resolve(1) },
+                     1000
+                   )
+                 })
+               })
+            """)
 
         let wrapper = WrappedFunction<Int>(rawValue: function)
 
@@ -92,19 +73,19 @@ class WrappedFunctionTests: XCTestCase {
     }
 
     func testWrappedFunctionAsyncReturnsStrings() async {
-        JSUtilities.polyfill(self.context)
+        JSUtilities.polyfill(context)
 
-        let function = self.context
+        let function = context
             .evaluateScript("""
-                              (() => {
-                                return new Promise((resolve) => {
-                                  setTimeout(
-                                    () => { resolve(["firstString", "secondString"]) },
-                                    1000
-                                  )
-                                })
-                              })
-                           """)
+               (() => {
+                 return new Promise((resolve) => {
+                   setTimeout(
+                     () => { resolve(["firstString", "secondString"]) },
+                     1000
+                   )
+                 })
+               })
+            """)
 
         let wrapper = WrappedFunction<PromiseValues>(rawValue: function)
 
@@ -117,37 +98,43 @@ class WrappedFunctionTests: XCTestCase {
     }
 
     func testWrappedFunctionAsyncReturnsCustomStructs() async {
-        JSUtilities.polyfill(self.context)
+        JSUtilities.polyfill(context)
 
-        let function = self.context
+        let function = context
             .evaluateScript("""
-                              (() => {
-                                return new Promise((resolve) => {
-                                  setTimeout(
-                                    () => { resolve([{someString: 'test1'}, {someString: 'test2'}]) },
-                                    1000
-                                  )
-                                })
-                              })
-                           """)
+               (() => {
+                 return new Promise((resolve) => {
+                   setTimeout(
+                     () => { resolve([{someString: 'test1'}, {someString: 'test2'}]) },
+                     1000
+                   )
+                 })
+               })
+            """)
 
         let wrapper = WrappedFunction<PromiseValues>(rawValue: function)
 
         do {
             let result = try await wrapper.callAsFunctionAsync(args: "")
-            XCTAssertEqual(result, .listOfCustomStruct([CustomStruct(someString: "test1"), CustomStruct(someString: "test2")]))
+            XCTAssertEqual(
+                result,
+                .listOfCustomStruct([
+                    CustomStruct(someString: "test1"),
+                    CustomStruct(someString: "test2"),
+                ])
+            )
         } catch {
             XCTFail("could not call async wrapped function")
         }
     }
 
     func testWrappedFunctionAsyncThrowsError() async {
-        JSUtilities.polyfill(self.context)
+        JSUtilities.polyfill(context)
 
-        let function = self.context
+        let function = context
             .evaluateScript("""
-                              ( () => Promise.reject(new Error("promise rejected")) )
-                           """)
+               ( () => Promise.reject(new Error("promise rejected")) )
+            """)
 
         let wrapper = WrappedFunction<Int>(rawValue: function)
 
@@ -157,9 +144,11 @@ class WrappedFunctionTests: XCTestCase {
             XCTAssertEqual(
                 WrappedFunction<Int>.Error.promiseFailed(
                     error: """
-                                (extension in PlayerUISwiftUI):PlayerUISwiftUI.WrappedFunction<Swift.Int>.Error.promiseFailed(error: \"Error: promise rejected\")
-                                """),
-                WrappedFunction<Int>.Error.promiseFailed(error: error.playerDescription))
+                    (extension in PlayerUISwiftUI):PlayerUISwiftUI.WrappedFunction<Swift.Int>.Error.promiseFailed(error: \"Error: promise rejected\")
+                    """
+                ),
+                WrappedFunction<Int>.Error.promiseFailed(error: error.playerDescription)
+            )
         }
     }
 
@@ -180,11 +169,29 @@ class WrappedFunctionTests: XCTestCase {
 
     func testModelReference() throws {
         let context = JSContext()
-        guard let val = JSValue(object: "Hello World", in: context!) else {
+        guard let val = try JSValue(object: "Hello World", in: XCTUnwrap(context)) else {
             return XCTFail("could not create JSValue")
         }
         let wrapper = try JSONDecoder().decode(ModelReference.self, from: val)
 
         XCTAssertEqual("Hello World", wrapper.stringValue)
+    }
+
+    private enum PromiseValues: Decodable, Equatable {
+        case listOfString([String])
+        case listOfCustomStruct([CustomStruct])
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            do {
+                self = try .listOfString(container.decode([String].self))
+            } catch {
+                self = try .listOfCustomStruct(container.decode([CustomStruct].self))
+            }
+        }
+    }
+
+    private struct CustomStruct: Decodable, Equatable, Encodable {
+        var someString: String
     }
 }

--- a/ios/swiftui/Tests/types/assets/ControlledAssetTests.swift
+++ b/ios/swiftui/Tests/types/assets/ControlledAssetTests.swift
@@ -6,39 +6,32 @@
 //  Copyright © 2021 CocoaPods. All rights reserved.
 //
 
-import Foundation
-import XCTest
-import JavaScriptCore
 import Combine
+import Foundation
+import JavaScriptCore
 @testable import PlayerUI
-@testable import PlayerUISwiftUI
 @testable import PlayerUILogger
+@testable import PlayerUISwiftUI
+import XCTest
 
 class ControlledAssetTests: XCTestCase {
-    let context: JSContext = JSContext()
-
-    struct SomeData: AssetData {
-        var id: String
-        var type: String
-        var value: String
-        var nested: WrappedAsset?
-    }
-
-    struct SomeOtherData: AssetData {
-        var id: String
-        var type: String
-        var value: String
-    }
+    private let context: JSContext = .init()
 
     func testAssetViewModel() {
-        let viewModel = AssetViewModel<SomeData>(SomeData(id: "someId", type: "someType", value: "test"))
+        let viewModel = AssetViewModel<SomeData>(SomeData(
+            id: "someId",
+            type: "someType",
+            value: "test"
+        ))
 
         let updated = expectation(description: "data updated")
-        viewModel.$data.sink { newData in
-            if newData.value == "tested" {
-                updated.fulfill()
+        viewModel.$data
+            .sink { newData in
+                if newData.value == "tested" {
+                    updated.fulfill()
+                }
             }
-        }.store(in: &viewModel.bag)
+            .store(in: &viewModel.bag)
 
         viewModel.data = SomeData(id: "someId", type: "someType", value: "tested")
         wait(for: [updated], timeout: 1)
@@ -57,17 +50,21 @@ class ControlledAssetTests: XCTestCase {
 
         guard let value = val else { return XCTFail("value should not have been nil") }
 
-        guard let asset = try? registry.decode(value) as? SomeAsset else { return XCTFail("could not decode asset") }
+        guard let asset = try? registry.decode(value) as? SomeAsset
+        else { return XCTFail("could not decode asset") }
 
         XCTAssertEqual(asset.valueData.id, "someId")
         XCTAssertEqual(asset.valueData.type, "someType")
 
         let updated = expectation(description: "data updated")
-        asset.model.$data.sink { newData in
-            if newData.value == "tested" {
-                updated.fulfill()
+        asset.model
+            .$data
+            .sink { newData in
+                if newData.value == "tested" {
+                    updated.fulfill()
+                }
             }
-        }.store(in: &asset.model.bag)
+            .store(in: &asset.model.bag)
 
         asset.model.data = SomeData(id: "someId", type: "someType", value: "tested")
 
@@ -112,10 +109,10 @@ class ControlledAssetTests: XCTestCase {
         XCTAssertFalse(model === model2)
         watchData.cancel()
     }
-    
+
     func testDecoderError() throws {
         class SomeAsset: ControlledAsset<SomeData, AssetViewModel<SomeData>> {}
-        
+
         let val = context.evaluateScript("({id: 'someId', type: 'someType', value: 123 })")
         let partialMatch = PartialMatchFingerprintPlugin()
         partialMatch.context = context
@@ -123,25 +120,30 @@ class ControlledAssetTests: XCTestCase {
         let registry = SwiftUIRegistry(logger: TapableLogger())
         registry.register("someType", asset: SomeAsset.self)
         registry.partialMatchRegistry = partialMatch
-        
+
         guard let value = val else { return XCTFail("value should not have been nil") }
-        
+
         var thrownError: Error?
-        
+
         do {
             try registry.decode(value)
         } catch {
             thrownError = error
         }
-        
-        guard let err = thrownError else { return XCTFail("expected asset to throw error while decoding") }
-        XCTAssertTrue(err.playerDescription.contains("Exception occurred in asset with id 'someId' of type 'someType'"))
+
+        guard let err = thrownError
+        else { return XCTFail("expected asset to throw error while decoding") }
+        XCTAssertTrue(err.playerDescription
+            .contains("Exception occurred in asset with id 'someId' of type 'someType'"))
     }
-    
+
     func testNestedDecoderError() throws {
         class SomeAsset: ControlledAsset<SomeData, AssetViewModel<SomeData>> {}
-        
-        let val = context.evaluateScript("({id: 'someId', type: 'someType', value: '123', nested: { asset: { id: 'nestedId', type: 'someType', value: 123  }}})")
+
+        let val = context
+            .evaluateScript(
+                "({id: 'someId', type: 'someType', value: '123', nested: { asset: { id: 'nestedId', type: 'someType', value: 123  }}})"
+            )
         let partialMatch = PartialMatchFingerprintPlugin()
         partialMatch.context = context
         partialMatch.setMapping(assetId: "someId", index: 0)
@@ -149,20 +151,41 @@ class ControlledAssetTests: XCTestCase {
         let registry = SwiftUIRegistry(logger: TapableLogger())
         registry.register("someType", asset: SomeAsset.self)
         registry.partialMatchRegistry = partialMatch
-        
+
         guard let value = val else { return XCTFail("value should not have been nil") }
-        
+
         var thrownError: Error?
-        
+
         do {
             try registry.decode(value)
         } catch {
             thrownError = error
         }
-        
-        guard let err = thrownError else { return XCTFail("expected asset to throw error while decoding") }
-        XCTAssertTrue(err.playerDescription.contains("Exception occurred in asset with id 'nestedId' of type 'someType'"), err.playerDescription)
-        XCTAssertTrue(err.playerDescription.contains("Found in (id: 'someId', type: 'someType')"), err.playerDescription)
+
+        guard let err = thrownError
+        else { return XCTFail("expected asset to throw error while decoding") }
+        XCTAssertTrue(
+            err.playerDescription
+                .contains("Exception occurred in asset with id 'nestedId' of type 'someType'"),
+            err.playerDescription
+        )
+        XCTAssertTrue(
+            err.playerDescription.contains("Found in (id: 'someId', type: 'someType')"),
+            err.playerDescription
+        )
+    }
+
+    struct SomeData: AssetData {
+        var id: String
+        var type: String
+        var value: String
+        var nested: WrappedAsset?
+    }
+
+    struct SomeOtherData: AssetData {
+        var id: String
+        var type: String
+        var value: String
     }
 }
 
@@ -180,7 +203,7 @@ private extension String {
     static let asset12 = """
     { "id": "abc", "type": "Equatable", "value": "value2" }
     """
-    
+
     static let asset13 = """
     { "id": 12, "type": { "value": "Equatable" } }
     """
@@ -188,6 +211,9 @@ private extension String {
 
 private struct EquatableAssetData: AssetData, Equatable {
     var id: String
-    var type: String { "Equatable" }
     var value: String
+
+    var type: String {
+        "Equatable"
+    }
 }

--- a/ios/swiftui/Tests/types/assets/ControlledAssetTests.swift
+++ b/ios/swiftui/Tests/types/assets/ControlledAssetTests.swift
@@ -6,39 +6,32 @@
 //  Copyright © 2021 Intuit. All rights reserved.
 //
 
-import Foundation
-import XCTest
-import JavaScriptCore
 import Combine
+import Foundation
+import JavaScriptCore
 @testable import PlayerUI
-@testable import PlayerUISwiftUI
 @testable import PlayerUILogger
+@testable import PlayerUISwiftUI
+import XCTest
 
 class ControlledAssetTests: XCTestCase {
-    let context: JSContext = JSContext()
-
-    struct SomeData: AssetData {
-        var id: String
-        var type: String
-        var value: String
-        var nested: WrappedAsset?
-    }
-
-    struct SomeOtherData: AssetData {
-        var id: String
-        var type: String
-        var value: String
-    }
+    private let context: JSContext = .init()
 
     func testAssetViewModel() {
-        let viewModel = AssetViewModel<SomeData>(SomeData(id: "someId", type: "someType", value: "test"))
+        let viewModel = AssetViewModel<SomeData>(SomeData(
+            id: "someId",
+            type: "someType",
+            value: "test"
+        ))
 
         let updated = expectation(description: "data updated")
-        viewModel.$data.sink { newData in
-            if newData.value == "tested" {
-                updated.fulfill()
+        viewModel.$data
+            .sink { newData in
+                if newData.value == "tested" {
+                    updated.fulfill()
+                }
             }
-        }.store(in: &viewModel.bag)
+            .store(in: &viewModel.bag)
 
         viewModel.data = SomeData(id: "someId", type: "someType", value: "tested")
         wait(for: [updated], timeout: 1)
@@ -57,17 +50,21 @@ class ControlledAssetTests: XCTestCase {
 
         guard let value = val else { return XCTFail("value should not have been nil") }
 
-        guard let asset = try? registry.decode(value) as? SomeAsset else { return XCTFail("could not decode asset") }
+        guard let asset = try? registry.decode(value) as? SomeAsset
+        else { return XCTFail("could not decode asset") }
 
         XCTAssertEqual(asset.valueData.id, "someId")
         XCTAssertEqual(asset.valueData.type, "someType")
 
         let updated = expectation(description: "data updated")
-        asset.model.$data.sink { newData in
-            if newData.value == "tested" {
-                updated.fulfill()
+        asset.model
+            .$data
+            .sink { newData in
+                if newData.value == "tested" {
+                    updated.fulfill()
+                }
             }
-        }.store(in: &asset.model.bag)
+            .store(in: &asset.model.bag)
 
         asset.model.data = SomeData(id: "someId", type: "someType", value: "tested")
 
@@ -112,10 +109,10 @@ class ControlledAssetTests: XCTestCase {
         XCTAssertFalse(model === model2)
         watchData.cancel()
     }
-    
+
     func testDecoderError() throws {
         class SomeAsset: ControlledAsset<SomeData, AssetViewModel<SomeData>> {}
-        
+
         let val = context.evaluateScript("({id: 'someId', type: 'someType', value: 123 })")
         let partialMatch = PartialMatchFingerprintPlugin()
         partialMatch.context = context
@@ -123,25 +120,30 @@ class ControlledAssetTests: XCTestCase {
         let registry = SwiftUIRegistry(logger: TapableLogger())
         registry.register("someType", asset: SomeAsset.self)
         registry.partialMatchRegistry = partialMatch
-        
+
         guard let value = val else { return XCTFail("value should not have been nil") }
-        
+
         var thrownError: Error?
-        
+
         do {
             try registry.decode(value)
         } catch {
             thrownError = error
         }
-        
-        guard let err = thrownError else { return XCTFail("expected asset to throw error while decoding") }
-        XCTAssertTrue(err.playerDescription.contains("Exception occurred in asset with id 'someId' of type 'someType'"))
+
+        guard let err = thrownError
+        else { return XCTFail("expected asset to throw error while decoding") }
+        XCTAssertTrue(err.playerDescription
+            .contains("Exception occurred in asset with id 'someId' of type 'someType'"))
     }
-    
+
     func testNestedDecoderError() throws {
         class SomeAsset: ControlledAsset<SomeData, AssetViewModel<SomeData>> {}
-        
-        let val = context.evaluateScript("({id: 'someId', type: 'someType', value: '123', nested: { asset: { id: 'nestedId', type: 'someType', value: 123  }}})")
+
+        let val = context
+            .evaluateScript(
+                "({id: 'someId', type: 'someType', value: '123', nested: { asset: { id: 'nestedId', type: 'someType', value: 123  }}})"
+            )
         let partialMatch = PartialMatchFingerprintPlugin()
         partialMatch.context = context
         partialMatch.setMapping(assetId: "someId", index: 0)
@@ -149,20 +151,41 @@ class ControlledAssetTests: XCTestCase {
         let registry = SwiftUIRegistry(logger: TapableLogger())
         registry.register("someType", asset: SomeAsset.self)
         registry.partialMatchRegistry = partialMatch
-        
+
         guard let value = val else { return XCTFail("value should not have been nil") }
-        
+
         var thrownError: Error?
-        
+
         do {
             try registry.decode(value)
         } catch {
             thrownError = error
         }
-        
-        guard let err = thrownError else { return XCTFail("expected asset to throw error while decoding") }
-        XCTAssertTrue(err.playerDescription.contains("Exception occurred in asset with id 'nestedId' of type 'someType'"), err.playerDescription)
-        XCTAssertTrue(err.playerDescription.contains("Found in (id: 'someId', type: 'someType')"), err.playerDescription)
+
+        guard let err = thrownError
+        else { return XCTFail("expected asset to throw error while decoding") }
+        XCTAssertTrue(
+            err.playerDescription
+                .contains("Exception occurred in asset with id 'nestedId' of type 'someType'"),
+            err.playerDescription
+        )
+        XCTAssertTrue(
+            err.playerDescription.contains("Found in (id: 'someId', type: 'someType')"),
+            err.playerDescription
+        )
+    }
+
+    struct SomeData: AssetData {
+        var id: String
+        var type: String
+        var value: String
+        var nested: WrappedAsset?
+    }
+
+    struct SomeOtherData: AssetData {
+        var id: String
+        var type: String
+        var value: String
     }
 }
 
@@ -180,7 +203,7 @@ private extension String {
     static let asset12 = """
     { "id": "abc", "type": "Equatable", "value": "value2" }
     """
-    
+
     static let asset13 = """
     { "id": 12, "type": { "value": "Equatable" } }
     """
@@ -188,6 +211,9 @@ private extension String {
 
 private struct EquatableAssetData: AssetData, Equatable {
     var id: String
-    var type: String { "Equatable" }
     var value: String
+
+    var type: String {
+        "Equatable"
+    }
 }

--- a/ios/swiftui/Tests/types/assets/SwiftUIAssetTests.swift
+++ b/ios/swiftui/Tests/types/assets/SwiftUIAssetTests.swift
@@ -7,16 +7,16 @@
 //
 
 import Foundation
-import XCTest
 import JavaScriptCore
-
 @testable import PlayerUI
-@testable import PlayerUISwiftUI
 @testable import PlayerUILogger
 @testable import PlayerUIReferenceAssets
+@testable import PlayerUISwiftUI
+import XCTest
 
 class SwiftUIAssetTests: XCTestCase {
-    let context: JSContext = JSContext()
+    private let context: JSContext = .init()
+
     func testBaseAssetDecoding() throws {
         let val = context.evaluateScript("({id: 'someId', type: 'someType', value: 'someValue'})")
 
@@ -37,7 +37,8 @@ class SwiftUIAssetTests: XCTestCase {
     }
 
     func testWrappedAssetDecoding() throws {
-        let val = context.evaluateScript("({asset: {id: 'someId', type: 'someType', value: 'someValue'}})")
+        let val = context
+            .evaluateScript("({asset: {id: 'someId', type: 'someType', value: 'someValue'}})")
 
         let partialMatch = PartialMatchFingerprintPlugin()
         partialMatch.context = context
@@ -71,6 +72,5 @@ class SwiftUIAssetTests: XCTestCase {
 
         XCTAssertEqual(wrapper.asset?.id, "someId")
         XCTAssertEqual(wrapper.asset?.type, "someType")
-
     }
 }

--- a/ios/swiftui/ViewInspector/ManagedPlayer/ManagedPlayerTests.swift
+++ b/ios/swiftui/ViewInspector/ManagedPlayer/ManagedPlayerTests.swift
@@ -5,50 +5,79 @@
 //  Created by Harris Borawski on 4/5/21.
 //  Copyright © 2021 CocoaPods. All rights reserved.
 //
-import Foundation
-import XCTest
-import SwiftUI
 @preconcurrency import Combine
-import ViewInspector
-
+import Foundation
 @testable import PlayerUI
-@testable import PlayerUISwiftUI
 @testable import PlayerUIInternalTestUtilities
 @testable import PlayerUIReferenceAssets
+@testable import PlayerUISwiftUI
+import SwiftUI
+import ViewInspector
+import XCTest
 
 extension Inspection: @retroactive @unchecked Sendable {}
-extension Inspection: @retroactive InspectionEmissary { }
+extension Inspection: @retroactive InspectionEmissary {}
 
 class ManagedPlayer14Tests: XCTestCase {
     func testLoadingView() throws {
-        let viewModel = ManagedPlayerViewModel(manager: NeverLoad(), onComplete: {_ in })
-        let player = ManagedPlayer(plugins: [], context: .init(), viewModel: viewModel, fallback: { _ in Text("Error")}, loading: { Text("Loading")})
+        let viewModel = ManagedPlayerViewModel(manager: NeverLoad(), onComplete: { _ in })
+        let player = ManagedPlayer(
+            plugins: [],
+            context: .init(),
+            viewModel: viewModel,
+            fallback: { _ in Text("Error") },
+            loading: { Text("Loading") }
+        )
 
         let playerView = try player.inspect()
 
-        try playerView.find(ManagedPlayer14<Text, EmptyView>.self).vStack().group(0).color(0).callOnAppear()
+        try playerView.find(ManagedPlayer14<Text, EmptyView>.self)
+            .vStack()
+            .group(0)
+            .color(0)
+            .callOnAppear()
 
-        waitOnChange(viewModel.$loadingState.eraseToAnyPublisher()) { $0 == ManagedPlayerViewModel.LoadingState.loading }
+        waitOnChange(viewModel.$loadingState.eraseToAnyPublisher()) {
+            $0 == ManagedPlayerViewModel.LoadingState.loading
+        }
 
-        let text = try playerView.find(ManagedPlayer14<Text, EmptyView>.self).vStack().group(0).zStack(0).text(0)
+        let text = try playerView.find(ManagedPlayer14<Text, EmptyView>.self)
+            .vStack()
+            .group(0)
+            .zStack(0)
+            .text(0)
 
         XCTAssertEqual("Loading", try text.string())
     }
 
     func testFallbackView() throws {
-        let viewModel = ManagedPlayerViewModel(manager: ErrorLoaded(), onComplete: {_ in })
-        let player = ManagedPlayer(plugins: [], context: .init(), viewModel: viewModel, fallback: { _ in Text("Error")}, loading: { Text("Loading")})
+        let viewModel = ManagedPlayerViewModel(manager: ErrorLoaded(), onComplete: { _ in })
+        let player = ManagedPlayer(
+            plugins: [],
+            context: .init(),
+            viewModel: viewModel,
+            fallback: { _ in Text("Error") },
+            loading: { Text("Loading") }
+        )
 
         let playerView = try player.inspect()
 
-        try playerView.find(ManagedPlayer14<Text, EmptyView>.self).vStack().group(0).color(0).callOnAppear()
+        try playerView.find(ManagedPlayer14<Text, EmptyView>.self)
+            .vStack()
+            .group(0)
+            .color(0)
+            .callOnAppear()
 
         waitOnChange(viewModel.$loadingState.eraseToAnyPublisher()) {
             guard case .failed = $0 else { return false }
             return true
         }
 
-        let text = try playerView.find(ManagedPlayer14<Text, EmptyView>.self).vStack().group(0).text(0).string()
+        let text = try playerView.find(ManagedPlayer14<Text, EmptyView>.self)
+            .vStack()
+            .group(0)
+            .text(0)
+            .string()
         XCTAssertEqual(text, "Error")
     }
 
@@ -57,14 +86,19 @@ class ManagedPlayer14Tests: XCTestCase {
             plugins: [ReferenceAssetsPlugin()],
             flowManager: AlwaysLoaded(),
             context: .init(),
-            onComplete: {_ in},
-            fallback: {(_) in},
+            onComplete: { _ in },
+            fallback: { _ in },
             loading: {
                 Text("Loading")
             }
         )
 
-        try player.inspect().find(ManagedPlayer14<Text, EmptyView>.self).vStack().group(0).color(0).callOnAppear()
+        try player.inspect()
+            .find(ManagedPlayer14<Text, EmptyView>.self)
+            .vStack()
+            .group(0)
+            .color(0)
+            .callOnAppear()
 
         ViewHosting.host(view: player)
 
@@ -89,16 +123,32 @@ class ManagedPlayer14Tests: XCTestCase {
     }
 
     func testLoadingViewBeforeActionFlow() throws {
-        let viewModel = ManagedPlayerViewModel(manager: ActionLoaded(), onComplete: {_ in })
-        let player = ManagedPlayer(plugins: [], context: .init(), viewModel: viewModel, fallback: { _ in Text("Error")}, loading: { Text("Loading Flow")})
+        let viewModel = ManagedPlayerViewModel(manager: ActionLoaded(), onComplete: { _ in })
+        let player = ManagedPlayer(
+            plugins: [],
+            context: .init(),
+            viewModel: viewModel,
+            fallback: { _ in Text("Error") },
+            loading: { Text("Loading Flow") }
+        )
 
         let playerView = try player.inspect()
 
-        try playerView.find(ManagedPlayer14<Text, EmptyView>.self).vStack().group(0).color(0).callOnAppear()
+        try playerView.find(ManagedPlayer14<Text, EmptyView>.self)
+            .vStack()
+            .group(0)
+            .color(0)
+            .callOnAppear()
 
-        waitOnChange(viewModel.$loadingState.eraseToAnyPublisher()) { $0 == ManagedPlayerViewModel.LoadingState.loading }
+        waitOnChange(viewModel.$loadingState.eraseToAnyPublisher()) {
+            $0 == ManagedPlayerViewModel.LoadingState.loading
+        }
 
-        let text = try playerView.find(ManagedPlayer14<Text, EmptyView>.self).vStack().group(0).zStack(0).text(0)
+        let text = try playerView.find(ManagedPlayer14<Text, EmptyView>.self)
+            .vStack()
+            .group(0)
+            .zStack(0)
+            .text(0)
 
         XCTAssertEqual("Loading Flow", try text.string())
     }
@@ -109,14 +159,19 @@ class ManagedPlayer14Tests: XCTestCase {
             flowManager: AlwaysLoaded(),
             context: .init(),
             handleScroll: false, // Passed in ScrollPlugin should ignore this
-            onComplete: {_ in},
-            fallback: {(_) in},
+            onComplete: { _ in },
+            fallback: { _ in },
             loading: {
                 Text("Loading")
             }
         )
 
-        try player.inspect().find(ManagedPlayer14<Text, EmptyView>.self).vStack().group(0).color(0).callOnAppear()
+        try player.inspect()
+            .find(ManagedPlayer14<Text, EmptyView>.self)
+            .vStack()
+            .group(0)
+            .color(0)
+            .callOnAppear()
 
         ViewHosting.host(view: player)
 
@@ -146,14 +201,19 @@ class ManagedPlayer14Tests: XCTestCase {
             flowManager: AlwaysLoaded(),
             context: .init(),
             handleScroll: false,
-            onComplete: {_ in},
-            fallback: {(_) in},
+            onComplete: { _ in },
+            fallback: { _ in },
             loading: {
                 Text("Loading")
             }
         )
 
-        try player.inspect().find(ManagedPlayer14<Text, EmptyView>.self).vStack().group(0).color(0).callOnAppear()
+        try player.inspect()
+            .find(ManagedPlayer14<Text, EmptyView>.self)
+            .vStack()
+            .group(0)
+            .color(0)
+            .callOnAppear()
 
         ViewHosting.host(view: player)
 
@@ -178,7 +238,7 @@ class ManagedPlayer14Tests: XCTestCase {
 }
 
 class NeverLoad: FlowManager {
-    func next(_ result: CompletedState?) async throws -> NextState {
+    func next(_: CompletedState?) async throws -> NextState {
         try await Task.sleep(nanoseconds: 1_000_000_000 * 5)
         return .flow("")
     }
@@ -186,7 +246,8 @@ class NeverLoad: FlowManager {
 
 class ErrorLoaded: FlowManager {
     init() {}
-    func next(_ result: CompletedState?) async throws -> NextState {
+
+    func next(_: CompletedState?) async throws -> NextState {
         try await Task.sleep(nanoseconds: 500_000_000)
         throw PlayerError.jsConversionFailure
     }
@@ -194,15 +255,16 @@ class ErrorLoaded: FlowManager {
 
 class AlwaysLoaded: FlowManager {
     init() {}
-    func next(_ result: CompletedState?) async throws -> NextState {
-        return .flow(FlowData.COUNTER)
+
+    func next(_: CompletedState?) async throws -> NextState {
+        .flow(FlowData.COUNTER)
     }
 }
 
 class ActionLoaded: FlowManager {
     init() {}
 
-    func next(_ result: CompletedState?) async throws -> NextState {
+    func next(_: CompletedState?) async throws -> NextState {
         try await Task.sleep(nanoseconds: 1_000_000_000 * 5)
         return .flow(FlowData.flowAction)
     }
@@ -210,9 +272,13 @@ class ActionLoaded: FlowManager {
 
 extension XCTestCase {
     @discardableResult
-    func waitOnChange<T>(_ publisher: AnyPublisher<T, Never>, timeout: Double = 5, condition: @escaping (T) -> Bool) -> Cancellable {
+    func waitOnChange<T>(
+        _ publisher: AnyPublisher<T, Never>,
+        timeout: Double = 5,
+        condition: @escaping (T) -> Bool
+    ) -> Cancellable {
         let expectation = XCTestExpectation(description: "Waiting for publisher to emit value")
-        let cancel = publisher.sink { (value) in
+        let cancel = publisher.sink { value in
             guard condition(value) else { return }
             expectation.fulfill()
         }

--- a/ios/swiftui/ViewInspector/ManagedPlayer/ManagedPlayerTests.swift
+++ b/ios/swiftui/ViewInspector/ManagedPlayer/ManagedPlayerTests.swift
@@ -5,50 +5,79 @@
 //  Created by Harris Borawski on 4/5/21.
 //  Copyright © 2021 Intuit. All rights reserved.
 //
-import Foundation
-import XCTest
-import SwiftUI
 @preconcurrency import Combine
-import ViewInspector
-
+import Foundation
 @testable import PlayerUI
-@testable import PlayerUISwiftUI
 @testable import PlayerUIInternalTestUtilities
 @testable import PlayerUIReferenceAssets
+@testable import PlayerUISwiftUI
+import SwiftUI
+import ViewInspector
+import XCTest
 
 extension Inspection: @retroactive @unchecked Sendable {}
-extension Inspection: @retroactive InspectionEmissary { }
+extension Inspection: @retroactive InspectionEmissary {}
 
 class ManagedPlayer14Tests: XCTestCase {
     func testLoadingView() throws {
-        let viewModel = ManagedPlayerViewModel(manager: NeverLoad(), onComplete: {_ in })
-        let player = ManagedPlayer(plugins: [], context: .init(), viewModel: viewModel, fallback: { _ in Text("Error")}, loading: { Text("Loading")})
+        let viewModel = ManagedPlayerViewModel(manager: NeverLoad(), onComplete: { _ in })
+        let player = ManagedPlayer(
+            plugins: [],
+            context: .init(),
+            viewModel: viewModel,
+            fallback: { _ in Text("Error") },
+            loading: { Text("Loading") }
+        )
 
         let playerView = try player.inspect()
 
-        try playerView.find(ManagedPlayer14<Text, EmptyView>.self).vStack().group(0).color(0).callOnAppear()
+        try playerView.find(ManagedPlayer14<Text, EmptyView>.self)
+            .vStack()
+            .group(0)
+            .color(0)
+            .callOnAppear()
 
-        waitOnChange(viewModel.$loadingState.eraseToAnyPublisher()) { $0 == ManagedPlayerViewModel.LoadingState.loading }
+        waitOnChange(viewModel.$loadingState.eraseToAnyPublisher()) {
+            $0 == ManagedPlayerViewModel.LoadingState.loading
+        }
 
-        let text = try playerView.find(ManagedPlayer14<Text, EmptyView>.self).vStack().group(0).zStack(0).text(0)
+        let text = try playerView.find(ManagedPlayer14<Text, EmptyView>.self)
+            .vStack()
+            .group(0)
+            .zStack(0)
+            .text(0)
 
         XCTAssertEqual("Loading", try text.string())
     }
 
     func testFallbackView() throws {
-        let viewModel = ManagedPlayerViewModel(manager: ErrorLoaded(), onComplete: {_ in })
-        let player = ManagedPlayer(plugins: [], context: .init(), viewModel: viewModel, fallback: { _ in Text("Error")}, loading: { Text("Loading")})
+        let viewModel = ManagedPlayerViewModel(manager: ErrorLoaded(), onComplete: { _ in })
+        let player = ManagedPlayer(
+            plugins: [],
+            context: .init(),
+            viewModel: viewModel,
+            fallback: { _ in Text("Error") },
+            loading: { Text("Loading") }
+        )
 
         let playerView = try player.inspect()
 
-        try playerView.find(ManagedPlayer14<Text, EmptyView>.self).vStack().group(0).color(0).callOnAppear()
+        try playerView.find(ManagedPlayer14<Text, EmptyView>.self)
+            .vStack()
+            .group(0)
+            .color(0)
+            .callOnAppear()
 
         waitOnChange(viewModel.$loadingState.eraseToAnyPublisher()) {
             guard case .failed = $0 else { return false }
             return true
         }
 
-        let text = try playerView.find(ManagedPlayer14<Text, EmptyView>.self).vStack().group(0).text(0).string()
+        let text = try playerView.find(ManagedPlayer14<Text, EmptyView>.self)
+            .vStack()
+            .group(0)
+            .text(0)
+            .string()
         XCTAssertEqual(text, "Error")
     }
 
@@ -57,14 +86,19 @@ class ManagedPlayer14Tests: XCTestCase {
             plugins: [ReferenceAssetsPlugin()],
             flowManager: AlwaysLoaded(),
             context: .init(),
-            onComplete: {_ in},
-            fallback: {(_) in},
+            onComplete: { _ in },
+            fallback: { _ in },
             loading: {
                 Text("Loading")
             }
         )
 
-        try player.inspect().find(ManagedPlayer14<Text, EmptyView>.self).vStack().group(0).color(0).callOnAppear()
+        try player.inspect()
+            .find(ManagedPlayer14<Text, EmptyView>.self)
+            .vStack()
+            .group(0)
+            .color(0)
+            .callOnAppear()
 
         ViewHosting.host(view: player)
 
@@ -89,16 +123,32 @@ class ManagedPlayer14Tests: XCTestCase {
     }
 
     func testLoadingViewBeforeActionFlow() throws {
-        let viewModel = ManagedPlayerViewModel(manager: ActionLoaded(), onComplete: {_ in })
-        let player = ManagedPlayer(plugins: [], context: .init(), viewModel: viewModel, fallback: { _ in Text("Error")}, loading: { Text("Loading Flow")})
+        let viewModel = ManagedPlayerViewModel(manager: ActionLoaded(), onComplete: { _ in })
+        let player = ManagedPlayer(
+            plugins: [],
+            context: .init(),
+            viewModel: viewModel,
+            fallback: { _ in Text("Error") },
+            loading: { Text("Loading Flow") }
+        )
 
         let playerView = try player.inspect()
 
-        try playerView.find(ManagedPlayer14<Text, EmptyView>.self).vStack().group(0).color(0).callOnAppear()
+        try playerView.find(ManagedPlayer14<Text, EmptyView>.self)
+            .vStack()
+            .group(0)
+            .color(0)
+            .callOnAppear()
 
-        waitOnChange(viewModel.$loadingState.eraseToAnyPublisher()) { $0 == ManagedPlayerViewModel.LoadingState.loading }
+        waitOnChange(viewModel.$loadingState.eraseToAnyPublisher()) {
+            $0 == ManagedPlayerViewModel.LoadingState.loading
+        }
 
-        let text = try playerView.find(ManagedPlayer14<Text, EmptyView>.self).vStack().group(0).zStack(0).text(0)
+        let text = try playerView.find(ManagedPlayer14<Text, EmptyView>.self)
+            .vStack()
+            .group(0)
+            .zStack(0)
+            .text(0)
 
         XCTAssertEqual("Loading Flow", try text.string())
     }
@@ -109,14 +159,19 @@ class ManagedPlayer14Tests: XCTestCase {
             flowManager: AlwaysLoaded(),
             context: .init(),
             handleScroll: false, // Passed in ScrollPlugin should ignore this
-            onComplete: {_ in},
-            fallback: {(_) in},
+            onComplete: { _ in },
+            fallback: { _ in },
             loading: {
                 Text("Loading")
             }
         )
 
-        try player.inspect().find(ManagedPlayer14<Text, EmptyView>.self).vStack().group(0).color(0).callOnAppear()
+        try player.inspect()
+            .find(ManagedPlayer14<Text, EmptyView>.self)
+            .vStack()
+            .group(0)
+            .color(0)
+            .callOnAppear()
 
         ViewHosting.host(view: player)
 
@@ -146,14 +201,19 @@ class ManagedPlayer14Tests: XCTestCase {
             flowManager: AlwaysLoaded(),
             context: .init(),
             handleScroll: false,
-            onComplete: {_ in},
-            fallback: {(_) in},
+            onComplete: { _ in },
+            fallback: { _ in },
             loading: {
                 Text("Loading")
             }
         )
 
-        try player.inspect().find(ManagedPlayer14<Text, EmptyView>.self).vStack().group(0).color(0).callOnAppear()
+        try player.inspect()
+            .find(ManagedPlayer14<Text, EmptyView>.self)
+            .vStack()
+            .group(0)
+            .color(0)
+            .callOnAppear()
 
         ViewHosting.host(view: player)
 
@@ -178,7 +238,7 @@ class ManagedPlayer14Tests: XCTestCase {
 }
 
 class NeverLoad: FlowManager {
-    func next(result: CompletedState?) async throws -> String? {
+    func next(result _: CompletedState?) async throws -> String? {
         try await Task.sleep(nanoseconds: 1_000_000_000 * 5)
         return ""
     }
@@ -186,7 +246,8 @@ class NeverLoad: FlowManager {
 
 class ErrorLoaded: FlowManager {
     init() {}
-    func next(result: CompletedState?) async throws -> String? {
+
+    func next(result _: CompletedState?) async throws -> String? {
         try await Task.sleep(nanoseconds: 500_000_000)
         throw PlayerError.jsConversionFailure
     }
@@ -194,15 +255,16 @@ class ErrorLoaded: FlowManager {
 
 class AlwaysLoaded: FlowManager {
     init() {}
-    func next(result: CompletedState?) async throws -> String? {
-        return FlowData.COUNTER
+
+    func next(result _: CompletedState?) async throws -> String? {
+        FlowData.COUNTER
     }
 }
 
 class ActionLoaded: FlowManager {
     init() {}
 
-    func next(result: CompletedState?) async throws -> String? {
+    func next(result _: CompletedState?) async throws -> String? {
         try await Task.sleep(nanoseconds: 1_000_000_000 * 5)
         return FlowData.flowAction
     }
@@ -210,9 +272,13 @@ class ActionLoaded: FlowManager {
 
 extension XCTestCase {
     @discardableResult
-    func waitOnChange<T>(_ publisher: AnyPublisher<T, Never>, timeout: Double = 5, condition: @escaping (T) -> Bool) -> Cancellable {
+    func waitOnChange<T>(
+        _ publisher: AnyPublisher<T, Never>,
+        timeout: Double = 5,
+        condition: @escaping (T) -> Bool
+    ) -> Cancellable {
         let expectation = XCTestExpectation(description: "Waiting for publisher to emit value")
-        let cancel = publisher.sink { (value) in
+        let cancel = publisher.sink { value in
             guard condition(value) else { return }
             expectation.fulfill()
         }

--- a/ios/swiftui/ViewInspector/SwiftUIPlayerTests.swift
+++ b/ios/swiftui/ViewInspector/SwiftUIPlayerTests.swift
@@ -6,29 +6,35 @@
 //  Copyright © 2021 CocoaPods. All rights reserved.
 //
 
-import Foundation
-import XCTest
-import ViewInspector
-import SwiftUI
 import Combine
+import Foundation
 import JavaScriptCore
-
 @testable import PlayerUI
-@testable import PlayerUISwiftUI
 @testable import PlayerUIInternalTestUtilities
 @testable import PlayerUIReferenceAssets
+@testable import PlayerUISwiftUI
+import SwiftUI
+import ViewInspector
+import XCTest
 
 class SwiftUIPlayerTests: XCTestCase {
     func testFlowLoads() throws {
         var bag = Set<AnyCancellable>()
         let context = SwiftUIPlayer.Context { JSContext() }
-        let player = SwiftUIPlayer(flow: FlowData.COUNTER, plugins: [ReferenceAssetsPlugin()], context: context)
+        let player = SwiftUIPlayer(
+            flow: FlowData.COUNTER,
+            plugins: [ReferenceAssetsPlugin()],
+            context: context
+        )
 
         let initialLoad = expectation(description: "Root loaded")
-        player.assetRegistry.$root.sink { (asset) in
-            guard asset != nil else { return }
-            initialLoad.fulfill()
-        }.store(in: &bag)
+        player.assetRegistry
+            .$root
+            .sink { asset in
+                guard asset != nil else { return }
+                initialLoad.fulfill()
+            }
+            .store(in: &bag)
 
         let view = try player.inspect().vStack().first?.anyView()
         XCTAssertNotNil(view)
@@ -38,12 +44,12 @@ class SwiftUIPlayerTests: XCTestCase {
         XCTAssertTrue(context.isLoaded)
     }
 
-    func testbadDecodeGoesToErrorState() throws {
+    func testbadDecodeGoesToErrorState() {
         var result: Result<CompletedState, PlayerError>?
 
         let failed = XCTestExpectation(description: "Error State reached")
 
-        let binding = Binding<Result<CompletedState, PlayerError>?>(get: {result}, set: {
+        let binding = Binding<Result<CompletedState, PlayerError>?>(get: { result }, set: {
             result = $0
             guard
                 case let .failure(error) = $0,
@@ -63,13 +69,19 @@ class SwiftUIPlayerTests: XCTestCase {
 
     func testViewHook() throws {
         var bag = Set<AnyCancellable>()
-        let player = SwiftUIPlayer(flow: FlowData.COUNTER, plugins: [ReferenceAssetsPlugin(), ViewHookPlugin()])
+        let player = SwiftUIPlayer(
+            flow: FlowData.COUNTER,
+            plugins: [ReferenceAssetsPlugin(), ViewHookPlugin()]
+        )
 
         let initialLoad = expectation(description: "Root loaded")
-        player.assetRegistry.$root.sink { (asset) in
-            guard asset != nil else { return }
-            initialLoad.fulfill()
-        }.store(in: &bag)
+        player.assetRegistry
+            .$root
+            .sink { asset in
+                guard asset != nil else { return }
+                initialLoad.fulfill()
+            }
+            .store(in: &bag)
         wait(for: [initialLoad], timeout: 3)
 
         let color = try player.body.inspect().vStack().first?.anyView().anyView().foregroundColor()
@@ -81,10 +93,10 @@ class SwiftUIPlayerTests: XCTestCase {
 class ViewHookPlugin: NativePlugin {
     var pluginName: String = "ViewHookPlugin"
 
-    func apply<P>(player: P) where P: HeadlessPlayer {
+    func apply<P: HeadlessPlayer>(player: P) {
         guard let swiftuiplayer = player as? SwiftUIPlayer else { return }
         swiftuiplayer.hooks?.view.tap(name: pluginName) { view in
-            return AnyView(view.foregroundColor(.black))
+            AnyView(view.foregroundColor(.black))
         }
     }
 }

--- a/ios/swiftui/ViewInspector/SwiftUIPlayerTests.swift
+++ b/ios/swiftui/ViewInspector/SwiftUIPlayerTests.swift
@@ -83,7 +83,7 @@ class SwiftUIPlayerTests: XCTestCase {
         })
         let context = SwiftUIPlayer.Context { JSContext() }
         _ = SwiftUIPlayer(
-            flow: FlowData.COUNTER.replacing("value\"", with: "valu\""),
+            flow: FlowData.COUNTER.replacingOccurrences(of: "value\"", with: "valu\""),
             plugins: [ReferenceAssetsPlugin()],
             result: binding,
             context: context

--- a/ios/swiftui/ViewInspector/SwiftUIPlayerTests.swift
+++ b/ios/swiftui/ViewInspector/SwiftUIPlayerTests.swift
@@ -6,29 +6,35 @@
 //  Copyright © 2021 Intuit. All rights reserved.
 //
 
-import Foundation
-import XCTest
-import ViewInspector
-import SwiftUI
 import Combine
+import Foundation
 import JavaScriptCore
-
 @testable import PlayerUI
-@testable import PlayerUISwiftUI
 @testable import PlayerUIInternalTestUtilities
 @testable import PlayerUIReferenceAssets
+@testable import PlayerUISwiftUI
+import SwiftUI
+import ViewInspector
+import XCTest
 
 class SwiftUIPlayerTests: XCTestCase {
     func testFlowLoads() throws {
         var bag = Set<AnyCancellable>()
         let context = SwiftUIPlayer.Context { JSContext() }
-        let player = SwiftUIPlayer(flow: FlowData.COUNTER, plugins: [ReferenceAssetsPlugin()], context: context)
+        let player = SwiftUIPlayer(
+            flow: FlowData.COUNTER,
+            plugins: [ReferenceAssetsPlugin()],
+            context: context
+        )
 
         let initialLoad = expectation(description: "Root loaded")
-        player.assetRegistry.$root.sink { (asset) in
-            guard asset != nil else { return }
-            initialLoad.fulfill()
-        }.store(in: &bag)
+        player.assetRegistry
+            .$root
+            .sink { asset in
+                guard asset != nil else { return }
+                initialLoad.fulfill()
+            }
+            .store(in: &bag)
 
         let view = try player.inspect().vStack().first?.anyView()
         XCTAssertNotNil(view)
@@ -38,28 +44,35 @@ class SwiftUIPlayerTests: XCTestCase {
         XCTAssertTrue(context.isLoaded)
     }
 
-    func testLogsInitializationTime() throws {
+    func testLogsInitializationTime() {
         let context = SwiftUIPlayer.Context { JSContext() }
         context.logger.logLevel = .info
 
         let logged = expectation(description: "Initialization time logged")
         context.logger.hooks.info.tap(name: "test") { messages in
             let message = (messages as? [String])?.first ?? ""
-            guard message.range(of: #"SwiftUIPlayer initialized in \d+ ms\."#, options: .regularExpression) != nil else { return }
+            guard message.range(
+                of: #"SwiftUIPlayer initialized in \d+ ms\."#,
+                options: .regularExpression
+            ) != nil else { return }
             logged.fulfill()
         }
 
-        _ = SwiftUIPlayer(flow: FlowData.COUNTER, plugins: [ReferenceAssetsPlugin()], context: context)
+        _ = SwiftUIPlayer(
+            flow: FlowData.COUNTER,
+            plugins: [ReferenceAssetsPlugin()],
+            context: context
+        )
 
         wait(for: [logged], timeout: 5)
     }
 
-    func testbadDecodeGoesToErrorState() throws {
+    func testbadDecodeGoesToErrorState() {
         var result: Result<CompletedState, PlayerError>?
 
         let failed = XCTestExpectation(description: "Error State reached")
 
-        let binding = Binding<Result<CompletedState, PlayerError>?>(get: {result}, set: {
+        let binding = Binding<Result<CompletedState, PlayerError>?>(get: { result }, set: {
             result = $0
             guard
                 case let .failure(error) = $0,
@@ -79,13 +92,19 @@ class SwiftUIPlayerTests: XCTestCase {
 
     func testViewHook() throws {
         var bag = Set<AnyCancellable>()
-        let player = SwiftUIPlayer(flow: FlowData.COUNTER, plugins: [ReferenceAssetsPlugin(), ViewHookPlugin()])
+        let player = SwiftUIPlayer(
+            flow: FlowData.COUNTER,
+            plugins: [ReferenceAssetsPlugin(), ViewHookPlugin()]
+        )
 
         let initialLoad = expectation(description: "Root loaded")
-        player.assetRegistry.$root.sink { (asset) in
-            guard asset != nil else { return }
-            initialLoad.fulfill()
-        }.store(in: &bag)
+        player.assetRegistry
+            .$root
+            .sink { asset in
+                guard asset != nil else { return }
+                initialLoad.fulfill()
+            }
+            .store(in: &bag)
         wait(for: [initialLoad], timeout: 3)
 
         let color = try player.body.inspect().vStack().first?.anyView().anyView().foregroundColor()
@@ -97,10 +116,10 @@ class SwiftUIPlayerTests: XCTestCase {
 class ViewHookPlugin: NativePlugin {
     var pluginName: String = "ViewHookPlugin"
 
-    func apply<P>(player: P) where P: HeadlessPlayer {
+    func apply<P: HeadlessPlayer>(player: P) {
         guard let swiftuiplayer = player as? SwiftUIPlayer else { return }
         swiftuiplayer.hooks?.view.tap(name: pluginName) { view in
-            return AnyView(view.foregroundColor(.black))
+            AnyView(view.foregroundColor(.black))
         }
     }
 }

--- a/ios/swiftui/ViewInspector/SwiftUIPlayerTests.swift
+++ b/ios/swiftui/ViewInspector/SwiftUIPlayerTests.swift
@@ -83,7 +83,7 @@ class SwiftUIPlayerTests: XCTestCase {
         })
         let context = SwiftUIPlayer.Context { JSContext() }
         _ = SwiftUIPlayer(
-            flow: FlowData.COUNTER.replacingOccurrences(of: "value\"", with: "valu\""),
+            flow: FlowData.COUNTER.replacing("value\"", with: "valu\""),
             plugins: [ReferenceAssetsPlugin()],
             result: binding,
             context: context
@@ -116,7 +116,7 @@ class SwiftUIPlayerTests: XCTestCase {
 class ViewHookPlugin: NativePlugin {
     var pluginName: String = "ViewHookPlugin"
 
-    func apply<P: HeadlessPlayer>(player: P) {
+    func apply(player: some HeadlessPlayer) {
         guard let swiftuiplayer = player as? SwiftUIPlayer else { return }
         swiftuiplayer.hooks?.view.tap(name: pluginName) { view in
             AnyView(view.foregroundColor(.black))

--- a/ios/test-utils-core/Sources/ui-test/AssetCollection.swift
+++ b/ios/test-utils-core/Sources/ui-test/AssetCollection.swift
@@ -119,6 +119,7 @@ public enum FlowLoader {
                     )
                     if !isDir.boolValue {
                         let data = fileManager.contents(atPath: "\(subdirectory)/\(name)")
+                        // swiftlint:disable:next force_unwrapping
                         let json = String(data: data!, encoding: .utf8)!
                         return [(
                             name: name.lowercased().replacingOccurrences(of: ".json", with: ""),

--- a/ios/test-utils-core/Sources/ui-test/AssetCollection.swift
+++ b/ios/test-utils-core/Sources/ui-test/AssetCollection.swift
@@ -1,46 +1,24 @@
 //
-//  AssetCollectionViewController.swift
+//  AssetCollection.swift
 //  PlayerUI
 //
 //  Created by Harris Borawski on 2/18/21.
 //
 
+import Combine
 import Foundation
 import SwiftUI
-import Combine
 
 #if SWIFT_PACKAGE
-import PlayerUI
+    import PlayerUI
 #endif
 
-/**
- A SwiftUI View to load flows for ease of UI testing
- */
+/// A SwiftUI View to load flows for ease of UI testing
 public struct AssetCollection: View {
     let plugins: [NativePlugin]
     let sections: [FlowLoader.FlowSection]
     let padding: CGFloat
     let result: Binding<Result<CompletedState, PlayerError>?>
-
-    /**
-     Initializes and loads flows
-     - parameters:
-        - plugins: Plugins to add to Player instance that is created
-        - sections: The `[FlowSection]` to display
-        - padding: Padding around the AssetFlowView
-        - completion: A handler for when a flow reaches an end state
-     */
-    public init(
-        plugins: [NativePlugin],
-        sections: [FlowLoader.FlowSection],
-        padding: CGFloat = 16,
-        result: Binding<Result<CompletedState, PlayerError>?>
-    ) {
-        self.plugins = plugins
-        self.padding = padding
-        self.result = result
-        self.sections = sections
-    }
 
     public var body: some View {
         List {
@@ -57,22 +35,37 @@ public struct AssetCollection: View {
                 } header: {
                     Text(section.title)
                 }
-
             }
         }
         .accessibility(identifier: "AssetCollection")
         .navigationBarTitle(Text("Flows"))
     }
+
+    /// Initializes and loads flows
+    /// - parameters:
+    ///   - plugins: Plugins to add to Player instance that is created
+    ///   - sections: The `[FlowSection]` to display
+    ///   - padding: Padding around the AssetFlowView
+    ///   - completion: A handler for when a flow reaches an end state
+    public init(
+        plugins: [NativePlugin],
+        sections: [FlowLoader.FlowSection],
+        padding: CGFloat = 16,
+        result: Binding<Result<CompletedState, PlayerError>?>
+    ) {
+        self.plugins = plugins
+        self.padding = padding
+        self.result = result
+        self.sections = sections
+    }
 }
 
 public extension AssetCollection {
-    /**
-     Initializes and loads flows
-     - parameters:
-     - plugins: Plugins to add to Player instance that is created
-     - sections: The `[FlowSection]` to display
-     - completion: A handler for when a flow reaches an end state
-     */
+    /// Initializes and loads flows
+    /// - parameters:
+    /// - plugins: Plugins to add to Player instance that is created
+    /// - sections: The `[FlowSection]` to display
+    /// - completion: A handler for when a flow reaches an end state
     init(
         plugins: [NativePlugin],
         sections: [FlowLoader.FlowSection],
@@ -84,7 +77,7 @@ public extension AssetCollection {
             sections: sections,
             padding: padding,
             result: Binding(
-                get: {nil},
+                get: { nil },
                 set: { result in
                     guard let res = result else { return }
                     completion?(res)
@@ -94,32 +87,23 @@ public extension AssetCollection {
     }
 }
 
-/**
- Helper for loading player flows
- */
-public struct FlowLoader {
-    /// A single flow to render as a `UITableViewCell`
-    public typealias Flow = (name: String, flow: String)
-    /// A section of flows, the title being the asset type
-    public typealias FlowSection = (title: String, flows: [Flow])
-
-    /**
-     Loads a tree of Player Flows from the root of a given directory
-     The provided path should be to a folder containing folders listed by asset type,
-     Example:
-     ```
-     root
-        - action
-            - action-with-expression.json
-        - text
-            - text-basic.json
-            - modifiers
-                - text-with-modifiers.json
-     ```
-     - parameters:
-        - path: The path in the bundle to the root directory
-     - returns: An array of FlowSections for display
-     */
+/// Helper for loading player flows
+public enum FlowLoader {
+    /// Loads a tree of Player Flows from the root of a given directory
+    /// The provided path should be to a folder containing folders listed by asset type,
+    /// Example:
+    /// ```
+    /// root
+    ///   - action
+    ///       - action-with-expression.json
+    ///   - text
+    ///       - text-basic.json
+    ///       - modifiers
+    ///           - text-with-modifiers.json
+    /// ```
+    /// - parameters:
+    ///   - path: The path in the bundle to the root directory
+    /// - returns: An array of FlowSections for display
     public static func loadTree(at path: String) -> [FlowSection] {
         let fileManager = FileManager.default
         let folders = (try? fileManager.contentsOfDirectory(atPath: path).sorted()) ?? []
@@ -127,22 +111,25 @@ public struct FlowLoader {
             let subdirectory = "\(path)/\(folder)"
             let files = (try? fileManager.contentsOfDirectory(atPath: subdirectory)) ?? []
             return files
-            .map { (name) -> [Flow] in
-                var isDir: ObjCBool = false
-                _ = fileManager.fileExists(atPath: "\(subdirectory)/\(name)", isDirectory: &isDir)
-                if !isDir.boolValue {
-                    let data = fileManager.contents(atPath: "\(subdirectory)/\(name)")
-                    let json = String(data: data!, encoding: .utf8)!
-                    return [(
-                        name: name.lowercased().replacingOccurrences(of: ".json", with: ""),
-                        flow: json
-                    )]
+                .map { name -> [Flow] in
+                    var isDir: ObjCBool = false
+                    _ = fileManager.fileExists(
+                        atPath: "\(subdirectory)/\(name)",
+                        isDirectory: &isDir
+                    )
+                    if !isDir.boolValue {
+                        let data = fileManager.contents(atPath: "\(subdirectory)/\(name)")
+                        let json = String(data: data!, encoding: .utf8)!
+                        return [(
+                            name: name.lowercased().replacingOccurrences(of: ".json", with: ""),
+                            flow: json
+                        )]
+                    }
+                    return loadFlows("\(folder)/\(name)")
                 }
-                return loadFlows("\(folder)/\(name)")
-            }
-            .reduce([]) { (accumulated, current) -> [Flow] in
-                return accumulated + current
-            }
+                .reduce([]) { accumulated, current -> [Flow] in
+                    return accumulated + current
+                }
         }
         return folders.map { folder in
             (title: folder, flows: loadFlows(folder).map { flow in
@@ -156,4 +143,9 @@ public struct FlowLoader {
             })
         }
     }
+
+    /// A single flow to render as a `UITableViewCell`
+    public typealias Flow = (name: String, flow: String)
+    /// A section of flows, the title being the asset type
+    public typealias FlowSection = (title: String, flows: [Flow])
 }

--- a/ios/test-utils-core/Sources/ui-test/AssetCollection.swift
+++ b/ios/test-utils-core/Sources/ui-test/AssetCollection.swift
@@ -1,44 +1,21 @@
 //
-//  AssetCollectionViewController.swift
+//  AssetCollection.swift
 //  PlayerUI
 //
 //  Created by Harris Borawski on 2/18/21.
 //
 
-import Foundation
-import SwiftUI
 import Combine
-
+import Foundation
 import PlayerUI
+import SwiftUI
 
-/**
- A SwiftUI View to load flows for ease of UI testing
- */
+/// A SwiftUI View to load flows for ease of UI testing
 public struct AssetCollection: View {
     let plugins: [NativePlugin]
     let sections: [FlowLoader.FlowSection]
     let padding: CGFloat
     let result: Binding<Result<CompletedState, PlayerError>?>
-
-    /**
-     Initializes and loads flows
-     - parameters:
-        - plugins: Plugins to add to Player instance that is created
-        - sections: The `[FlowSection]` to display
-        - padding: Padding around the AssetFlowView
-        - completion: A handler for when a flow reaches an end state
-     */
-    public init(
-        plugins: [NativePlugin],
-        sections: [FlowLoader.FlowSection],
-        padding: CGFloat = 16,
-        result: Binding<Result<CompletedState, PlayerError>?>
-    ) {
-        self.plugins = plugins
-        self.padding = padding
-        self.result = result
-        self.sections = sections
-    }
 
     public var body: some View {
         List {
@@ -55,22 +32,37 @@ public struct AssetCollection: View {
                 } header: {
                     Text(section.title)
                 }
-
             }
         }
         .accessibility(identifier: "AssetCollection")
         .navigationBarTitle(Text("Flows"))
     }
+
+    /// Initializes and loads flows
+    /// - parameters:
+    ///   - plugins: Plugins to add to Player instance that is created
+    ///   - sections: The `[FlowSection]` to display
+    ///   - padding: Padding around the AssetFlowView
+    ///   - completion: A handler for when a flow reaches an end state
+    public init(
+        plugins: [NativePlugin],
+        sections: [FlowLoader.FlowSection],
+        padding: CGFloat = 16,
+        result: Binding<Result<CompletedState, PlayerError>?>
+    ) {
+        self.plugins = plugins
+        self.padding = padding
+        self.result = result
+        self.sections = sections
+    }
 }
 
 public extension AssetCollection {
-    /**
-     Initializes and loads flows
-     - parameters:
-     - plugins: Plugins to add to Player instance that is created
-     - sections: The `[FlowSection]` to display
-     - completion: A handler for when a flow reaches an end state
-     */
+    /// Initializes and loads flows
+    /// - parameters:
+    /// - plugins: Plugins to add to Player instance that is created
+    /// - sections: The `[FlowSection]` to display
+    /// - completion: A handler for when a flow reaches an end state
     init(
         plugins: [NativePlugin],
         sections: [FlowLoader.FlowSection],
@@ -82,7 +74,7 @@ public extension AssetCollection {
             sections: sections,
             padding: padding,
             result: Binding(
-                get: {nil},
+                get: { nil },
                 set: { result in
                     guard let res = result else { return }
                     completion?(res)
@@ -92,32 +84,23 @@ public extension AssetCollection {
     }
 }
 
-/**
- Helper for loading player flows
- */
-public struct FlowLoader {
-    /// A single flow to render as a `UITableViewCell`
-    public typealias Flow = (name: String, flow: String)
-    /// A section of flows, the title being the asset type
-    public typealias FlowSection = (title: String, flows: [Flow])
-
-    /**
-     Loads a tree of Player Flows from the root of a given directory
-     The provided path should be to a folder containing folders listed by asset type,
-     Example:
-     ```
-     root
-        - action
-            - action-with-expression.json
-        - text
-            - text-basic.json
-            - modifiers
-                - text-with-modifiers.json
-     ```
-     - parameters:
-        - path: The path in the bundle to the root directory
-     - returns: An array of FlowSections for display
-     */
+/// Helper for loading player flows
+public enum FlowLoader {
+    /// Loads a tree of Player Flows from the root of a given directory
+    /// The provided path should be to a folder containing folders listed by asset type,
+    /// Example:
+    /// ```
+    /// root
+    ///   - action
+    ///       - action-with-expression.json
+    ///   - text
+    ///       - text-basic.json
+    ///       - modifiers
+    ///           - text-with-modifiers.json
+    /// ```
+    /// - parameters:
+    ///   - path: The path in the bundle to the root directory
+    /// - returns: An array of FlowSections for display
     public static func loadTree(at path: String) -> [FlowSection] {
         let fileManager = FileManager.default
         let folders = (try? fileManager.contentsOfDirectory(atPath: path).sorted()) ?? []
@@ -125,22 +108,25 @@ public struct FlowLoader {
             let subdirectory = "\(path)/\(folder)"
             let files = (try? fileManager.contentsOfDirectory(atPath: subdirectory)) ?? []
             return files
-            .map { (name) -> [Flow] in
-                var isDir: ObjCBool = false
-                _ = fileManager.fileExists(atPath: "\(subdirectory)/\(name)", isDirectory: &isDir)
-                if !isDir.boolValue {
-                    let data = fileManager.contents(atPath: "\(subdirectory)/\(name)")
-                    let json = String(data: data!, encoding: .utf8)!
-                    return [(
-                        name: name.lowercased().replacingOccurrences(of: ".json", with: ""),
-                        flow: json
-                    )]
+                .map { name -> [Flow] in
+                    var isDir: ObjCBool = false
+                    _ = fileManager.fileExists(
+                        atPath: "\(subdirectory)/\(name)",
+                        isDirectory: &isDir
+                    )
+                    if !isDir.boolValue {
+                        let data = fileManager.contents(atPath: "\(subdirectory)/\(name)")
+                        let json = String(data: data!, encoding: .utf8)!
+                        return [(
+                            name: name.lowercased().replacingOccurrences(of: ".json", with: ""),
+                            flow: json
+                        )]
+                    }
+                    return loadFlows("\(folder)/\(name)")
                 }
-                return loadFlows("\(folder)/\(name)")
-            }
-            .reduce([]) { (accumulated, current) -> [Flow] in
-                return accumulated + current
-            }
+                .reduce([]) { accumulated, current -> [Flow] in
+                    return accumulated + current
+                }
         }
         return folders.map { folder in
             (title: folder, flows: loadFlows(folder).map { flow in
@@ -154,4 +140,9 @@ public struct FlowLoader {
             })
         }
     }
+
+    /// A single flow to render as a `UITableViewCell`
+    public typealias Flow = (name: String, flow: String)
+    /// A section of flows, the title being the asset type
+    public typealias FlowSection = (title: String, flows: [Flow])
 }

--- a/ios/test-utils-core/Sources/ui-test/AssetCollection.swift
+++ b/ios/test-utils-core/Sources/ui-test/AssetCollection.swift
@@ -115,8 +115,9 @@ public enum FlowLoader {
                         isDirectory: &isDir
                     )
                     if !isDir.boolValue {
-                        let data = fileManager.contents(atPath: "\(subdirectory)/\(name)")
-                        let json = String(data: data!, encoding: .utf8)!
+                        guard let data = fileManager.contents(atPath: "\(subdirectory)/\(name)"),
+                              let json = String(data: data, encoding: .utf8)
+                        else { return [] }
                         return [(
                             name: name.lowercased().replacingOccurrences(of: ".json", with: ""),
                             flow: json

--- a/ios/test-utils-core/Sources/ui-test/AssetCollection.swift
+++ b/ios/test-utils-core/Sources/ui-test/AssetCollection.swift
@@ -119,7 +119,7 @@ public enum FlowLoader {
                               let json = String(data: data, encoding: .utf8)
                         else { return [] }
                         return [(
-                            name: name.lowercased().replacing(".json", with: ""),
+                            name: name.lowercased().replacingOccurrences(of: ".json", with: ""),
                             flow: json
                         )]
                     }
@@ -134,8 +134,8 @@ public enum FlowLoader {
                 (
                     // Remove the section name from the beginning of the name, and remove dashes
                     name: flow.name
-                        .replacing("\(folder.lowercased())-", with: "")
-                        .replacing("-", with: " "),
+                        .replacingOccurrences(of: "\(folder.lowercased())-", with: "")
+                        .replacingOccurrences(of: "-", with: " "),
                     flow: flow.flow
                 )
             })

--- a/ios/test-utils-core/Sources/ui-test/AssetCollection.swift
+++ b/ios/test-utils-core/Sources/ui-test/AssetCollection.swift
@@ -119,7 +119,7 @@ public enum FlowLoader {
                               let json = String(data: data, encoding: .utf8)
                         else { return [] }
                         return [(
-                            name: name.lowercased().replacingOccurrences(of: ".json", with: ""),
+                            name: name.lowercased().replacing(".json", with: ""),
                             flow: json
                         )]
                     }
@@ -134,8 +134,8 @@ public enum FlowLoader {
                 (
                     // Remove the section name from the beginning of the name, and remove dashes
                     name: flow.name
-                        .replacingOccurrences(of: "\(folder.lowercased())-", with: "")
-                        .replacingOccurrences(of: "-", with: " "),
+                        .replacing("\(folder.lowercased())-", with: "")
+                        .replacing("-", with: " "),
                     flow: flow.flow
                 )
             })

--- a/ios/test-utils-core/Sources/ui-test/AssetFlowView.swift
+++ b/ios/test-utils-core/Sources/ui-test/AssetFlowView.swift
@@ -8,29 +8,16 @@
 import SwiftUI
 
 #if SWIFT_PACKAGE
-import PlayerUI
-import PlayerUISwiftUI
+    import PlayerUI
+    import PlayerUISwiftUI
 #endif
 
-/**
- SwiftUI View to wrap the `SwiftUIPlayer` in a scroll view and handle the result
- for use in UI testing
- */
+/// SwiftUI View to wrap the `SwiftUIPlayer` in a scroll view and handle the result
+/// for use in UI testing
 public struct AssetFlowView: View {
     let flow: String
     let plugins: [NativePlugin]
     let result: Binding<Result<CompletedState, PlayerError>?>
-
-    public init(flow: String, plugins: [NativePlugin], result: Binding<Result<CompletedState, PlayerError>?>) {
-        self.flow = flow
-        self.plugins = plugins
-        self.result = result
-        for plugin in self.plugins {
-            if let plugin = plugin as? JSBasePlugin {
-                plugin.context = nil
-            }
-        }
-    }
 
     public var body: some View {
         ScrollView {
@@ -46,15 +33,34 @@ public struct AssetFlowView: View {
             result: result
         )
     }
+
+    public init(
+        flow: String,
+        plugins: [NativePlugin],
+        result: Binding<Result<CompletedState, PlayerError>?>
+    ) {
+        self.flow = flow
+        self.plugins = plugins
+        self.result = result
+        for plugin in self.plugins {
+            if let plugin = plugin as? JSBasePlugin {
+                plugin.context = nil
+            }
+        }
+    }
 }
 
 public extension AssetFlowView {
-    init(flow: String, plugins: [NativePlugin], completion: ((Result<CompletedState, PlayerError>) -> Void)? = nil) {
+    init(
+        flow: String,
+        plugins: [NativePlugin],
+        completion: ((Result<CompletedState, PlayerError>) -> Void)? = nil
+    ) {
         self.init(
             flow: flow,
             plugins: plugins,
             result: Binding(
-                get: {nil},
+                get: { nil },
                 set: { result in
                     guard let res = result else { return }
                     completion?(res)

--- a/ios/test-utils-core/Sources/ui-test/AssetFlowView.swift
+++ b/ios/test-utils-core/Sources/ui-test/AssetFlowView.swift
@@ -5,30 +5,16 @@
 //  Created by Harris Borawski on 3/15/21.
 //
 
-import SwiftUI
-
 import PlayerUI
 import PlayerUISwiftUI
+import SwiftUI
 
-/**
- SwiftUI View to wrap the `SwiftUIPlayer` in a scroll view and handle the result
- for use in UI testing
- */
+/// SwiftUI View to wrap the `SwiftUIPlayer` in a scroll view and handle the result
+/// for use in UI testing
 public struct AssetFlowView: View {
     let flow: String
     let plugins: [NativePlugin]
     let result: Binding<Result<CompletedState, PlayerError>?>
-
-    public init(flow: String, plugins: [NativePlugin], result: Binding<Result<CompletedState, PlayerError>?>) {
-        self.flow = flow
-        self.plugins = plugins
-        self.result = result
-        for plugin in self.plugins {
-            if let plugin = plugin as? JSBasePlugin {
-                plugin.context = nil
-            }
-        }
-    }
 
     public var body: some View {
         ScrollView {
@@ -44,15 +30,34 @@ public struct AssetFlowView: View {
             result: result
         )
     }
+
+    public init(
+        flow: String,
+        plugins: [NativePlugin],
+        result: Binding<Result<CompletedState, PlayerError>?>
+    ) {
+        self.flow = flow
+        self.plugins = plugins
+        self.result = result
+        for plugin in self.plugins {
+            if let plugin = plugin as? JSBasePlugin {
+                plugin.context = nil
+            }
+        }
+    }
 }
 
 public extension AssetFlowView {
-    init(flow: String, plugins: [NativePlugin], completion: ((Result<CompletedState, PlayerError>) -> Void)? = nil) {
+    init(
+        flow: String,
+        plugins: [NativePlugin],
+        completion: ((Result<CompletedState, PlayerError>) -> Void)? = nil
+    ) {
         self.init(
             flow: flow,
             plugins: plugins,
             result: Binding(
-                get: {nil},
+                get: { nil },
                 set: { result in
                     guard let res = result else { return }
                     completion?(res)

--- a/ios/test-utils-core/Sources/utilities/AssetTestHelper.swift
+++ b/ios/test-utils-core/Sources/utilities/AssetTestHelper.swift
@@ -2,14 +2,15 @@ import Foundation
 import JavaScriptCore
 
 #if SWIFT_PACKAGE
-import PlayerUI
-import PlayerUILogger
-import PlayerUISwiftUI
+    import PlayerUI
+    import PlayerUILogger
+    import PlayerUISwiftUI
 #endif
 
 extension JSContext {
     func createAssetJsValue(string: String) -> JSValue {
-        guard let container = self.evaluateScript("(\(string))") else { fatalError("JSON was malformed") }
+        guard let container = evaluateScript("(\(string))")
+        else { fatalError("JSON was malformed") }
         return container
     }
 
@@ -24,25 +25,27 @@ extension JSContext {
 
     var bundleUrl: URL? {
         #if SWIFT_PACKAGE
-        ResourceUtilities.urlForFile(name: "MakeFlow.native", ext: "js", bundle: Bundle.module)
+            ResourceUtilities.urlForFile(name: "MakeFlow.native", ext: "js", bundle: Bundle.module)
         #else
-        ResourceUtilities.urlForFile(
-            name: "MakeFlow.native",
-            ext: "js",
-            bundle: Bundle(for: MakeFlowResourceShim.self), 
-            pathComponent: "TestUtilities.bundle"
-        )
+            ResourceUtilities.urlForFile(
+                name: "MakeFlow.native",
+                ext: "js",
+                bundle: Bundle(for: MakeFlowResourceShim.self),
+                pathComponent: "TestUtilities.bundle"
+            )
         #endif
     }
 }
 
 class MakeFlowResourceShim {}
 
-open class AssetTestHelper<WrapperType: AssetContainer & Decodable, Registry> where Registry: BaseAssetRegistry<WrapperType> {
-
+open class AssetTestHelper<
+    WrapperType: AssetContainer & Decodable,
+    Registry: BaseAssetRegistry<WrapperType>
+> {
     /// The JSContext where utilities are loaded
     /// and asset resolution is performed
-    public var context: JSContext = JSContext()
+    public var context: JSContext = .init()
 
     /// A closure to create the registry for this instance of the AssetTestHelper
     public var makeRegistry: () -> Registry
@@ -70,15 +73,15 @@ open class AssetTestHelper<WrapperType: AssetContainer & Decodable, Registry> wh
             )
 
             let root: JSValue? = try? await withCheckedThrowingContinuation { result in
-                player.hooks?.viewController.tap({ (viewController) in
-                    viewController.hooks.view.tap { (view) in
+                player.hooks?.viewController.tap { viewController in
+                    viewController.hooks.view.tap { view in
                         view.hooks.onUpdate.tap { val in
                             result.resume(returning: val)
                         }
                     }
-                })
+                }
                 player.start(flow: flow) { res in
-                    guard case .failure(let error) = res else { return }
+                    guard case let .failure(error) = res else { return }
                     result.resume(throwing: error)
                 }
             }
@@ -89,20 +92,18 @@ open class AssetTestHelper<WrapperType: AssetContainer & Decodable, Registry> wh
             } catch {
                 // If the user passed in an entire flow, decode the asset that was the root of
                 // the flow
-                guard let root = root else { return nil }
+                guard let root else { return nil }
                 return try? player.assetRegistry.decode(root) as? Asset
             }
         }.value
     }
 
-    /**
-     Turns a single Asset JSON definition into a full flow
-     - parameters:
-        - json: The JSON definition of a single asset
-     - returns: A string that is a full JSON flow containing the single asset
-     */
+    /// Turns a single Asset JSON definition into a full flow
+    /// - parameters:
+    ///   - json: The JSON definition of a single asset
+    /// - returns: A string that is a full JSON flow containing the single asset
     public func makeFlow(_ json: String) -> String? {
-        return context.evaluateScript("JSON.stringify(MakeFlow.makeFlow(\(json)))")?.toString()
+        context.evaluateScript("JSON.stringify(MakeFlow.makeFlow(\(json)))")?.toString()
     }
 }
 
@@ -116,13 +117,12 @@ public extension AssetTestHelper where WrapperType == WrappedAsset, Registry == 
 }
 
 public extension AssetTestHelper where WrapperType == WrappedAsset {
-    /**
-     Wraps a completion handler into a WrappedFunction for using XCTestExpectations to test functions
-     that are added to assets via a JS transform
-     - parameters:
-        - completion: A completion handler to run when the function is invoked
-     - returns: A WrappedFunction that will call your completion handler
-     */
+    /// Wraps a completion handler into a WrappedFunction for using XCTestExpectations to test
+    /// functions
+    /// that are added to assets via a JS transform
+    /// - parameters:
+    ///   - completion: A completion handler to run when the function is invoked
+    /// - returns: A WrappedFunction that will call your completion handler
     func getWrappedFunction<T>(completion: @escaping () -> Void) -> WrappedFunction<T>? {
         let callback: @convention(block) (JSValue) -> JSValue = { value in
             completion()

--- a/ios/test-utils-core/Sources/utilities/AssetTestHelper.swift
+++ b/ios/test-utils-core/Sources/utilities/AssetTestHelper.swift
@@ -1,13 +1,13 @@
 import Foundation
 import JavaScriptCore
-
 import PlayerUI
 import PlayerUILogger
 import PlayerUISwiftUI
 
 extension JSContext {
     func createAssetJsValue(string: String) -> JSValue {
-        guard let container = self.evaluateScript("(\(string))") else { fatalError("JSON was malformed") }
+        guard let container = evaluateScript("(\(string))")
+        else { fatalError("JSON was malformed") }
         return container
     }
 
@@ -25,11 +25,13 @@ extension JSContext {
     }
 }
 
-open class AssetTestHelper<WrapperType: AssetContainer & Decodable, Registry> where Registry: BaseAssetRegistry<WrapperType> {
-
+open class AssetTestHelper<
+    WrapperType: AssetContainer & Decodable,
+    Registry: BaseAssetRegistry<WrapperType>
+> {
     /// The JSContext where utilities are loaded
     /// and asset resolution is performed
-    public var context: JSContext = JSContext()
+    public var context: JSContext = .init()
 
     /// A closure to create the registry for this instance of the AssetTestHelper
     public var makeRegistry: () -> Registry
@@ -57,15 +59,15 @@ open class AssetTestHelper<WrapperType: AssetContainer & Decodable, Registry> wh
             )
 
             let root: JSValue? = try? await withCheckedThrowingContinuation { result in
-                player.hooks?.viewController.tap({ (viewController) in
-                    viewController.hooks.view.tap { (view) in
+                player.hooks?.viewController.tap { viewController in
+                    viewController.hooks.view.tap { view in
                         view.hooks.onUpdate.tap { val in
                             result.resume(returning: val)
                         }
                     }
-                })
+                }
                 player.start(flow: flow) { res in
-                    guard case .failure(let error) = res else { return }
+                    guard case let .failure(error) = res else { return }
                     result.resume(throwing: error)
                 }
             }
@@ -76,20 +78,18 @@ open class AssetTestHelper<WrapperType: AssetContainer & Decodable, Registry> wh
             } catch {
                 // If the user passed in an entire flow, decode the asset that was the root of
                 // the flow
-                guard let root = root else { return nil }
+                guard let root else { return nil }
                 return try? player.assetRegistry.decode(root) as? Asset
             }
         }.value
     }
 
-    /**
-     Turns a single Asset JSON definition into a full flow
-     - parameters:
-        - json: The JSON definition of a single asset
-     - returns: A string that is a full JSON flow containing the single asset
-     */
+    /// Turns a single Asset JSON definition into a full flow
+    /// - parameters:
+    ///   - json: The JSON definition of a single asset
+    /// - returns: A string that is a full JSON flow containing the single asset
     public func makeFlow(_ json: String) -> String? {
-        return context.evaluateScript("JSON.stringify(MakeFlow.makeFlow(\(json)))")?.toString()
+        context.evaluateScript("JSON.stringify(MakeFlow.makeFlow(\(json)))")?.toString()
     }
 }
 
@@ -103,13 +103,12 @@ public extension AssetTestHelper where WrapperType == WrappedAsset, Registry == 
 }
 
 public extension AssetTestHelper where WrapperType == WrappedAsset {
-    /**
-     Wraps a completion handler into a WrappedFunction for using XCTestExpectations to test functions
-     that are added to assets via a JS transform
-     - parameters:
-        - completion: A completion handler to run when the function is invoked
-     - returns: A WrappedFunction that will call your completion handler
-     */
+    /// Wraps a completion handler into a WrappedFunction for using XCTestExpectations to test
+    /// functions
+    /// that are added to assets via a JS transform
+    /// - parameters:
+    ///   - completion: A completion handler to run when the function is invoked
+    /// - returns: A WrappedFunction that will call your completion handler
     func getWrappedFunction<T>(completion: @escaping () -> Void) -> WrappedFunction<T>? {
         let callback: @convention(block) (JSValue) -> JSValue = { value in
             completion()

--- a/ios/test-utils-core/Sources/utilities/HeadlessPlayerImpl.swift
+++ b/ios/test-utils-core/Sources/utilities/HeadlessPlayerImpl.swift
@@ -1,18 +1,17 @@
 import JavaScriptCore
-
 import PlayerUI
 #if SWIFT_PACKAGE
-import PlayerUILogger
+    import PlayerUILogger
 #endif
 
 open class HeadlessPlayerImpl: HeadlessPlayer {
     public var assetRegistry: BaseAssetRegistry<TestWrapper>
     public var hooks: HeadlessHooks?
-    public var logger = TapableLogger()
+    public var logger: TapableLogger = .init()
 
     public var jsPlayerReference: JSValue?
 
-    let match = PartialMatchFingerprintPlugin()
+    let match: PartialMatchFingerprintPlugin = .init()
 
     public init(plugins: [NativePlugin], context: JSContext = JSContext()) {
         assetRegistry = BaseAssetRegistry<TestWrapper>(logger: logger)
@@ -20,7 +19,9 @@ open class HeadlessPlayerImpl: HeadlessPlayer {
         assetRegistry.partialMatchRegistry = match
         guard let player = jsPlayerReference else { return }
         hooks = HeadlessHooks(from: player)
-        for plugin in plugins { plugin.apply(player: self) }
+        for plugin in plugins {
+            plugin.apply(player: self)
+        }
     }
 }
 
@@ -35,7 +36,7 @@ public class HeadlessHooks: CoreHooks {
 
     public var onStart: Hook<FlowType>
 
-    required public init(from value: JSValue) {
+    public required init(from value: JSValue) {
         flowController = Hook(baseValue: value, name: "flowController")
         viewController = Hook(baseValue: value, name: "viewController")
         dataController = Hook(baseValue: value, name: "dataController")
@@ -45,30 +46,31 @@ public class HeadlessHooks: CoreHooks {
 }
 
 public class TestAssetType: PlayerAsset, Decodable {
-    var rawValue: JSValue?
     public var id: String
     public var type: String
+
+    var rawValue: JSValue?
     var value: String?
-    struct Data: Decodable {
-        var id: String
-        var type: String
-        var value: String?
-    }
-    required public init(from decoder: Decoder) throws {
+
+    public required init(from decoder: Decoder) throws {
         let data = try decoder.singleValueContainer().decode(Data.self)
         id = data.id
         type = data.type
         value = data.value
     }
+
+    struct Data: Decodable {
+        var id: String
+        var type: String
+        var value: String?
+    }
 }
 
 public class TestWrapper: AssetContainer, Decodable {
-    public enum CodingKeys: String, CodingKey {
-        case asset
-    }
     public var asset: TestAssetType?
-    required public init(forAsset: TestAssetType) {
-        self.asset = forAsset
+
+    public required init(forAsset: TestAssetType) {
+        asset = forAsset
     }
 
     public required init(from decoder: Decoder) throws {
@@ -82,18 +84,20 @@ public class TestWrapper: AssetContainer, Decodable {
             asset = try decodeAsset(singleContainer)
         }
     }
+
+    public enum CodingKeys: String, CodingKey {
+        case asset
+    }
 }
 
 /// A function that decodes a `SwiftUIAsset`
-typealias DecodeTestFunction = ((Any) throws -> TestAssetType?)
+typealias DecodeTestFunction = (Any) throws -> TestAssetType?
 
 extension Decoder {
-    /**
-     Retrieves a `DecodeSwiftUIFunction` if the decoder has one
-     - returns: A `DecodeSwiftUIFunction`
-     */
+    /// Retrieves a `DecodeSwiftUIFunction` if the decoder has one
+    /// - returns: A `DecodeSwiftUIFunction`
     func getTestDecodeFunction() throws -> DecodeTestFunction {
-        guard let decodeFunction = self.userInfo[self.decodeFunctionKey] as? DecodeTestFunction else {
+        guard let decodeFunction = userInfo[decodeFunctionKey] as? DecodeTestFunction else {
             throw DecodingError.decoderNotAnAssetDecoder
         }
         return decodeFunction

--- a/ios/test-utils-core/Sources/utilities/HeadlessPlayerImpl.swift
+++ b/ios/test-utils-core/Sources/utilities/HeadlessPlayerImpl.swift
@@ -1,16 +1,15 @@
 import JavaScriptCore
-
 import PlayerUI
 import PlayerUILogger
 
 open class HeadlessPlayerImpl: HeadlessPlayer {
     public var assetRegistry: BaseAssetRegistry<TestWrapper>
     public var hooks: HeadlessHooks?
-    public var logger = TapableLogger()
+    public var logger: TapableLogger = .init()
 
     public var jsPlayerReference: JSValue?
 
-    let match = PartialMatchFingerprintPlugin()
+    let match: PartialMatchFingerprintPlugin = .init()
 
     public init(plugins: [NativePlugin], context: JSContext = JSContext()) {
         assetRegistry = BaseAssetRegistry<TestWrapper>(logger: logger)
@@ -18,7 +17,9 @@ open class HeadlessPlayerImpl: HeadlessPlayer {
         assetRegistry.partialMatchRegistry = match
         guard let player = jsPlayerReference else { return }
         hooks = HeadlessHooks(from: player)
-        for plugin in plugins { plugin.apply(player: self) }
+        for plugin in plugins {
+            plugin.apply(player: self)
+        }
     }
 }
 
@@ -35,7 +36,7 @@ public class HeadlessHooks: CoreHooks {
 
     public var onStart: Hook<FlowType>
 
-    required public init(from value: JSValue) {
+    public required init(from value: JSValue) {
         flowController = Hook(baseValue: value, name: "flowController")
         viewController = Hook(baseValue: value, name: "viewController")
         dataController = Hook(baseValue: value, name: "dataController")
@@ -46,30 +47,31 @@ public class HeadlessHooks: CoreHooks {
 }
 
 public class TestAssetType: PlayerAsset, Decodable {
-    var rawValue: JSValue?
     public var id: String
     public var type: String
+
+    var rawValue: JSValue?
     var value: String?
-    struct Data: Decodable {
-        var id: String
-        var type: String
-        var value: String?
-    }
-    required public init(from decoder: Decoder) throws {
+
+    public required init(from decoder: Decoder) throws {
         let data = try decoder.singleValueContainer().decode(Data.self)
         id = data.id
         type = data.type
         value = data.value
     }
+
+    struct Data: Decodable {
+        var id: String
+        var type: String
+        var value: String?
+    }
 }
 
 public class TestWrapper: AssetContainer, Decodable {
-    public enum CodingKeys: String, CodingKey {
-        case asset
-    }
     public var asset: TestAssetType?
-    required public init(forAsset: TestAssetType) {
-        self.asset = forAsset
+
+    public required init(forAsset: TestAssetType) {
+        asset = forAsset
     }
 
     public required init(from decoder: Decoder) throws {
@@ -83,18 +85,20 @@ public class TestWrapper: AssetContainer, Decodable {
             asset = try decodeAsset(singleContainer)
         }
     }
+
+    public enum CodingKeys: String, CodingKey {
+        case asset
+    }
 }
 
 /// A function that decodes a `SwiftUIAsset`
-typealias DecodeTestFunction = ((Any) throws -> TestAssetType?)
+typealias DecodeTestFunction = (Any) throws -> TestAssetType?
 
 extension Decoder {
-    /**
-     Retrieves a `DecodeSwiftUIFunction` if the decoder has one
-     - returns: A `DecodeSwiftUIFunction`
-     */
+    /// Retrieves a `DecodeSwiftUIFunction` if the decoder has one
+    /// - returns: A `DecodeSwiftUIFunction`
     func getTestDecodeFunction() throws -> DecodeTestFunction {
-        guard let decodeFunction = self.userInfo[self.decodeFunctionKey] as? DecodeTestFunction else {
+        guard let decodeFunction = userInfo[decodeFunctionKey] as? DecodeTestFunction else {
             throw DecodingError.decoderNotAnAssetDecoder
         }
         return decodeFunction

--- a/ios/test-utils-core/Sources/utilities/TestPlayer.swift
+++ b/ios/test-utils-core/Sources/utilities/TestPlayer.swift
@@ -9,20 +9,22 @@ import Foundation
 import JavaScriptCore
 
 #if SWIFT_PACKAGE
-import PlayerUI
-import PlayerUILogger
+    import PlayerUI
+    import PlayerUILogger
 #endif
 
-/**
- A `HeadlessPlayer` implementation for testing purposes. It utilizes @player-ui/make-flow as a means of resolving assets IDs to types
- so the registry can decode assets without needing to forcefully map them
- */
-public class TestPlayer<WrapperType: AssetContainer, RegistryType: BaseAssetRegistry<WrapperType>>: HeadlessPlayer {
+/// A `HeadlessPlayer` implementation for testing purposes. It utilizes @player-ui/make-flow as a
+/// means of resolving assets IDs to types
+/// so the registry can decode assets without needing to forcefully map them
+public class TestPlayer<
+    WrapperType: AssetContainer,
+    RegistryType: BaseAssetRegistry<WrapperType>
+>: HeadlessPlayer {
     public var jsPlayerReference: JSValue?
 
     public var hooks: TestHooks?
 
-    public var logger = TapableLogger()
+    public var logger: TapableLogger = .init()
 
     public let assetRegistry: RegistryType
 
@@ -33,7 +35,9 @@ public class TestPlayer<WrapperType: AssetContainer, RegistryType: BaseAssetRegi
         jsPlayerReference = setupPlayer(context: context, plugins: allPlugins)
         guard let player = jsPlayerReference else { return }
         hooks = TestHooks(from: player)
-        for plugin in allPlugins { plugin.apply(player: self) }
+        for plugin in allPlugins {
+            plugin.apply(player: self)
+        }
         partialMatchPlugin.pluginRef?.invokeMethod("apply", withArguments: [player as Any])
         assetRegistry.partialMatchRegistry = partialMatchPlugin
     }

--- a/ios/test-utils-core/Sources/utilities/TestPlayer.swift
+++ b/ios/test-utils-core/Sources/utilities/TestPlayer.swift
@@ -7,20 +7,21 @@
 
 import Foundation
 import JavaScriptCore
-
 import PlayerUI
 import PlayerUILogger
 
-/**
- A `HeadlessPlayer` implementation for testing purposes. It utilizes @player-ui/make-flow as a means of resolving assets IDs to types
- so the registry can decode assets without needing to forcefully map them
- */
-public class TestPlayer<WrapperType: AssetContainer, RegistryType: BaseAssetRegistry<WrapperType>>: HeadlessPlayer {
+/// A `HeadlessPlayer` implementation for testing purposes. It utilizes @player-ui/make-flow as a
+/// means of resolving assets IDs to types
+/// so the registry can decode assets without needing to forcefully map them
+public class TestPlayer<
+    WrapperType: AssetContainer,
+    RegistryType: BaseAssetRegistry<WrapperType>
+>: HeadlessPlayer {
     public var jsPlayerReference: JSValue?
 
     public var hooks: TestHooks?
 
-    public var logger = TapableLogger()
+    public var logger: TapableLogger = .init()
 
     public let assetRegistry: RegistryType
 
@@ -31,7 +32,9 @@ public class TestPlayer<WrapperType: AssetContainer, RegistryType: BaseAssetRegi
         jsPlayerReference = setupPlayer(context: context, plugins: allPlugins)
         guard let player = jsPlayerReference else { return }
         hooks = TestHooks(from: player)
-        for plugin in allPlugins { plugin.apply(player: self) }
+        for plugin in allPlugins {
+            plugin.apply(player: self)
+        }
         partialMatchPlugin.pluginRef?.invokeMethod("apply", withArguments: [player as Any])
         assetRegistry.partialMatchRegistry = partialMatchPlugin
     }
@@ -43,7 +46,7 @@ public class TestHooks: CoreHooks {
     public var viewController: Hook<ViewController>
 
     public var dataController: Hook<DataController>
-    
+
     public var errorController: Hook<ErrorController>
 
     public var state: Hook<BaseFlowState>

--- a/ios/test-utils-core/Tests/AssetTestHelperTests.swift
+++ b/ios/test-utils-core/Tests/AssetTestHelperTests.swift
@@ -1,24 +1,16 @@
-import XCTest
 @testable import PlayerUI
-@testable import PlayerUITestUtilitiesCore
 @testable import PlayerUIInternalTestUtilities
 @testable import PlayerUILogger
+@testable import PlayerUITestUtilitiesCore
+import XCTest
 
 class AssetTestHelperTests: XCTestCase {
-    let helper = AssetTestHelper<TestWrapper, BaseAssetRegistry<TestWrapper>> {
+    private let helper = AssetTestHelper<TestWrapper, BaseAssetRegistry<TestWrapper>> {
         BaseAssetRegistry<TestWrapper>(logger: TapableLogger())
     }
 
-    struct TestPlugin: NativePlugin {
-        var pluginName: String = "TestPlugin"
-        func apply<P>(player: P) where P: HeadlessPlayer {
-            guard let player = player as? TestPlayer<TestWrapper, BaseAssetRegistry<TestWrapper>> else { return }
-            player.assetRegistry.register("test", asset: TestAssetType.self)
-        }
-    }
-
-    var plugins: [NativePlugin] = [
-        TestPlugin()
+    private var plugins: [NativePlugin] = [
+        TestPlugin(),
     ]
 
     func testRegistration() {
@@ -91,5 +83,15 @@ class AssetTestHelperTests: XCTestCase {
 
         XCTAssertNotNil(asset)
         XCTAssertEqual("test value", asset?.value)
+    }
+
+    struct TestPlugin: NativePlugin {
+        var pluginName: String = "TestPlugin"
+
+        func apply<P: HeadlessPlayer>(player: P) {
+            guard let player = player as? TestPlayer<TestWrapper, BaseAssetRegistry<TestWrapper>>
+            else { return }
+            player.assetRegistry.register("test", asset: TestAssetType.self)
+        }
     }
 }

--- a/ios/test-utils-core/Tests/AssetTestHelperTests.swift
+++ b/ios/test-utils-core/Tests/AssetTestHelperTests.swift
@@ -88,7 +88,7 @@ class AssetTestHelperTests: XCTestCase {
     struct TestPlugin: NativePlugin {
         var pluginName: String = "TestPlugin"
 
-        func apply<P: HeadlessPlayer>(player: P) {
+        func apply(player: some HeadlessPlayer) {
             guard let player = player as? TestPlayer<TestWrapper, BaseAssetRegistry<TestWrapper>>
             else { return }
             player.assetRegistry.register("test", asset: TestAssetType.self)

--- a/ios/test-utils/Sources/ui-test/AssetUITestCase.swift
+++ b/ios/test-utils/Sources/ui-test/AssetUITestCase.swift
@@ -8,84 +8,70 @@
 import Foundation
 import XCTest
 
-/**
- Base Class for Asset UI Testing when using `AssetCollectionController`
- */
+/// Base Class for Asset UI Testing when using `AssetCollectionController`
 open class AssetUITestCase: XCTestCase {
     /// The current XCUIApplication instance
-    public var app: XCUIApplication = XCUIApplication()
+    public var app: XCUIApplication = .init()
 
-    /**
-     Sets up before each test
-     */
-    open override func setUp() {
-        app = XCUIApplication()
-        app.launchEnvironment = [
-            "UI_TESTING": "true"
-        ]
-        app.launch()
-    }
-
-    /**
-     Tears down after each test
-     */
-    open override func tearDown() {
-        app.terminate()
-    }
-
-    /**
-     If the `AssetCollectionController` is not the first screen in your testing app
-     override this function to navigate to where it is
-     */
+    /// If the `AssetCollectionController` is not the first screen in your testing app
+    /// override this function to navigate to where it is
     open func navigateToAssetCollection() {}
 
-    /**
-     Opens a flow with the specified mock name.
-     Mock names are the name of the section and then the text in the cell
-     generally just the JSON file name with spaces instead of dashes
-
-     Example:
-     `action-basic.json` -> `"action basic"`
-     - parameters:
-        - mockName: The name of the mock to open
-     */
+    /// Opens a flow with the specified mock name.
+    /// Mock names are the name of the section and then the text in the cell
+    /// generally just the JSON file name with spaces instead of dashes
+    ///
+    /// Example:
+    /// `action-basic.json` -> `"action basic"`
+    /// - parameters:
+    ///   - mockName: The name of the mock to open
     open func openFlow(_ mockName: String) {
         navigateToAssetCollection()
 
         app.otherElements.buttons[mockName].firstMatch.tap()
     }
 
-    /**
-     Waits for an element to exist before tapping it
-     - parameters:
-        - element: The XCUIElement to wait for
-        - timeout: How long to wait for it to exist
-     */
+    /// Waits for an element to exist before tapping it
+    /// - parameters:
+    ///   - element: The XCUIElement to wait for
+    ///   - timeout: How long to wait for it to exist
     public func waitAndTap(_ element: XCUIElement, timeout: TimeInterval = 5) {
         waitFor(element, timeout: timeout)
         tap(element)
     }
 
-    /**
-     Tap the first matching element from an XCUIElement query
+    /// Tap the first matching element from an XCUIElement query
+    ///
+    /// Just cleans up the code to remove lots of `.firstMatch.tap()`
+    /// - parameters:
+    ///   - element: The XCUIElement to tap
+    public func tap(_ element: XCUIElement) {
+        element.firstMatch.tap()
+    }
 
-     Just cleans up the code to remove lots of `.firstMatch.tap()`
-     - parameters:
-        - element: The XCUIElement to tap
-     */
-    public func tap(_ element: XCUIElement) { element.firstMatch.tap() }
-
-    /**
-     Waits for an XCUIElement to exist
-     - parameters:
-        - element: The XCUIElement to wait for
-        - timeout: How long to wait for it to exist
-     */
+    /// Waits for an XCUIElement to exist
+    /// - parameters:
+    ///   - element: The XCUIElement to wait for
+    ///   - timeout: How long to wait for it to exist
     public func waitFor(_ element: XCUIElement, timeout: TimeInterval = 5) {
-        let predicate = NSPredicate { (_, _) -> Bool in
+        let predicate = NSPredicate { _, _ -> Bool in
             return element.firstMatch.exists
         }
-        let expectation = self.expectation(for: predicate, evaluatedWith: nil, handler: nil)
+        let expectation = expectation(for: predicate, evaluatedWith: nil, handler: nil)
         wait(for: [expectation], timeout: timeout)
+    }
+
+    /// Sets up before each test
+    override open func setUp() {
+        app = XCUIApplication()
+        app.launchEnvironment = [
+            "UI_TESTING": "true",
+        ]
+        app.launch()
+    }
+
+    /// Tears down after each test
+    override open func tearDown() {
+        app.terminate()
     }
 }

--- a/ios/test-utils/Sources/ui-test/AssetUITestCase.swift
+++ b/ios/test-utils/Sources/ui-test/AssetUITestCase.swift
@@ -8,84 +8,56 @@
 import Foundation
 import XCTest
 
-/**
- Base Class for Asset UI Testing when using `AssetCollectionController`
- */
+/// Base Class for Asset UI Testing when using `AssetCollectionController`
 open class AssetUITestCase: XCTestCase {
     /// The current XCUIApplication instance
-    public var app: XCUIApplication = XCUIApplication()
+    public var app: XCUIApplication = .init()
 
-    /**
-     Sets up before each test
-     */
-    open override func setUp() {
-        app = XCUIApplication()
-        app.launchEnvironment = [
-            "UI_TESTING": "true"
-        ]
-        app.launch()
-    }
-
-    /**
-     Tears down after each test
-     */
-    open override func tearDown() {
-        app.terminate()
-    }
-
-    /**
-     If the `AssetCollectionController` is not the first screen in your testing app
-     override this function to navigate to where it is
-     */
+    /// If the `AssetCollectionController` is not the first screen in your testing app
+    /// override this function to navigate to where it is
     open func navigateToAssetCollection() {}
 
-    /**
-     Opens a flow with the specified mock name.
-     Mock names are the name of the section and then the text in the cell
-     generally just the JSON file name with spaces instead of dashes
-
-     Example:
-     `action-basic.json` -> `"action basic"`
-     - parameters:
-        - mockName: The name of the mock to open
-     */
+    /// Opens a flow with the specified mock name.
+    /// Mock names are the name of the section and then the text in the cell
+    /// generally just the JSON file name with spaces instead of dashes
+    ///
+    /// Example:
+    /// `action-basic.json` -> `"action basic"`
+    /// - parameters:
+    ///   - mockName: The name of the mock to open
     open func openFlow(_ mockName: String) {
         navigateToAssetCollection()
 
         app.otherElements.buttons[mockName].firstMatch.tap()
     }
 
-    /**
-     Waits for an element to exist before tapping it
-     - parameters:
-        - element: The XCUIElement to wait for
-        - timeout: How long to wait for it to exist
-     */
+    /// Waits for an element to exist before tapping it
+    /// - parameters:
+    ///   - element: The XCUIElement to wait for
+    ///   - timeout: How long to wait for it to exist
     public func waitAndTap(_ element: XCUIElement, timeout: TimeInterval = 5) {
         waitFor(element, timeout: timeout)
         tap(element)
     }
 
-    /**
-     Tap the first matching element from an XCUIElement query
+    /// Tap the first matching element from an XCUIElement query
+    ///
+    /// Just cleans up the code to remove lots of `.firstMatch.tap()`
+    /// - parameters:
+    ///   - element: The XCUIElement to tap
+    public func tap(_ element: XCUIElement) {
+        element.firstMatch.tap()
+    }
 
-     Just cleans up the code to remove lots of `.firstMatch.tap()`
-     - parameters:
-        - element: The XCUIElement to tap
-     */
-    public func tap(_ element: XCUIElement) { element.firstMatch.tap() }
-
-    /**
-     Waits for an XCUIElement to exist
-     - parameters:
-        - element: The XCUIElement to wait for
-        - timeout: How long to wait for it to exist
-     */
+    /// Waits for an XCUIElement to exist
+    /// - parameters:
+    ///   - element: The XCUIElement to wait for
+    ///   - timeout: How long to wait for it to exist
     public func waitFor(_ element: XCUIElement, timeout: TimeInterval = 5) {
-        let predicate = NSPredicate { (_, _) -> Bool in
+        let predicate = NSPredicate { _, _ -> Bool in
             return element.firstMatch.exists
         }
-        let expectation = self.expectation(for: predicate, evaluatedWith: nil, handler: nil)
+        let expectation = expectation(for: predicate, evaluatedWith: nil, handler: nil)
         wait(for: [expectation], timeout: timeout)
     }
 
@@ -103,11 +75,25 @@ open class AssetUITestCase: XCTestCase {
         timeout: TimeInterval = 3,
         retries: Int = 3
     ) {
-        for _ in 0..<retries {
+        for _ in 0 ..< retries {
             if expectedOutcome.exists { return }
             guard element.exists else { break }
             element.tap()
             if expectedOutcome.waitForExistence(timeout: timeout) { return }
         }
+    }
+
+    /// Sets up before each test
+    override open func setUp() {
+        app = XCUIApplication()
+        app.launchEnvironment = [
+            "UI_TESTING": "true",
+        ]
+        app.launch()
+    }
+
+    /// Tears down after each test
+    override open func tearDown() {
+        app.terminate()
     }
 }

--- a/ios/test-utils/Sources/unit-test/SwiftUIAssetUnitTestCase.swift
+++ b/ios/test-utils/Sources/unit-test/SwiftUIAssetUnitTestCase.swift
@@ -5,74 +5,68 @@
 //  Created by Harris Borawski on 3/8/21.
 //
 
+import Combine
 import Foundation
 import JavaScriptCore
 import SwiftUI
-import Combine
 import XCTest
 
 #if SWIFT_PACKAGE
-import PlayerUI
-import PlayerUISwiftUI
-import PlayerUITestUtilitiesCore
+    import PlayerUI
+    import PlayerUISwiftUI
+    import PlayerUITestUtilitiesCore
 #endif
 
-/**
- A base class to use for SwiftUIAsset unit tests
- */
+/// A base class to use for SwiftUIAsset unit tests
 open class SwiftUIAssetUnitTestCase: XCTestCase, NativePlugin {
     // MARK: NativePlugin protocol adherence
 
     /// The name of this plugin
     public var pluginName: String = "AssetUnitTestCase"
 
-    /**
-     Apply this class as a plugin to a `HeadlessPlayer` implementation
-     - parameters:
-        - player: Player to apply to
-     */
+    public var helper: AssetTestHelper = .swiftui
+
+    public var context: JSContext {
+        helper.context
+    }
+
+    // MARK: Public API
+
+    /// Function to be overriden by subclass to register assets for use in the unit tests
+    /// - parameters:
+    ///   - registry: The SwiftUIRegistry to register assets to
+    open func register(registry _: SwiftUIRegistry) {}
+
+    /// Function to provide additional plugins when using `getAsset(_:)`
+    /// - returns: An array of `NativePlugin`s to add to the flow parsing
+    open func plugins() -> [NativePlugin] {
+        []
+    }
+
+    /// Apply this class as a plugin to a `HeadlessPlayer` implementation
+    /// - parameters:
+    ///   - player: Player to apply to
     public func apply<P: HeadlessPlayer>(player: P) {
         if let registry = player.assetRegistry as? SwiftUIRegistry {
             register(registry: registry)
         }
     }
 
-    // MARK: Public API
-    /**
-     Function to be overriden by subclass to register assets for use in the unit tests
-     - parameters:
-        - registry: The SwiftUIRegistry to register assets to
-     */
-    open func register(registry: SwiftUIRegistry) {}
-
-    /**
-     Function to provide additional plugins when using `getAsset(_:)`
-     - returns: An array of `NativePlugin`s to add to the flow parsing
-     */
-    open func plugins() -> [NativePlugin] { [] }
-
-    public var helper = AssetTestHelper.swiftui
-
-    public var context: JSContext { helper.context }
-
-    /**
-     Gets an asset from the given JSON if it is decodable
-     - parameters:
-        - json: The JSON definition for the asset you want to construct
-        - plugins: Additional plugins to include when resolving the asset
-     - returns: The decoded asset if it was possible to decode
-     */
+    /// Gets an asset from the given JSON if it is decodable
+    /// - parameters:
+    ///   - json: The JSON definition for the asset you want to construct
+    ///   - plugins: Additional plugins to include when resolving the asset
+    /// - returns: The decoded asset if it was possible to decode
     public func getAsset<T>(_ json: String, plugins: [NativePlugin] = []) async -> T? {
         await helper.getAsset(json, plugins: plugins + self.plugins() + [self])
     }
 
-    /**
-     Wraps a completion handler into a WrappedFunction for using XCTestExpectations to test functions
-     that are added to assets via a JS transform
-     - parameters:
-        - completion: A completion handler to run when the function is invoked
-     - returns: A WrappedFunction that will call your completion handler
-     */
+    /// Wraps a completion handler into a WrappedFunction for using XCTestExpectations to test
+    /// functions
+    /// that are added to assets via a JS transform
+    /// - parameters:
+    ///   - completion: A completion handler to run when the function is invoked
+    /// - returns: A WrappedFunction that will call your completion handler
     public func getWrappedFunction<T>(completion: @escaping () -> Void) -> WrappedFunction<T>? {
         helper.getWrappedFunction(completion: completion)
     }

--- a/ios/test-utils/Sources/unit-test/SwiftUIAssetUnitTestCase.swift
+++ b/ios/test-utils/Sources/unit-test/SwiftUIAssetUnitTestCase.swift
@@ -43,7 +43,7 @@ open class SwiftUIAssetUnitTestCase: XCTestCase, NativePlugin {
     /// Apply this class as a plugin to a `HeadlessPlayer` implementation
     /// - parameters:
     ///   - player: Player to apply to
-    public func apply<P: HeadlessPlayer>(player: P) {
+    public func apply(player: some HeadlessPlayer) {
         if let registry = player.assetRegistry as? SwiftUIRegistry {
             register(registry: registry)
         }

--- a/ios/test-utils/Sources/unit-test/SwiftUIAssetUnitTestCase.swift
+++ b/ios/test-utils/Sources/unit-test/SwiftUIAssetUnitTestCase.swift
@@ -5,72 +5,65 @@
 //  Created by Harris Borawski on 3/8/21.
 //
 
+import Combine
 import Foundation
 import JavaScriptCore
-import SwiftUI
-import Combine
-import XCTest
-
 import PlayerUI
 import PlayerUISwiftUI
 import PlayerUITestUtilitiesCore
+import SwiftUI
+import XCTest
 
-/**
- A base class to use for SwiftUIAsset unit tests
- */
+/// A base class to use for SwiftUIAsset unit tests
 open class SwiftUIAssetUnitTestCase: XCTestCase, NativePlugin {
     // MARK: NativePlugin protocol adherence
 
     /// The name of this plugin
     public var pluginName: String = "AssetUnitTestCase"
 
-    /**
-     Apply this class as a plugin to a `HeadlessPlayer` implementation
-     - parameters:
-        - player: Player to apply to
-     */
+    public var helper: AssetTestHelper = .swiftui
+
+    public var context: JSContext {
+        helper.context
+    }
+
+    // MARK: Public API
+
+    /// Function to be overriden by subclass to register assets for use in the unit tests
+    /// - parameters:
+    ///   - registry: The SwiftUIRegistry to register assets to
+    open func register(registry _: SwiftUIRegistry) {}
+
+    /// Function to provide additional plugins when using `getAsset(_:)`
+    /// - returns: An array of `NativePlugin`s to add to the flow parsing
+    open func plugins() -> [NativePlugin] {
+        []
+    }
+
+    /// Apply this class as a plugin to a `HeadlessPlayer` implementation
+    /// - parameters:
+    ///   - player: Player to apply to
     public func apply<P: HeadlessPlayer>(player: P) {
         if let registry = player.assetRegistry as? SwiftUIRegistry {
             register(registry: registry)
         }
     }
 
-    // MARK: Public API
-    /**
-     Function to be overriden by subclass to register assets for use in the unit tests
-     - parameters:
-        - registry: The SwiftUIRegistry to register assets to
-     */
-    open func register(registry: SwiftUIRegistry) {}
-
-    /**
-     Function to provide additional plugins when using `getAsset(_:)`
-     - returns: An array of `NativePlugin`s to add to the flow parsing
-     */
-    open func plugins() -> [NativePlugin] { [] }
-
-    public var helper = AssetTestHelper.swiftui
-
-    public var context: JSContext { helper.context }
-
-    /**
-     Gets an asset from the given JSON if it is decodable
-     - parameters:
-        - json: The JSON definition for the asset you want to construct
-        - plugins: Additional plugins to include when resolving the asset
-     - returns: The decoded asset if it was possible to decode
-     */
+    /// Gets an asset from the given JSON if it is decodable
+    /// - parameters:
+    ///   - json: The JSON definition for the asset you want to construct
+    ///   - plugins: Additional plugins to include when resolving the asset
+    /// - returns: The decoded asset if it was possible to decode
     public func getAsset<T>(_ json: String, plugins: [NativePlugin] = []) async -> T? {
         await helper.getAsset(json, plugins: plugins + self.plugins() + [self])
     }
 
-    /**
-     Wraps a completion handler into a WrappedFunction for using XCTestExpectations to test functions
-     that are added to assets via a JS transform
-     - parameters:
-        - completion: A completion handler to run when the function is invoked
-     - returns: A WrappedFunction that will call your completion handler
-     */
+    /// Wraps a completion handler into a WrappedFunction for using XCTestExpectations to test
+    /// functions
+    /// that are added to assets via a JS transform
+    /// - parameters:
+    ///   - completion: A completion handler to run when the function is invoked
+    /// - returns: A WrappedFunction that will call your completion handler
     public func getWrappedFunction<T>(completion: @escaping () -> Void) -> WrappedFunction<T>? {
         helper.getWrappedFunction(completion: completion)
     }

--- a/ios/test-utils/Tests/unit-test/AssetUnitTestCaseTests.swift
+++ b/ios/test-utils/Tests/unit-test/AssetUnitTestCaseTests.swift
@@ -6,13 +6,13 @@
 //  Copyright © 2021 CocoaPods. All rights reserved.
 //
 
-import XCTest
-import SwiftUI
 @testable import PlayerUI
 @testable import PlayerUILogger
 @testable import PlayerUISwiftUI
 @testable import PlayerUITestUtilities
 @testable import PlayerUITestUtilitiesCore
+import SwiftUI
+import XCTest
 
 struct ExampleAssetData: AssetData {
     var id: String
@@ -31,28 +31,32 @@ struct ExampleAssetView: View {
 }
 
 class ExampleAsset: UncontrolledAsset<ExampleAssetData> {
-    override var view: AnyView { AnyView(ExampleAssetView(model: model)) }
+    override var view: AnyView {
+        AnyView(ExampleAssetView(model: model))
+    }
 }
 
 class AssetUnitTestDefaultTests: SwiftUIAssetUnitTestCase {
     func testDefaultRegister() {
-        let player = TestPlayer<WrappedAsset, SwiftUIRegistry>(plugins: [self], registry: SwiftUIRegistry(logger: TapableLogger()))
+        let player = TestPlayer<WrappedAsset, SwiftUIRegistry>(
+            plugins: [self],
+            registry: SwiftUIRegistry(logger: TapableLogger())
+        )
         XCTAssertEqual(player.assetRegistry.registeredAssets.count, 0)
     }
 }
 
 class AssetUnitTestCaseTests: SwiftUIAssetUnitTestCase {
-    override func register(registry: SwiftUIRegistry) {
-        registry.register("test", asset: ExampleAsset.self)
-    }
-
     func testRegistration() {
-        let player = TestPlayer<WrappedAsset, SwiftUIRegistry>(plugins: [self], registry: SwiftUIRegistry(logger: TapableLogger()))
+        let player = TestPlayer<WrappedAsset, SwiftUIRegistry>(
+            plugins: [self],
+            registry: SwiftUIRegistry(logger: TapableLogger())
+        )
         XCTAssertEqual(player.assetRegistry.registeredAssets.count, 1)
     }
 
     func testDefaultPlugins() {
-        XCTAssertEqual(0, self.plugins().count)
+        XCTAssertEqual(0, plugins().count)
     }
 
     func testShouldNotDecode() async {
@@ -167,7 +171,10 @@ class AssetUnitTestCaseTests: SwiftUIAssetUnitTestCase {
     func testDifferentEquatableTypesAreNotEqual() {
         struct OtherEquatableAssetData: AssetData, Equatable {
             let id: String
-            var type: String { "Equatable" }
+            var type: String {
+                "Equatable"
+            }
+
             var value: String = "value"
         }
 
@@ -175,15 +182,25 @@ class AssetUnitTestCaseTests: SwiftUIAssetUnitTestCase {
         let asset2 = EquatableAssetData(id: asset1.id)
         XCTAssertFalse(asset1.isEqual(asset2))
     }
+
+    override func register(registry: SwiftUIRegistry) {
+        registry.register("test", asset: ExampleAsset.self)
+    }
 }
 
 private struct EquatableAssetData: AssetData, Equatable {
     let id: String
-    var type: String { "Equatable" }
     var value: String = "value"
+
+    var type: String {
+        "Equatable"
+    }
 }
 
 private struct NotEquatableAssetData: AssetData {
     let id: String
-    var type: String { "NotEquatable" }
+
+    var type: String {
+        "NotEquatable"
+    }
 }

--- a/ios/test-utils/Tests/unit-test/AssetUnitTestCaseTests.swift
+++ b/ios/test-utils/Tests/unit-test/AssetUnitTestCaseTests.swift
@@ -6,13 +6,13 @@
 //  Copyright © 2021 Intuit. All rights reserved.
 //
 
-import XCTest
-import SwiftUI
 @testable import PlayerUI
 @testable import PlayerUILogger
 @testable import PlayerUISwiftUI
 @testable import PlayerUITestUtilities
 @testable import PlayerUITestUtilitiesCore
+import SwiftUI
+import XCTest
 
 struct ExampleAssetData: AssetData {
     var id: String
@@ -31,28 +31,32 @@ struct ExampleAssetView: View {
 }
 
 class ExampleAsset: UncontrolledAsset<ExampleAssetData> {
-    override var view: AnyView { AnyView(ExampleAssetView(model: model)) }
+    override var view: AnyView {
+        AnyView(ExampleAssetView(model: model))
+    }
 }
 
 class AssetUnitTestDefaultTests: SwiftUIAssetUnitTestCase {
     func testDefaultRegister() {
-        let player = TestPlayer<WrappedAsset, SwiftUIRegistry>(plugins: [self], registry: SwiftUIRegistry(logger: TapableLogger()))
+        let player = TestPlayer<WrappedAsset, SwiftUIRegistry>(
+            plugins: [self],
+            registry: SwiftUIRegistry(logger: TapableLogger())
+        )
         XCTAssertEqual(player.assetRegistry.registeredAssets.count, 0)
     }
 }
 
 class AssetUnitTestCaseTests: SwiftUIAssetUnitTestCase {
-    override func register(registry: SwiftUIRegistry) {
-        registry.register("test", asset: ExampleAsset.self)
-    }
-
     func testRegistration() {
-        let player = TestPlayer<WrappedAsset, SwiftUIRegistry>(plugins: [self], registry: SwiftUIRegistry(logger: TapableLogger()))
+        let player = TestPlayer<WrappedAsset, SwiftUIRegistry>(
+            plugins: [self],
+            registry: SwiftUIRegistry(logger: TapableLogger())
+        )
         XCTAssertEqual(player.assetRegistry.registeredAssets.count, 1)
     }
 
     func testDefaultPlugins() {
-        XCTAssertEqual(0, self.plugins().count)
+        XCTAssertEqual(0, plugins().count)
     }
 
     func testShouldNotDecode() async {
@@ -167,7 +171,10 @@ class AssetUnitTestCaseTests: SwiftUIAssetUnitTestCase {
     func testDifferentEquatableTypesAreNotEqual() {
         struct OtherEquatableAssetData: AssetData, Equatable {
             let id: String
-            var type: String { "Equatable" }
+            var type: String {
+                "Equatable"
+            }
+
             var value: String = "value"
         }
 
@@ -175,15 +182,25 @@ class AssetUnitTestCaseTests: SwiftUIAssetUnitTestCase {
         let asset2 = EquatableAssetData(id: asset1.id)
         XCTAssertFalse(asset1.isEqual(asset2))
     }
+
+    override func register(registry: SwiftUIRegistry) {
+        registry.register("test", asset: ExampleAsset.self)
+    }
 }
 
 private struct EquatableAssetData: AssetData, Equatable {
     let id: String
-    var type: String { "Equatable" }
     var value: String = "value"
+
+    var type: String {
+        "Equatable"
+    }
 }
 
 private struct NotEquatableAssetData: AssetData {
     let id: String
-    var type: String { "NotEquatable" }
+
+    var type: String {
+        "NotEquatable"
+    }
 }

--- a/ios/test-utils/ViewInspector/ui-test/AssetFlowViewTests.swift
+++ b/ios/test-utils/ViewInspector/ui-test/AssetFlowViewTests.swift
@@ -7,28 +7,24 @@
 //
 
 import Foundation
-import XCTest
-import SwiftUI
-import ViewInspector
-
 @testable import PlayerUI
+@testable import PlayerUIInternalTestUtilities
 @testable import PlayerUIReferenceAssets
+@testable import PlayerUISwiftUI
 @testable import PlayerUITestUtilities
 @testable import PlayerUITestUtilitiesCore
-@testable import PlayerUISwiftUI
-@testable import PlayerUIInternalTestUtilities
+import SwiftUI
+import ViewInspector
+import XCTest
 
 class AssetFlowViewTests: XCTestCase {
-  override func setUp() {
-        XCUIApplication().terminate()
-    }
     func testVersionBodies() throws {
         let flow = FlowData.COUNTER
 
         let view = AssetFlowView(
             flow: flow,
             plugins: [
-                ReferenceAssetsPlugin()
+                ReferenceAssetsPlugin(),
             ]
         ) { _ in
         }
@@ -40,7 +36,7 @@ class AssetFlowViewTests: XCTestCase {
     }
 
     // swiftlint:disable function_body_length
-    func testAssetFlowView() throws {
+    func testAssetFlowView() {
         let flow = """
         {
           "id": "generated-flow",
@@ -107,7 +103,7 @@ class AssetFlowViewTests: XCTestCase {
             flow: flow,
             plugins: [
                 ReferenceAssetsPlugin(),
-                ForceTransitionPlugin()
+                ForceTransitionPlugin(),
             ]
         ) { _ in
             transitioned.fulfill()
@@ -117,14 +113,18 @@ class AssetFlowViewTests: XCTestCase {
         wait(for: [transitioned], timeout: 2)
         ViewHosting.expel()
     }
+
+    override func setUp() {
+        XCUIApplication().terminate()
+    }
 }
 
 class ForceTransitionPlugin: NativePlugin {
     var pluginName: String = "ForceTransition"
 
-    func apply<P>(player: P) where P: HeadlessPlayer {
+    func apply<P: HeadlessPlayer>(player: P) {
         guard let player = player as? SwiftUIPlayer else { return }
-        player.hooks?.flowController.tap({ flowController in
+        player.hooks?.flowController.tap { flowController in
             flowController.hooks.flow.tap { flow in
                 flow.hooks.afterTransition.tap { _ in
                     guard let state = player.state as? InProgressState else { return }
@@ -135,6 +135,6 @@ class ForceTransitionPlugin: NativePlugin {
                     }
                 }
             }
-        })
+        }
     }
 }

--- a/ios/test-utils/ViewInspector/ui-test/AssetFlowViewTests.swift
+++ b/ios/test-utils/ViewInspector/ui-test/AssetFlowViewTests.swift
@@ -122,7 +122,7 @@ class AssetFlowViewTests: XCTestCase {
 class ForceTransitionPlugin: NativePlugin {
     var pluginName: String = "ForceTransition"
 
-    func apply<P: HeadlessPlayer>(player: P) {
+    func apply(player: some HeadlessPlayer) {
         guard let player = player as? SwiftUIPlayer else { return }
         player.hooks?.flowController.tap { flowController in
             flowController.hooks.flow.tap { flow in

--- a/ios/test-utils/ViewInspector/unit-test/SwiftUIAssetUnitTestCaseTests.swift
+++ b/ios/test-utils/ViewInspector/unit-test/SwiftUIAssetUnitTestCaseTests.swift
@@ -8,15 +8,14 @@
 
 import Foundation
 import JavaScriptCore
-import SwiftUI
-import ViewInspector
-import XCTest
-
 @testable import PlayerUI
 @testable import PlayerUILogger
 @testable import PlayerUISwiftUI
 @testable import PlayerUITestUtilities
 @testable import PlayerUITestUtilitiesCore
+import SwiftUI
+import ViewInspector
+import XCTest
 
 struct ExampleData: AssetData {
     var id: String
@@ -28,37 +27,42 @@ struct ExampleData: AssetData {
 
 struct ExampleView: View {
     @ObservedObject var model: AssetViewModel<ExampleData>
+
     var body: some View {
         Button(
-            action: {self.model.data.function?()},
+            action: { model.data.function?() },
             label: { EmptyView() }
         )
     }
 }
 
 class ExampleSwiftUIAsset: UncontrolledAsset<ExampleData> {
-    override var view: AnyView { AnyView(ExampleView(model: model)) }
+    override var view: AnyView {
+        AnyView(ExampleView(model: model))
+    }
 }
 
 class SwiftUIAssetUnitTestDefaultTests: SwiftUIAssetUnitTestCase {
     func testDefaultRegister() {
-        let player = TestPlayer<WrappedAsset, SwiftUIRegistry>(plugins: [self], registry: SwiftUIRegistry(logger: TapableLogger()))
+        let player = TestPlayer<WrappedAsset, SwiftUIRegistry>(
+            plugins: [self],
+            registry: SwiftUIRegistry(logger: TapableLogger())
+        )
         XCTAssertEqual(player.assetRegistry.registeredAssets.count, 0)
     }
 }
 
 class SwiftUIAssetUnitTestCaseTests: SwiftUIAssetUnitTestCase {
-    override func register(registry: SwiftUIRegistry) {
-        registry.register("test", asset: ExampleSwiftUIAsset.self)
-    }
-
     func testRegistration() {
-        let player = TestPlayer<WrappedAsset, SwiftUIRegistry>(plugins: [self], registry: SwiftUIRegistry(logger: TapableLogger()))
+        let player = TestPlayer<WrappedAsset, SwiftUIRegistry>(
+            plugins: [self],
+            registry: SwiftUIRegistry(logger: TapableLogger())
+        )
         XCTAssertEqual(player.assetRegistry.registeredAssets.count, 1)
     }
 
     func testDefaultPlugins() {
-        XCTAssertEqual(0, self.plugins().count)
+        XCTAssertEqual(0, plugins().count)
     }
 
     func testShouldNotDecode() async {
@@ -132,7 +136,13 @@ class SwiftUIAssetUnitTestCaseTests: SwiftUIAssetUnitTestCase {
             })
         else { return XCTFail("could not create function") }
 
-        let model = AssetViewModel<ExampleData>(ExampleData(id: "id", type: "test", value: "hello", nested: nil, function: function))
+        let model = AssetViewModel<ExampleData>(ExampleData(
+            id: "id",
+            type: "test",
+            value: "hello",
+            nested: nil,
+            function: function
+        ))
 
         let view = ExampleView(model: model)
         let button = try view.inspect().button()
@@ -140,5 +150,9 @@ class SwiftUIAssetUnitTestCaseTests: SwiftUIAssetUnitTestCase {
         try button.tap()
 
         wait(for: [functionExpecation], timeout: 1)
+    }
+
+    override func register(registry: SwiftUIRegistry) {
+        registry.register("test", asset: ExampleSwiftUIAsset.self)
     }
 }

--- a/justfile
+++ b/justfile
@@ -126,13 +126,18 @@ dev-ios: build-core-native
 start-ios-demo:
   bazel run //ios/demo:PlayerUIDemo
 
-[doc('Fix all auto-fixable Swift lint errors')]
-swift-lint-fix:
-  mint run swiftlint --fix ios plugins
-
 [doc('Format all Swift files in-place')]
-swift-format:
+format-ios:
+  mint run swiftlint --fix ios plugins
   mint run swiftformat ios plugins
+
+[doc('Lint all Swift files with SwiftLint')]
+swift-lint-ios:
+  mint run swiftlint lint --strict ios plugins
+
+[doc('Lint all Swift files with SwiftFormat')]
+swift-format-lint-ios:
+  mint run swiftformat ios plugins --lint
 
 [doc("List all test iOS targets. You should run them individually with `bazel test` locally or they won't pass.
 

--- a/justfile
+++ b/justfile
@@ -130,6 +130,14 @@ start-ios-demo:
 lint-ios:
   bazel test $(bazel query --noshow_progress --output=label "attr(name, '.*SwiftLint', //ios/... + //plugins/...)")
 
+[doc('Format all Swift files in-place')]
+swift-format:
+  mint run swiftformat ios plugins
+
+[doc('Check Swift formatting without modifying files (used in CI)')]
+swift-format-lint:
+  mint run swiftformat ios plugins --lint
+
 [doc("List all test iOS targets. You should run them individually with `bazel test` locally or they won't pass.
 
 If you run them all at once locally, too many simulators will open and they'll all time out and fail.")]

--- a/justfile
+++ b/justfile
@@ -126,17 +126,13 @@ dev-ios: build-core-native
 start-ios-demo:
   bazel run //ios/demo:PlayerUIDemo
 
-[doc('Lint all iOS files')]
-lint-ios:
-  bazel test $(bazel query --noshow_progress --output=label "attr(name, '.*SwiftLint', //ios/... + //plugins/...)")
+[doc('Fix all auto-fixable Swift lint errors')]
+swift-lint-fix:
+  mint run swiftlint --fix ios plugins
 
 [doc('Format all Swift files in-place')]
 swift-format:
   mint run swiftformat ios plugins
-
-[doc('Check Swift formatting without modifying files (used in CI)')]
-swift-format-lint:
-  mint run swiftformat ios plugins --lint
 
 [doc("List all test iOS targets. You should run them individually with `bazel test` locally or they won't pass.
 

--- a/justfile
+++ b/justfile
@@ -131,16 +131,16 @@ start-ios-demo:
 
 [doc('Format all Swift files in-place')]
 format-ios:
-  swift run --package-path xcode mint run swiftlint --fix ios plugins
-  swift run --package-path xcode mint run swiftformat ios plugins
+  swift run --package-path xcode swiftlint --fix ios plugins
+  swift run --package-path xcode swiftformat ios plugins
 
 [doc('Lint all Swift files with SwiftLint')]
 swift-lint-ios:
-  swift run --package-path xcode mint run swiftlint lint --strict ios plugins
+  swift run --package-path xcode swiftlint lint --strict ios plugins
 
 [doc('Lint all Swift files with SwiftFormat')]
 swift-format-lint-ios:
-  swift run --package-path xcode mint run swiftformat ios plugins --lint
+  swift run --package-path xcode swiftformat ios plugins --lint
 
 [doc("List all test iOS targets. You should run them individually with `bazel test` locally or they won't pass.
 

--- a/justfile
+++ b/justfile
@@ -131,16 +131,16 @@ start-ios-demo:
 
 [doc('Format all Swift files in-place')]
 format-ios:
-  mint run swiftlint --fix ios plugins
-  mint run swiftformat ios plugins
+  swift run --package-path xcode mint run swiftlint --fix ios plugins
+  swift run --package-path xcode mint run swiftformat ios plugins
 
 [doc('Lint all Swift files with SwiftLint')]
 swift-lint-ios:
-  mint run swiftlint lint --strict ios plugins
+  swift run --package-path xcode mint run swiftlint lint --strict ios plugins
 
 [doc('Lint all Swift files with SwiftFormat')]
 swift-format-lint-ios:
-  mint run swiftformat ios plugins --lint
+  swift run --package-path xcode mint run swiftformat ios plugins --lint
 
 [doc("List all test iOS targets. You should run them individually with `bazel test` locally or they won't pass.
 

--- a/justfile
+++ b/justfile
@@ -129,9 +129,18 @@ dev-ios: build-core-native
 start-ios-demo:
   bazel run //ios/demo:PlayerUIDemo
 
-[doc('Lint all iOS files')]
-lint-ios:
-  bazel test $(bazel query --noshow_progress --output=label "attr(name, '.*SwiftLint', //ios/... + //plugins/...)")
+[doc('Format all Swift files in-place')]
+format-ios:
+  mint run swiftlint --fix ios plugins
+  mint run swiftformat ios plugins
+
+[doc('Lint all Swift files with SwiftLint')]
+swift-lint-ios:
+  mint run swiftlint lint --strict ios plugins
+
+[doc('Lint all Swift files with SwiftFormat')]
+swift-format-lint-ios:
+  mint run swiftformat ios plugins --lint
 
 [doc("List all test iOS targets. You should run them individually with `bazel test` locally or they won't pass.
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "packageManager": "pnpm@10.18.1",
   "scripts": {
-    "fmt": "prettier --write '**/*.{ts,tsx}'"
+    "fmt": "prettier --write '**/*.{ts,tsx}'",
+    "prepare": "husky install"
   },
   "dependencies": {
     "@astrojs/react": "^4.0.0",

--- a/plugins/async-node/ios/Sources/AsyncNodePlugin.swift
+++ b/plugins/async-node/ios/Sources/AsyncNodePlugin.swift
@@ -25,15 +25,16 @@ public extension ReplacementNode {
     /// - Returns: A `JSValue` representing the `ReplacementNode`, or `nil` if the conversion fails.
     func toJSValue(context: JSContext) -> JSValue? {
         switch self {
-        case .encodable(let encodable):
+        case let .encodable(encodable):
             let encoder = JSONEncoder()
             do {
                 let res = try encoder.encode(encodable)
-                return context.evaluateScript("(\(String(data: res, encoding: .utf8) ?? ""))") as JSValue
+                return context
+                    .evaluateScript("(\(String(data: res, encoding: .utf8) ?? ""))") as JSValue
             } catch {
                 return nil
             }
-        case .concrete(let jsValue):
+        case let .concrete(jsValue):
             return jsValue
         }
     }
@@ -44,16 +45,19 @@ public extension AsyncNodeHandlerType {
     /// Converts the `AsyncNodeHandlerType` to a `JSValue` in the provided `JSContext`.
     ///
     /// - Parameter context: The `JSContext` in which the `JSValue` will be created.
-    /// - Returns: A `JSValue` representing the `AsyncNodeHandlerType`, or `nil` if the conversion fails.
+    /// - Returns: A `JSValue` representing the `AsyncNodeHandlerType`, or `nil` if the conversion
+    /// fails.
     func handlerTypeToJSValue(context: JSContext) -> JSValue? {
         switch self {
-        case .multiNode(let replacementNodes):
+        case let .multiNode(replacementNodes):
             let jsValueArray = replacementNodes.compactMap {
                 $0.toJSValue(context: context)
             }
-            return context.objectForKeyedSubscript("Array").objectForKeyedSubscript("from").call(withArguments: [jsValueArray])
+            return context.objectForKeyedSubscript("Array")
+                .objectForKeyedSubscript("from")
+                .call(withArguments: [jsValueArray])
 
-        case .singleNode(let replacementNode):
+        case let .singleNode(replacementNode):
             return replacementNode.toJSValue(context: context)
 
         case .emptyNode:
@@ -62,37 +66,53 @@ public extension AsyncNodeHandlerType {
     }
 }
 
-/**
- Wraps the core AsyncNodePlugin and taps into the `onAsyncNode` hook to allow asynchronous replacement of the node object that contains `async`
- */
+/// Wraps the core AsyncNodePlugin and taps into the `onAsyncNode` hook to allow asynchronous
+/// replacement of the node object that contains `async`
 public class AsyncNodePlugin: JSBasePlugin, NativePlugin {
     public var hooks: AsyncNodeHook?
 
-    private var asyncHookHandler: AsyncHookHandler?
-
     public var plugins: [JSBasePlugin] = []
 
-    /**
-     Constructs the AsyncNodePlugin
-     - Parameters:
-     - handler: The callback that is used to tap into the core `onAsyncNode` hook
-     exposed to users of the plugin allowing them to supply the replacement node used in the tap callback
-     */
-    public convenience init(plugins: [JSBasePlugin] = [AsyncNodePluginPlugin()], asyncHookHandler: AsyncHookHandler? = nil) {
+    private var asyncHookHandler: AsyncHookHandler?
 
+    /// Constructs the AsyncNodePlugin
+    /// - Parameters:
+    /// - handler: The callback that is used to tap into the core `onAsyncNode` hook
+    /// exposed to users of the plugin allowing them to supply the replacement node used in the tap
+    /// callback
+    public convenience init(
+        plugins: [JSBasePlugin] = [AsyncNodePluginPlugin()],
+        asyncHookHandler: AsyncHookHandler? = nil
+    ) {
         self.init(fileName: "AsyncNodePlugin.native", pluginName: "AsyncNodePlugin.AsyncNodePlugin")
         self.asyncHookHandler = asyncHookHandler
         self.plugins = plugins
     }
 
+    override open func getUrlForFile(fileName: String) -> URL? {
+        #if SWIFT_PACKAGE
+            ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
+        #else
+            ResourceUtilities.urlForFile(
+                name: fileName,
+                ext: "js",
+                bundle: Bundle(for: AsyncNodePlugin.self),
+                pathComponent: "PlayerUIAsyncNodePlugin.bundle"
+            )
+        #endif
+    }
+
     override public func setup(context: JSContext) {
         super.setup(context: context)
 
-        if let pluginRef = pluginRef {
-            self.hooks = AsyncNodeHook(onAsyncNode: AsyncHook2(baseValue: pluginRef, name: "onAsyncNode"), onAsyncNodeError: Hook2(baseValue: pluginRef, name: "onAsyncNodeError"))
+        if let pluginRef {
+            hooks = AsyncNodeHook(
+                onAsyncNode: AsyncHook2(baseValue: pluginRef, name: "onAsyncNode"),
+                onAsyncNodeError: Hook2(baseValue: pluginRef, name: "onAsyncNodeError")
+            )
         }
-        
-        if let asyncHookHandler = self.asyncHookHandler {
+
+        if let asyncHookHandler {
             hooks?.onAsyncNode.tap { node, callback in
                 let replacementNode = try await asyncHookHandler(node, callback)
                 return replacementNode.handlerTypeToJSValue(context: context) ?? JSValue()
@@ -100,30 +120,16 @@ public class AsyncNodePlugin: JSBasePlugin, NativePlugin {
         }
     }
 
-    /**
-     Retrieves the arguments for constructing this plugin, this is necessary because the arguments need to be supplied after
-     construction of the swift object, once the context has been provided
-     - returns: An array of arguments to construct the plugin
-     */
+    /// Retrieves the arguments for constructing this plugin, this is necessary because the
+    /// arguments need to be supplied after
+    /// construction of the swift object, once the context has been provided
+    /// - returns: An array of arguments to construct the plugin
     override public func getArguments() -> [Any] {
         for plugin in plugins {
-            plugin.context = self.context
+            plugin.context = context
         }
 
-        return [["plugins": plugins.map { $0.pluginRef }]]
-    }
-
-    override open func getUrlForFile(fileName: String) -> URL? {
-#if SWIFT_PACKAGE
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
-#else
-        ResourceUtilities.urlForFile(
-            name: fileName,
-            ext: "js",
-            bundle: Bundle(for: AsyncNodePlugin.self),
-            pathComponent: "PlayerUIAsyncNodePlugin.bundle"
-        )
-#endif
+        return [["plugins": plugins.map(\.pluginRef)]]
     }
 }
 
@@ -132,9 +138,8 @@ public struct AsyncNodeHook {
     public let onAsyncNodeError: Hook2<JSValue, JSValue>
 }
 
-/**
- Replacement node that the callback of this plugin expects, users can supply either a JSValue or an Encodable object that gets converted to a JSValue in the `setup`
- */
+/// Replacement node that the callback of this plugin expects, users can supply either a JSValue or
+/// an Encodable object that gets converted to a JSValue in the `setup`
 public enum ReplacementNode: Encodable {
     case concrete(JSValue)
     case encodable(Encodable)
@@ -143,20 +148,17 @@ public enum ReplacementNode: Encodable {
         var container = encoder.singleValueContainer()
 
         switch self {
-        case .encodable(let value):
+        case let .encodable(value):
             try container.encode(value)
-        case .concrete( _):
+        case .concrete:
             break
         }
     }
 }
 
 public struct AssetPlaceholderNode: Encodable {
-    public enum CodingKeys: String, CodingKey {
-        case asset
-    }
-
     var asset: Encodable
+
     public init(asset: Encodable) {
         self.asset = asset
     }
@@ -165,35 +167,41 @@ public struct AssetPlaceholderNode: Encodable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try? container.encode(asset, forKey: .asset)
     }
+
+    public enum CodingKeys: String, CodingKey {
+        case asset
+    }
 }
 
 public struct AsyncNode: Codable, Equatable {
     var id: String
     var async: Bool = true
-    
+
     public init(id: String) {
         self.id = id
     }
 }
 
-/**
- Wraps the core AsyncNodePlugins AsyncNodePluginPlugin, which has functionality that should be applied to each AsyncNodePluginPlugin passed in
- */
+/// Wraps the core AsyncNodePlugins AsyncNodePluginPlugin, which has functionality that should be
+/// applied to each AsyncNodePluginPlugin passed in
 public class AsyncNodePluginPlugin: JSBasePlugin {
     public convenience init() {
-        self.init(fileName: "AsyncNodePlugin.native", pluginName: "AsyncNodePlugin.AsyncNodePluginPlugin")
+        self.init(
+            fileName: "AsyncNodePlugin.native",
+            pluginName: "AsyncNodePlugin.AsyncNodePluginPlugin"
+        )
     }
 
     override open func getUrlForFile(fileName: String) -> URL? {
-#if SWIFT_PACKAGE
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
-#else
-        ResourceUtilities.urlForFile(
-            name: fileName,
-            ext: "js",
-            bundle: Bundle(for: AsyncNodePluginPlugin.self),
-            pathComponent: "PlayerUIAsyncNodePlugin.bundle"
-        )
-#endif
+        #if SWIFT_PACKAGE
+            ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
+        #else
+            ResourceUtilities.urlForFile(
+                name: fileName,
+                ext: "js",
+                bundle: Bundle(for: AsyncNodePluginPlugin.self),
+                pathComponent: "PlayerUIAsyncNodePlugin.bundle"
+            )
+        #endif
     }
 }

--- a/plugins/async-node/ios/Sources/AsyncNodePlugin.swift
+++ b/plugins/async-node/ios/Sources/AsyncNodePlugin.swift
@@ -25,15 +25,16 @@ public extension ReplacementNode {
     /// - Returns: A `JSValue` representing the `ReplacementNode`, or `nil` if the conversion fails.
     func toJSValue(context: JSContext) -> JSValue? {
         switch self {
-        case .encodable(let encodable):
+        case let .encodable(encodable):
             let encoder = JSONEncoder()
             do {
                 let res = try encoder.encode(encodable)
-                return context.evaluateScript("(\(String(data: res, encoding: .utf8) ?? ""))") as JSValue
+                return context
+                    .evaluateScript("(\(String(data: res, encoding: .utf8) ?? ""))") as JSValue
             } catch {
                 return nil
             }
-        case .concrete(let jsValue):
+        case let .concrete(jsValue):
             return jsValue
         }
     }
@@ -44,16 +45,19 @@ public extension AsyncNodeHandlerType {
     /// Converts the `AsyncNodeHandlerType` to a `JSValue` in the provided `JSContext`.
     ///
     /// - Parameter context: The `JSContext` in which the `JSValue` will be created.
-    /// - Returns: A `JSValue` representing the `AsyncNodeHandlerType`, or `nil` if the conversion fails.
+    /// - Returns: A `JSValue` representing the `AsyncNodeHandlerType`, or `nil` if the conversion
+    /// fails.
     func handlerTypeToJSValue(context: JSContext) -> JSValue? {
         switch self {
-        case .multiNode(let replacementNodes):
+        case let .multiNode(replacementNodes):
             let jsValueArray = replacementNodes.compactMap {
                 $0.toJSValue(context: context)
             }
-            return context.objectForKeyedSubscript("Array").objectForKeyedSubscript("from").call(withArguments: [jsValueArray])
+            return context.objectForKeyedSubscript("Array")
+                .objectForKeyedSubscript("from")
+                .call(withArguments: [jsValueArray])
 
-        case .singleNode(let replacementNode):
+        case let .singleNode(replacementNode):
             return replacementNode.toJSValue(context: context)
 
         case .emptyNode:
@@ -62,37 +66,44 @@ public extension AsyncNodeHandlerType {
     }
 }
 
-/**
- Wraps the core AsyncNodePlugin and taps into the `onAsyncNode` hook to allow asynchronous replacement of the node object that contains `async`
- */
+/// Wraps the core AsyncNodePlugin and taps into the `onAsyncNode` hook to allow asynchronous
+/// replacement of the node object that contains `async`
 public class AsyncNodePlugin: JSBasePlugin, NativePlugin {
     public var hooks: AsyncNodeHook?
 
-    private var asyncHookHandler: AsyncHookHandler?
-
     public var plugins: [JSBasePlugin] = []
 
-    /**
-     Constructs the AsyncNodePlugin
-     - Parameters:
-     - handler: The callback that is used to tap into the core `onAsyncNode` hook
-     exposed to users of the plugin allowing them to supply the replacement node used in the tap callback
-     */
-    public convenience init(plugins: [JSBasePlugin] = [AsyncNodePluginPlugin()], asyncHookHandler: AsyncHookHandler? = nil) {
+    private var asyncHookHandler: AsyncHookHandler?
 
+    /// Constructs the AsyncNodePlugin
+    /// - Parameters:
+    /// - handler: The callback that is used to tap into the core `onAsyncNode` hook
+    /// exposed to users of the plugin allowing them to supply the replacement node used in the tap
+    /// callback
+    public convenience init(
+        plugins: [JSBasePlugin] = [AsyncNodePluginPlugin()],
+        asyncHookHandler: AsyncHookHandler? = nil
+    ) {
         self.init(fileName: "AsyncNodePlugin.native", pluginName: "AsyncNodePlugin.AsyncNodePlugin")
         self.asyncHookHandler = asyncHookHandler
         self.plugins = plugins
     }
 
+    override open func getUrlForFile(fileName: String) -> URL? {
+        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
+    }
+
     override public func setup(context: JSContext) {
         super.setup(context: context)
 
-        if let pluginRef = pluginRef {
-            self.hooks = AsyncNodeHook(onAsyncNode: AsyncHook2(baseValue: pluginRef, name: "onAsyncNode"), onAsyncNodeError: Hook2(baseValue: pluginRef, name: "onAsyncNodeError"))
+        if let pluginRef {
+            hooks = AsyncNodeHook(
+                onAsyncNode: AsyncHook2(baseValue: pluginRef, name: "onAsyncNode"),
+                onAsyncNodeError: Hook2(baseValue: pluginRef, name: "onAsyncNodeError")
+            )
         }
-        
-        if let asyncHookHandler = self.asyncHookHandler {
+
+        if let asyncHookHandler {
             hooks?.onAsyncNode.tap { node, callback in
                 let replacementNode = try await asyncHookHandler(node, callback)
                 return replacementNode.handlerTypeToJSValue(context: context) ?? JSValue()
@@ -100,21 +111,16 @@ public class AsyncNodePlugin: JSBasePlugin, NativePlugin {
         }
     }
 
-    /**
-     Retrieves the arguments for constructing this plugin, this is necessary because the arguments need to be supplied after
-     construction of the swift object, once the context has been provided
-     - returns: An array of arguments to construct the plugin
-     */
+    /// Retrieves the arguments for constructing this plugin, this is necessary because the
+    /// arguments need to be supplied after
+    /// construction of the swift object, once the context has been provided
+    /// - returns: An array of arguments to construct the plugin
     override public func getArguments() -> [Any] {
         for plugin in plugins {
-            plugin.context = self.context
+            plugin.context = context
         }
 
-        return [["plugins": plugins.map { $0.pluginRef }]]
-    }
-
-    override open func getUrlForFile(fileName: String) -> URL? {
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
+        return [["plugins": plugins.map(\.pluginRef)]]
     }
 }
 
@@ -123,9 +129,8 @@ public struct AsyncNodeHook {
     public let onAsyncNodeError: Hook2<JSValue, JSValue>
 }
 
-/**
- Replacement node that the callback of this plugin expects, users can supply either a JSValue or an Encodable object that gets converted to a JSValue in the `setup`
- */
+/// Replacement node that the callback of this plugin expects, users can supply either a JSValue or
+/// an Encodable object that gets converted to a JSValue in the `setup`
 public enum ReplacementNode: Encodable {
     case concrete(JSValue)
     case encodable(Encodable)
@@ -134,20 +139,17 @@ public enum ReplacementNode: Encodable {
         var container = encoder.singleValueContainer()
 
         switch self {
-        case .encodable(let value):
+        case let .encodable(value):
             try container.encode(value)
-        case .concrete( _):
+        case .concrete:
             break
         }
     }
 }
 
 public struct AssetPlaceholderNode: Encodable {
-    public enum CodingKeys: String, CodingKey {
-        case asset
-    }
-
     var asset: Encodable
+
     public init(asset: Encodable) {
         self.asset = asset
     }
@@ -156,23 +158,29 @@ public struct AssetPlaceholderNode: Encodable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try? container.encode(asset, forKey: .asset)
     }
+
+    public enum CodingKeys: String, CodingKey {
+        case asset
+    }
 }
 
 public struct AsyncNode: Codable, Equatable {
     var id: String
     var async: Bool = true
-    
+
     public init(id: String) {
         self.id = id
     }
 }
 
-/**
- Wraps the core AsyncNodePlugins AsyncNodePluginPlugin, which has functionality that should be applied to each AsyncNodePluginPlugin passed in
- */
+/// Wraps the core AsyncNodePlugins AsyncNodePluginPlugin, which has functionality that should be
+/// applied to each AsyncNodePluginPlugin passed in
 public class AsyncNodePluginPlugin: JSBasePlugin {
     public convenience init() {
-        self.init(fileName: "AsyncNodePlugin.native", pluginName: "AsyncNodePlugin.AsyncNodePluginPlugin")
+        self.init(
+            fileName: "AsyncNodePlugin.native",
+            pluginName: "AsyncNodePlugin.AsyncNodePluginPlugin"
+        )
     }
 
     override open func getUrlForFile(fileName: String) -> URL? {

--- a/plugins/async-node/ios/Tests/AsynNodePluginTests.swift
+++ b/plugins/async-node/ios/Tests/AsynNodePluginTests.swift
@@ -1,102 +1,104 @@
 //
-//  AsyncNodePluginTests.swift
+//  AsynNodePluginTests.swift
 //  PlayerUI
 //
 //  Created by Zhao Xia Wu on 2024-02-05.
 //
 
 import Foundation
-import XCTest
-import SwiftUI
 import JavaScriptCore
-
 @testable import PlayerUI
-@testable import PlayerUITestUtilitiesCore
-@testable import PlayerUIReferenceAssets
 @testable import PlayerUIAsyncNodePlugin
+@testable import PlayerUIReferenceAssets
+@testable import PlayerUITestUtilitiesCore
+import SwiftUI
+import XCTest
 
 class AsyncNodePluginTests: XCTestCase {
-    
     func testConstructionAsyncPlugin() {
         let context = JSContext()
-        let plugin = AsyncNodePlugin { _,_ in
-            return .singleNode(.concrete(JSValue()))
+        let plugin = AsyncNodePlugin { _, _ in
+            .singleNode(.concrete(JSValue()))
         }
         plugin.context = context
-        
+
         XCTAssertNotNil(plugin.pluginRef)
     }
-    
+
     func testContructionAsyncPluginWithoutHandler() {
         let context = JSContext()
         let asyncNodePluginPlugin = AsyncNodePluginPlugin()
-        let resolveHandler: AsyncHookHandler = { _,_ in
-            return .singleNode(.concrete(JSValue()))
+        let resolveHandler: AsyncHookHandler = { _, _ in
+            .singleNode(.concrete(JSValue()))
         }
-        
+
         let plugin = AsyncNodePlugin(plugins: [asyncNodePluginPlugin])
-        
+
         plugin.context = context
-        
-        plugin.hooks?.onAsyncNode.tap({ node, callback in
+
+        plugin.hooks?.onAsyncNode.tap { node, callback in
             let replacementNode = try await (resolveHandler)(node, callback)
-            return replacementNode.handlerTypeToJSValue(context: context ?? JSContext()) ?? JSValue()
-        })
-        
+            return replacementNode
+                .handlerTypeToJSValue(context: context ?? JSContext()) ?? JSValue()
+        }
+
         XCTAssertNotNil(plugin.hooks?.onAsyncNode)
     }
 
     func testConstructionAsyncPluginPlugin() {
         let context = JSContext()
-        
+
         let plugin = AsyncNodePluginPlugin()
         plugin.context = context
-        
+
         XCTAssertNotNil(plugin.pluginRef)
     }
-    
-    
+
     func testAsyncNodeWithAnotherAsyncNodeDelay() {
         let handlerExpectation = XCTestExpectation(description: "first data did not change")
-        
+
         let context = JSContext()
-        
+
         var count = 0
-        
-        let resolveHandler: AsyncHookHandler = { _,_ in
+
+        let resolveHandler: AsyncHookHandler = { _, _ in
             handlerExpectation.fulfill()
-            
+
             sleep(3)
             return .singleNode(.concrete(context?.evaluateScript("""
-                    ([
-                        {"asset": {"id": "text", "type": "text", "value":"new node from the hook 1"}}
-                       ])
-                    """) ?? JSValue()))
+            ([
+                {"asset": {"id": "text", "type": "text", "value":"new node from the hook 1"}}
+               ])
+            """) ?? JSValue()))
         }
-        
+
         let asyncNodePluginPlugin = AsyncNodePluginPlugin()
         let plugin = AsyncNodePlugin(plugins: [asyncNodePluginPlugin])
-        
+
         plugin.context = context
-        
-        plugin.hooks?.onAsyncNode.tap({ node, callback in
+
+        plugin.hooks?.onAsyncNode.tap { node, callback in
             let replacementNode = try await (resolveHandler)(node, callback)
-            return replacementNode.handlerTypeToJSValue(context: context ?? JSContext()) ?? JSValue()
-        })
-        
+            return replacementNode
+                .handlerTypeToJSValue(context: context ?? JSContext()) ?? JSValue()
+        }
+
         XCTAssertNotNil(asyncNodePluginPlugin.context)
-        
-        let player = HeadlessPlayerImpl(plugins: [ReferenceAssetsPlugin(), plugin], context: context ?? JSContext())
-        
+
+        let player = HeadlessPlayerImpl(
+            plugins: [ReferenceAssetsPlugin(), plugin],
+            context: context ?? JSContext()
+        )
+
         let textExpectation = XCTestExpectation(description: "newText1 found")
-        
-        var expectedMultiNode1Text: String = ""
-        
-        player.hooks?.viewController.tap({ (viewController) in
-            viewController.hooks.view.tap { (view) in
+
+        var expectedMultiNode1Text = ""
+
+        player.hooks?.viewController.tap { viewController in
+            viewController.hooks.view.tap { view in
                 view.hooks.onUpdate.tap { val in
                     count += 1
-                    
+
                     if count == 2 {
                         let newText1 = val
                             .objectForKeyedSubscript("values")
@@ -104,75 +106,89 @@ class AsyncNodePluginTests: XCTestCase {
                             .objectAtIndexedSubscript(0)
                             .objectForKeyedSubscript("asset")
                             .objectForKeyedSubscript("value")
-                        guard let textString1 = newText1?.toString() else { return XCTFail("newText1 was not a string") }
-                        
+                        guard let textString1 = newText1?.toString()
+                        else { return XCTFail("newText1 was not a string") }
+
                         expectedMultiNode1Text = textString1
                         textExpectation.fulfill()
                     }
                 }
             }
-        })
-        
-        player.start(flow: .asyncNodeJson, completion: {_ in})
-        
+        }
+
+        player.start(flow: .asyncNodeJson, completion: { _ in })
+
         wait(for: [handlerExpectation, textExpectation], timeout: 5)
-        
+
         XCTAssert(count == 2)
         XCTAssertEqual(expectedMultiNode1Text, "new node from the hook 1")
     }
-    
+
     func testReplaceAsyncNodeWithChainedMultiNodes() {
         let handlerExpectation = XCTestExpectation(description: "first data did not change")
-        
+
         let context = JSContext()
         var count = 0
-        
-        let resolve: AsyncHookHandler = { _,_ in
+
+        let resolve: AsyncHookHandler = { _, _ in
             handlerExpectation.fulfill()
-            
+
             if count == 1 {
                 return .multiNode([
                     ReplacementNode.concrete(context?.evaluateScript("""
-                        (
-                            {"asset": {"id": "text", "type": "text", "value":"1st value in the multinode"}}
-                           )
-                        """) ?? JSValue()),
-                    ReplacementNode.encodable(AsyncNode(id: "id"))])
+                    (
+                        {"asset": {"id": "text", "type": "text", "value":"1st value in the multinode"}}
+                       )
+                    """) ?? JSValue()),
+                    ReplacementNode.encodable(AsyncNode(id: "id")),
+                ])
             } else if count == 2 {
                 return .multiNode([
-                    ReplacementNode.encodable(AssetPlaceholderNode(asset: PlaceholderNode(id: "text-2", type: "text", value: "2nd value in the multinode"))),
-                    ReplacementNode.encodable(AsyncNode(id: "id-1"))])
+                    ReplacementNode.encodable(AssetPlaceholderNode(asset: PlaceholderNode(
+                        id: "text-2",
+                        type: "text",
+                        value: "2nd value in the multinode"
+                    ))),
+                    ReplacementNode.encodable(AsyncNode(id: "id-1")),
+                ])
             } else if count == 3 {
                 return .singleNode(ReplacementNode.encodable(
-                    AssetPlaceholderNode(asset: PlaceholderNode(id: "text", type: "text", value: "3rd value in the multinode"))
+                    AssetPlaceholderNode(asset: PlaceholderNode(
+                        id: "text",
+                        type: "text",
+                        value: "3rd value in the multinode"
+                    ))
                 ))
             }
-            
+
             return .singleNode(ReplacementNode.concrete(context?.evaluateScript("") ?? JSValue()))
         }
-        
+
         let asyncNodePluginPlugin = AsyncNodePluginPlugin()
         let plugin = AsyncNodePlugin(plugins: [asyncNodePluginPlugin], asyncHookHandler: resolve)
-        
+
         plugin.context = context
-        
+
         XCTAssertNotNil(asyncNodePluginPlugin.context)
-        
-        let player = HeadlessPlayerImpl(plugins: [ReferenceAssetsPlugin(), plugin], context: context ?? JSContext())
-        
+
+        let player = HeadlessPlayerImpl(
+            plugins: [ReferenceAssetsPlugin(), plugin],
+            context: context ?? JSContext()
+        )
+
         let textExpectation = XCTestExpectation(description: "newText found")
         let textExpectation2 = XCTestExpectation(description: "newText found")
         let textExpectation3 = XCTestExpectation(description: "newText found")
-        
-        var expectedMultiNode1Text: String = ""
-        var expectedMultiNode2Text: String = ""
-        var expectedMultiNode3Text: String = ""
-        
-        player.hooks?.viewController.tap({ (viewController) in
-            viewController.hooks.view.tap { (view) in
+
+        var expectedMultiNode1Text = ""
+        var expectedMultiNode2Text = ""
+        var expectedMultiNode3Text = ""
+
+        player.hooks?.viewController.tap { viewController in
+            viewController.hooks.view.tap { view in
                 view.hooks.onUpdate.tap { val in
                     count += 1
-                    
+
                     if count == 2 {
                         let newText1 = val
                             .objectForKeyedSubscript("values")
@@ -180,12 +196,13 @@ class AsyncNodePluginTests: XCTestCase {
                             .objectAtIndexedSubscript(0)
                             .objectForKeyedSubscript("asset")
                             .objectForKeyedSubscript("value")
-                        guard let textString1 = newText1?.toString() else { return XCTFail("newText was not a string") }
-                        
+                        guard let textString1 = newText1?.toString()
+                        else { return XCTFail("newText was not a string") }
+
                         expectedMultiNode1Text = textString1
                         textExpectation.fulfill()
                     }
-                    
+
                     if count == 3 {
                         let newText2 = val
                             .objectForKeyedSubscript("values")
@@ -194,13 +211,14 @@ class AsyncNodePluginTests: XCTestCase {
                             .objectAtIndexedSubscript(0)
                             .objectForKeyedSubscript("asset")
                             .objectForKeyedSubscript("value")
-                        guard let textString2 = newText2?.toString() else { return XCTFail("newText was not a string") }
-                        
+                        guard let textString2 = newText2?.toString()
+                        else { return XCTFail("newText was not a string") }
+
                         expectedMultiNode2Text = textString2
-                        
+
                         textExpectation2.fulfill()
                     }
-                    
+
                     if count == 4 {
                         let newText3 = val
                             .objectForKeyedSubscript("values")
@@ -209,47 +227,52 @@ class AsyncNodePluginTests: XCTestCase {
                             .objectAtIndexedSubscript(1)
                             .objectForKeyedSubscript("asset")
                             .objectForKeyedSubscript("value")
-                        guard let textString3 = newText3?.toString() else { return XCTFail("newText was not a string") }
-                        
+                        guard let textString3 = newText3?.toString()
+                        else { return XCTFail("newText was not a string") }
+
                         expectedMultiNode3Text = textString3
                         textExpectation3.fulfill()
                     }
                 }
             }
-        })
-        
-        player.start(flow: .asyncNodeJson, completion: { _ in})
-        
+        }
+
+        player.start(flow: .asyncNodeJson, completion: { _ in })
+
         wait(for: [handlerExpectation, textExpectation], timeout: 5)
-        
+
         XCTAssert(count == 2)
         XCTAssertEqual(expectedMultiNode1Text, "1st value in the multinode")
-        
+
         wait(for: [textExpectation2], timeout: 6)
-        
+
         XCTAssert(count == 3)
         XCTAssertEqual(expectedMultiNode2Text, "2nd value in the multinode")
-        
+
         wait(for: [textExpectation3], timeout: 7)
-        
+
         XCTAssert(count == 4)
         XCTAssertEqual(expectedMultiNode3Text, "3rd value in the multinode")
     }
-    
+
     func testAsyncNodeReplacementWithChainedMultiNodesSinglular() {
         let handlerExpectation = XCTestExpectation(description: "first data did not change")
-        
+
         let context = JSContext()
-        
+
         var count = 0
-        
-        let resolve: AsyncHookHandler = { _,_ in
+
+        let resolve: AsyncHookHandler = { _, _ in
             handlerExpectation.fulfill()
-            
+
             if count == 1 {
                 return .multiNode([
-                    ReplacementNode.encodable(AssetPlaceholderNode(asset: PlaceholderNode(id: "text", type: "text", value: "new node from the hook 1"))),
-                    ReplacementNode.encodable(AsyncNode(id: "id"))
+                    ReplacementNode.encodable(AssetPlaceholderNode(asset: PlaceholderNode(
+                        id: "text",
+                        type: "text",
+                        value: "new node from the hook 1"
+                    ))),
+                    ReplacementNode.encodable(AsyncNode(id: "id")),
                 ])
             } else if count == 2 {
                 return .singleNode(.concrete(context?.evaluateScript("""
@@ -258,30 +281,33 @@ class AsyncNodePluginTests: XCTestCase {
                    )
                 """) ?? JSValue()))
             }
-            
+
             return .singleNode(ReplacementNode.concrete(context?.evaluateScript("") ?? JSValue()))
         }
-        
+
         let asyncNodePluginPlugin = AsyncNodePluginPlugin()
         let plugin = AsyncNodePlugin(plugins: [asyncNodePluginPlugin], asyncHookHandler: resolve)
-        
+
         plugin.context = context
-        
+
         XCTAssertNotNil(asyncNodePluginPlugin.context)
-        
-        let player = HeadlessPlayerImpl(plugins: [ReferenceAssetsPlugin(), plugin], context: context ?? JSContext())
-        
+
+        let player = HeadlessPlayerImpl(
+            plugins: [ReferenceAssetsPlugin(), plugin],
+            context: context ?? JSContext()
+        )
+
         let textExpectation = XCTestExpectation(description: "newText found")
         let textExpectation2 = XCTestExpectation(description: "newText found")
-        
-        var expectedMultiNode1Text: String = ""
-        var expectedMultiNode2Text: String = ""
-        
-        player.hooks?.viewController.tap({ (viewController) in
-            viewController.hooks.view.tap { (view) in
+
+        var expectedMultiNode1Text = ""
+        var expectedMultiNode2Text = ""
+
+        player.hooks?.viewController.tap { viewController in
+            viewController.hooks.view.tap { view in
                 view.hooks.onUpdate.tap { val in
                     count += 1
-                    
+
                     if count == 2 {
                         let newText1 = val
                             .objectForKeyedSubscript("values")
@@ -289,12 +315,13 @@ class AsyncNodePluginTests: XCTestCase {
                             .objectAtIndexedSubscript(0)
                             .objectForKeyedSubscript("asset")
                             .objectForKeyedSubscript("value")
-                        guard let textString1 = newText1?.toString() else { return XCTFail("newText was not a string") }
-                        
+                        guard let textString1 = newText1?.toString()
+                        else { return XCTFail("newText was not a string") }
+
                         expectedMultiNode1Text = textString1
                         textExpectation.fulfill()
                     }
-                    
+
                     if count == 3 {
                         let newText2 = val
                             .objectForKeyedSubscript("values")
@@ -302,190 +329,191 @@ class AsyncNodePluginTests: XCTestCase {
                             .objectAtIndexedSubscript(1)
                             .objectForKeyedSubscript("asset")
                             .objectForKeyedSubscript("value")
-                        guard let textString2 = newText2?.toString() else { return XCTFail("newText was not a string") }
-                        
+                        guard let textString2 = newText2?.toString()
+                        else { return XCTFail("newText was not a string") }
+
                         expectedMultiNode2Text = textString2
                         textExpectation2.fulfill()
-                        
                     }
                 }
             }
-        })
-        
-        player.start(flow: .asyncNodeJson, completion: { _ in})
-        
+        }
+
+        player.start(flow: .asyncNodeJson, completion: { _ in })
+
         wait(for: [handlerExpectation, textExpectation], timeout: 5)
-        
+
         XCTAssert(count == 2)
         XCTAssertEqual(expectedMultiNode1Text, "new node from the hook 1")
-        
+
         wait(for: [textExpectation2], timeout: 5)
-        
+
         XCTAssert(count == 3)
         XCTAssertEqual(expectedMultiNode2Text, "new node from the hook 2")
     }
-    
-    func testHandleEmptyNode() {
+
+    func testHandleEmptyNode() throws {
         let handlerExpectation = XCTestExpectation(description: "first data did not change")
-        
-        guard let context = JSContext() else {
-            XCTFail("JSContext initialization failed")
-            return
-        }
-        
+
+        let context = try XCTUnwrap(JSContext(), "JSContext initialization failed")
+
         var count = 0
         var args: JSValue?
         var callbackFunction: JSValue?
-        
-        let resolve: AsyncHookHandler = { node, callback in
+
+        let resolve: AsyncHookHandler = { _, callback in
             handlerExpectation.fulfill()
             callbackFunction = callback
-            
+
             return .singleNode(.concrete(context.evaluateScript("""
-            (
-                {"asset": {"id": "text", "type": "text", "value":"new node from the hook 1"}}
-            )
-        """) ?? JSValue()))
+                (
+                    {"asset": {"id": "text", "type": "text", "value":"new node from the hook 1"}}
+                )
+            """) ?? JSValue()))
         }
-        
+
         let asyncNodePluginPlugin = AsyncNodePluginPlugin()
         let plugin = AsyncNodePlugin(plugins: [asyncNodePluginPlugin], asyncHookHandler: resolve)
-        
+
         plugin.context = context
-        
+
         XCTAssertNotNil(asyncNodePluginPlugin.context)
-        
-        let player = HeadlessPlayerImpl(plugins: [ReferenceAssetsPlugin(), plugin], context: context)
-        
+
+        let player = HeadlessPlayerImpl(
+            plugins: [ReferenceAssetsPlugin(), plugin],
+            context: context
+        )
+
         let textExpectation = XCTestExpectation(description: "newText found")
         let textExpectation2 = XCTestExpectation(description: "newText found")
-        
-        var expectedMultiNode1Text: String = ""
-        var expectedMultiNode2Text: String = ""
-        
-        player.hooks?.viewController.tap({ (viewController) in
-            viewController.hooks.view.tap { (view) in
+
+        var expectedMultiNode1Text = ""
+        var expectedMultiNode2Text = ""
+
+        player.hooks?.viewController.tap { viewController in
+            viewController.hooks.view.tap { view in
                 view.hooks.onUpdate.tap { val in
                     count += 1
-                    
+
                     if count == 2 {
                         let newText1 = val
                             .objectForKeyedSubscript("values")
                             .objectAtIndexedSubscript(1)
                             .objectForKeyedSubscript("asset")
                             .objectForKeyedSubscript("value")
-                        guard let textString1 = newText1?.toString() else { return XCTFail("newText was not a string") }
-                        
+                        guard let textString1 = newText1?.toString()
+                        else { return XCTFail("newText was not a string") }
+
                         expectedMultiNode1Text = textString1
                         textExpectation.fulfill()
                     }
-                    
+
                     if count == 3 {
                         let newText2 = val
                             .objectForKeyedSubscript("values")
                             .objectAtIndexedSubscript(1)
                             .objectForKeyedSubscript("asset")
                             .objectForKeyedSubscript("value")
-                        guard let textString2 = newText2?.toString() else { return XCTFail("newText was not a string") }
-                        
+                        guard let textString2 = newText2?.toString()
+                        else { return XCTFail("newText was not a string") }
+
                         expectedMultiNode2Text = textString2
                         textExpectation2.fulfill()
                     }
                 }
             }
-        })
-        
-        player.start(flow: .asyncNodeJson, completion: { _ in})
-        
+        }
+
+        player.start(flow: .asyncNodeJson, completion: { _ in })
+
         wait(for: [handlerExpectation, textExpectation], timeout: 5)
-        
+
         XCTAssert(count == 2)
         XCTAssertEqual(expectedMultiNode1Text, "new node from the hook 1")
-        
+
         let replacementResult = AsyncNodeHandlerType.emptyNode
-        
+
         args = replacementResult.handlerTypeToJSValue(context: context ?? JSContext())
-        
-        let _ = callbackFunction?.call(withArguments: [args])
-        
+
+        _ = callbackFunction?.call(withArguments: [args])
+
         XCTAssert(count == 3)
         XCTAssertEqual(expectedMultiNode2Text, "undefined")
     }
-    
-    
-    func testHandleMultipleUpdatesThroughCallback() {
-        
+
+    func testHandleMultipleUpdatesThroughCallback() throws {
         let handlerExpectation = XCTestExpectation(description: "first data did not change")
-        
-        guard let context = JSContext() else {
-            XCTFail("JSContext initialization failed")
-            return
-        }
-        
+
+        let context = try XCTUnwrap(JSContext(), "JSContext initialization failed")
+
         var count = 0
         var args: JSValue?
         var callbackFunction: JSValue?
-        
-        let resolve: AsyncHookHandler = { node, callback in
+
+        let resolve: AsyncHookHandler = { _, callback in
             handlerExpectation.fulfill()
             callbackFunction = callback
-            
+
             return .singleNode(.concrete(context.evaluateScript("""
-            (
-                {"asset": {"id": "text", "type": "text", "value":"new node from the hook 1"}}
-            )
-        """) ?? JSValue()))
+                (
+                    {"asset": {"id": "text", "type": "text", "value":"new node from the hook 1"}}
+                )
+            """) ?? JSValue()))
         }
-        
+
         let asyncNodePluginPlugin = AsyncNodePluginPlugin()
         let plugin = AsyncNodePlugin(plugins: [asyncNodePluginPlugin], asyncHookHandler: resolve)
-        
+
         plugin.context = context
-        
+
         XCTAssertNotNil(asyncNodePluginPlugin.context)
-        
-        let player = HeadlessPlayerImpl(plugins: [ReferenceAssetsPlugin(), plugin], context: context)
-        
+
+        let player = HeadlessPlayerImpl(
+            plugins: [ReferenceAssetsPlugin(), plugin],
+            context: context
+        )
+
         let textExpectation = XCTestExpectation(description: "newText found")
         let textExpectation2 = XCTestExpectation(description: "newText found")
         let textExpectation3 = XCTestExpectation(description: "newText found")
-        
-        var expectedMultiNode1Text: String = ""
-        var expectedMultiNode2Text: String = ""
-        var expectedMultiNode3Text: String = ""
-        var expectedMultiNode4Text: String = ""
-        
-        player.hooks?.viewController.tap({ (viewController) in
-            viewController.hooks.view.tap { (view) in
+
+        var expectedMultiNode1Text = ""
+        var expectedMultiNode2Text = ""
+        var expectedMultiNode3Text = ""
+        var expectedMultiNode4Text = ""
+
+        player.hooks?.viewController.tap { viewController in
+            viewController.hooks.view.tap { view in
                 view.hooks.onUpdate.tap { val in
                     count += 1
-                    
+
                     if count == 2 {
                         let newText1 = val
                             .objectForKeyedSubscript("values")
                             .objectAtIndexedSubscript(1)
                             .objectForKeyedSubscript("asset")
                             .objectForKeyedSubscript("value")
-                        guard let textString1 = newText1?.toString() else { return XCTFail("newText was not a string") }
-                        
+                        guard let textString1 = newText1?.toString()
+                        else { return XCTFail("newText was not a string") }
+
                         expectedMultiNode1Text = textString1
                         textExpectation.fulfill()
                     }
-                    
+
                     if count == 3 {
                         let newText2 = val
                             .objectForKeyedSubscript("values")
                             .objectAtIndexedSubscript(1)
                             .objectForKeyedSubscript("asset")
                             .objectForKeyedSubscript("value")
-                        guard let textString2 = newText2?.toString() else { return XCTFail("newText was not a string") }
-                        
+                        guard let textString2 = newText2?.toString()
+                        else { return XCTFail("newText was not a string") }
+
                         expectedMultiNode2Text = textString2
                         textExpectation2.fulfill()
                     }
-                    
+
                     if count == 4 {
-                        
                         let newText3 = val
                             .objectForKeyedSubscript("values")
                             .objectAtIndexedSubscript(0)
@@ -493,475 +521,498 @@ class AsyncNodePluginTests: XCTestCase {
                             .objectForKeyedSubscript("label")
                             .objectForKeyedSubscript("asset")
                             .objectForKeyedSubscript("value")
-                        guard let textString3 = newText3?.toString() else { return XCTFail("newText was not a string") }
-                        
+                        guard let textString3 = newText3?.toString()
+                        else { return XCTFail("newText was not a string") }
+
                         let newText4 = val
                             .objectForKeyedSubscript("values")
                             .objectAtIndexedSubscript(1)
                             .objectForKeyedSubscript("asset")
                             .objectForKeyedSubscript("value")
-                        guard let textString4 = newText4?.toString() else { return XCTFail("newText was not a string") }
-                        
+                        guard let textString4 = newText4?.toString()
+                        else { return XCTFail("newText was not a string") }
+
                         expectedMultiNode3Text = textString3
                         expectedMultiNode4Text = textString4
                         textExpectation3.fulfill()
                     }
                 }
             }
-        })
-        
-        player.start(flow: .asyncNodeJson, completion: { _ in})
-        
+        }
+
+        player.start(flow: .asyncNodeJson, completion: { _ in })
+
         wait(for: [handlerExpectation, textExpectation], timeout: 5)
-        
+
         XCTAssert(count == 2)
         XCTAssertEqual(expectedMultiNode1Text, "new node from the hook 1")
-        
+
         var replacementResult = AsyncNodeHandlerType.singleNode(.concrete(context.evaluateScript("""
-                (
-                    {"asset": {"id": "text", "type": "text", "value":"new node from the hook 2"}}
-                )
-            """) ?? JSValue()))
-        
+            (
+                {"asset": {"id": "text", "type": "text", "value":"new node from the hook 2"}}
+            )
+        """) ?? JSValue()))
+
         args = replacementResult.handlerTypeToJSValue(context: context ?? JSContext())
-        
-        let _ = callbackFunction?.call(withArguments: [args])
-        
+
+        _ = callbackFunction?.call(withArguments: [args])
+
         XCTAssert(count == 3)
         XCTAssertEqual(expectedMultiNode2Text, "new node from the hook 2")
-        
-        
+
         wait(for: [textExpectation2], timeout: 5)
-        
+
         replacementResult = AsyncNodeHandlerType.emptyNode
-        
+
         args = replacementResult.handlerTypeToJSValue(context: context ?? JSContext())
-        
+
         _ = callbackFunction?.call(withArguments: [args])
-        
+
         XCTAssert(count == 4)
         // asset that the value at index 0 for the object
         XCTAssertEqual(expectedMultiNode3Text, "test")
         XCTAssertEqual(expectedMultiNode4Text, "undefined")
     }
-    
+
     func testChatMessageReplaceAsyncNodeWithProvidedNode() {
-       let handlerExpectation = XCTestExpectation(description: "first data did not change")
-       
-       let context = JSContext()
-       var count = 0
-       
-       let resolve: AsyncHookHandler = { _,_ in
-           handlerExpectation.fulfill()
-           
-           if count == 1 {
-               return .singleNode(ReplacementNode.encodable(
-                   AssetPlaceholderNode(asset: PlaceholderNode(id: "text", type: "text", value: "new node"))
-               ))
-           }
-           
-           return .singleNode(ReplacementNode.concrete(context?.evaluateScript("") ?? JSValue()))
-       }
-       
-       let asyncNodePluginPlugin = AsyncNodePluginPlugin()
-        let plugin = AsyncNodePlugin(plugins: [asyncNodePluginPlugin], asyncHookHandler: resolve)
-       
-       plugin.context = context
-       
-       XCTAssertNotNil(asyncNodePluginPlugin.context)
-
-       let player = HeadlessPlayerImpl(plugins: [ReferenceAssetsPlugin(), plugin], context: context ?? JSContext())
-
-       let textExpectation = XCTestExpectation(description: "newText found")
-       
-       var expectedNode1Text: String = ""
-       
-       player.hooks?.viewController.tap({ (viewController) in
-           viewController.hooks.view.tap { (view) in
-               view.hooks.onUpdate.tap { val in
-                   count += 1
-                   
-                   if count == 2 {
-                       let newText1 = val
-                           .objectForKeyedSubscript("values")
-                           .objectAtIndexedSubscript(1)
-                           .objectForKeyedSubscript("asset")
-                           .objectForKeyedSubscript("value")
-                       guard let textString1 = newText1?.toString() else { return XCTFail("newText was not a string") }
-                       
-                       expectedNode1Text = textString1
-                       textExpectation.fulfill()
-                   }
-               }
-           }
-       })
-       
-       player.start(flow: .chatMessageJson, completion: { _ in})
-       
-       wait(for: [handlerExpectation, textExpectation], timeout: 5)
-       
-       XCTAssert(count == 2)
-       XCTAssertEqual(expectedNode1Text, "new node")
-    }
-    
-    func testChatMessageReplaceAsyncNodeWithChatMessageAsset() {
         let handlerExpectation = XCTestExpectation(description: "first data did not change")
-        
+
         let context = JSContext()
         var count = 0
-        
-        let resolve: AsyncHookHandler = { _,_ in
+
+        let resolve: AsyncHookHandler = { _, _ in
             handlerExpectation.fulfill()
-            
+
             if count == 1 {
-                return .singleNode(.concrete(context?.evaluateScript("""
-                        ({"asset": {"id": "2", "type": "chat-message", "value": {
-                        "asset": {
-                              "id": "text2",
-                               "type": "text",
-                               "value": "chat message2",
-                             }}}})
-                        """) ?? JSValue()))
+                return .singleNode(ReplacementNode.encodable(
+                    AssetPlaceholderNode(asset: PlaceholderNode(
+                        id: "text",
+                        type: "text",
+                        value: "new node"
+                    ))
+                ))
             }
-            
+
             return .singleNode(ReplacementNode.concrete(context?.evaluateScript("") ?? JSValue()))
         }
-        
+
         let asyncNodePluginPlugin = AsyncNodePluginPlugin()
         let plugin = AsyncNodePlugin(plugins: [asyncNodePluginPlugin], asyncHookHandler: resolve)
-        
+
         plugin.context = context
-        
+
         XCTAssertNotNil(asyncNodePluginPlugin.context)
 
-        let player = HeadlessPlayerImpl(plugins: [ReferenceAssetsPlugin(), plugin], context: context ?? JSContext())
-        
+        let player = HeadlessPlayerImpl(
+            plugins: [ReferenceAssetsPlugin(), plugin],
+            context: context ?? JSContext()
+        )
+
         let textExpectation = XCTestExpectation(description: "newText found")
-        
-        var expectedNode1Text: String = ""
-        
-        player.hooks?.viewController.tap({ (viewController) in
-            viewController.hooks.view.tap { (view) in
+
+        var expectedNode1Text = ""
+
+        player.hooks?.viewController.tap { viewController in
+            viewController.hooks.view.tap { view in
                 view.hooks.onUpdate.tap { val in
                     count += 1
-                    
+
                     if count == 2 {
                         let newText1 = val
                             .objectForKeyedSubscript("values")
                             .objectAtIndexedSubscript(1)
                             .objectForKeyedSubscript("asset")
                             .objectForKeyedSubscript("value")
-                        guard let textString1 = newText1?.toString() else { return XCTFail("newText was not a string") }
-                        
+                        guard let textString1 = newText1?.toString()
+                        else { return XCTFail("newText was not a string") }
+
                         expectedNode1Text = textString1
                         textExpectation.fulfill()
                     }
                 }
             }
-        })
-        
-        player.start(flow: .chatMessageJson, completion: { _ in})
-        
+        }
+
+        player.start(flow: .chatMessageJson, completion: { _ in })
+
         wait(for: [handlerExpectation, textExpectation], timeout: 5)
-        
+
         XCTAssert(count == 2)
-        XCTAssertEqual(expectedNode1Text, "chat message2")
+        XCTAssertEqual(expectedNode1Text, "new node")
     }
-    
-    func testChatMessageReplaceAsyncNodeWithChainedChatMessageAsset() {
+
+    func testChatMessageReplaceAsyncNodeWithChatMessageAsset() {
         let handlerExpectation = XCTestExpectation(description: "first data did not change")
-        
+
         let context = JSContext()
         var count = 0
-        
-        let resolve: AsyncHookHandler = { _,_ in
+
+        let resolve: AsyncHookHandler = { _, _ in
             handlerExpectation.fulfill()
-            
+
             if count == 1 {
                 return .singleNode(.concrete(context?.evaluateScript("""
-                        ({"asset": {"id": "2", "type": "chat-message", "value": {
-                        "asset": {
-                              "id": "text2",
-                               "type": "text",
-                               "value": "chat message2",
-                             }}}})
-                        """) ?? JSValue()))
-
-            } else if count == 2 {
-                return .singleNode(ReplacementNode.encodable(
-                    AssetPlaceholderNode(asset: PlaceholderNode(id: "text", type: "text", value: "chained chat message"))
-                ))
+                ({"asset": {"id": "2", "type": "chat-message", "value": {
+                "asset": {
+                      "id": "text2",
+                       "type": "text",
+                       "value": "chat message2",
+                     }}}})
+                """) ?? JSValue()))
             }
-            
+
             return .singleNode(ReplacementNode.concrete(context?.evaluateScript("") ?? JSValue()))
         }
-        
+
         let asyncNodePluginPlugin = AsyncNodePluginPlugin()
         let plugin = AsyncNodePlugin(plugins: [asyncNodePluginPlugin], asyncHookHandler: resolve)
-        
+
         plugin.context = context
-        
+
         XCTAssertNotNil(asyncNodePluginPlugin.context)
 
-        let player = HeadlessPlayerImpl(plugins: [ReferenceAssetsPlugin(), plugin], context: context ?? JSContext())
-        
-        let textExpectation = XCTestExpectation(description: "newText found")
-        let textExpectation2 = XCTestExpectation(description: "newText found")
+        let player = HeadlessPlayerImpl(
+            plugins: [ReferenceAssetsPlugin(), plugin],
+            context: context ?? JSContext()
+        )
 
-        var expectedNode1Text: String = ""
-        var expectedNode2Text: String = ""
-        
-        player.hooks?.viewController.tap({ (viewController) in
-            viewController.hooks.view.tap { (view) in
+        let textExpectation = XCTestExpectation(description: "newText found")
+
+        var expectedNode1Text = ""
+
+        player.hooks?.viewController.tap { viewController in
+            viewController.hooks.view.tap { view in
                 view.hooks.onUpdate.tap { val in
                     count += 1
-                    
+
                     if count == 2 {
                         let newText1 = val
                             .objectForKeyedSubscript("values")
                             .objectAtIndexedSubscript(1)
                             .objectForKeyedSubscript("asset")
                             .objectForKeyedSubscript("value")
-                        guard let textString1 = newText1?.toString() else { return XCTFail("newText was not a string") }
-                        
+                        guard let textString1 = newText1?.toString()
+                        else { return XCTFail("newText was not a string") }
+
                         expectedNode1Text = textString1
                         textExpectation.fulfill()
                     }
-                    
+                }
+            }
+        }
+
+        player.start(flow: .chatMessageJson, completion: { _ in })
+
+        wait(for: [handlerExpectation, textExpectation], timeout: 5)
+
+        XCTAssert(count == 2)
+        XCTAssertEqual(expectedNode1Text, "chat message2")
+    }
+
+    func testChatMessageReplaceAsyncNodeWithChainedChatMessageAsset() {
+        let handlerExpectation = XCTestExpectation(description: "first data did not change")
+
+        let context = JSContext()
+        var count = 0
+
+        let resolve: AsyncHookHandler = { _, _ in
+            handlerExpectation.fulfill()
+
+            if count == 1 {
+                return .singleNode(.concrete(context?.evaluateScript("""
+                ({"asset": {"id": "2", "type": "chat-message", "value": {
+                "asset": {
+                      "id": "text2",
+                       "type": "text",
+                       "value": "chat message2",
+                     }}}})
+                """) ?? JSValue()))
+
+            } else if count == 2 {
+                return .singleNode(ReplacementNode.encodable(
+                    AssetPlaceholderNode(asset: PlaceholderNode(
+                        id: "text",
+                        type: "text",
+                        value: "chained chat message"
+                    ))
+                ))
+            }
+
+            return .singleNode(ReplacementNode.concrete(context?.evaluateScript("") ?? JSValue()))
+        }
+
+        let asyncNodePluginPlugin = AsyncNodePluginPlugin()
+        let plugin = AsyncNodePlugin(plugins: [asyncNodePluginPlugin], asyncHookHandler: resolve)
+
+        plugin.context = context
+
+        XCTAssertNotNil(asyncNodePluginPlugin.context)
+
+        let player = HeadlessPlayerImpl(
+            plugins: [ReferenceAssetsPlugin(), plugin],
+            context: context ?? JSContext()
+        )
+
+        let textExpectation = XCTestExpectation(description: "newText found")
+        let textExpectation2 = XCTestExpectation(description: "newText found")
+
+        var expectedNode1Text = ""
+        var expectedNode2Text = ""
+
+        player.hooks?.viewController.tap { viewController in
+            viewController.hooks.view.tap { view in
+                view.hooks.onUpdate.tap { val in
+                    count += 1
+
+                    if count == 2 {
+                        let newText1 = val
+                            .objectForKeyedSubscript("values")
+                            .objectAtIndexedSubscript(1)
+                            .objectForKeyedSubscript("asset")
+                            .objectForKeyedSubscript("value")
+                        guard let textString1 = newText1?.toString()
+                        else { return XCTFail("newText was not a string") }
+
+                        expectedNode1Text = textString1
+                        textExpectation.fulfill()
+                    }
+
                     if count == 3 {
                         let newText2 = val
                             .objectForKeyedSubscript("values")
                             .objectAtIndexedSubscript(2)
                             .objectForKeyedSubscript("asset")
                             .objectForKeyedSubscript("value")
-                        guard let textString2 = newText2?.toString() else { return XCTFail("newText was not a string") }
-                        
+                        guard let textString2 = newText2?.toString()
+                        else { return XCTFail("newText was not a string") }
+
                         expectedNode2Text = textString2
                         textExpectation2.fulfill()
                     }
                 }
             }
-        })
-        
-        player.start(flow: .chatMessageJson, completion: { _ in})
-        
+        }
+
+        player.start(flow: .chatMessageJson, completion: { _ in })
+
         wait(for: [handlerExpectation, textExpectation], timeout: 5)
-        
+
         XCTAssertEqual(expectedNode1Text, "chat message2")
 
         wait(for: [textExpectation2], timeout: 5)
         XCTAssertEqual(expectedNode2Text, "chained chat message")
     }
-    
-    
-    func testChatMessageHandleMultipleUpdatesThroughCallback() {
-        
+
+    func testChatMessageHandleMultipleUpdatesThroughCallback() throws {
         let handlerExpectation = XCTestExpectation(description: "first data did not change")
-        
-        guard let context = JSContext() else {
-            XCTFail("JSContext initialization failed")
-            return
-        }
-        
+
+        let context = try XCTUnwrap(JSContext(), "JSContext initialization failed")
+
         var count = 0
         var args: JSValue?
         var callbackFunction: JSValue?
-        
-        let resolve: AsyncHookHandler = { node, callback in
+
+        let resolve: AsyncHookHandler = { _, callback in
             handlerExpectation.fulfill()
             callbackFunction = callback
-            
+
             return .singleNode(.concrete(context.evaluateScript("""
-            (
-                {"asset": {"id": "text", "type": "text", "value":"new node from the hook 1"}}
-            )
-        """) ?? JSValue()))
+                (
+                    {"asset": {"id": "text", "type": "text", "value":"new node from the hook 1"}}
+                )
+            """) ?? JSValue()))
         }
-        
+
         let asyncNodePluginPlugin = AsyncNodePluginPlugin()
         let plugin = AsyncNodePlugin(plugins: [asyncNodePluginPlugin], asyncHookHandler: resolve)
-        
+
         plugin.context = context
-        
+
         XCTAssertNotNil(asyncNodePluginPlugin.context)
-        
-        let player = HeadlessPlayerImpl(plugins: [ReferenceAssetsPlugin(), plugin], context: context)
-        
+
+        let player = HeadlessPlayerImpl(
+            plugins: [ReferenceAssetsPlugin(), plugin],
+            context: context
+        )
+
         let textExpectation = XCTestExpectation(description: "newText found")
         let textExpectation2 = XCTestExpectation(description: "newText found")
         let textExpectation3 = XCTestExpectation(description: "newText found")
-        
-        var expectedMultiNode1Text: String = ""
-        var expectedMultiNode2Text: String = ""
-        var expectedMultiNode3Text: String = ""
-        var expectedMultiNode4Text: String = ""
-        
-        player.hooks?.viewController.tap({ (viewController) in
-            viewController.hooks.view.tap { (view) in
+
+        var expectedMultiNode1Text = ""
+        var expectedMultiNode2Text = ""
+        var expectedMultiNode3Text = ""
+        var expectedMultiNode4Text = ""
+
+        player.hooks?.viewController.tap { viewController in
+            viewController.hooks.view.tap { view in
                 view.hooks.onUpdate.tap { val in
                     count += 1
-                    
+
                     if count == 2 {
                         let newText1 = val
                             .objectForKeyedSubscript("values")
                             .objectAtIndexedSubscript(1)
                             .objectForKeyedSubscript("asset")
                             .objectForKeyedSubscript("value")
-                        guard let textString1 = newText1?.toString() else { return XCTFail("newText was not a string") }
-                        
+                        guard let textString1 = newText1?.toString()
+                        else { return XCTFail("newText was not a string") }
+
                         expectedMultiNode1Text = textString1
                         textExpectation.fulfill()
                     }
-                    
+
                     if count == 3 {
                         let newText2 = val
                             .objectForKeyedSubscript("values")
                             .objectAtIndexedSubscript(1)
                             .objectForKeyedSubscript("asset")
                             .objectForKeyedSubscript("value")
-                        guard let textString2 = newText2?.toString() else { return XCTFail("newText was not a string") }
-                        
+                        guard let textString2 = newText2?.toString()
+                        else { return XCTFail("newText was not a string") }
+
                         expectedMultiNode2Text = textString2
                         textExpectation2.fulfill()
                     }
-                    
+
                     if count == 4 {
-                        
                         let newText3 = val
                             .objectForKeyedSubscript("values")
                             .objectAtIndexedSubscript(0)
                             .objectForKeyedSubscript("asset")
                             .objectForKeyedSubscript("value")
-                        guard let textString3 = newText3?.toString() else { return XCTFail("newText was not a string") }
-                        
+                        guard let textString3 = newText3?.toString()
+                        else { return XCTFail("newText was not a string") }
+
                         let newText4 = val
                             .objectForKeyedSubscript("values")
                             .objectAtIndexedSubscript(1)
                             .objectForKeyedSubscript("asset")
                             .objectForKeyedSubscript("value")
-                        guard let textString4 = newText4?.toString() else { return XCTFail("newText was not a string") }
-                        
+                        guard let textString4 = newText4?.toString()
+                        else { return XCTFail("newText was not a string") }
+
                         expectedMultiNode3Text = textString3
                         expectedMultiNode4Text = textString4
                         textExpectation3.fulfill()
                     }
                 }
             }
-        })
-        
-        player.start(flow: .chatMessageJson, completion: { _ in})
-        
+        }
+
+        player.start(flow: .chatMessageJson, completion: { _ in })
+
         wait(for: [handlerExpectation, textExpectation], timeout: 5)
-        
+
         XCTAssert(count == 2)
         XCTAssertEqual(expectedMultiNode1Text, "new node from the hook 1")
-        
+
         var replacementResult = AsyncNodeHandlerType.singleNode(.concrete(context.evaluateScript("""
-                (
-                    {"asset": {"id": "text", "type": "text", "value":"new node from the hook 2"}}
-                )
-            """) ?? JSValue()))
-        
+            (
+                {"asset": {"id": "text", "type": "text", "value":"new node from the hook 2"}}
+            )
+        """) ?? JSValue()))
+
         args = replacementResult.handlerTypeToJSValue(context: context ?? JSContext())
-        
-        let _ = callbackFunction?.call(withArguments: [args])
-        
+
+        _ = callbackFunction?.call(withArguments: [args])
+
         XCTAssert(count == 3)
         XCTAssertEqual(expectedMultiNode2Text, "new node from the hook 2")
-        
-        
+
         wait(for: [textExpectation2], timeout: 5)
-        
+
         replacementResult = AsyncNodeHandlerType.emptyNode
-        
+
         args = replacementResult.handlerTypeToJSValue(context: context ?? JSContext())
-        
+
         _ = callbackFunction?.call(withArguments: [args])
-        
+
         XCTAssert(count == 4)
         // asset that the value at index 0 for the object
         XCTAssertEqual(expectedMultiNode3Text, "chat message")
         XCTAssertEqual(expectedMultiNode4Text, "undefined")
     }
-    
-    func testConstructorWithCallback() {
-        
+
+    func testConstructorWithCallback() throws {
         let handlerExpectation = XCTestExpectation(description: "first data did not change")
-        
-        guard let context = JSContext() else {
-            XCTFail("JSContext initialization failed")
-            return
-        }
-        
+
+        let context = try XCTUnwrap(JSContext(), "JSContext initialization failed")
+
         var count = 0
         var args: JSValue?
         var callbackFunction: JSValue?
-        
-        let resolve: AsyncHookHandler = { node, callback in
+
+        let resolve: AsyncHookHandler = { _, callback in
             handlerExpectation.fulfill()
             callbackFunction = callback
-            
+
             return .singleNode(.concrete(context.evaluateScript("""
-            (
-                {"asset": {"id": "text", "type": "text", "value":"new node from the hook 1"}}
-            )
-        """) ?? JSValue()))
+                (
+                    {"asset": {"id": "text", "type": "text", "value":"new node from the hook 1"}}
+                )
+            """) ?? JSValue()))
         }
-        
+
         let asyncNodePluginPlugin = AsyncNodePluginPlugin()
         let plugin = AsyncNodePlugin(plugins: [asyncNodePluginPlugin])
-        
+
         plugin.context = context
-        
+
         XCTAssertNotNil(asyncNodePluginPlugin.context)
-        
-        plugin.hooks?.onAsyncNode.tap({ node, callback in
+
+        plugin.hooks?.onAsyncNode.tap { node, callback in
             let replacementNode = try await (resolve)(node, callback)
-            return replacementNode.handlerTypeToJSValue(context: context ?? JSContext()) ?? JSValue()
-        })
-        
-        let player = HeadlessPlayerImpl(plugins: [ReferenceAssetsPlugin(), plugin], context: context)
-        
+            return replacementNode
+                .handlerTypeToJSValue(context: context ?? JSContext()) ?? JSValue()
+        }
+
+        let player = HeadlessPlayerImpl(
+            plugins: [ReferenceAssetsPlugin(), plugin],
+            context: context
+        )
+
         let textExpectation = XCTestExpectation(description: "newText found")
         let textExpectation2 = XCTestExpectation(description: "newText found")
         let textExpectation3 = XCTestExpectation(description: "newText found")
-        
-        var expectedMultiNode1Text: String = ""
-        var expectedMultiNode2Text: String = ""
-        var expectedMultiNode3Text: String = ""
-        var expectedMultiNode4Text: String = ""
-        
-        player.hooks?.viewController.tap({ (viewController) in
-            viewController.hooks.view.tap { (view) in
+
+        var expectedMultiNode1Text = ""
+        var expectedMultiNode2Text = ""
+        var expectedMultiNode3Text = ""
+        var expectedMultiNode4Text = ""
+
+        player.hooks?.viewController.tap { viewController in
+            viewController.hooks.view.tap { view in
                 view.hooks.onUpdate.tap { val in
                     count += 1
-                    
+
                     if count == 2 {
                         let newText1 = val
                             .objectForKeyedSubscript("values")
                             .objectAtIndexedSubscript(1)
                             .objectForKeyedSubscript("asset")
                             .objectForKeyedSubscript("value")
-                        guard let textString1 = newText1?.toString() else { return XCTFail("newText was not a string") }
-                        
+                        guard let textString1 = newText1?.toString()
+                        else { return XCTFail("newText was not a string") }
+
                         expectedMultiNode1Text = textString1
                         textExpectation.fulfill()
                     }
-                    
+
                     if count == 3 {
                         let newText2 = val
                             .objectForKeyedSubscript("values")
                             .objectAtIndexedSubscript(1)
                             .objectForKeyedSubscript("asset")
                             .objectForKeyedSubscript("value")
-                        guard let textString2 = newText2?.toString() else { return XCTFail("newText was not a string") }
-                        
+                        guard let textString2 = newText2?.toString()
+                        else { return XCTFail("newText was not a string") }
+
                         expectedMultiNode2Text = textString2
                         textExpectation2.fulfill()
                     }
-                    
+
                     if count == 4 {
-                        
                         let newText3 = val
                             .objectForKeyedSubscript("values")
                             .objectAtIndexedSubscript(0)
@@ -969,132 +1020,133 @@ class AsyncNodePluginTests: XCTestCase {
                             .objectForKeyedSubscript("label")
                             .objectForKeyedSubscript("asset")
                             .objectForKeyedSubscript("value")
-                        guard let textString3 = newText3?.toString() else { return XCTFail("newText was not a string") }
-                        
+                        guard let textString3 = newText3?.toString()
+                        else { return XCTFail("newText was not a string") }
+
                         let newText4 = val
                             .objectForKeyedSubscript("values")
                             .objectAtIndexedSubscript(1)
                             .objectForKeyedSubscript("asset")
                             .objectForKeyedSubscript("value")
-                        guard let textString4 = newText4?.toString() else { return XCTFail("newText was not a string") }
-                        
+                        guard let textString4 = newText4?.toString()
+                        else { return XCTFail("newText was not a string") }
+
                         expectedMultiNode3Text = textString3
                         expectedMultiNode4Text = textString4
                         textExpectation3.fulfill()
                     }
                 }
             }
-        })
-        
-        player.start(flow: .asyncNodeJson, completion: { _ in})
-        
+        }
+
+        player.start(flow: .asyncNodeJson, completion: { _ in })
+
         wait(for: [handlerExpectation, textExpectation], timeout: 5)
-        
+
         XCTAssert(count == 2)
         XCTAssertEqual(expectedMultiNode1Text, "new node from the hook 1")
-        
+
         var replacementResult = AsyncNodeHandlerType.singleNode(.concrete(context.evaluateScript("""
-                (
-                    {"asset": {"id": "text", "type": "text", "value":"new node from the hook 2"}}
-                )
-            """) ?? JSValue()))
-        
+            (
+                {"asset": {"id": "text", "type": "text", "value":"new node from the hook 2"}}
+            )
+        """) ?? JSValue()))
+
         args = replacementResult.handlerTypeToJSValue(context: context ?? JSContext())
-        
-        let _ = callbackFunction?.call(withArguments: [args])
-        
+
+        _ = callbackFunction?.call(withArguments: [args])
+
         XCTAssert(count == 3)
         XCTAssertEqual(expectedMultiNode2Text, "new node from the hook 2")
-        
-        
+
         wait(for: [textExpectation2], timeout: 5)
-        
+
         replacementResult = AsyncNodeHandlerType.emptyNode
-        
+
         args = replacementResult.handlerTypeToJSValue(context: context ?? JSContext())
-        
+
         _ = callbackFunction?.call(withArguments: [args])
-        
+
         XCTAssert(count == 4)
         // asset that the value at index 0 for the object
         XCTAssertEqual(expectedMultiNode3Text, "test")
         XCTAssertEqual(expectedMultiNode4Text, "undefined")
     }
-    
-    enum TestError : Error {
-        case fail
-    }
-    
-    func testNodesFailure() {
+
+    func testNodesFailure() throws {
         let handlerExpectation = XCTestExpectation(description: "async node handler started")
         let errorExpectation = XCTestExpectation(description: "error was caught and handled")
-        
-        guard let context = JSContext() else {
-            XCTFail("JSContext initialization failed")
-            return
-        }
-        
+
+        let context = try XCTUnwrap(JSContext(), "JSContext initialization failed")
+
         var count = 0
-        
+
         let asyncNodePluginPlugin = AsyncNodePluginPlugin()
         let plugin = AsyncNodePlugin(plugins: [asyncNodePluginPlugin])
-        
+
         plugin.context = context
-        
-        plugin.hooks?.onAsyncNode.tap({ (node, callback) async throws -> JSValue in
+
+        plugin.hooks?.onAsyncNode.tap { _, _ async throws -> JSValue in
             handlerExpectation.fulfill()
             throw TestError.fail
-        })
-        
-        
-        plugin.hooks?.onAsyncNodeError.tap({ err, node in
+        }
+
+        plugin.hooks?.onAsyncNodeError.tap { _, _ in
             errorExpectation.fulfill()
-            
+
             return context.evaluateScript("""
-                    ({
-                        "asset": {
-                            "id": "error-asset",
-                            "type": "text",
-                            "value": "fallback"
-                        }
-                    })
-                    """) ?? JSValue()
-        })
-        
+            ({
+                "asset": {
+                    "id": "error-asset",
+                    "type": "text",
+                    "value": "fallback"
+                }
+            })
+            """) ?? JSValue()
+        }
+
         XCTAssertNotNil(asyncNodePluginPlugin.context)
-        
-        let player = HeadlessPlayerImpl(plugins: [ReferenceAssetsPlugin(), plugin], context: context)
-        
+
+        let player = HeadlessPlayerImpl(
+            plugins: [ReferenceAssetsPlugin(), plugin],
+            context: context
+        )
+
         let textExpectation = XCTestExpectation(description: "fallback asset found")
-        
-        var expectedMultiNode1Text: String = ""
-        
-        player.hooks?.viewController.tap({ (viewController) in
-            viewController.hooks.view.tap { (view) in
+
+        var expectedMultiNode1Text = ""
+
+        player.hooks?.viewController.tap { viewController in
+            viewController.hooks.view.tap { view in
                 view.hooks.onUpdate.tap { val in
                     count += 1
-                    
+
                     if count == 2 {
                         let newText1 = val
                             .objectForKeyedSubscript("values")
                             .objectAtIndexedSubscript(1)
                             .objectForKeyedSubscript("asset")
                             .objectForKeyedSubscript("value")
-                        guard let textString1 = newText1?.toString() else { return XCTFail("fallback text was not a string") }
-                        
+                        guard let textString1 = newText1?.toString()
+                        else { return XCTFail("fallback text was not a string") }
+
                         expectedMultiNode1Text = textString1
                         textExpectation.fulfill()
                     }
                 }
             }
-        })
-        
-        player.start(flow: .asyncNodeJson, completion: {_ in})
-        
+        }
+
+        player.start(flow: .asyncNodeJson, completion: { _ in })
+
         wait(for: [handlerExpectation, errorExpectation, textExpectation], timeout: 5)
-        
+
         XCTAssert(count == 2)
         XCTAssertEqual(expectedMultiNode1Text, "fallback")
+    }
+
+    enum TestError: Error {
+        case fail
     }
 }
 
@@ -1123,7 +1175,7 @@ extension String {
              },
              {
                "id": "async",
-    
+
                "async": true
              }
            ]
@@ -1192,11 +1244,11 @@ extension String {
 }
 
 struct PlaceholderNode: Codable, Equatable, AssetData {
-    public var id: String
-    public var type: String
+    var id: String
+    var type: String
     var value: String?
-    
-    public init(id: String, type: String, value: String? = nil) {
+
+    init(id: String, type: String, value: String? = nil) {
         self.id = id
         self.type = type
         self.value = value

--- a/plugins/async-node/ios/ViewInspector/AsynNodePluginViewInspectorTests.swift
+++ b/plugins/async-node/ios/ViewInspector/AsynNodePluginViewInspectorTests.swift
@@ -1,37 +1,36 @@
 //
-//  AsyncNodePluginTests.swift
+//  AsynNodePluginViewInspectorTests.swift
 //  PlayerUI
 //
 //  Created by Zhao Xia Wu on 2024-02-05.
 //
 
 import Foundation
-import XCTest
-import SwiftUI
 import JavaScriptCore
-import ViewInspector
-
 @testable import PlayerUI
-@testable import PlayerUIInternalTestUtilities
-@testable import PlayerUISwiftUI
-@testable import PlayerUIReferenceAssets
 @testable import PlayerUIAsyncNodePlugin
+@testable import PlayerUIInternalTestUtilities
+@testable import PlayerUIReferenceAssets
+@testable import PlayerUISwiftUI
+import SwiftUI
+import ViewInspector
+import XCTest
 
-extension Inspection: InspectionEmissary { }
+extension Inspection: InspectionEmissary {}
 
 class AsyncNodePluginViewInspectorTests: XCTestCase {
-    @MainActor func testAsyncNodeWithSwiftUIPlayerUsingJSValue() throws {
+    @MainActor func testAsyncNodeWithSwiftUIPlayerUsingJSValue() {
         let handlerExpectation = XCTestExpectation(description: "handler called")
         let jsContext = JSContext()
 
         let asyncNodePluginPlugin = AsyncNodePluginPlugin()
 
-        let plugin = AsyncNodePlugin(plugins: [asyncNodePluginPlugin]) { _,_ in
+        let plugin = AsyncNodePlugin(plugins: [asyncNodePluginPlugin]) { _, _ in
             handlerExpectation.fulfill()
 
             return .singleNode(.concrete(jsContext?.evaluateScript("""
-                ({"asset": {"id": "text", "type": "text", "value":"new node from the hook"}})
-                """) ?? JSValue()))
+            ({"asset": {"id": "text", "type": "text", "value":"new node from the hook"}})
+            """) ?? JSValue()))
         }
 
         plugin.context = jsContext
@@ -39,7 +38,8 @@ class AsyncNodePluginViewInspectorTests: XCTestCase {
         let context = SwiftUIPlayer.Context { jsContext ?? JSContext() }
 
         let player = SwiftUIPlayer(
-            flow: .asyncNodeJson, plugins: [ReferenceAssetsPlugin(), plugin], context: context)
+            flow: .asyncNodeJson, plugins: [ReferenceAssetsPlugin(), plugin], context: context
+        )
 
         ViewHosting.host(view: player)
 

--- a/plugins/beacon/ios/Sources/BaseBeaconPlugin.swift
+++ b/plugins/beacon/ios/Sources/BaseBeaconPlugin.swift
@@ -9,28 +9,26 @@ import Foundation
 import JavaScriptCore
 
 #if SWIFT_PACKAGE
-import PlayerUI
+    import PlayerUI
 #endif
 
-/**
- Represenation of a Beacon coming from Player
- */
+/// Represenation of a Beacon coming from Player
 public struct DefaultBeacon: Codable, Hashable {
     /// The action the user performed
     public let action: String
-    
+
     /// The element that performed the action
     public let element: String
-    
+
     /// The ID of the asset triggering the beacon
     public let assetId: String?
-    
+
     /// The ID of the view triggering the beacon
     public let viewId: String?
-    
+
     /// Additional data added from the asset or metaData
     public let data: AnyType?
-    
+
     /// Construct a ``DefaultBeacon``
     /// - Parameters:
     ///   - action: The action the user performed
@@ -38,7 +36,8 @@ public struct DefaultBeacon: Codable, Hashable {
     ///   - assetId: The ID of the asset triggering the beacon
     ///   - viewId: The ID of the view triggering the beacon
     ///   - data: Additional data added from the asset or metaData
-    public init(action: String, element: String, assetId: String?, viewId: String?, data: AnyType?) {
+    public init(action: String, element: String, assetId: String?, viewId: String?,
+                data: AnyType?) {
         self.action = action
         self.element = element
         self.assetId = assetId
@@ -47,84 +46,30 @@ public struct DefaultBeacon: Codable, Hashable {
     }
 }
 
-/**
- A Base implementation wrapping @player-ui/beacon-plugin
- Used as a base for framework specific integrations
- */
+/// A Base implementation wrapping @player-ui/beacon-plugin
+/// Used as a base for framework specific integrations
 open class BaseBeaconPlugin<BeaconStruct: Decodable>: JSBasePlugin {
-    
     public var hooks: BeaconPluginHooks?
     /// The callback to call when a beacon is fired from the plugin
     public var callback: ((BeaconStruct) -> Void)?
-    
+
     /// BeaconPluginPlugin's to use for this BeaconPlugin
     public var plugins: [JSBasePlugin] = []
-    
-    /**
-     Constructs a BeaconPlugin
-     - parameters:
-     - context: The context to load the plugin into
-     - onBeacon: A callback to receive beacon events
-     */
+
+    /// Constructs a BeaconPlugin
+    /// - parameters:
+    /// - context: The context to load the plugin into
+    /// - onBeacon: A callback to receive beacon events
     public convenience init(plugins: [JSBasePlugin] = [], onBeacon: ((BeaconStruct) -> Void)?) {
         self.init(fileName: "BeaconPlugin.native", pluginName: "BeaconPlugin.BeaconPlugin")
-        self.callback = onBeacon
+        callback = onBeacon
         self.plugins = plugins
     }
-    
-    override open func setup(context: JSContext) {
-        super.setup(context: context)
-        guard let pluginRef = self.pluginRef else {
-            fatalError("pluginRef is nil after setup")
-        }
-        self.hooks = BeaconPluginHooks(
-            buildBeacon: AsyncHook2(baseValue: pluginRef, name: "buildBeacon"),
-            cancelBeacon: Hook2(baseValue: pluginRef, name: "cancelBeacon")
-        )
-    }
-    
-    override open func getUrlForFile(fileName: String) -> URL? {
-#if SWIFT_PACKAGE
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
-#else
-        ResourceUtilities.urlForFile(
-            name: fileName,
-            ext: "js",
-            bundle: Bundle(for: BaseBeaconPlugin<DefaultBeacon>.self),
-            pathComponent: "PlayerUI_BaseBeaconPlugin.bundle"
-        )
-#endif
-    }
-    
-    /**
-     Retrieves the arguments for constructing this plugin, this is necessary because the arguments need to be supplied after
-     construction of the swift object, once the context has been provided
-     - returns: An array of arguments to construct the plugin
-     */
-    override public func getArguments() -> [Any] {
-        for plugin in plugins {
-            plugin.context = self.context
-        }
-        let callback: @convention(block) (JSValue?) -> Void = { [weak self] rawBeacon in
-            guard
-                let object = rawBeacon?.toObject(),
-                let data = try? JSONSerialization.data(withJSONObject: object),
-                let beacon = try? AnyTypeDecodingContext(rawData: data)
-                    .inject(to: JSONDecoder())
-                    .decode(BeaconStruct.self, from: data)
-            else { return }
-            self?.callback?(beacon)
-        }
-        let jsCallback = JSValue(object: callback, in: context) as Any
-        return [["callback": jsCallback, "plugins": plugins.map { $0.pluginRef }]]
-    }
-    
-    /**
-     Function to send a beacon event through the plugin for processing
-     - parameters:
-     - action: The action that was taken for the beacon
-     - args: The context of the beacon
-     */
+
+    /// Function to send a beacon event through the plugin for processing
+    /// - parameters:
+    /// - action: The action that was taken for the beacon
+    /// - args: The context of the beacon
     public func beacon(assetBeacon: AssetBeacon) {
         guard
             let beacon = try? JSONEncoder().encode(assetBeacon),
@@ -133,12 +78,61 @@ open class BaseBeaconPlugin<BeaconStruct: Decodable>: JSBasePlugin {
         else { return }
         pluginRef?.invokeMethod("beacon", withArguments: [beaconObject])
     }
-    
+
+    override open func setup(context: JSContext) {
+        super.setup(context: context)
+        guard let pluginRef else {
+            fatalError("pluginRef is nil after setup")
+        }
+        hooks = BeaconPluginHooks(
+            buildBeacon: AsyncHook2(baseValue: pluginRef, name: "buildBeacon"),
+            cancelBeacon: Hook2(baseValue: pluginRef, name: "cancelBeacon")
+        )
+    }
+
+    override open func getUrlForFile(fileName: String) -> URL? {
+        #if SWIFT_PACKAGE
+            ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
+        #else
+            ResourceUtilities.urlForFile(
+                name: fileName,
+                ext: "js",
+                bundle: Bundle(for: BaseBeaconPlugin<DefaultBeacon>.self),
+                pathComponent: "PlayerUI_BaseBeaconPlugin.bundle"
+            )
+        #endif
+    }
+
+    /// Retrieves the arguments for constructing this plugin, this is necessary because the
+    /// arguments need to be supplied after
+    /// construction of the swift object, once the context has been provided
+    /// - returns: An array of arguments to construct the plugin
+    override public func getArguments() -> [Any] {
+        for plugin in plugins {
+            plugin.context = context
+        }
+        let callback: @convention(block) (JSValue?) -> Void = { [weak self] rawBeacon in
+            guard
+                let object = rawBeacon?.toObject(),
+                let data = try? JSONSerialization.data(withJSONObject: object),
+                let beacon = try? AnyTypeDecodingContext(rawData: data)
+                .inject(to: JSONDecoder())
+                .decode(BeaconStruct.self, from: data)
+            else { return }
+            self?.callback?(beacon)
+        }
+        let jsCallback = JSValue(object: callback, in: context) as Any
+        return [["callback": jsCallback, "plugins": plugins.map(\.pluginRef)]]
+    }
+
     public struct BeaconPluginHooks {
         public let buildBeacon: AsyncHook2<JSValue, JSValue>
         public let cancelBeacon: Hook2<JSValue, JSValue>
-        
-        public init(buildBeacon: AsyncHook2<JSValue, JSValue>, cancelBeacon: Hook2<JSValue, JSValue>) {
+
+        public init(
+            buildBeacon: AsyncHook2<JSValue, JSValue>,
+            cancelBeacon: Hook2<JSValue, JSValue>
+        ) {
             self.buildBeacon = buildBeacon
             self.cancelBeacon = cancelBeacon
         }

--- a/plugins/beacon/ios/Sources/BaseBeaconPlugin.swift
+++ b/plugins/beacon/ios/Sources/BaseBeaconPlugin.swift
@@ -7,28 +7,25 @@
 
 import Foundation
 import JavaScriptCore
-
 import PlayerUI
 
-/**
- Represenation of a Beacon coming from Player
- */
+/// Represenation of a Beacon coming from Player
 public struct DefaultBeacon: Codable, Hashable {
     /// The action the user performed
     public let action: String
-    
+
     /// The element that performed the action
     public let element: String
-    
+
     /// The ID of the asset triggering the beacon
     public let assetId: String?
-    
+
     /// The ID of the view triggering the beacon
     public let viewId: String?
-    
+
     /// Additional data added from the asset or metaData
     public let data: AnyType?
-    
+
     /// Construct a ``DefaultBeacon``
     /// - Parameters:
     ///   - action: The action the user performed
@@ -36,7 +33,8 @@ public struct DefaultBeacon: Codable, Hashable {
     ///   - assetId: The ID of the asset triggering the beacon
     ///   - viewId: The ID of the view triggering the beacon
     ///   - data: Additional data added from the asset or metaData
-    public init(action: String, element: String, assetId: String?, viewId: String?, data: AnyType?) {
+    public init(action: String, element: String, assetId: String?, viewId: String?,
+                data: AnyType?) {
         self.action = action
         self.element = element
         self.assetId = assetId
@@ -45,75 +43,30 @@ public struct DefaultBeacon: Codable, Hashable {
     }
 }
 
-/**
- A Base implementation wrapping @player-ui/beacon-plugin
- Used as a base for framework specific integrations
- */
+/// A Base implementation wrapping @player-ui/beacon-plugin
+/// Used as a base for framework specific integrations
 open class BaseBeaconPlugin<BeaconStruct: Decodable>: JSBasePlugin {
-    
     public var hooks: BeaconPluginHooks?
     /// The callback to call when a beacon is fired from the plugin
     public var callback: ((BeaconStruct) -> Void)?
-    
+
     /// BeaconPluginPlugin's to use for this BeaconPlugin
     public var plugins: [JSBasePlugin] = []
-    
-    /**
-     Constructs a BeaconPlugin
-     - parameters:
-     - context: The context to load the plugin into
-     - onBeacon: A callback to receive beacon events
-     */
+
+    /// Constructs a BeaconPlugin
+    /// - parameters:
+    /// - context: The context to load the plugin into
+    /// - onBeacon: A callback to receive beacon events
     public convenience init(plugins: [JSBasePlugin] = [], onBeacon: ((BeaconStruct) -> Void)?) {
         self.init(fileName: "BeaconPlugin.native", pluginName: "BeaconPlugin.BeaconPlugin")
-        self.callback = onBeacon
+        callback = onBeacon
         self.plugins = plugins
     }
-    
-    override open func setup(context: JSContext) {
-        super.setup(context: context)
-        guard let pluginRef = self.pluginRef else {
-            fatalError("pluginRef is nil after setup")
-        }
-        self.hooks = BeaconPluginHooks(
-            buildBeacon: AsyncHook2(baseValue: pluginRef, name: "buildBeacon"),
-            cancelBeacon: Hook2(baseValue: pluginRef, name: "cancelBeacon")
-        )
-    }
-    
-    override open func getUrlForFile(fileName: String) -> URL? {
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
-    }
-    
-    /**
-     Retrieves the arguments for constructing this plugin, this is necessary because the arguments need to be supplied after
-     construction of the swift object, once the context has been provided
-     - returns: An array of arguments to construct the plugin
-     */
-    override public func getArguments() -> [Any] {
-        for plugin in plugins {
-            plugin.context = self.context
-        }
-        let callback: @convention(block) (JSValue?) -> Void = { [weak self] rawBeacon in
-            guard
-                let object = rawBeacon?.toObject(),
-                let data = try? JSONSerialization.data(withJSONObject: object),
-                let beacon = try? AnyTypeDecodingContext(rawData: data)
-                    .inject(to: JSONDecoder())
-                    .decode(BeaconStruct.self, from: data)
-            else { return }
-            self?.callback?(beacon)
-        }
-        let jsCallback = JSValue(object: callback, in: context) as Any
-        return [["callback": jsCallback, "plugins": plugins.map { $0.pluginRef }]]
-    }
-    
-    /**
-     Function to send a beacon event through the plugin for processing
-     - parameters:
-     - action: The action that was taken for the beacon
-     - args: The context of the beacon
-     */
+
+    /// Function to send a beacon event through the plugin for processing
+    /// - parameters:
+    /// - action: The action that was taken for the beacon
+    /// - args: The context of the beacon
     public func beacon(assetBeacon: AssetBeacon) {
         guard
             let beacon = try? JSONEncoder().encode(assetBeacon),
@@ -122,12 +75,52 @@ open class BaseBeaconPlugin<BeaconStruct: Decodable>: JSBasePlugin {
         else { return }
         pluginRef?.invokeMethod("beacon", withArguments: [beaconObject])
     }
-    
+
+    override open func setup(context: JSContext) {
+        super.setup(context: context)
+        guard let pluginRef else {
+            fatalError("pluginRef is nil after setup")
+        }
+        hooks = BeaconPluginHooks(
+            buildBeacon: AsyncHook2(baseValue: pluginRef, name: "buildBeacon"),
+            cancelBeacon: Hook2(baseValue: pluginRef, name: "cancelBeacon")
+        )
+    }
+
+    override open func getUrlForFile(fileName: String) -> URL? {
+        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
+    }
+
+    /// Retrieves the arguments for constructing this plugin, this is necessary because the
+    /// arguments need to be supplied after
+    /// construction of the swift object, once the context has been provided
+    /// - returns: An array of arguments to construct the plugin
+    override public func getArguments() -> [Any] {
+        for plugin in plugins {
+            plugin.context = context
+        }
+        let callback: @convention(block) (JSValue?) -> Void = { [weak self] rawBeacon in
+            guard
+                let object = rawBeacon?.toObject(),
+                let data = try? JSONSerialization.data(withJSONObject: object),
+                let beacon = try? AnyTypeDecodingContext(rawData: data)
+                .inject(to: JSONDecoder())
+                .decode(BeaconStruct.self, from: data)
+            else { return }
+            self?.callback?(beacon)
+        }
+        let jsCallback = JSValue(object: callback, in: context) as Any
+        return [["callback": jsCallback, "plugins": plugins.map(\.pluginRef)]]
+    }
+
     public struct BeaconPluginHooks {
         public let buildBeacon: AsyncHook2<JSValue, JSValue>
         public let cancelBeacon: Hook2<JSValue, JSValue>
-        
-        public init(buildBeacon: AsyncHook2<JSValue, JSValue>, cancelBeacon: Hook2<JSValue, JSValue>) {
+
+        public init(
+            buildBeacon: AsyncHook2<JSValue, JSValue>,
+            cancelBeacon: Hook2<JSValue, JSValue>
+        ) {
             self.buildBeacon = buildBeacon
             self.cancelBeacon = cancelBeacon
         }

--- a/plugins/beacon/ios/Tests/BaseBeaconPluginTests.swift
+++ b/plugins/beacon/ios/Tests/BaseBeaconPluginTests.swift
@@ -7,31 +7,34 @@
 //
 
 import Foundation
-import XCTest
 import JavaScriptCore
 @testable import PlayerUI
 @testable import PlayerUIBaseBeaconPlugin
+import XCTest
 
 class BPPlugin: JSBasePlugin {
-    override open func setup(context: JSContext) {
-
-    }
+    override open func setup(context _: JSContext) {}
 }
 
 class BaseBeaconPluginTests: XCTestCase {
-    func testBundleLoadsSymbols() {
-        let context = JSContext()!
+    func testBundleLoadsSymbols() throws {
+        let context = try XCTUnwrap(JSContext())
 
         let plugin = BaseBeaconPlugin<DefaultBeacon>() { _ in }
 
         plugin.context = context
 
         // as accessed on main from beacon-plugin.prod.js
-        XCTAssertFalse(context.objectForKeyedSubscript("BeaconPlugin").objectForKeyedSubscript("BeaconPlugin").isUndefined)
-        XCTAssertFalse(context.objectForKeyedSubscript("BeaconPlugin").objectForKeyedSubscript("BeaconPluginSymbol").isUndefined)
+        XCTAssertFalse(context.objectForKeyedSubscript("BeaconPlugin")
+            .objectForKeyedSubscript("BeaconPlugin")
+            .isUndefined)
+        XCTAssertFalse(context.objectForKeyedSubscript("BeaconPlugin")
+            .objectForKeyedSubscript("BeaconPluginSymbol")
+            .isUndefined)
     }
-    func testBeaconPluginAppliesContextToPlugins() {
-        let context = JSContext()!
+
+    func testBeaconPluginAppliesContextToPlugins() throws {
+        let context = try XCTUnwrap(JSContext())
         JSUtilities.polyfill(context)
         let bpp = BPPlugin(fileName: "", pluginName: "")
 
@@ -41,8 +44,8 @@ class BaseBeaconPluginTests: XCTestCase {
         XCTAssertNotNil(bpp.context)
     }
 
-    func testBeaconFunction() {
-        let context = JSContext()!
+    func testBeaconFunction() throws {
+        let context = try XCTUnwrap(JSContext())
         JSUtilities.polyfill(context)
 
         let beaconed = expectation(description: "Beacon sent")
@@ -50,20 +53,24 @@ class BaseBeaconPluginTests: XCTestCase {
         let plugin = BaseBeaconPlugin<DefaultBeacon>(plugins: []) { _ in beaconed.fulfill() }
         plugin.context = context
 
-        plugin.beacon(assetBeacon: AssetBeacon(action: "action", element: "element", asset: BeaconableAsset(id: "id")))
+        plugin.beacon(assetBeacon: AssetBeacon(
+            action: "action",
+            element: "element",
+            asset: BeaconableAsset(id: "id")
+        ))
         wait(for: [beaconed], timeout: 1)
     }
 
-    func testBeaconPluginStringData() {
-        let context = JSContext()!
+    func testBeaconPluginStringData() throws {
+        let context = try XCTUnwrap(JSContext())
         JSUtilities.polyfill(context)
 
         let expectation = XCTestExpectation(description: "beacon callback called")
-        let plugin = BaseBeaconPlugin<DefaultBeacon>( onBeacon: { (beacon) in
+        let plugin = BaseBeaconPlugin<DefaultBeacon>(onBeacon: { beacon in
             XCTAssertEqual(beacon.assetId, "test")
             XCTAssertEqual(beacon.element, BeaconElement.button.rawValue)
             switch beacon.data {
-            case .string(let string):
+            case let .string(string):
                 XCTAssertEqual(string, "example")
             default:
                 XCTFail("beacon data was not a string")
@@ -81,16 +88,16 @@ class BaseBeaconPluginTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
 
-    func testBeaconPluginDictionaryData() {
-        let context = JSContext()!
+    func testBeaconPluginDictionaryData() throws {
+        let context = try XCTUnwrap(JSContext())
         JSUtilities.polyfill(context)
 
         let expectation = XCTestExpectation(description: "beacon callback called")
-        let plugin = BaseBeaconPlugin<DefaultBeacon>(onBeacon: { (beacon) in
+        let plugin = BaseBeaconPlugin<DefaultBeacon>(onBeacon: { beacon in
             XCTAssertEqual(beacon.assetId, "test")
             XCTAssertEqual(beacon.element, BeaconElement.button.rawValue)
             switch beacon.data {
-            case .dictionary(let dict):
+            case let .dictionary(dict):
                 XCTAssertEqual(dict, ["data": "example"])
             default:
                 XCTFail("beacon data was not a dictionary")
@@ -108,16 +115,16 @@ class BaseBeaconPluginTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
 
-    func testBeaconPluginAnyDictionaryData() {
-        let context = JSContext()!
+    func testBeaconPluginAnyDictionaryData() throws {
+        let context = try XCTUnwrap(JSContext())
         JSUtilities.polyfill(context)
 
         let expectation = XCTestExpectation(description: "beacon callback called")
-        let plugin = BaseBeaconPlugin<DefaultBeacon>(onBeacon: { (beacon) in
+        let plugin = BaseBeaconPlugin<DefaultBeacon>(onBeacon: { beacon in
             XCTAssertEqual(beacon.assetId, "test")
             XCTAssertEqual(beacon.element, BeaconElement.button.rawValue)
             switch beacon.data {
-            case .anyDictionary(let dict):
+            case let .anyDictionary(dict):
                 XCTAssertEqual(2, dict.keys.count)
                 XCTAssertEqual("example", dict["data"] as? String)
                 XCTAssertEqual(3, dict["value"] as? Double)
@@ -137,19 +144,19 @@ class BaseBeaconPluginTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
 
-    func testCancelSpecificBeaconsUsingHooks() {
-        let context = JSContext()!
+    func testCancelSpecificBeaconsUsingHooks() throws {
+        let context = try XCTUnwrap(JSContext())
         JSUtilities.polyfill(context)
 
         let cancelBeaconHandler = expectation(description: "Cancel Beacon Handler called")
         let handlerExpectation = expectation(description: "Handler called")
         handlerExpectation.isInverted = true
 
-        let plugin = BaseBeaconPlugin<DefaultBeacon>( onBeacon: { (beacon) in
+        let plugin = BaseBeaconPlugin<DefaultBeacon>(onBeacon: { beacon in
             XCTAssertEqual(beacon.assetId, "test")
             XCTAssertEqual(beacon.element, BeaconElement.button.rawValue)
             switch beacon.data {
-            case .string(let string):
+            case let .string(string):
                 XCTAssertEqual(string, "example")
             default:
                 XCTFail("beacon data was not a string")
@@ -160,14 +167,12 @@ class BaseBeaconPluginTests: XCTestCase {
         plugin.context = context
         plugin.setup(context: context)
 
-        guard let hooks = plugin.hooks else {
-            XCTFail("Hooks are not initialized")
-            return
-        }
+        let hooks = try XCTUnwrap(plugin.hooks, "Hooks are not initialized")
 
-        hooks.cancelBeacon.tap { (arg1: JSValue, arg2: JSValue) -> Bool in
+        hooks.cancelBeacon.tap { (arg1: JSValue, _: JSValue) -> Bool in
             cancelBeaconHandler.fulfill()
-            if let action = arg1.toDictionary()?["action"] as? String, action == BeaconAction.clicked.rawValue {
+            if let action = arg1.toDictionary()?["action"] as? String,
+               action == BeaconAction.clicked.rawValue {
                 return true
             }
             return false
@@ -183,8 +188,8 @@ class BaseBeaconPluginTests: XCTestCase {
         wait(for: [handlerExpectation, cancelBeaconHandler], timeout: 10)
     }
 
-    func testBuildSpecificBeaconsUsingHooks() {
-        let context = JSContext()!
+    func testBuildSpecificBeaconsUsingHooks() throws {
+        let context = try XCTUnwrap(JSContext())
         JSUtilities.polyfill(context)
         let buildBeaconHandler = expectation(description: "Build Beacon Handler called")
         let handlerExpectation = expectation(description: "Handler called")
@@ -192,12 +197,12 @@ class BaseBeaconPluginTests: XCTestCase {
 
         var handlerCallCount = 0
 
-        let plugin = BaseBeaconPlugin<DefaultBeacon>(onBeacon: { (beacon) in
+        let plugin = BaseBeaconPlugin<DefaultBeacon>(onBeacon: { beacon in
             handlerCallCount += 1
             XCTAssertEqual(beacon.assetId, "test")
             XCTAssertEqual(beacon.element, BeaconElement.button.rawValue)
             switch beacon.data {
-            case .string(let string):
+            case let .string(string):
                 XCTAssertEqual(string, "modified example")
             default:
                 XCTFail("beacon data was not a string")
@@ -208,12 +213,9 @@ class BaseBeaconPluginTests: XCTestCase {
         plugin.context = context
         plugin.setup(context: context)
 
-        guard let hooks = plugin.hooks else {
-            XCTFail("Hooks are not initialized")
-            return
-        }
+        let hooks = try XCTUnwrap(plugin.hooks, "Hooks are not initialized")
 
-        hooks.buildBeacon.tap { (arg1: JSValue, arg2: JSValue) -> JSValue? in
+        hooks.buildBeacon.tap { (arg1: JSValue, _: JSValue) -> JSValue? in
             buildBeaconHandler.fulfill()
             if var actionDict = arg1.toDictionary() as? [String: Any],
                let action = actionDict["action"] as? String,

--- a/plugins/beacon/ios/Tests/BaseBeaconPluginTests.swift
+++ b/plugins/beacon/ios/Tests/BaseBeaconPluginTests.swift
@@ -7,31 +7,34 @@
 //
 
 import Foundation
-import XCTest
 import JavaScriptCore
 @testable import PlayerUI
 @testable import PlayerUIBaseBeaconPlugin
+import XCTest
 
 class BPPlugin: JSBasePlugin {
-    override open func setup(context: JSContext) {
-
-    }
+    override open func setup(context _: JSContext) {}
 }
 
 class BaseBeaconPluginTests: XCTestCase {
-    func testBundleLoadsSymbols() {
-        let context = JSContext()!
+    func testBundleLoadsSymbols() throws {
+        let context = try XCTUnwrap(JSContext())
 
         let plugin = BaseBeaconPlugin<DefaultBeacon>() { _ in }
 
         plugin.context = context
 
         // as accessed on main from beacon-plugin.prod.js
-        XCTAssertFalse(context.objectForKeyedSubscript("BeaconPlugin").objectForKeyedSubscript("BeaconPlugin").isUndefined)
-        XCTAssertFalse(context.objectForKeyedSubscript("BeaconPlugin").objectForKeyedSubscript("BeaconPluginSymbol").isUndefined)
+        XCTAssertFalse(context.objectForKeyedSubscript("BeaconPlugin")
+            .objectForKeyedSubscript("BeaconPlugin")
+            .isUndefined)
+        XCTAssertFalse(context.objectForKeyedSubscript("BeaconPlugin")
+            .objectForKeyedSubscript("BeaconPluginSymbol")
+            .isUndefined)
     }
-    func testBeaconPluginAppliesContextToPlugins() {
-        let context = JSContext()!
+
+    func testBeaconPluginAppliesContextToPlugins() throws {
+        let context = try XCTUnwrap(JSContext())
         JSUtilities.polyfill(context)
         let bpp = BPPlugin(fileName: "", pluginName: "")
 
@@ -41,8 +44,8 @@ class BaseBeaconPluginTests: XCTestCase {
         XCTAssertNotNil(bpp.context)
     }
 
-    func testBeaconFunction() {
-        let context = JSContext()!
+    func testBeaconFunction() throws {
+        let context = try XCTUnwrap(JSContext())
         JSUtilities.polyfill(context)
 
         let beaconed = expectation(description: "Beacon sent")
@@ -50,20 +53,24 @@ class BaseBeaconPluginTests: XCTestCase {
         let plugin = BaseBeaconPlugin<DefaultBeacon>(plugins: []) { _ in beaconed.fulfill() }
         plugin.context = context
 
-        plugin.beacon(assetBeacon: AssetBeacon(action: "action", element: "element", asset: BeaconableAsset(id: "id")))
+        plugin.beacon(assetBeacon: AssetBeacon(
+            action: "action",
+            element: "element",
+            asset: BeaconableAsset(id: "id")
+        ))
         wait(for: [beaconed], timeout: 1)
     }
 
-    func testBeaconPluginStringData() {
-        let context = JSContext()!
+    func testBeaconPluginStringData() throws {
+        let context = try XCTUnwrap(JSContext())
         JSUtilities.polyfill(context)
 
         let expectation = XCTestExpectation(description: "beacon callback called")
-        let plugin = BaseBeaconPlugin<DefaultBeacon>( onBeacon: { (beacon) in
+        let plugin = BaseBeaconPlugin<DefaultBeacon>(onBeacon: { beacon in
             XCTAssertEqual(beacon.assetId, "test")
             XCTAssertEqual(beacon.element, BeaconElement.button.rawValue)
             switch beacon.data {
-            case .string(let string):
+            case let .string(string):
                 XCTAssertEqual(string, "example")
             default:
                 XCTFail("beacon data was not a string")
@@ -81,16 +88,16 @@ class BaseBeaconPluginTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
 
-    func testBeaconPluginDictionaryData() {
-        let context = JSContext()!
+    func testBeaconPluginDictionaryData() throws {
+        let context = try XCTUnwrap(JSContext())
         JSUtilities.polyfill(context)
 
         let expectation = XCTestExpectation(description: "beacon callback called")
-        let plugin = BaseBeaconPlugin<DefaultBeacon>(onBeacon: { (beacon) in
+        let plugin = BaseBeaconPlugin<DefaultBeacon>(onBeacon: { beacon in
             XCTAssertEqual(beacon.assetId, "test")
             XCTAssertEqual(beacon.element, BeaconElement.button.rawValue)
             switch beacon.data {
-            case .dictionary(let dict):
+            case let .dictionary(dict):
                 XCTAssertEqual(dict, ["data": "example"])
             default:
                 XCTFail("beacon data was not a dictionary")
@@ -108,16 +115,16 @@ class BaseBeaconPluginTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
 
-    func testBeaconPluginAnyDictionaryData() {
-        let context = JSContext()!
+    func testBeaconPluginAnyDictionaryData() throws {
+        let context = try XCTUnwrap(JSContext())
         JSUtilities.polyfill(context)
 
         let expectation = XCTestExpectation(description: "beacon callback called")
-        let plugin = BaseBeaconPlugin<DefaultBeacon>(onBeacon: { (beacon) in
+        let plugin = BaseBeaconPlugin<DefaultBeacon>(onBeacon: { beacon in
             XCTAssertEqual(beacon.assetId, "test")
             XCTAssertEqual(beacon.element, BeaconElement.button.rawValue)
             switch beacon.data {
-            case .anyDictionary(let dict):
+            case let .anyDictionary(dict):
                 XCTAssertEqual(2, dict.keys.count)
                 XCTAssertEqual("example", dict["data"]?.as(String.self))
                 XCTAssertEqual(3, dict["value"]?.as(Double.self))
@@ -132,24 +139,27 @@ class BaseBeaconPluginTests: XCTestCase {
             action: BeaconAction.clicked.rawValue,
             element: BeaconElement.button.rawValue,
             asset: BeaconableAsset(id: "test"),
-            data: .anyDictionary(data: ["data": .string(data: "example"), "value": .number(data: 3)])
+            data: .anyDictionary(data: [
+                "data": .string(data: "example"),
+                "value": .number(data: 3),
+            ])
         ))
         wait(for: [expectation], timeout: 2)
     }
 
-    func testCancelSpecificBeaconsUsingHooks() {
-        let context = JSContext()!
+    func testCancelSpecificBeaconsUsingHooks() throws {
+        let context = try XCTUnwrap(JSContext())
         JSUtilities.polyfill(context)
 
         let cancelBeaconHandler = expectation(description: "Cancel Beacon Handler called")
         let handlerExpectation = expectation(description: "Handler called")
         handlerExpectation.isInverted = true
 
-        let plugin = BaseBeaconPlugin<DefaultBeacon>( onBeacon: { (beacon) in
+        let plugin = BaseBeaconPlugin<DefaultBeacon>(onBeacon: { beacon in
             XCTAssertEqual(beacon.assetId, "test")
             XCTAssertEqual(beacon.element, BeaconElement.button.rawValue)
             switch beacon.data {
-            case .string(let string):
+            case let .string(string):
                 XCTAssertEqual(string, "example")
             default:
                 XCTFail("beacon data was not a string")
@@ -160,14 +170,12 @@ class BaseBeaconPluginTests: XCTestCase {
         plugin.context = context
         plugin.setup(context: context)
 
-        guard let hooks = plugin.hooks else {
-            XCTFail("Hooks are not initialized")
-            return
-        }
+        let hooks = try XCTUnwrap(plugin.hooks, "Hooks are not initialized")
 
-        hooks.cancelBeacon.tap { (arg1: JSValue, arg2: JSValue) -> Bool in
+        hooks.cancelBeacon.tap { (arg1: JSValue, _: JSValue) -> Bool in
             cancelBeaconHandler.fulfill()
-            if let action = arg1.toDictionary()?["action"] as? String, action == BeaconAction.clicked.rawValue {
+            if let action = arg1.toDictionary()?["action"] as? String,
+               action == BeaconAction.clicked.rawValue {
                 return true
             }
             return false
@@ -183,8 +191,8 @@ class BaseBeaconPluginTests: XCTestCase {
         wait(for: [handlerExpectation, cancelBeaconHandler], timeout: 10)
     }
 
-    func testBuildSpecificBeaconsUsingHooks() {
-        let context = JSContext()!
+    func testBuildSpecificBeaconsUsingHooks() throws {
+        let context = try XCTUnwrap(JSContext())
         JSUtilities.polyfill(context)
         let buildBeaconHandler = expectation(description: "Build Beacon Handler called")
         let handlerExpectation = expectation(description: "Handler called")
@@ -192,12 +200,12 @@ class BaseBeaconPluginTests: XCTestCase {
 
         var handlerCallCount = 0
 
-        let plugin = BaseBeaconPlugin<DefaultBeacon>(onBeacon: { (beacon) in
+        let plugin = BaseBeaconPlugin<DefaultBeacon>(onBeacon: { beacon in
             handlerCallCount += 1
             XCTAssertEqual(beacon.assetId, "test")
             XCTAssertEqual(beacon.element, BeaconElement.button.rawValue)
             switch beacon.data {
-            case .string(let string):
+            case let .string(string):
                 XCTAssertEqual(string, "modified example")
             default:
                 XCTFail("beacon data was not a string")
@@ -208,12 +216,9 @@ class BaseBeaconPluginTests: XCTestCase {
         plugin.context = context
         plugin.setup(context: context)
 
-        guard let hooks = plugin.hooks else {
-            XCTFail("Hooks are not initialized")
-            return
-        }
+        let hooks = try XCTUnwrap(plugin.hooks, "Hooks are not initialized")
 
-        hooks.buildBeacon.tap { (arg1: JSValue, arg2: JSValue) -> JSValue? in
+        hooks.buildBeacon.tap { (arg1: JSValue, _: JSValue) -> JSValue? in
             buildBeaconHandler.fulfill()
             if var actionDict = arg1.toDictionary() as? [String: Any],
                let action = actionDict["action"] as? String,

--- a/plugins/beacon/swiftui/Sources/SwiftUIBeaconPlugin.swift
+++ b/plugins/beacon/swiftui/Sources/SwiftUIBeaconPlugin.swift
@@ -1,5 +1,5 @@
 //
-//  BeaconPlugin.swift
+//  SwiftUIBeaconPlugin.swift
 //  PlayerUI
 //
 //  Created by Borawski, Harris on 3/11/20.
@@ -10,60 +10,50 @@ import JavaScriptCore
 import SwiftUI
 
 #if SWIFT_PACKAGE
-import PlayerUI
-import PlayerUISwiftUI
-import PlayerUIBaseBeaconPlugin
+    import PlayerUI
+    import PlayerUIBaseBeaconPlugin
+    import PlayerUISwiftUI
 #endif
 
-/**
- Plugin used by `SwiftUIPlayer` for beaconing in a uniform format between platforms
- */
+/// Plugin used by `SwiftUIPlayer` for beaconing in a uniform format between platforms
 open class BeaconPlugin<BeaconStruct: Decodable>: BaseBeaconPlugin<BeaconStruct>, NativePlugin {
-    /**
-     Constructs a BeaconPlugin
-     - parameters:
-     - context: The context to load the plugin into
-     - onBeacon: A callback to receive beacon events
-     */
+    /// Constructs a BeaconPlugin
+    /// - parameters:
+    /// - context: The context to load the plugin into
+    /// - onBeacon: A callback to receive beacon events
     public convenience init(plugins: [JSBasePlugin] = [], onBeacon: ((BeaconStruct) -> Void)?) {
         self.init(fileName: "BeaconPlugin.native", pluginName: "BeaconPlugin.BeaconPlugin")
-        self.callback = onBeacon
+        callback = onBeacon
         self.plugins = plugins
     }
-    
-    open func apply<P>(player: P) where P: HeadlessPlayer {
+
+    open func apply<P: HeadlessPlayer>(player: P) {
         guard let player = player as? SwiftUIPlayer else { return }
-        let beacon = self.beacon(assetBeacon:)
+        let beacon = beacon(assetBeacon:)
         player.hooks?.view.tap(name: "BeaconPlugin") { view in
             AnyView(view.environment(\.beaconContext, BeaconContext(beacon)))
         }
     }
 }
 
-/**
- Context object that contains a function to send a beacon
- */
+/// Context object that contains a function to send a beacon
 public class BeaconContext: ObservableObject {
     private let beaconFn: (AssetBeacon) -> Void
-    
-    /**
-     Constructs a BeaconContext
-     - parameters:
-     - beacon: The function to use for sending the beacon
-     */
+
+    /// Constructs a BeaconContext
+    /// - parameters:
+    /// - beacon: The function to use for sending the beacon
     public init(_ beacon: @escaping (AssetBeacon) -> Void) {
-        self.beaconFn = beacon
+        beaconFn = beacon
     }
-    
-    /**
-     Sends a beacon through the JavaScript beacon plugin
-     - parameters:
-     - action: The type of action that occurred
-     - element: The type of element in the asset that triggered the beacon
-     - id: The ID of the asset that triggered the beacon
-     - metaData: `BeaconableMetaData` to include as extra data to the core BeaconPlugin
-     - data: Additional arbitrary data to include in the beacon
-     */
+
+    /// Sends a beacon through the JavaScript beacon plugin
+    /// - parameters:
+    /// - action: The type of action that occurred
+    /// - element: The type of element in the asset that triggered the beacon
+    /// - id: The ID of the asset that triggered the beacon
+    /// - metaData: `BeaconableMetaData` to include as extra data to the core BeaconPlugin
+    /// - data: Additional arbitrary data to include in the beacon
     public func beacon<MetaDataType: BeaconableMetaData>(
         action: String,
         element: String,
@@ -72,24 +62,26 @@ public class BeaconContext: ObservableObject {
         metaData: MetaDataType? = nil,
         data: AnyType? = nil
     ) {
-        self.beaconFn(
+        beaconFn(
             AssetBeacon(
                 action: action,
                 element: element,
-                asset: BeaconableAsset(id: id, type: type, metaData: metaData.map { MetaData(beacon: $0.beacon) }),
+                asset: BeaconableAsset(
+                    id: id,
+                    type: type,
+                    metaData: metaData.map { MetaData(beacon: $0.beacon) }
+                ),
                 data: data
             )
         )
     }
-    
-    /**
-     Sends a beacon through the JavaScript beacon plugin
-     - parameters:
-     - action: The type of action that occurred
-     - element: The type of element in the asset that triggered the beacon
-     - id: The ID of the asset that triggered the beacon
-     - data: Additional arbitrary data to include in the beacon
-     */
+
+    /// Sends a beacon through the JavaScript beacon plugin
+    /// - parameters:
+    /// - action: The type of action that occurred
+    /// - element: The type of element in the asset that triggered the beacon
+    /// - id: The ID of the asset that triggered the beacon
+    /// - data: Additional arbitrary data to include in the beacon
     public func beacon(
         action: String,
         element: String,
@@ -97,7 +89,7 @@ public class BeaconContext: ObservableObject {
         type: String? = nil,
         data: AnyType? = nil
     ) {
-        self.beaconFn(
+        beaconFn(
             AssetBeacon(
                 action: action,
                 element: element,

--- a/plugins/beacon/swiftui/Sources/SwiftUIBeaconPlugin.swift
+++ b/plugins/beacon/swiftui/Sources/SwiftUIBeaconPlugin.swift
@@ -24,7 +24,7 @@ open class BeaconPlugin<BeaconStruct: Decodable>: BaseBeaconPlugin<BeaconStruct>
         self.plugins = plugins
     }
 
-    open func apply<P: HeadlessPlayer>(player: P) {
+    open func apply(player: some HeadlessPlayer) {
         guard let player = player as? SwiftUIPlayer else { return }
         let beacon = beacon(assetBeacon:)
         player.hooks?.view.tap(name: "BeaconPlugin") { view in
@@ -51,12 +51,12 @@ public class BeaconContext: ObservableObject {
     /// - id: The ID of the asset that triggered the beacon
     /// - metaData: `BeaconableMetaData` to include as extra data to the core BeaconPlugin
     /// - data: Additional arbitrary data to include in the beacon
-    public func beacon<MetaDataType: BeaconableMetaData>(
+    public func beacon(
         action: String,
         element: String,
         id: String,
         type: String? = nil,
-        metaData: MetaDataType? = nil,
+        metaData: (some BeaconableMetaData)? = nil,
         data: AnyType? = nil
     ) {
         beaconFn(

--- a/plugins/beacon/swiftui/Sources/SwiftUIBeaconPlugin.swift
+++ b/plugins/beacon/swiftui/Sources/SwiftUIBeaconPlugin.swift
@@ -1,5 +1,5 @@
 //
-//  BeaconPlugin.swift
+//  SwiftUIBeaconPlugin.swift
 //  PlayerUI
 //
 //  Created by Borawski, Harris on 3/11/20.
@@ -7,61 +7,50 @@
 
 import Foundation
 import JavaScriptCore
+import PlayerUI
+import PlayerUIBaseBeaconPlugin
+import PlayerUISwiftUI
 import SwiftUI
 
-import PlayerUI
-import PlayerUISwiftUI
-import PlayerUIBaseBeaconPlugin
-
-/**
- Plugin used by `SwiftUIPlayer` for beaconing in a uniform format between platforms
- */
+/// Plugin used by `SwiftUIPlayer` for beaconing in a uniform format between platforms
 open class BeaconPlugin<BeaconStruct: Decodable>: BaseBeaconPlugin<BeaconStruct>, NativePlugin {
-    /**
-     Constructs a BeaconPlugin
-     - parameters:
-     - context: The context to load the plugin into
-     - onBeacon: A callback to receive beacon events
-     */
+    /// Constructs a BeaconPlugin
+    /// - parameters:
+    /// - context: The context to load the plugin into
+    /// - onBeacon: A callback to receive beacon events
     public convenience init(plugins: [JSBasePlugin] = [], onBeacon: ((BeaconStruct) -> Void)?) {
         self.init(fileName: "BeaconPlugin.native", pluginName: "BeaconPlugin.BeaconPlugin")
-        self.callback = onBeacon
+        callback = onBeacon
         self.plugins = plugins
     }
-    
-    open func apply<P>(player: P) where P: HeadlessPlayer {
+
+    open func apply<P: HeadlessPlayer>(player: P) {
         guard let player = player as? SwiftUIPlayer else { return }
-        let beacon = self.beacon(assetBeacon:)
+        let beacon = beacon(assetBeacon:)
         player.hooks?.view.tap(name: "BeaconPlugin") { view in
             AnyView(view.environment(\.beaconContext, BeaconContext(beacon)))
         }
     }
 }
 
-/**
- Context object that contains a function to send a beacon
- */
+/// Context object that contains a function to send a beacon
 public class BeaconContext: ObservableObject {
     private let beaconFn: (AssetBeacon) -> Void
-    
-    /**
-     Constructs a BeaconContext
-     - parameters:
-     - beacon: The function to use for sending the beacon
-     */
+
+    /// Constructs a BeaconContext
+    /// - parameters:
+    /// - beacon: The function to use for sending the beacon
     public init(_ beacon: @escaping (AssetBeacon) -> Void) {
-        self.beaconFn = beacon
+        beaconFn = beacon
     }
-    
-    /**
-     Sends a beacon through the JavaScript beacon plugin
-     - parameters:
-     - action: The type of action that occurred
-     - element: The type of element in the asset that triggered the beacon
-     - id: The ID of the asset that triggered the beacon
-     - metaData: `BeaconableMetaData` to include as extra data to the core BeaconPlugin
-     - data: Additional arbitrary data to include in the beacon
-     */
+
+    /// Sends a beacon through the JavaScript beacon plugin
+    /// - parameters:
+    /// - action: The type of action that occurred
+    /// - element: The type of element in the asset that triggered the beacon
+    /// - id: The ID of the asset that triggered the beacon
+    /// - metaData: `BeaconableMetaData` to include as extra data to the core BeaconPlugin
+    /// - data: Additional arbitrary data to include in the beacon
     public func beacon<MetaDataType: BeaconableMetaData>(
         action: String,
         element: String,
@@ -70,24 +59,26 @@ public class BeaconContext: ObservableObject {
         metaData: MetaDataType? = nil,
         data: AnyType? = nil
     ) {
-        self.beaconFn(
+        beaconFn(
             AssetBeacon(
                 action: action,
                 element: element,
-                asset: BeaconableAsset(id: id, type: type, metaData: metaData.map { MetaData(beacon: $0.beacon) }),
+                asset: BeaconableAsset(
+                    id: id,
+                    type: type,
+                    metaData: metaData.map { MetaData(beacon: $0.beacon) }
+                ),
                 data: data
             )
         )
     }
-    
-    /**
-     Sends a beacon through the JavaScript beacon plugin
-     - parameters:
-     - action: The type of action that occurred
-     - element: The type of element in the asset that triggered the beacon
-     - id: The ID of the asset that triggered the beacon
-     - data: Additional arbitrary data to include in the beacon
-     */
+
+    /// Sends a beacon through the JavaScript beacon plugin
+    /// - parameters:
+    /// - action: The type of action that occurred
+    /// - element: The type of element in the asset that triggered the beacon
+    /// - id: The ID of the asset that triggered the beacon
+    /// - data: Additional arbitrary data to include in the beacon
     public func beacon(
         action: String,
         element: String,
@@ -95,7 +86,7 @@ public class BeaconContext: ObservableObject {
         type: String? = nil,
         data: AnyType? = nil
     ) {
-        self.beaconFn(
+        beaconFn(
             AssetBeacon(
                 action: action,
                 element: element,

--- a/plugins/beacon/swiftui/ViewInspector/BeaconPluginTests.swift
+++ b/plugins/beacon/swiftui/ViewInspector/BeaconPluginTests.swift
@@ -7,20 +7,17 @@
 //
 
 import Foundation
-import XCTest
-import SwiftUI
-import ViewInspector
 @testable import PlayerUI
-@testable import PlayerUIInternalTestUtilities
-@testable import PlayerUISwiftUI
-@testable import PlayerUIReferenceAssets
 @testable import PlayerUIBaseBeaconPlugin
 @testable import PlayerUIBeaconPlugin
+@testable import PlayerUIInternalTestUtilities
+@testable import PlayerUIReferenceAssets
+@testable import PlayerUISwiftUI
+import SwiftUI
+import ViewInspector
+import XCTest
 
 class BeaconPluginTests: XCTestCase {
-    override func setUp() {
-        XCUIApplication().terminate()
-    }
     //    func testContextAttachment() throws {
     //        let player = SwiftUIPlayer(flow: "", plugins: [BeaconPlugin<DefaultBeacon> { _ in}])
     //
@@ -79,38 +76,49 @@ class BeaconPluginTests: XCTestCase {
     //
     //        wait(for: [exp, expect], timeout: 10)
     //    }
-    
+
     func testSendsViewBeacon() {
         let beaconed = expectation(description: "View beacon called")
-        let plugin = BeaconPlugin<DefaultBeacon>(plugins: []) { (beacon) in
+        let plugin = BeaconPlugin<DefaultBeacon>(plugins: []) { beacon in
             guard beacon.action == "viewed" else { return }
             beaconed.fulfill()
         }
-        
+
         let player = SwiftUIPlayer(
             flow: FlowData.COUNTER,
             plugins: [ReferenceAssetsPlugin(), plugin]
         )
         ViewHosting.host(view: player)
-        
+
         wait(for: [beaconed], timeout: 10)
-        
+
         ViewHosting.expel()
+    }
+
+    override func setUp() {
+        XCUIApplication().terminate()
     }
 }
 
 struct TestButton: View {
     @Environment(\.beaconContext) var beaconContext
+
     var metaData: MetaData?
-    internal var didAppear: ((Self) -> Void)?
+    var didAppear: ((Self) -> Void)?
+
     var body: some View {
         Button(action: {
             if let data = metaData {
-                beaconContext?.beacon(action: "clicked", element: "button", id: "test", metaData: data)
+                beaconContext?.beacon(
+                    action: "clicked",
+                    element: "button",
+                    id: "test",
+                    metaData: data
+                )
             } else {
                 beaconContext?.beacon(action: "clicked", element: "button", id: "test")
             }
-        }, label: {Text("Beacon")})
-        .onAppear { self.didAppear?(self) }
+        }, label: { Text("Beacon") })
+            .onAppear { didAppear?(self) }
     }
 }

--- a/plugins/check-path/ios/Sources/CheckPathPlugin.swift
+++ b/plugins/check-path/ios/Sources/CheckPathPlugin.swift
@@ -24,6 +24,7 @@ open class BaseCheckPathPlugin: JSBasePlugin {
     ///   - id: The ID of the asset to check
     ///   - query: The type of the parent to check for
     public func getParentContext(id: String, query: String? = nil) -> Any? {
+        // swiftlint:disable:next force_unwrapping
         let arguments = query != nil ? [id, query!] : [id]
         return pluginRef?.invokeMethod("getParent", withArguments: arguments)?.toObject()
     }

--- a/plugins/check-path/ios/Sources/CheckPathPlugin.swift
+++ b/plugins/check-path/ios/Sources/CheckPathPlugin.swift
@@ -8,74 +8,70 @@
 import Foundation
 
 #if SWIFT_PACKAGE
-import PlayerUI
+    import PlayerUI
 #endif
 
 /// Base functionality for CheckPath
 open class BaseCheckPathPlugin: JSBasePlugin {
-    /**
-     The getParent method allows you to query up the tree and return the first parent that matches the given query if such exists.
-     In case when query is not provided, the closest parent returned.
-     ```swift
-     // return an "action" asset if an asset has the "action" asset as a parent
-     checkPathPlugin.getParentContext(id: "some-asset-id", query: "action")
-     ```
-     - parameters:
-        - id: The ID of the asset to check
-        - query: The type of the parent to check for
-     */
+    /// The getParent method allows you to query up the tree and return the first parent that
+    /// matches the given query if such exists.
+    /// In case when query is not provided, the closest parent returned.
+    /// ```swift
+    /// // return an "action" asset if an asset has the "action" asset as a parent
+    /// checkPathPlugin.getParentContext(id: "some-asset-id", query: "action")
+    /// ```
+    /// - parameters:
+    ///   - id: The ID of the asset to check
+    ///   - query: The type of the parent to check for
     public func getParentContext(id: String, query: String? = nil) -> Any? {
         let arguments = query != nil ? [id, query!] : [id]
-        let parent = pluginRef?.invokeMethod("getParent", withArguments: arguments)?.toObject()
-        return parent
+        return pluginRef?.invokeMethod("getParent", withArguments: arguments)?.toObject()
     }
 
-    /**
-     The getParentProp method returns the property on the parent object that the current object falls under.
-     ```swift
-     // an input with a text asset as the label,
-     // will return label for the parentProp of the text asset
-     checkPathPlugin.getParentProp(id: "some-asset-id")
-     ```
-     - parameters:
-        - id: The ID of the asset to check
-     */
+    /// The getParentProp method returns the property on the parent object that the current object
+    /// falls under.
+    /// ```swift
+    /// // an input with a text asset as the label,
+    /// // will return label for the parentProp of the text asset
+    /// checkPathPlugin.getParentProp(id: "some-asset-id")
+    /// ```
+    /// - parameters:
+    ///   - id: The ID of the asset to check
     public func getParentProp(id: String) -> String? {
-        let parentProp = pluginRef?.invokeMethod("getParentProp", withArguments: [id])?.toString()
-        return parentProp
+        pluginRef?.invokeMethod("getParentProp", withArguments: [id])?.toString()
     }
 
-    /**
-     Checks if the id has a parent that matches the query
-     ```swift
-     // check if an asset has an "action" asset as a parent
-     checkPathPlugin.hasParentContext(id: "some-asset-id", query: "action")
-     ```
-     - parameters:
-        - id: The ID of the asset to check
-        - query: The type of the parent to check for
-     */
+    /// Checks if the id has a parent that matches the query
+    /// ```swift
+    /// // check if an asset has an "action" asset as a parent
+    /// checkPathPlugin.hasParentContext(id: "some-asset-id", query: "action")
+    /// ```
+    /// - parameters:
+    ///   - id: The ID of the asset to check
+    ///   - query: The type of the parent to check for
     public func hasParentContext(id: String, query: String) -> Bool {
-        guard let exists = pluginRef?.invokeMethod("hasParentContext", withArguments: [id, query])?.toBool() else { return false }
+        guard let exists = pluginRef?.invokeMethod("hasParentContext", withArguments: [id, query])?
+            .toBool() else { return false }
         return exists
     }
 
     override open func getUrlForFile(fileName: String) -> URL? {
         #if SWIFT_PACKAGE
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
+            ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
         #else
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle(for: BaseCheckPathPlugin.self), pathComponent: "PlayerUI_CheckPathPlugin.bundle")
+            ResourceUtilities.urlForFile(
+                name: fileName,
+                ext: "js",
+                bundle: Bundle(for: BaseCheckPathPlugin.self),
+                pathComponent: "PlayerUI_CheckPathPlugin.bundle"
+            )
         #endif
     }
 }
 
-/**
- A plugin that can query the asset tree for contextual information about the hierarchy
- */
+/// A plugin that can query the asset tree for contextual information about the hierarchy
 open class CheckPathPlugin: BaseCheckPathPlugin, NativePlugin {
-    /**
-     Constructs the CheckPathPlugin
-     */
+    /// Constructs the CheckPathPlugin
     public convenience init() {
         self.init(fileName: "CheckPathPlugin.native", pluginName: "CheckPathPlugin.CheckPathPlugin")
     }

--- a/plugins/check-path/ios/Sources/CheckPathPlugin.swift
+++ b/plugins/check-path/ios/Sources/CheckPathPlugin.swift
@@ -21,7 +21,7 @@ open class BaseCheckPathPlugin: JSBasePlugin {
     ///   - id: The ID of the asset to check
     ///   - query: The type of the parent to check for
     public func getParentContext(id: String, query: String? = nil) -> Any? {
-        let arguments = query != nil ? [id, query!] : [id]
+        let arguments = query.map { [id, $0] } ?? [id]
         return pluginRef?.invokeMethod("getParent", withArguments: arguments)?.toObject()
     }
 

--- a/plugins/check-path/ios/Sources/CheckPathPlugin.swift
+++ b/plugins/check-path/ios/Sources/CheckPathPlugin.swift
@@ -6,55 +6,49 @@
 //
 
 import Foundation
-
 import PlayerUI
 
 /// Base functionality for CheckPath
 open class BaseCheckPathPlugin: JSBasePlugin {
-    /**
-     The getParent method allows you to query up the tree and return the first parent that matches the given query if such exists.
-     In case when query is not provided, the closest parent returned.
-     ```swift
-     // return an "action" asset if an asset has the "action" asset as a parent
-     checkPathPlugin.getParentContext(id: "some-asset-id", query: "action")
-     ```
-     - parameters:
-        - id: The ID of the asset to check
-        - query: The type of the parent to check for
-     */
+    /// The getParent method allows you to query up the tree and return the first parent that
+    /// matches the given query if such exists.
+    /// In case when query is not provided, the closest parent returned.
+    /// ```swift
+    /// // return an "action" asset if an asset has the "action" asset as a parent
+    /// checkPathPlugin.getParentContext(id: "some-asset-id", query: "action")
+    /// ```
+    /// - parameters:
+    ///   - id: The ID of the asset to check
+    ///   - query: The type of the parent to check for
     public func getParentContext(id: String, query: String? = nil) -> Any? {
         let arguments = query != nil ? [id, query!] : [id]
-        let parent = pluginRef?.invokeMethod("getParent", withArguments: arguments)?.toObject()
-        return parent
+        return pluginRef?.invokeMethod("getParent", withArguments: arguments)?.toObject()
     }
 
-    /**
-     The getParentProp method returns the property on the parent object that the current object falls under.
-     ```swift
-     // an input with a text asset as the label,
-     // will return label for the parentProp of the text asset
-     checkPathPlugin.getParentProp(id: "some-asset-id")
-     ```
-     - parameters:
-        - id: The ID of the asset to check
-     */
+    /// The getParentProp method returns the property on the parent object that the current object
+    /// falls under.
+    /// ```swift
+    /// // an input with a text asset as the label,
+    /// // will return label for the parentProp of the text asset
+    /// checkPathPlugin.getParentProp(id: "some-asset-id")
+    /// ```
+    /// - parameters:
+    ///   - id: The ID of the asset to check
     public func getParentProp(id: String) -> String? {
-        let parentProp = pluginRef?.invokeMethod("getParentProp", withArguments: [id])?.toString()
-        return parentProp
+        pluginRef?.invokeMethod("getParentProp", withArguments: [id])?.toString()
     }
 
-    /**
-     Checks if the id has a parent that matches the query
-     ```swift
-     // check if an asset has an "action" asset as a parent
-     checkPathPlugin.hasParentContext(id: "some-asset-id", query: "action")
-     ```
-     - parameters:
-        - id: The ID of the asset to check
-        - query: The type of the parent to check for
-     */
+    /// Checks if the id has a parent that matches the query
+    /// ```swift
+    /// // check if an asset has an "action" asset as a parent
+    /// checkPathPlugin.hasParentContext(id: "some-asset-id", query: "action")
+    /// ```
+    /// - parameters:
+    ///   - id: The ID of the asset to check
+    ///   - query: The type of the parent to check for
     public func hasParentContext(id: String, query: String) -> Bool {
-        guard let exists = pluginRef?.invokeMethod("hasParentContext", withArguments: [id, query])?.toBool() else { return false }
+        guard let exists = pluginRef?.invokeMethod("hasParentContext", withArguments: [id, query])?
+            .toBool() else { return false }
         return exists
     }
 
@@ -63,13 +57,9 @@ open class BaseCheckPathPlugin: JSBasePlugin {
     }
 }
 
-/**
- A plugin that can query the asset tree for contextual information about the hierarchy
- */
+/// A plugin that can query the asset tree for contextual information about the hierarchy
 open class CheckPathPlugin: BaseCheckPathPlugin, NativePlugin {
-    /**
-     Constructs the CheckPathPlugin
-     */
+    /// Constructs the CheckPathPlugin
     public convenience init() {
         self.init(fileName: "CheckPathPlugin.native", pluginName: "CheckPathPlugin.CheckPathPlugin")
     }

--- a/plugins/check-path/ios/Tests/CheckPathPluginTests.swift
+++ b/plugins/check-path/ios/Tests/CheckPathPluginTests.swift
@@ -7,17 +7,16 @@
 //
 
 import Foundation
-import XCTest
 import JavaScriptCore
-
 @testable import PlayerUI
+@testable import PlayerUICheckPathPlugin
 @testable import PlayerUIInternalTestUtilities
 @testable import PlayerUITestUtilitiesCore
-@testable import PlayerUICheckPathPlugin
+import XCTest
 
 class CheckPathPluginTests: XCTestCase {
-    func testCheckPathPluginConstructs() {
-        let context = JSContext()!
+    func testCheckPathPluginConstructs() throws {
+        let context = try XCTUnwrap(JSContext())
 
         let plugin = CheckPathPlugin()
         plugin.context = context
@@ -29,7 +28,7 @@ class CheckPathPluginTests: XCTestCase {
         let plugin = CheckPathPlugin()
         let player = HeadlessPlayerImpl(plugins: [plugin])
 
-        player.start(flow: FlowData.COUNTER) { _ in}
+        player.start(flow: FlowData.COUNTER) { _ in }
 
         let parentAsset = plugin.getParentContext(id: "action-label", query: "action")
         XCTAssertNotNil(parentAsset)
@@ -39,7 +38,7 @@ class CheckPathPluginTests: XCTestCase {
         let plugin = CheckPathPlugin()
         let player = HeadlessPlayerImpl(plugins: [plugin])
 
-        player.start(flow: FlowData.COUNTER) { _ in}
+        player.start(flow: FlowData.COUNTER) { _ in }
 
         let parentProp = plugin.getParentProp(id: "action-label")
         XCTAssertNotNil(parentProp)
@@ -50,7 +49,7 @@ class CheckPathPluginTests: XCTestCase {
         let plugin = CheckPathPlugin()
         let player = HeadlessPlayerImpl(plugins: [plugin])
 
-        player.start(flow: FlowData.COUNTER) { _ in}
+        player.start(flow: FlowData.COUNTER) { _ in }
 
         XCTAssertTrue(plugin.hasParentContext(id: "action-label", query: "action"))
     }

--- a/plugins/check-path/swiftui/Sources/SwiftUICheckPathPlugin.swift
+++ b/plugins/check-path/swiftui/Sources/SwiftUICheckPathPlugin.swift
@@ -2,23 +2,21 @@ import Foundation
 import SwiftUI
 
 #if SWIFT_PACKAGE
-import PlayerUI
-import PlayerUISwiftUI
-import PlayerUICheckPathPlugin
+    import PlayerUI
+    import PlayerUICheckPathPlugin
+    import PlayerUISwiftUI
 #endif
 
 /// SwiftUI Version of `CheckPathPlugin` that puts itself into `\.checkPath` in EnvironmentValues
 public class SwiftUICheckPathPlugin: BaseCheckPathPlugin, NativePlugin {
-    /**
-     Constructs the SwiftUICheckPathPlugin
-     */
+    /// Constructs the SwiftUICheckPathPlugin
     public convenience init() {
         self.init(fileName: "CheckPathPlugin.native", pluginName: "CheckPathPlugin.CheckPathPlugin")
     }
 
-    public func apply<P>(player: P) where P: HeadlessPlayer {
+    public func apply<P: HeadlessPlayer>(player: P) {
         guard let player = player as? SwiftUIPlayer else { return }
-        player.hooks?.view.tap(name: self.pluginName) { [weak self] view in
+        player.hooks?.view.tap(name: pluginName) { [weak self] view in
             AnyView(view.environment(\.checkPath, self))
         }
     }

--- a/plugins/check-path/swiftui/Sources/SwiftUICheckPathPlugin.swift
+++ b/plugins/check-path/swiftui/Sources/SwiftUICheckPathPlugin.swift
@@ -1,22 +1,19 @@
 import Foundation
-import SwiftUI
-
 import PlayerUI
-import PlayerUISwiftUI
 import PlayerUICheckPathPlugin
+import PlayerUISwiftUI
+import SwiftUI
 
 /// SwiftUI Version of `CheckPathPlugin` that puts itself into `\.checkPath` in EnvironmentValues
 public class SwiftUICheckPathPlugin: BaseCheckPathPlugin, NativePlugin {
-    /**
-     Constructs the SwiftUICheckPathPlugin
-     */
+    /// Constructs the SwiftUICheckPathPlugin
     public convenience init() {
         self.init(fileName: "CheckPathPlugin.native", pluginName: "CheckPathPlugin.CheckPathPlugin")
     }
 
-    public func apply<P>(player: P) where P: HeadlessPlayer {
+    public func apply<P: HeadlessPlayer>(player: P) {
         guard let player = player as? SwiftUIPlayer else { return }
-        player.hooks?.view.tap(name: self.pluginName) { [weak self] view in
+        player.hooks?.view.tap(name: pluginName) { [weak self] view in
             AnyView(view.environment(\.checkPath, self))
         }
     }

--- a/plugins/check-path/swiftui/Sources/SwiftUICheckPathPlugin.swift
+++ b/plugins/check-path/swiftui/Sources/SwiftUICheckPathPlugin.swift
@@ -11,7 +11,7 @@ public class SwiftUICheckPathPlugin: BaseCheckPathPlugin, NativePlugin {
         self.init(fileName: "CheckPathPlugin.native", pluginName: "CheckPathPlugin.CheckPathPlugin")
     }
 
-    public func apply<P: HeadlessPlayer>(player: P) {
+    public func apply(player: some HeadlessPlayer) {
         guard let player = player as? SwiftUIPlayer else { return }
         player.hooks?.view.tap(name: pluginName) { [weak self] view in
             AnyView(view.environment(\.checkPath, self))

--- a/plugins/check-path/swiftui/ViewInspector/SwiftUICheckPathPluginTests.swift
+++ b/plugins/check-path/swiftui/ViewInspector/SwiftUICheckPathPluginTests.swift
@@ -1,14 +1,14 @@
 import Foundation
-import XCTest
-import SwiftUI
-import ViewInspector
 @testable import PlayerUI
 @testable import PlayerUIInternalTestUtilities
 @testable import PlayerUISwiftUI
 @testable import PlayerUISwiftUICheckPathPlugin
+import SwiftUI
+import ViewInspector
+import XCTest
 
 class SwiftUICheckPathPluginTests: XCTestCase {
-    func testContextAttachment() throws {
+    func testContextAttachment() {
         let player = SwiftUIPlayer(flow: FlowData.COUNTER, plugins: [SwiftUICheckPathPlugin()])
         var baseView = CheckPathTestAssetView()
 
@@ -33,8 +33,8 @@ class SwiftUICheckPathPluginTests: XCTestCase {
 private struct CheckPathTestAssetView: View {
     @Environment(\.checkPath) var checkPath
 
-    // For Testing Purposes
-    internal var didAppear: ((Self) -> Void)?
+    /// For Testing Purposes
+    var didAppear: ((Self) -> Void)?
 
     var body: some View {
         Text(checkPath == nil ? "Not Found" : "Found").onAppear { didAppear?(self) }

--- a/plugins/check-path/swiftui/ViewInspector/SwiftUICheckPathPluginTests.swift
+++ b/plugins/check-path/swiftui/ViewInspector/SwiftUICheckPathPluginTests.swift
@@ -14,7 +14,7 @@ class SwiftUICheckPathPluginTests: XCTestCase {
 
         let appear = baseView.on(\.didAppear) { view in
             let value = try view.actualView().checkPath
-            guard let value = value else { return }
+            guard let value else { return }
             XCTAssertEqual(value.getParentProp(id: "action-label"), "label")
             XCTAssertTrue(value.hasParentContext(id: "action-label", query: "action"))
             XCTAssertNotNil(value.getParentContext(id: "action-label", query: "action"))

--- a/plugins/common-expressions/ios/Sources/CommonExpressionsPlugin.swift
+++ b/plugins/common-expressions/ios/Sources/CommonExpressionsPlugin.swift
@@ -1,15 +1,11 @@
 import Foundation
 #if SWIFT_PACKAGE
-import PlayerUI
+    import PlayerUI
 #endif
 
-/**
- Wrapper to instantiate @player-ui/common-expressions-plugin
- */
+/// Wrapper to instantiate @player-ui/common-expressions-plugin
 public class CommonExpressionsPlugin: JSBasePlugin, NativePlugin {
-    /**
-     Constructs a PartialMatchRegistry JS object
-     */
+    /// Constructs a PartialMatchRegistry JS object
     public convenience init() {
         self.init(
             fileName: "CommonExpressionsPlugin.native",
@@ -19,9 +15,14 @@ public class CommonExpressionsPlugin: JSBasePlugin, NativePlugin {
 
     override open func getUrlForFile(fileName: String) -> URL? {
         #if SWIFT_PACKAGE
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
+            ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
         #else
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle(for: CommonExpressionsPlugin.self), pathComponent: "PlayerUI_CommonExpressionsPlugin.bundle")
+            ResourceUtilities.urlForFile(
+                name: fileName,
+                ext: "js",
+                bundle: Bundle(for: CommonExpressionsPlugin.self),
+                pathComponent: "PlayerUI_CommonExpressionsPlugin.bundle"
+            )
         #endif
     }
 }

--- a/plugins/common-expressions/ios/Tests/CommonExpressionsPluginTests.swift
+++ b/plugins/common-expressions/ios/Tests/CommonExpressionsPluginTests.swift
@@ -7,10 +7,10 @@
 //
 
 import Foundation
-import XCTest
 import JavaScriptCore
 @testable import PlayerUI
 @testable import PlayerUICommonExpressionsPlugin
+import XCTest
 
 class CommonExpressionsPluginTests: XCTestCase {
     func testPluginConstructs() {

--- a/plugins/common-types/ios/Sources/CommonTypesPlugin.swift
+++ b/plugins/common-types/ios/Sources/CommonTypesPlugin.swift
@@ -1,25 +1,29 @@
 import Foundation
 
 #if SWIFT_PACKAGE
-import PlayerUI
+    import PlayerUI
 #endif
 
-/**
- Wrapper to instantiate @player-ui/common-types-plugin
- */
+/// Wrapper to instantiate @player-ui/common-types-plugin
 public class CommonTypesPlugin: JSBasePlugin, NativePlugin {
-    /**
-     Constructs a PartialMatchRegistry JS object
-     */
+    /// Constructs a PartialMatchRegistry JS object
     public convenience init() {
-        self.init(fileName: "CommonTypesPlugin.native", pluginName: "CommonTypesPlugin.CommonTypesPlugin")
+        self.init(
+            fileName: "CommonTypesPlugin.native",
+            pluginName: "CommonTypesPlugin.CommonTypesPlugin"
+        )
     }
 
     override open func getUrlForFile(fileName: String) -> URL? {
         #if SWIFT_PACKAGE
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
+            ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
         #else
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle(for: CommonTypesPlugin.self), pathComponent: "PlayerUI_CommonTypesPlugin.bundle")
+            ResourceUtilities.urlForFile(
+                name: fileName,
+                ext: "js",
+                bundle: Bundle(for: CommonTypesPlugin.self),
+                pathComponent: "PlayerUI_CommonTypesPlugin.bundle"
+            )
         #endif
     }
 }

--- a/plugins/common-types/ios/Tests/CommonTypesPluginTests.swift
+++ b/plugins/common-types/ios/Tests/CommonTypesPluginTests.swift
@@ -7,10 +7,10 @@
 //
 
 import Foundation
-import XCTest
 import JavaScriptCore
 @testable import PlayerUI
 @testable import PlayerUICommonTypesPlugin
+import XCTest
 
 class CommonTypesPluginTests: XCTestCase {
     func testPluginConstructs() {

--- a/plugins/computed-properties/ios/Sources/ComputedPropertiesPlugin.swift
+++ b/plugins/computed-properties/ios/Sources/ComputedPropertiesPlugin.swift
@@ -1,30 +1,29 @@
 import Foundation
 
 #if SWIFT_PACKAGE
-import PlayerUI
+    import PlayerUI
 #endif
 
-/**
- Wrapper to instantiate @player/computed-properties-plugin
- */
+/// Wrapper to instantiate @player/computed-properties-plugin
 public class ComputedPropertiesPlugin: JSBasePlugin, NativePlugin {
-    /**
-     Constructs a PartialMatchRegistry JS object
-     */
+    /// Constructs a PartialMatchRegistry JS object
     public convenience init() {
-        self.init(fileName: "ComputedPropertiesPlugin.native", pluginName: "ComputedPropertiesPlugin.ComputedPropertiesPlugin")
+        self.init(
+            fileName: "ComputedPropertiesPlugin.native",
+            pluginName: "ComputedPropertiesPlugin.ComputedPropertiesPlugin"
+        )
     }
 
     override open func getUrlForFile(fileName: String) -> URL? {
         #if SWIFT_PACKAGE
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
+            ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
         #else
-        ResourceUtilities.urlForFile(
-            name: fileName,
-            ext: "js",
-            bundle: Bundle(for: ComputedPropertiesPlugin.self),
-            pathComponent: "PlayerUI_ComputedPropertiesPlugin.bundle"
-        )
+            ResourceUtilities.urlForFile(
+                name: fileName,
+                ext: "js",
+                bundle: Bundle(for: ComputedPropertiesPlugin.self),
+                pathComponent: "PlayerUI_ComputedPropertiesPlugin.bundle"
+            )
         #endif
     }
 }

--- a/plugins/computed-properties/ios/Tests/ComputedPropertiesPluginTests.swift
+++ b/plugins/computed-properties/ios/Tests/ComputedPropertiesPluginTests.swift
@@ -1,9 +1,9 @@
 import Foundation
-import XCTest
 import JavaScriptCore
 @testable import PlayerUI
-@testable import PlayerUITestUtilitiesCore
 @testable import PlayerUIComputedPropertiesPlugin
+@testable import PlayerUITestUtilitiesCore
+import XCTest
 
 class ComputedPropertiesPluginTests: XCTestCase {
     func testPluginConstructs() {
@@ -60,7 +60,7 @@ class ComputedPropertiesPluginTests: XCTestCase {
 
         player.start(flow: flow) { result in
             guard
-                case .success(let success) = result
+                case let .success(success) = result
             else {
                 return XCTFail("Flow Failed")
             }
@@ -70,6 +70,5 @@ class ComputedPropertiesPluginTests: XCTestCase {
         }
 
         wait(for: [expectation], timeout: 1)
-
     }
 }

--- a/plugins/console-logger/ios/Sources/PrintLoggerPlugin.swift
+++ b/plugins/console-logger/ios/Sources/PrintLoggerPlugin.swift
@@ -8,48 +8,54 @@
 import Foundation
 
 #if SWIFT_PACKAGE
-import PlayerUI
-import PlayerUILogger
+    import PlayerUI
+    import PlayerUILogger
 #endif
 
-/**
- A Logger plugin that prints messages
- */
+/// A Logger plugin that prints messages
 public class PrintLoggerPlugin: NativePlugin {
     public var pluginName: String = "PrintLoggerPlugin"
 
     private var logLevel: LogLevel
 
-    /**
-     Creates a PrintLoggerPlugin to log to the given severity
-     - parameters:
-        - level: The LogLevel to use
-     */
+    /// Creates a PrintLoggerPlugin to log to the given severity
+    /// - parameters:
+    ///   - level: The LogLevel to use
     public init(level: LogLevel = .error) {
-        self.logLevel = level
-    }
-    
-    private func printMessage(level: LogLevel, items: [Any]) {
-        let message = items.compactMap { $0 }.map { "\($0)" }.joined()
-        print("[Player] [\(level.description)]: \(message)")
+        logLevel = level
     }
 
-    /**
-     Applies itself to Player
-     */
-    public func apply<P>(player: P) where P: HeadlessPlayer {
+    /// Applies itself to Player
+    public func apply<P: HeadlessPlayer>(player: P) {
         player.logger.logLevel = logLevel
 
-        player.logger.hooks.trace.tap(name: pluginName, { self.printMessage(level: .trace, items: $0) })
-        player.logger.hooks.debug.tap(name: pluginName, { self.printMessage(level: .debug, items: $0) })
-        player.logger.hooks.info.tap(name: pluginName, { self.printMessage(level: .info, items: $0) })
-        player.logger.hooks.warn.tap(name: pluginName, { self.printMessage(level: .warning, items: $0) })
-        player.logger.hooks.error.tap(name: pluginName, {
+        player.logger
+            .hooks
+            .trace
+            .tap(name: pluginName) { self.printMessage(level: .trace, items: $0) }
+        player.logger
+            .hooks
+            .debug
+            .tap(name: pluginName) { self.printMessage(level: .debug, items: $0) }
+        player.logger
+            .hooks
+            .info
+            .tap(name: pluginName) { self.printMessage(level: .info, items: $0) }
+        player.logger.hooks.warn.tap(name: pluginName) { self.printMessage(
+            level: .warning,
+            items: $0
+        ) }
+        player.logger.hooks.error.tap(name: pluginName) {
             var items = $0.message ?? []
             if let err = $0.error {
                 items += [err.localizedDescription]
             }
             self.printMessage(level: .error, items: items)
-        })
+        }
+    }
+
+    private func printMessage(level: LogLevel, items: [Any]) {
+        let message = items.compactMap { $0 }.map { "\($0)" }.joined()
+        print("[Player] [\(level.description)]: \(message)")
     }
 }

--- a/plugins/console-logger/ios/Sources/PrintLoggerPlugin.swift
+++ b/plugins/console-logger/ios/Sources/PrintLoggerPlugin.swift
@@ -6,48 +6,53 @@
 //
 
 import Foundation
-
 import PlayerUI
 import PlayerUILogger
 
-/**
- A Logger plugin that prints messages
- */
+/// A Logger plugin that prints messages
 public class PrintLoggerPlugin: NativePlugin {
     public var pluginName: String = "PrintLoggerPlugin"
 
     private var logLevel: LogLevel
 
-    /**
-     Creates a PrintLoggerPlugin to log to the given severity
-     - parameters:
-        - level: The LogLevel to use
-     */
+    /// Creates a PrintLoggerPlugin to log to the given severity
+    /// - parameters:
+    ///   - level: The LogLevel to use
     public init(level: LogLevel = .error) {
-        self.logLevel = level
-    }
-    
-    private func printMessage(level: LogLevel, items: [Any]) {
-        let message = items.compactMap { $0 }.map { "\($0)" }.joined()
-        print("[Player] [\(level.description)]: \(message)")
+        logLevel = level
     }
 
-    /**
-     Applies itself to Player
-     */
-    public func apply<P>(player: P) where P: HeadlessPlayer {
+    /// Applies itself to Player
+    public func apply<P: HeadlessPlayer>(player: P) {
         player.logger.logLevel = logLevel
 
-        player.logger.hooks.trace.tap(name: pluginName, { self.printMessage(level: .trace, items: $0) })
-        player.logger.hooks.debug.tap(name: pluginName, { self.printMessage(level: .debug, items: $0) })
-        player.logger.hooks.info.tap(name: pluginName, { self.printMessage(level: .info, items: $0) })
-        player.logger.hooks.warn.tap(name: pluginName, { self.printMessage(level: .warning, items: $0) })
-        player.logger.hooks.error.tap(name: pluginName, {
+        player.logger
+            .hooks
+            .trace
+            .tap(name: pluginName) { self.printMessage(level: .trace, items: $0) }
+        player.logger
+            .hooks
+            .debug
+            .tap(name: pluginName) { self.printMessage(level: .debug, items: $0) }
+        player.logger
+            .hooks
+            .info
+            .tap(name: pluginName) { self.printMessage(level: .info, items: $0) }
+        player.logger.hooks.warn.tap(name: pluginName) { self.printMessage(
+            level: .warning,
+            items: $0
+        ) }
+        player.logger.hooks.error.tap(name: pluginName) {
             var items = $0.message ?? []
             if let err = $0.error {
                 items += [err.localizedDescription]
             }
             self.printMessage(level: .error, items: items)
-        })
+        }
+    }
+
+    private func printMessage(level: LogLevel, items: [Any]) {
+        let message = items.compactMap { $0 }.map { "\($0)" }.joined()
+        print("[Player] [\(level.description)]: \(message)")
     }
 }

--- a/plugins/console-logger/ios/Sources/PrintLoggerPlugin.swift
+++ b/plugins/console-logger/ios/Sources/PrintLoggerPlugin.swift
@@ -23,7 +23,7 @@ public class PrintLoggerPlugin: NativePlugin {
     }
 
     /// Applies itself to Player
-    public func apply<P: HeadlessPlayer>(player: P) {
+    public func apply(player: some HeadlessPlayer) {
         player.logger.logLevel = logLevel
 
         player.logger

--- a/plugins/console-logger/ios/Tests/PrintLoggerPluginTests.swift
+++ b/plugins/console-logger/ios/Tests/PrintLoggerPluginTests.swift
@@ -8,11 +8,11 @@
 
 import Foundation
 import JavaScriptCore
-import XCTest
 @testable import PlayerUI
-@testable import PlayerUIPrintLoggerPlugin
 @testable import PlayerUILogger
+@testable import PlayerUIPrintLoggerPlugin
 @testable import PlayerUITestUtilitiesCore
+import XCTest
 
 class PrintLoggerPluginTests: XCTestCase {
     func testPrintLogger() {
@@ -21,13 +21,13 @@ class PrintLoggerPluginTests: XCTestCase {
         let player = HeadlessPlayerImpl(plugins: [PrintLoggerPlugin(level: .trace)])
         XCTAssertEqual(LogLevel.trace, player.logger.logLevel)
 
-        player.logger.hooks.trace.tap(name: "test") { (message) in
+        player.logger.hooks.trace.tap(name: "test") { message in
             XCTAssertEqual("Message 1", (message as? [String])?.first)
             XCTAssertEqual("Message 2", (message as? [String])?[1])
             XCTAssertEqual("Message 3", (message as? [String])?[2])
             logExpect.fulfill()
         }
-        
+
         player.logger.t("Message 1", "Message 2", "Message 3")
         player.logger.d("Message")
         player.logger.i("Message")

--- a/plugins/expression/ios/Sources/ExpressionPlugin.swift
+++ b/plugins/expression/ios/Sources/ExpressionPlugin.swift
@@ -9,46 +9,55 @@ import Foundation
 import JavaScriptCore
 
 #if SWIFT_PACKAGE
-import PlayerUI
+    import PlayerUI
 #endif
 
-/**
- Plugin for registering custom expressions with Player
- */
+/// Plugin for registering custom expressions with Player
 public class ExpressionPlugin: JSBasePlugin, NativePlugin {
     private var expressions: [String: ([Any]) -> Any?] = [:]
-    /**
-     Constructs the ExpressionPlugin
-     Handler functions receive the positional arguments from the call in the content as an array
-     - parameters:
-        - expressions: A dictionary of expression name to handler function
-     */
+
+    /// Constructs the ExpressionPlugin
+    /// Handler functions receive the positional arguments from the call in the content as an array
+    /// - parameters:
+    ///   - expressions: A dictionary of expression name to handler function
     public convenience init(expressions: [String: ([Any]) -> Any?] = [:]) {
-        self.init(fileName: "ExpressionPlugin.native", pluginName: "ExpressionPlugin.ExpressionPlugin")
+        self.init(
+            fileName: "ExpressionPlugin.native",
+            pluginName: "ExpressionPlugin.ExpressionPlugin"
+        )
         self.expressions = expressions
     }
 
     override open func getUrlForFile(fileName: String) -> URL? {
         #if SWIFT_PACKAGE
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
+            ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
         #else
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle(for: ExpressionPlugin.self), pathComponent: "PlayerUI_ExpressionPlugin.bundle")
+            ResourceUtilities.urlForFile(
+                name: fileName,
+                ext: "js",
+                bundle: Bundle(for: ExpressionPlugin.self),
+                pathComponent: "PlayerUI_ExpressionPlugin.bundle"
+            )
         #endif
     }
 
     override public func getArguments() -> [Any] {
         guard
             let map = context?.evaluateScript("Map")?.construct(withArguments: []),
-            let restWrapper = context?.evaluateScript("(fn) => (context, ...args) => fn(context, args)"),
-            let context = self.context
+            let restWrapper = context?
+            .evaluateScript("(fn) => (context, ...args) => fn(context, args)"),
+            let context
         else { return [] }
         for (key, value) in expressions {
-            let callback: @convention(block) (JSValue?, JSValue?) -> JSValue? = { (_, params) in
+            let callback: @convention(block) (JSValue?, JSValue?) -> JSValue? = { _, params in
                 let args = params?.toObject() as? [Any] ?? []
                 return JSValue(object: value(args), in: context)
             }
             let jsCallback = JSValue(object: callback, in: context)
-            map.invokeMethod("set", withArguments: [key, restWrapper.call(withArguments: [jsCallback as Any]) as Any])
+            map.invokeMethod(
+                "set",
+                withArguments: [key, restWrapper.call(withArguments: [jsCallback as Any]) as Any]
+            )
         }
         return [map]
     }

--- a/plugins/expression/ios/Sources/ExpressionPlugin.swift
+++ b/plugins/expression/ios/Sources/ExpressionPlugin.swift
@@ -7,22 +7,21 @@
 
 import Foundation
 import JavaScriptCore
-
 import PlayerUI
 
-/**
- Plugin for registering custom expressions with Player
- */
+/// Plugin for registering custom expressions with Player
 public class ExpressionPlugin: JSBasePlugin, NativePlugin {
     private var expressions: [String: ([Any]) -> Any?] = [:]
-    /**
-     Constructs the ExpressionPlugin
-     Handler functions receive the positional arguments from the call in the content as an array
-     - parameters:
-        - expressions: A dictionary of expression name to handler function
-     */
+
+    /// Constructs the ExpressionPlugin
+    /// Handler functions receive the positional arguments from the call in the content as an array
+    /// - parameters:
+    ///   - expressions: A dictionary of expression name to handler function
     public convenience init(expressions: [String: ([Any]) -> Any?] = [:]) {
-        self.init(fileName: "ExpressionPlugin.native", pluginName: "ExpressionPlugin.ExpressionPlugin")
+        self.init(
+            fileName: "ExpressionPlugin.native",
+            pluginName: "ExpressionPlugin.ExpressionPlugin"
+        )
         self.expressions = expressions
     }
 
@@ -33,16 +32,20 @@ public class ExpressionPlugin: JSBasePlugin, NativePlugin {
     override public func getArguments() -> [Any] {
         guard
             let map = context?.evaluateScript("Map")?.construct(withArguments: []),
-            let restWrapper = context?.evaluateScript("(fn) => (context, ...args) => fn(context, args)"),
-            let context = self.context
+            let restWrapper = context?
+            .evaluateScript("(fn) => (context, ...args) => fn(context, args)"),
+            let context
         else { return [] }
         for (key, value) in expressions {
-            let callback: @convention(block) (JSValue?, JSValue?) -> JSValue? = { (_, params) in
+            let callback: @convention(block) (JSValue?, JSValue?) -> JSValue? = { _, params in
                 let args = params?.toObject() as? [Any] ?? []
                 return JSValue(object: value(args), in: context)
             }
             let jsCallback = JSValue(object: callback, in: context)
-            map.invokeMethod("set", withArguments: [key, restWrapper.call(withArguments: [jsCallback as Any]) as Any])
+            map.invokeMethod(
+                "set",
+                withArguments: [key, restWrapper.call(withArguments: [jsCallback as Any]) as Any]
+            )
         }
         return [map]
     }

--- a/plugins/expression/ios/Tests/ExpressionPluginTests.swift
+++ b/plugins/expression/ios/Tests/ExpressionPluginTests.swift
@@ -7,10 +7,10 @@
 //
 
 import Foundation
-import XCTest
 import JavaScriptCore
 @testable import PlayerUI
 @testable import PlayerUIExpressionPlugin
+import XCTest
 
 class ExpressionPluginTests: XCTestCase {
     func testExpressionPluginConstructsWithoutExpressions() {
@@ -21,10 +21,15 @@ class ExpressionPluginTests: XCTestCase {
 
     func testExpressionPluginConstructsWithExpressions() {
         let expectation = XCTestExpectation(description: "custom expression called")
-        let plugin = ExpressionPlugin(expressions: ["test": {_ in expectation.fulfill() }])
+        let plugin = ExpressionPlugin(expressions: ["test": { _ in expectation.fulfill() }])
         plugin.context = JSContext()
         XCTAssertNotNil(plugin.pluginRef)
-        plugin.pluginRef?.objectForKeyedSubscript("expressions")?.invokeMethod("get", withArguments: ["test"])?.call(withArguments: [])
+        plugin.pluginRef?
+            .objectForKeyedSubscript("expressions")?
+            .invokeMethod(
+                "get",
+                withArguments: ["test"]
+            )?.call(withArguments: [])
         wait(for: [expectation], timeout: 1)
     }
 
@@ -38,7 +43,12 @@ class ExpressionPluginTests: XCTestCase {
         }])
         plugin.context = JSContext()
         XCTAssertNotNil(plugin.pluginRef)
-        plugin.pluginRef?.objectForKeyedSubscript("expressions")?.invokeMethod("get", withArguments: ["test"])?.call(withArguments: ["context", "example"])
+        plugin.pluginRef?
+            .objectForKeyedSubscript("expressions")?
+            .invokeMethod(
+                "get",
+                withArguments: ["test"]
+            )?.call(withArguments: ["context", "example"])
         wait(for: [expectation], timeout: 1)
     }
 

--- a/plugins/external-action/ios/Sources/ExternalActionPlugin.swift
+++ b/plugins/external-action/ios/Sources/ExternalActionPlugin.swift
@@ -9,29 +9,20 @@ import Foundation
 import JavaScriptCore
 
 #if SWIFT_PACKAGE
-import PlayerUI
+    import PlayerUI
 #endif
 
-/**
- This plugin is for registering a handler for EXTERNAL states
- */
+/// This plugin is for registering a handler for EXTERNAL states
 public class ExternalActionPlugin: JSBasePlugin, NativePlugin {
-    /**
-     The handler function to run when an external state is transitioned to
-     - parameters:
-        - state: The state object that represents the external state
-        - options: An object containing the dataModel instance and evaluate function
-        - transition: A completion handler that takes a string to transition with
-     */
-    public typealias ExternalStateHandler = (NavigationFlowExternalState, PlayerControllers, @escaping (String) -> Void) throws -> Void
+    #if SWIFT_PACKAGE
+        public static let bundle: Bundle = .module
+    #endif
 
     private var handler: ExternalStateHandler?
 
-    /**
-     Construct a plugin to handle external states
-     - parameters:
-        - handler: the function to call when an external state is transitioned to
-     */
+    /// Construct a plugin to handle external states
+    /// - parameters:
+    ///   - handler: the function to call when an external state is transitioned to
     public convenience init(handler: @escaping ExternalStateHandler) {
         self.init(
             fileName: "ExternalActionPlugin.native",
@@ -40,41 +31,61 @@ public class ExternalActionPlugin: JSBasePlugin, NativePlugin {
         self.handler = handler
     }
 
-    /**
-     Retrieves the arguments for constructing this plugin, this is necessary because the arguments need to be supplied after
-     construction of the swift object, once the context has been provided
-     - returns: An array of arguments to construct the plugin
-     */
-    override public func getArguments() -> [Any] {
-            let callback: @convention(block) (JSValue, JSValue) -> JSValue? = { [weak self] (state, options) in
-                guard
-                    let context = self?.context,
-                    let controllers = PlayerControllers(from: options),
-                    let promise = JSUtilities.createPromise(context: context, handler: { (resolve, reject) in
-                        do {
-                            try self?.handler?(NavigationFlowExternalState(state), controllers) { transition in
-                                resolve(transition)
-                            }
-                        } catch {
-                            reject(JSValue(newErrorFromMessage: error.playerDescription, in: context) as Any)
-                        }
-                    })
-                else { return nil }
-                return promise
-            }
-            let jsCallback = JSValue(object: callback, in: context) as Any
-            return [jsCallback]
-        }
-
     override open func getUrlForFile(fileName: String) -> URL? {
         #if SWIFT_PACKAGE
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
+            ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
         #else
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle(for: ExternalActionPlugin.self), pathComponent: "PlayerUI_ExternalActionPlugin.bundle")
+            ResourceUtilities.urlForFile(
+                name: fileName,
+                ext: "js",
+                bundle: Bundle(for: ExternalActionPlugin.self),
+                pathComponent: "PlayerUI_ExternalActionPlugin.bundle"
+            )
         #endif
     }
 
-    #if SWIFT_PACKAGE
-    public static let bundle = Bundle.module
-    #endif
+    /// Retrieves the arguments for constructing this plugin, this is necessary because the
+    /// arguments need to be supplied after
+    /// construction of the swift object, once the context has been provided
+    /// - returns: An array of arguments to construct the plugin
+    override public func getArguments() -> [Any] {
+        let callback: @convention(block) (JSValue, JSValue)
+            -> JSValue? = { [weak self] state, options in
+                guard
+                    let context = self?.context,
+                    let controllers = PlayerControllers(from: options),
+                    let promise = JSUtilities.createPromise(
+                        context: context,
+                        handler: { resolve, reject in
+                            do {
+                                try self?
+                                    .handler?(NavigationFlowExternalState(state),
+                                              controllers) { transition in
+                                        resolve(transition)
+                                    }
+                            } catch {
+                                reject(JSValue(
+                                    newErrorFromMessage: error.playerDescription,
+                                    in: context
+                                ) as Any)
+                            }
+                        }
+                    )
+                else { return nil }
+                return promise
+            }
+        let jsCallback = JSValue(object: callback, in: context) as Any
+        return [jsCallback]
+    }
+
+    /// The handler function to run when an external state is transitioned to
+    /// - parameters:
+    ///   - state: The state object that represents the external state
+    ///   - options: An object containing the dataModel instance and evaluate function
+    ///   - transition: A completion handler that takes a string to transition with
+    public typealias ExternalStateHandler = (
+        NavigationFlowExternalState,
+        PlayerControllers,
+        @escaping (String) -> Void
+    ) throws -> Void
 }

--- a/plugins/external-action/ios/Tests/ExternalActionPluginTests.swift
+++ b/plugins/external-action/ios/Tests/ExternalActionPluginTests.swift
@@ -7,11 +7,11 @@
 //
 
 import Foundation
-import XCTest
 import JavaScriptCore
 @testable import PlayerUI
-@testable import PlayerUITestUtilitiesCore
 @testable import PlayerUIExternalActionPlugin
+@testable import PlayerUITestUtilitiesCore
+import XCTest
 
 // swiftlint:disable type_body_length
 class ExternalActionPluginTests: XCTestCase {
@@ -50,7 +50,7 @@ class ExternalActionPluginTests: XCTestCase {
 
         let handlerExpectation = XCTestExpectation(description: "handler called")
         let completionExpectation = XCTestExpectation(description: "flow completed")
-        let plugin = ExternalActionPlugin { (state, _, handler) in
+        let plugin = ExternalActionPlugin { state, _, handler in
             XCTAssertEqual(state.transitions, ["Next": "END_FWD", "Prev": "END_BCK"])
             XCTAssertEqual(state.ref, "test-1")
             // Test out subscript fetching additional properties
@@ -61,9 +61,9 @@ class ExternalActionPluginTests: XCTestCase {
         }
         let player = HeadlessPlayerImpl(plugins: [plugin])
 
-        player.start(flow: json) { (result) in
+        player.start(flow: json) { result in
             switch result {
-            case .success(let state):
+            case let .success(state):
                 XCTAssertEqual(state.endState?.outcome, "FWD")
                 completionExpectation.fulfill()
             case .failure:
@@ -109,13 +109,13 @@ class ExternalActionPluginTests: XCTestCase {
 
         let handlerExpectation = XCTestExpectation(description: "handler called")
         let completionExpectation = XCTestExpectation(description: "flow completed")
-        let plugin = ExternalActionPlugin { (_, _, _) in
+        let plugin = ExternalActionPlugin { _, _, _ in
             handlerExpectation.fulfill()
             throw PlayerError.jsConversionFailure
         }
         let player = HeadlessPlayerImpl(plugins: [plugin])
 
-        player.start(flow: json) { (result) in
+        player.start(flow: json) { result in
             switch result {
             case .success:
                 XCTFail("flow should have failed")
@@ -171,7 +171,7 @@ class ExternalActionPluginTests: XCTestCase {
 
         let handlerExpectation = XCTestExpectation(description: "handler called")
         let completionExpectation = XCTestExpectation(description: "flow completed")
-        let plugin = ExternalActionPlugin { (state, _, handler) in
+        let plugin = ExternalActionPlugin { state, _, handler in
             XCTAssertEqual(state.transitions, ["Next": "END_FWD", "Prev": "END_BCK"])
             XCTAssertEqual(state.ref, "test-1")
             if let param: [String: Any] = state.param {
@@ -184,9 +184,9 @@ class ExternalActionPluginTests: XCTestCase {
         }
         let player = HeadlessPlayerImpl(plugins: [plugin])
 
-        player.start(flow: json) { (result) in
+        player.start(flow: json) { result in
             switch result {
-            case .success(let state):
+            case let .success(state):
                 XCTAssertEqual(state.endState?.outcome, "FWD")
                 completionExpectation.fulfill()
             case .failure:
@@ -232,7 +232,7 @@ class ExternalActionPluginTests: XCTestCase {
 
         let handlerExpectation = XCTestExpectation(description: "handler called")
         let completionExpectation = XCTestExpectation(description: "flow completed")
-        let plugin = ExternalActionPlugin { (_, _, handler) in
+        let plugin = ExternalActionPlugin { _, _, handler in
             DispatchQueue.global().asyncAfter(deadline: .now() + 1) {
                 handlerExpectation.fulfill()
                 handler("Next")
@@ -240,9 +240,9 @@ class ExternalActionPluginTests: XCTestCase {
         }
         let player = HeadlessPlayerImpl(plugins: [plugin])
 
-        player.start(flow: json) { (result) in
+        player.start(flow: json) { result in
             switch result {
-            case .success(let state):
+            case let .success(state):
                 XCTAssertEqual(state.endState?.outcome, "FWD")
                 completionExpectation.fulfill()
             case .failure:
@@ -288,7 +288,7 @@ class ExternalActionPluginTests: XCTestCase {
 
         let handlerExpectation = XCTestExpectation(description: "handler called")
         let completionExpectation = XCTestExpectation(description: "flow completed")
-        let plugin = ExternalActionPlugin { (_, options, handler) in
+        let plugin = ExternalActionPlugin { _, options, handler in
             XCTAssertEqual(options.data.get(binding: "transitionValue") as? String, "Next")
 
             // Test expression evaluation
@@ -296,16 +296,19 @@ class ExternalActionPluginTests: XCTestCase {
             options.expression.evaluate("{{transitionValue}} = 'Prev'")
             XCTAssertEqual(options.data.get(binding: "transitionValue") as? String, "Prev")
 
-            options.expression.evaluate(["{{transitionValue}} = 'Previous'", "{{transitionValue}} = 'Next'"])
+            options.expression.evaluate([
+                "{{transitionValue}} = 'Previous'",
+                "{{transitionValue}} = 'Next'",
+            ])
             XCTAssertEqual(options.data.get(binding: "transitionValue") as? String, "Next")
             handlerExpectation.fulfill()
             handler("Next")
         }
         let player = HeadlessPlayerImpl(plugins: [plugin])
 
-        player.start(flow: json) { (result) in
+        player.start(flow: json) { result in
             switch result {
-            case .success(let state):
+            case let .success(state):
                 XCTAssertEqual(state.endState?.outcome, "FWD")
                 completionExpectation.fulfill()
             case .failure:

--- a/plugins/external-action/swiftui/Sources/ExternalActionViewModifierPlugin.swift
+++ b/plugins/external-action/swiftui/Sources/ExternalActionViewModifierPlugin.swift
@@ -2,16 +2,15 @@ import JavaScriptCore
 import SwiftUI
 
 #if SWIFT_PACKAGE
-import PlayerUI
-import PlayerUISwiftUI
-import PlayerUIExternalActionPlugin
+    import PlayerUI
+    import PlayerUIExternalActionPlugin
+    import PlayerUISwiftUI
 #endif
 
-/**
- A variation on `ExternalActionPlugin` for `SwiftUIPlayer` that applies a ViewModifier to SwiftUIPlayer content when in an external state
- */
-open class ExternalActionViewModifierPlugin<ModifierType: ExternalStateViewModifier>: JSBasePlugin, NativePlugin, ObservableObject {
-
+/// A variation on `ExternalActionPlugin` for `SwiftUIPlayer` that applies a ViewModifier to
+/// SwiftUIPlayer content when in an external state
+open class ExternalActionViewModifierPlugin<ModifierType: ExternalStateViewModifier>: JSBasePlugin,
+    NativePlugin, ObservableObject {
     /// Whether or not Player is currently in an EXTERNAL state
     @Published public var isExternalState = false
     /// The content the plugin has determined to show during the current EXTERNAL state
@@ -19,39 +18,30 @@ open class ExternalActionViewModifierPlugin<ModifierType: ExternalStateViewModif
     /// The current state if player is in an EXTERNAL state
     @Published public var state: NavigationFlowExternalState?
 
-    /**
-     The handler function to run when an external state is transitioned to
-     - parameters:
-        - state: The state object that represents the external state
-        - options: An object containing the dataModel instance and evaluate function
-        - transition: A completion handler that takes a string to transition with
-     - returns: A view to show as content by the ViewModifier
-     */
-    public typealias ExternalStateViewModifierHandler = (NavigationFlowExternalState, PlayerControllers, @escaping (String) -> Void) throws -> AnyView
-
     private var handler: ExternalStateViewModifierHandler?
 
-    /**
-     Construct a plugin to handle external states
-     - parameters:
-        - handler: the function to call when an external state is transitioned to
-     */
+    /// Construct a plugin to handle external states
+    /// - parameters:
+    ///   - handler: the function to call when an external state is transitioned to
     public convenience init(handler: @escaping ExternalStateViewModifierHandler) {
-        self.init(fileName: "ExternalActionPlugin.native", pluginName: "ExternalActionPlugin.ExternalActionPlugin")
+        self.init(
+            fileName: "ExternalActionPlugin.native",
+            pluginName: "ExternalActionPlugin.ExternalActionPlugin"
+        )
         self.handler = handler
     }
 
-    open func apply<P>(player: P) where P: HeadlessPlayer {
+    open func apply<P: HeadlessPlayer>(player: P) {
         guard let player = player as? SwiftUIPlayer else { return }
-        player.hooks?.view.tap(name: pluginName, { (view) -> AnyView in
-            return AnyView(view.modifier(ModifierType.init(plugin: self)))
-        })
+        player.hooks?.view.tap(name: pluginName) { view -> AnyView in
+            return AnyView(view.modifier(ModifierType(plugin: self)))
+        }
 
         // If the state changes without our intervention
         // we should update our state
-        player.hooks?.flowController.tap({ flowController in
+        player.hooks?.flowController.tap { flowController in
             flowController.hooks.flow.tap { flow in
-                flow.hooks.transition.tap {[weak self] old, newState in
+                flow.hooks.transition.tap { [weak self] old, newState in
                     guard
                         old?.value?.stateType == .external,
                         newState.value?.stateType != .external
@@ -60,89 +50,103 @@ open class ExternalActionViewModifierPlugin<ModifierType: ExternalStateViewModif
                     self?.state = nil
                 }
             }
-        })
+        }
     }
 
-    /**
-     Retrieves the arguments for constructing this plugin, this is necessary because the arguments need to be supplied after
-     construction of the swift object, once the context has been provided
-     - returns: An array of arguments to construct the plugin
-     */
+    /// Retrieves the arguments for constructing this plugin, this is necessary because the
+    /// arguments need to be supplied after
+    /// construction of the swift object, once the context has been provided
+    /// - returns: An array of arguments to construct the plugin
     override open func getArguments() -> [Any] {
-        let callback: @convention(block) (JSValue, JSValue) -> JSValue? = { [weak self] (state, options) in
-            guard
-                let context = self?.context,
-                let controllers = PlayerControllers(from: options),
-                let promise = JSUtilities.createPromise(context: context, handler: { (resolve, reject) in
-                    self?.isExternalState = true
-                    let state = NavigationFlowExternalState(state)
-                    self?.state = state
-                    do {
-                        self?.content = try self?.handler?(state, controllers) { transition in
-                            resolve(transition)
-                            withAnimation {
-                                self?.isExternalState = false
-                                self?.state = nil
+        let callback: @convention(block) (JSValue, JSValue)
+            -> JSValue? = { [weak self] state, options in
+                guard
+                    let context = self?.context,
+                    let controllers = PlayerControllers(from: options),
+                    let promise = JSUtilities.createPromise(
+                        context: context,
+                        handler: { resolve, reject in
+                            self?.isExternalState = true
+                            let state = NavigationFlowExternalState(state)
+                            self?.state = state
+                            do {
+                                self?.content = try self?
+                                    .handler?(state, controllers) { transition in
+                                        resolve(transition)
+                                        withAnimation {
+                                            self?.isExternalState = false
+                                            self?.state = nil
+                                        }
+                                        self?.content = nil
+                                    }
+                            } catch {
+                                reject(JSValue(
+                                    newErrorFromMessage: error.playerDescription,
+                                    in: context
+                                ) as Any)
                             }
-                            self?.content = nil
                         }
-                    } catch {
-                        reject(JSValue(newErrorFromMessage: error.playerDescription, in: context) as Any)
-                    }
-                })
-            else { return nil }
-            return promise
-        }
+                    )
+                else { return nil }
+                return promise
+            }
         let jsCallback = JSValue(object: callback, in: context) as Any
         return [jsCallback]
     }
 
     override open func getUrlForFile(fileName: String) -> URL? {
         #if SWIFT_PACKAGE
-        ResourceUtilities.urlForFile(
-            name: fileName, ext: "js",
-            bundle: ExternalActionPlugin.bundle
-        )
+            ResourceUtilities.urlForFile(
+                name: fileName, ext: "js",
+                bundle: ExternalActionPlugin.bundle
+            )
         #else
-        ResourceUtilities.urlForFile(
-            name: fileName, ext: "js",
-            bundle: Bundle(for: ExternalActionPlugin.self),
-            pathComponent: "PlayerUI_ExternalActionPlugin.bundle"
-        )
+            ResourceUtilities.urlForFile(
+                name: fileName, ext: "js",
+                bundle: Bundle(for: ExternalActionPlugin.self),
+                pathComponent: "PlayerUI_ExternalActionPlugin.bundle"
+            )
         #endif
     }
+
+    /// The handler function to run when an external state is transitioned to
+    /// - parameters:
+    ///   - state: The state object that represents the external state
+    ///   - options: An object containing the dataModel instance and evaluate function
+    ///   - transition: A completion handler that takes a string to transition with
+    /// - returns: A view to show as content by the ViewModifier
+    public typealias ExternalStateViewModifierHandler = (
+        NavigationFlowExternalState,
+        PlayerControllers,
+        @escaping (String) -> Void
+    ) throws -> AnyView
 }
 
-/**
- ViewModifier type specifically for the `ExternalActionViewModifierPlugin` to provide observable properties
- to present content in an external action
- */
+/// ViewModifier type specifically for the `ExternalActionViewModifierPlugin` to provide observable
+/// properties
+/// to present content in an external action
 public protocol ExternalStateViewModifier: ViewModifier {
     /// An observable reference to the presenting plugin, to know when we are in an external state
     var plugin: ExternalActionViewModifierPlugin<Self> { get }
 
-    /**
-     Creates a new `ExternalStateViewModifier` with the plugin that is presenting it
-     - parameters:
-        - plugin: The plugin presenting this view modifier
-     */
+    /// Creates a new `ExternalStateViewModifier` with the plugin that is presenting it
+    /// - parameters:
+    ///   - plugin: The plugin presenting this view modifier
     init(plugin: ExternalActionViewModifierPlugin<Self>)
 }
 
-/**
- A ViewModifier for the `ExternalActionViewModifierPlugin` that presents the external state with the `.sheet` modifier
- */
+/// A ViewModifier for the `ExternalActionViewModifierPlugin` that presents the external state with
+/// the `.sheet` modifier
 public struct ExternalStateSheetModifier: ExternalStateViewModifier {
     @ObservedObject public var plugin: ExternalActionViewModifierPlugin<Self>
-    /**
-     Constructs this ViewModifier
-     - parameters:
-        - plugin: The plugin presenting the external state
-     */
+
+    /// Constructs this ViewModifier
+    /// - parameters:
+    ///   - plugin: The plugin presenting the external state
     public init(plugin: ExternalActionViewModifierPlugin<Self>) {
         self.plugin = plugin
     }
-    @ViewBuilder
+
     public func body(content: Content) -> some View {
         content.inspectableSheet(isPresented: $plugin.isExternalState, content: {
             plugin.content
@@ -151,15 +155,22 @@ public struct ExternalStateSheetModifier: ExternalStateViewModifier {
 }
 
 // MARK: ViewInspector
+
 extension View {
-    func inspectableSheet<Sheet>(isPresented: Binding<Bool>, onDismiss: (() -> Void)? = nil, @ViewBuilder content: @escaping () -> Sheet
-    ) -> some View where Sheet: View {
-        return self.modifier(InspectableSheet(isPresented: isPresented, onDismiss: onDismiss, popupBuilder: content))
+    func inspectableSheet<Sheet: View>(
+        isPresented: Binding<Bool>,
+        onDismiss: (() -> Void)? = nil,
+        @ViewBuilder content: @escaping () -> Sheet
+    ) -> some View {
+        modifier(InspectableSheet(
+            isPresented: isPresented,
+            onDismiss: onDismiss,
+            popupBuilder: content
+        ))
     }
 }
 
-struct InspectableSheet<Sheet>: ViewModifier where Sheet: View {
-
+struct InspectableSheet<Sheet: View>: ViewModifier {
     let isPresented: Binding<Bool>
     let onDismiss: (() -> Void)?
     let popupBuilder: () -> Sheet

--- a/plugins/external-action/swiftui/ViewInspector/ExternalActionViewModifierPluginTests.swift
+++ b/plugins/external-action/swiftui/ViewInspector/ExternalActionViewModifierPluginTests.swift
@@ -5,22 +5,19 @@
 //  Created by Harris Borawski on 8/19/21.
 //  Copyright © 2021 CocoaPods. All rights reserved.
 //
-import Foundation
-import XCTest
-import JavaScriptCore
 import Combine
+import Foundation
+import JavaScriptCore
+@testable import PlayerUI
+@testable import PlayerUIExternalActionViewModifierPlugin
+@testable import PlayerUIInternalTestUtilities
+@testable import PlayerUIReferenceAssets
+@testable import PlayerUISwiftUI
 import SwiftUI
 import ViewInspector
-@testable import PlayerUI
-@testable import PlayerUIInternalTestUtilities
-@testable import PlayerUISwiftUI
-@testable import PlayerUIReferenceAssets
-@testable import PlayerUIExternalActionViewModifierPlugin
+import XCTest
 
 class ExternalActionViewModifierPluginTests: XCTestCase {
-    override func setUp() {
-        XCUIApplication().terminate()
-    }
     // swiftlint:disable function_body_length
     func testExternalStateHandling() throws {
         let json = """
@@ -58,41 +55,54 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
         let handlerExpectation = XCTestExpectation(description: "handler called")
         let completionExpectation = XCTestExpectation(description: "flow completed")
         let renderExpectation = XCTestExpectation(description: "external view rendered")
-        let plugin = ExternalActionViewModifierPlugin<ExternalStateSheetModifier> { (state, _, transition) in
-            XCTAssertEqual(state.transitions, ["Next": "END_FWD", "Prev": "END_BCK"])
-            XCTAssertEqual(state.ref, "test-1")
-            // Test out subscript fetching additional properties
-            let extra: String? = state.extraProperty
-            XCTAssertEqual(extra, "extraValue")
-            handlerExpectation.fulfill()
-            return AnyView(
-                Text("External State")
-                    .onDisappear {
-                        transition("Next")
-                    }
-                    .onAppear {
-                        renderExpectation.fulfill()
-                    }
-            )
-        }
+        let plugin =
+            ExternalActionViewModifierPlugin<ExternalStateSheetModifier> { state, _, transition in
+                XCTAssertEqual(state.transitions, ["Next": "END_FWD", "Prev": "END_BCK"])
+                XCTAssertEqual(state.ref, "test-1")
+                // Test out subscript fetching additional properties
+                let extra: String? = state.extraProperty
+                XCTAssertEqual(extra, "extraValue")
+                handlerExpectation.fulfill()
+                return AnyView(
+                    Text("External State")
+                        .onDisappear {
+                            transition("Next")
+                        }
+                        .onAppear {
+                            renderExpectation.fulfill()
+                        }
+                )
+            }
 
         let context = SwiftUIPlayer.Context()
 
-        let player = SwiftUIPlayer(flow: json, plugins: [ReferenceAssetsPlugin(), plugin], result: Binding(get: {nil}, set: { (result) in
-            switch result {
-            case .success:
-                completionExpectation.fulfill()
-            default:
-                break
-            }
-        }), context: context, unloadOnDisappear: false)
+        let player = SwiftUIPlayer(
+            flow: json,
+            plugins: [ReferenceAssetsPlugin(), plugin],
+            result: Binding(get: { nil }, set: { result in
+                switch result {
+                case .success:
+                    completionExpectation.fulfill()
+                default:
+                    break
+                }
+            }),
+            context: context,
+            unloadOnDisappear: false
+        )
 
         ViewHosting.host(view: player)
 
         wait(for: [renderExpectation, handlerExpectation], timeout: 10)
 
         XCTAssertNotNil(plugin.state)
-        let content = try player.inspect().vStack().first?.anyView().anyView().modifier(ExternalStateSheetModifier.self).viewModifierContent()
+        let content = try player.inspect()
+            .vStack()
+            .first?
+            .anyView()
+            .anyView()
+            .modifier(ExternalStateSheetModifier.self)
+            .viewModifierContent()
         try content?.sheet().anyView().text().callOnDisappear()
 
         wait(for: [completionExpectation], timeout: 10)
@@ -152,7 +162,7 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
         let handlerExpectation = XCTestExpectation(description: "handler called")
         let completionExpectation = XCTestExpectation(description: "flow completed")
         let renderExpectation = XCTestExpectation(description: "external view rendered")
-        let plugin = ExternalActionViewModifierPlugin<ExternalStateSheetModifier> { (state, _, transition) in
+        let plugin = ExternalActionViewModifierPlugin<ExternalStateSheetModifier> { state, _, _ in
             XCTAssertEqual(state.transitions, ["Next": "VIEW_1", "Prev": "END_BCK"])
             XCTAssertEqual(state.ref, "test-1")
             // Test out subscript fetching additional properties
@@ -173,8 +183,8 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
                 self.expectation = expectation
             }
 
-            func apply<P>(player: P) where P : HeadlessPlayer {
-                player.hooks?.flowController.tap({ flowController in
+            func apply<P: HeadlessPlayer>(player: P) {
+                player.hooks?.flowController.tap { flowController in
                     flowController.hooks.flow.tap { flow in
                         flow.hooks.afterTransition.tap { [weak self] newFlow in
                             if newFlow.currentState?.value?.stateType == self?.expected {
@@ -182,7 +192,7 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
                             }
                         }
                     }
-                })
+                }
             }
         }
 
@@ -190,21 +200,36 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
 
         let context = SwiftUIPlayer.Context()
 
-        let player = SwiftUIPlayer(flow: json, plugins: [ReferenceAssetsPlugin(), plugin, HasTransitionedPlugin(expected: .view, expectation: viewTransition)], result: Binding(get: {nil}, set: { (result) in
-            switch result {
-            case .success:
-                completionExpectation.fulfill()
-            default:
-                break
-            }
-        }), context: context, unloadOnDisappear: false)
+        let player = SwiftUIPlayer(
+            flow: json,
+            plugins: [ReferenceAssetsPlugin(), plugin, HasTransitionedPlugin(
+                expected: .view,
+                expectation: viewTransition
+            )],
+            result: Binding(get: { nil }, set: { result in
+                switch result {
+                case .success:
+                    completionExpectation.fulfill()
+                default:
+                    break
+                }
+            }),
+            context: context,
+            unloadOnDisappear: false
+        )
 
         ViewHosting.host(view: player)
 
         wait(for: [renderExpectation, handlerExpectation], timeout: 10)
 
         XCTAssertNotNil(plugin.state)
-        let content = try player.inspect().vStack().first?.anyView().anyView().modifier(ExternalStateSheetModifier.self).viewModifierContent()
+        let content = try player.inspect()
+            .vStack()
+            .first?
+            .anyView()
+            .anyView()
+            .modifier(ExternalStateSheetModifier.self)
+            .viewModifierContent()
         let value = try content?.sheet().anyView().text().string()
         XCTAssertEqual(value, "External State")
         try (player.state as? InProgressState)?.controllers?.flow.transition(with: "Next")
@@ -260,22 +285,28 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
 
         let handlerExpectation = XCTestExpectation(description: "handler called")
         let completionExpectation = XCTestExpectation(description: "flow completed")
-        let plugin = ExternalActionViewModifierPlugin<ExternalStateSheetModifier> { (_, _, _) in
+        let plugin = ExternalActionViewModifierPlugin<ExternalStateSheetModifier> { _, _, _ in
             handlerExpectation.fulfill()
             throw PlayerError.jsConversionFailure
         }
 
         let context = SwiftUIPlayer.Context()
 
-        let player = SwiftUIPlayer(flow: json, plugins: [ReferenceAssetsPlugin(), plugin], result: Binding(get: {nil}, set: { (result) in
-            guard result != nil else { return }
-            switch result {
-            case .success:
-                XCTFail("Should have failed")
-            default:
-                completionExpectation.fulfill()
-            }
-        }), context: context, unloadOnDisappear: false)
+        let player = SwiftUIPlayer(
+            flow: json,
+            plugins: [ReferenceAssetsPlugin(), plugin],
+            result: Binding(get: { nil }, set: { result in
+                guard result != nil else { return }
+                switch result {
+                case .success:
+                    XCTFail("Should have failed")
+                default:
+                    completionExpectation.fulfill()
+                }
+            }),
+            context: context,
+            unloadOnDisappear: false
+        )
 
         ViewHosting.host(view: player)
 
@@ -283,7 +314,11 @@ class ExternalActionViewModifierPluginTests: XCTestCase {
 
         ViewHosting.expel()
     }
+
+    override func setUp() {
+        XCUIApplication().terminate()
+    }
 }
 
 extension InspectableSheet: PopupPresenter {}
-extension Inspection: InspectionEmissary { }
+extension Inspection: InspectionEmissary {}

--- a/plugins/external-state/ios/Sources/ExternalStatePlugin.swift
+++ b/plugins/external-state/ios/Sources/ExternalStatePlugin.swift
@@ -7,28 +7,9 @@
 
 import Foundation
 import JavaScriptCore
-
 import PlayerUI
 
 public struct ExternalStateHandler {
-    /// Map of properties to match against external states.
-    /// Must include "ref" key.
-    public typealias Match = [String: Any]
-
-    /**
-     The handler function to run when an external state is transitioned to
-     - parameters:
-        - state: The state object that represents the external state
-        - options: An object containing the dataModel instance and evaluate function
-        - transition: A completion handler that takes a string to transition with.
-            This completion handler lets the user transition at an appropriate time.
-     */
-    public typealias Function = (
-        NavigationFlowExternalState,
-        PlayerControllers,
-        @escaping (String) -> Void
-    ) throws -> Void
-
     public let ref: String
     public let match: Match?
     public let handlerFunction: Function
@@ -38,19 +19,33 @@ public struct ExternalStateHandler {
         self.match = match
         self.handlerFunction = handlerFunction
     }
+
+    /// Map of properties to match against external states.
+    /// Must include "ref" key.
+    public typealias Match = [String: Any]
+
+    /// The handler function to run when an external state is transitioned to
+    /// - parameters:
+    ///   - state: The state object that represents the external state
+    ///   - options: An object containing the dataModel instance and evaluate function
+    ///   - transition: A completion handler that takes a string to transition with.
+    ///       This completion handler lets the user transition at an appropriate time.
+    public typealias Function = (
+        NavigationFlowExternalState,
+        PlayerControllers,
+        @escaping (String) -> Void
+    ) throws -> Void
 }
 
-/**
- This plugin is for registering a handler for EXTERNAL states
- */
+/// This plugin is for registering a handler for EXTERNAL states
 public class ExternalStatePlugin: JSBasePlugin, NativePlugin {
+    public static let bundle: Bundle = .module
+
     private var handlers: [ExternalStateHandler]
 
-    /**
-     Construct a plugin to handle external states. Every match/key must include a `ref`.
-     - parameters:
-        - handlers: array of handlers with matchers and handler functions.
-     */
+    /// Construct a plugin to handle external states. Every match/key must include a `ref`.
+    /// - parameters:
+    ///   - handlers: array of handlers with matchers and handler functions.
     public init(handlers: [ExternalStateHandler]) {
         self.handlers = handlers
         super.init(
@@ -59,46 +54,53 @@ public class ExternalStatePlugin: JSBasePlugin, NativePlugin {
         )
     }
 
-    /**
-     Retrieves the arguments for constructing this plugin.
-     This is necessary because the arguments need to be supplied after construction of the swift object,
-     once the context has been provided.
-     - returns: An array of arguments to construct the plugin
-     */
+    override open func getUrlForFile(fileName: String) -> URL? {
+        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
+    }
+
+    /// Retrieves the arguments for constructing this plugin.
+    /// This is necessary because the arguments need to be supplied after construction of the swift
+    /// object,
+    /// once the context has been provided.
+    /// - returns: An array of arguments to construct the plugin
     override public func getArguments() -> [Any] {
-        guard let context = context else { return [] }
+        guard let context else { return [] }
 
         let jsHandlers = handlers.map { matchedHandler -> JSValue? in
-            let callback: @convention(block) (JSValue, JSValue) -> JSValue? = { [weak self] (state, options) in
-                guard
-                    let context = self?.context,
-                    let controllers = PlayerControllers(from: options),
-                    let promise = JSUtilities.createPromise(context: context, handler: { (resolve, reject) in
-                        do {
-                            try matchedHandler.handlerFunction(NavigationFlowExternalState(state), controllers) { transition in
-                                resolve(transition)
+            let callback: @convention(block) (JSValue, JSValue)
+                -> JSValue? = { [weak self] state, options in
+                    guard
+                        let context = self?.context,
+                        let controllers = PlayerControllers(from: options),
+                        let promise = JSUtilities.createPromise(
+                            context: context,
+                            handler: { resolve, reject in
+                                do {
+                                    try matchedHandler.handlerFunction(
+                                        NavigationFlowExternalState(state),
+                                        controllers
+                                    ) { transition in
+                                        resolve(transition)
+                                    }
+                                } catch {
+                                    reject(JSValue(
+                                        newErrorFromMessage: error.playerDescription,
+                                        in: context
+                                    ) as Any)
+                                }
                             }
-                        } catch {
-                            reject(JSValue(newErrorFromMessage: error.playerDescription, in: context) as Any)
-                        }
-                    })
-                else { return nil }
-                return promise
-            }
+                        )
+                    else { return nil }
+                    return promise
+                }
 
             return JSValue(object: [
                 "ref": matchedHandler.ref,
                 "match": matchedHandler.match as Any,
-                "handlerFunction": JSValue(object: callback, in: context) as Any
+                "handlerFunction": JSValue(object: callback, in: context) as Any,
             ], in: context)
         }
 
         return [jsHandlers]
     }
-
-    override open func getUrlForFile(fileName: String) -> URL? {
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
-    }
-
-    public static let bundle = Bundle.module
 }

--- a/plugins/external-state/ios/Tests/ExternalStatePluginTests.swift
+++ b/plugins/external-state/ios/Tests/ExternalStatePluginTests.swift
@@ -7,11 +7,11 @@
 //
 
 import Foundation
-import XCTest
 import JavaScriptCore
 @testable import PlayerUI
-@testable import PlayerUITestUtilitiesCore
 @testable import PlayerUIExternalStatePlugin
+@testable import PlayerUITestUtilitiesCore
+import XCTest
 
 // swiftlint:disable type_body_length force_try
 class ExternalStatePluginTests: XCTestCase {
@@ -54,7 +54,7 @@ class ExternalStatePluginTests: XCTestCase {
         let plugin = ExternalStatePlugin(handlers: [
             ExternalStateHandler(
                 ref: "test-1",
-                handlerFunction: { (state, _, handler) in
+                handlerFunction: { state, _, handler in
                     XCTAssertEqual(state.transitions, ["Next": "END_FWD", "Prev": "END_BCK"])
                     XCTAssertEqual(state.ref, "test-1")
                     // Test out subscript fetching additional properties
@@ -63,13 +63,13 @@ class ExternalStatePluginTests: XCTestCase {
                     handlerExpectation.fulfill()
                     handler("Next")
                 }
-            )
+            ),
         ])
         let player = HeadlessPlayerImpl(plugins: [plugin])
 
-        player.start(flow: json) { (result) in
+        player.start(flow: json) { result in
             switch result {
-            case .success(let state):
+            case let .success(state):
                 XCTAssertEqual(state.endState?.outcome, "FWD")
                 completionExpectation.fulfill()
             case .failure:
@@ -119,15 +119,15 @@ class ExternalStatePluginTests: XCTestCase {
         let plugin = ExternalStatePlugin(handlers: [
             ExternalStateHandler(
                 ref: "test-1",
-                handlerFunction: { (_, _, _) in
+                handlerFunction: { _, _, _ in
                     handlerExpectation.fulfill()
                     throw PlayerError.jsConversionFailure
                 }
-            )
+            ),
         ])
         let player = HeadlessPlayerImpl(plugins: [plugin])
 
-        player.start(flow: json) { (result) in
+        player.start(flow: json) { result in
             switch result {
             case .success:
                 XCTFail("flow should have failed")
@@ -187,7 +187,7 @@ class ExternalStatePluginTests: XCTestCase {
         let plugin = ExternalStatePlugin(handlers: [
             ExternalStateHandler(
                 ref: "test-1",
-                handlerFunction: { (state, _, handler) in
+                handlerFunction: { state, _, handler in
                     XCTAssertEqual(state.transitions, ["Next": "END_FWD", "Prev": "END_BCK"])
                     XCTAssertEqual(state.ref, "test-1")
                     if let param: [String: Any] = state.param {
@@ -198,13 +198,13 @@ class ExternalStatePluginTests: XCTestCase {
                     handlerExpectation.fulfill()
                     handler("Next")
                 }
-            )
+            ),
         ])
         let player = HeadlessPlayerImpl(plugins: [plugin])
 
-        player.start(flow: json) { (result) in
+        player.start(flow: json) { result in
             switch result {
-            case .success(let state):
+            case let .success(state):
                 XCTAssertEqual(state.endState?.outcome, "FWD")
                 completionExpectation.fulfill()
             case .failure:
@@ -253,19 +253,19 @@ class ExternalStatePluginTests: XCTestCase {
         let plugin = ExternalStatePlugin(handlers: [
             ExternalStateHandler(
                 ref: "test-1",
-                handlerFunction: { (_, _, handler) in
+                handlerFunction: { _, _, handler in
                     DispatchQueue.global().asyncAfter(deadline: .now() + 1) {
                         handlerExpectation.fulfill()
                         handler("Next")
                     }
                 }
-            )
+            ),
         ])
         let player = HeadlessPlayerImpl(plugins: [plugin])
 
-        player.start(flow: json) { (result) in
+        player.start(flow: json) { result in
             switch result {
-            case .success(let state):
+            case let .success(state):
                 XCTAssertEqual(state.endState?.outcome, "FWD")
                 completionExpectation.fulfill()
             case .failure:
@@ -314,7 +314,7 @@ class ExternalStatePluginTests: XCTestCase {
         let plugin = ExternalStatePlugin(handlers: [
             ExternalStateHandler(
                 ref: "test-1",
-                handlerFunction: { (_, options, handler) in
+                handlerFunction: { _, options, handler in
                     XCTAssertEqual(options.data.get(binding: "transitionValue") as? String, "Next")
 
                     // Test expression evaluation
@@ -322,18 +322,21 @@ class ExternalStatePluginTests: XCTestCase {
                     options.expression.evaluate("{{transitionValue}} = 'Prev'")
                     XCTAssertEqual(options.data.get(binding: "transitionValue") as? String, "Prev")
 
-                    options.expression.evaluate(["{{transitionValue}} = 'Previous'", "{{transitionValue}} = 'Next'"])
+                    options.expression.evaluate([
+                        "{{transitionValue}} = 'Previous'",
+                        "{{transitionValue}} = 'Next'",
+                    ])
                     XCTAssertEqual(options.data.get(binding: "transitionValue") as? String, "Next")
                     handlerExpectation.fulfill()
                     handler("Next")
                 }
-            )
+            ),
         ])
         let player = HeadlessPlayerImpl(plugins: [plugin])
 
-        player.start(flow: json) { (result) in
+        player.start(flow: json) { result in
             switch result {
-            case .success(let state):
+            case let .success(state):
                 XCTAssertEqual(state.endState?.outcome, "FWD")
                 completionExpectation.fulfill()
             case .failure:
@@ -378,7 +381,8 @@ class ExternalStatePluginTests: XCTestCase {
         }
         """
 
-        let lessSpecificExpectation = XCTestExpectation(description: "less specific handler should not be called")
+        let lessSpecificExpectation =
+            XCTestExpectation(description: "less specific handler should not be called")
         lessSpecificExpectation.isInverted = true
         let moreSpecificExpectation = XCTestExpectation(description: "more specific handler called")
         let completionExpectation = XCTestExpectation(description: "flow completed")
@@ -387,7 +391,7 @@ class ExternalStatePluginTests: XCTestCase {
             // Less specific - only matches ref
             ExternalStateHandler(
                 ref: "test-1",
-                handlerFunction: { (_, _, handler) in
+                handlerFunction: { _, _, handler in
                     lessSpecificExpectation.fulfill()
                     handler("Prev")
                 }
@@ -396,17 +400,17 @@ class ExternalStatePluginTests: XCTestCase {
             ExternalStateHandler(
                 ref: "test-1",
                 match: ["extraProperty": "extraValue"],
-                handlerFunction: { (_, _, handler) in
+                handlerFunction: { _, _, handler in
                     moreSpecificExpectation.fulfill()
                     handler("Next")
                 }
-            )
+            ),
         ])
         let player = HeadlessPlayerImpl(plugins: [plugin])
 
-        player.start(flow: json) { (result) in
+        player.start(flow: json) { result in
             switch result {
-            case .success(let state):
+            case let .success(state):
                 // More specific handler should have been called, returning "Next" -> outcome "FWD"
                 XCTAssertEqual(state.endState?.outcome, "FWD")
                 completionExpectation.fulfill()
@@ -415,7 +419,10 @@ class ExternalStatePluginTests: XCTestCase {
             }
         }
 
-        wait(for: [moreSpecificExpectation, lessSpecificExpectation, completionExpectation], timeout: 1)
+        wait(
+            for: [moreSpecificExpectation, lessSpecificExpectation, completionExpectation],
+            timeout: 1
+        )
     }
 
     // MARK: - Error Handling with Error Controller
@@ -425,9 +432,9 @@ class ExternalStatePluginTests: XCTestCase {
         let plugin = ExternalStatePlugin(handlers: [])
         let player = HeadlessPlayerImpl(plugins: [plugin])
 
-        player.start(flow: .flowWithErrorTransitions) { (result) in
+        player.start(flow: .flowWithErrorTransitions) { result in
             switch result {
-            case .success(let state):
+            case let .success(state):
                 XCTAssertEqual(state.endState?.outcome, "ERROR")
                 completionExpectation.fulfill()
             case .failure:
@@ -441,15 +448,15 @@ class ExternalStatePluginTests: XCTestCase {
     func testMissingTransitionValueNavigatesViaContentErrorTransitions() {
         let completionExpectation = XCTestExpectation(description: "flow completed")
         let plugin = ExternalStatePlugin(handlers: [
-            ExternalStateHandler(ref: "test-1") { (_, _, handler) in
+            ExternalStateHandler(ref: "test-1") { _, _, handler in
                 handler("")
-            }
+            },
         ])
         let player = HeadlessPlayerImpl(plugins: [plugin])
 
-        player.start(flow: .flowWithErrorTransitions) { (result) in
+        player.start(flow: .flowWithErrorTransitions) { result in
             switch result {
-            case .success(let state):
+            case let .success(state):
                 XCTAssertEqual(state.endState?.outcome, "ERROR")
                 completionExpectation.fulfill()
             case .failure:
@@ -482,9 +489,9 @@ class ExternalStatePluginTests: XCTestCase {
     func testMissingTransitionValueIsObservableViaOnErrorTap() {
         let onErrorCalled = XCTestExpectation(description: "onError fired")
         let plugin = ExternalStatePlugin(handlers: [
-            ExternalStateHandler(ref: "test-1") { (_, _, handler) in
+            ExternalStateHandler(ref: "test-1") { _, _, handler in
                 handler("")
-            }
+            },
         ])
         let player = HeadlessPlayerImpl(plugins: [plugin])
 
@@ -504,7 +511,7 @@ class ExternalStatePluginTests: XCTestCase {
 }
 
 private extension String {
-    // Use the basic externalFlow (no errorTransitions); the onError tap suppresses navigation.
+    /// Use the basic externalFlow (no errorTransitions); the onError tap suppresses navigation.
     static let basic = """
     {
       "id": "test-flow",

--- a/plugins/external-state/swiftui/Sources/ExternalStateViewModifierPlugin.swift
+++ b/plugins/external-state/swiftui/Sources/ExternalStateViewModifierPlugin.swift
@@ -89,6 +89,7 @@ open class ExternalStateViewModifierPlugin<ModifierType: ExternalStateViewModifi
     /// object,
     /// once the context has been provided.
     /// - returns: An array of arguments to construct the plugin
+    // swiftlint:disable:next function_body_length
     override open func getArguments() -> [Any] {
         guard let context else { return [] }
 

--- a/plugins/external-state/swiftui/Sources/ExternalStateViewModifierPlugin.swift
+++ b/plugins/external-state/swiftui/Sources/ExternalStateViewModifierPlugin.swift
@@ -1,11 +1,20 @@
 import JavaScriptCore
+import PlayerUI
+import PlayerUIExternalStatePlugin
+import PlayerUISwiftUI
 import SwiftUI
 
-import PlayerUI
-import PlayerUISwiftUI
-import PlayerUIExternalStatePlugin
-
 public struct ExternalStateViewModifierHandler {
+    public let ref: String
+    public let match: Match?
+    public let handlerFunction: Function
+
+    public init(ref: String, match: Match? = nil, handlerFunction: @escaping Function) {
+        self.ref = ref
+        self.match = match
+        self.handlerFunction = handlerFunction
+    }
+
     /// Map of properties to match against external states.
     /// Must include "ref" key.
     public typealias Match = [String: Any]
@@ -21,23 +30,12 @@ public struct ExternalStateViewModifierHandler {
         PlayerControllers,
         @escaping (String) -> Void
     ) throws -> AnyView
-
-    public let ref: String
-    public let match: Match?
-    public let handlerFunction: Function
-
-    public init(ref: String, match: Match? = nil, handlerFunction: @escaping Function) {
-        self.ref = ref
-        self.match = match
-        self.handlerFunction = handlerFunction
-    }
 }
 
 /// A variation on `ExternalStatePlugin` for `SwiftUIPlayer` that applies a ViewModifier to
 /// SwiftUIPlayer content when in an external state
 open class ExternalStateViewModifierPlugin<ModifierType: ExternalStateViewModifier>:
     JSBasePlugin, NativePlugin, ObservableObject {
-
     /// Whether or not Player is currently in an EXTERNAL state
     @Published public var isExternalState = false
     /// The content the plugin has determined to show during the current EXTERNAL state
@@ -58,17 +56,17 @@ open class ExternalStateViewModifierPlugin<ModifierType: ExternalStateViewModifi
         )
     }
 
-    open func apply<P>(player: P) where P: HeadlessPlayer {
+    open func apply<P: HeadlessPlayer>(player: P) {
         guard let player = player as? SwiftUIPlayer else { return }
-        player.hooks?.view.tap(name: pluginName, { (view) -> AnyView in
-            return AnyView(view.modifier(ModifierType.init(plugin: self)))
-        })
+        player.hooks?.view.tap(name: pluginName) { view -> AnyView in
+            return AnyView(view.modifier(ModifierType(plugin: self)))
+        }
 
         // If the state changes without our intervention
         // we should update our state
-        player.hooks?.flowController.tap({ flowController in
+        player.hooks?.flowController.tap { flowController in
             flowController.hooks.flow.tap { flow in
-                flow.hooks.transition.tap {[weak self] old, newState in
+                flow.hooks.transition.tap { [weak self] old, newState in
                     guard
                         old?.value?.stateType == .external,
                         newState.value?.stateType != .external
@@ -77,71 +75,80 @@ open class ExternalStateViewModifierPlugin<ModifierType: ExternalStateViewModifi
                     self?.state = nil
                 }
             }
-        })
-    }
-
-    /// Retrieves the arguments for constructing this plugin.
-    /// This is necessary because the arguments need to be supplied after construction of the swift object,
-    /// once the context has been provided.
-    /// - returns: An array of arguments to construct the plugin
-    override open func getArguments() -> [Any] {
-        guard let context = context else { return [] }
-
-        let jsHandlers = handlers.map { handler -> JSValue? in
-            let callback: @convention(block) (JSValue, JSValue) -> JSValue? = { [weak self] (state, options) in
-                guard
-                    let context = self?.context,
-                    let controllers = PlayerControllers(from: options),
-                    let promise = JSUtilities.createPromise(context: context, handler: { (resolve, reject) in
-                        let updateUI: () -> Void = {
-                            self?.isExternalState = true
-                            let state = NavigationFlowExternalState(state)
-                            self?.state = state
-                            do {
-                                self?.content = try handler.handlerFunction(state, controllers) { transition in
-                                    resolve(transition)
-                                    let resetWithAnimation: () -> Void = {
-                                        withAnimation {
-                                            self?.resetState()
-                                        }
-                                    }
-                                    if Thread.isMainThread {
-                                        resetWithAnimation()
-                                    } else {
-                                        DispatchQueue.main.sync { resetWithAnimation() }
-                                    }
-                                }
-                            } catch {
-                                // Reset state when handler throws
-                                self?.resetState()
-                                reject(JSValue(newErrorFromMessage: error.playerDescription, in: context) as Any)
-                            }
-                        }
-
-                        if Thread.isMainThread {
-                            updateUI()
-                        } else {
-                            DispatchQueue.main.sync(execute: updateUI)
-                        }
-                    })
-                else { return nil }
-                return promise
-            }
-
-            return JSValue(object: [
-                "ref": handler.ref,
-                "match": handler.match as Any,
-                "handlerFunction": JSValue(object: callback, in: context) as Any
-            ], in: context)
         }
-
-        return [jsHandlers]
     }
 
     private func resetState() {
         isExternalState = false
         state = nil
         content = nil
+    }
+
+    /// Retrieves the arguments for constructing this plugin.
+    /// This is necessary because the arguments need to be supplied after construction of the swift
+    /// object,
+    /// once the context has been provided.
+    /// - returns: An array of arguments to construct the plugin
+    override open func getArguments() -> [Any] {
+        guard let context else { return [] }
+
+        let jsHandlers = handlers.map { handler -> JSValue? in
+            let callback: @convention(block) (JSValue, JSValue)
+                -> JSValue? = { [weak self] state, options in
+                    guard
+                        let context = self?.context,
+                        let controllers = PlayerControllers(from: options),
+                        let promise = JSUtilities.createPromise(
+                            context: context,
+                            handler: { resolve, reject in
+                                let updateUI: () -> Void = {
+                                    self?.isExternalState = true
+                                    let state = NavigationFlowExternalState(state)
+                                    self?.state = state
+                                    do {
+                                        self?.content = try handler
+                                            .handlerFunction(state, controllers) { transition in
+                                                resolve(transition)
+                                                let resetWithAnimation: () -> Void = {
+                                                    withAnimation {
+                                                        self?.resetState()
+                                                    }
+                                                }
+                                                if Thread.isMainThread {
+                                                    resetWithAnimation()
+                                                } else {
+                                                    DispatchQueue.main.sync { resetWithAnimation() }
+                                                }
+                                            }
+                                    } catch {
+                                        // Reset state when handler throws
+                                        self?.resetState()
+                                        reject(JSValue(
+                                            newErrorFromMessage: error.playerDescription,
+                                            in: context
+                                        ) as Any)
+                                    }
+                                }
+
+                                if Thread.isMainThread {
+                                    updateUI()
+                                } else {
+                                    DispatchQueue.main.sync(execute: updateUI)
+                                }
+                            }
+                        )
+                    else { return nil }
+                    return promise
+                }
+
+            return JSValue(object: [
+                "ref": handler.ref,
+                "match": handler.match as Any,
+                "handlerFunction": JSValue(object: callback, in: context) as Any,
+            ], in: context)
+        }
+
+        return [jsHandlers]
     }
 
     override open func getUrlForFile(fileName: String) -> URL? {
@@ -152,7 +159,8 @@ open class ExternalStateViewModifierPlugin<ModifierType: ExternalStateViewModifi
     }
 }
 
-/// ViewModifier type specifically for the `ExternalStateViewModifierPlugin` to provide observable properties
+/// ViewModifier type specifically for the `ExternalStateViewModifierPlugin` to provide observable
+/// properties
 /// to present content in an external action
 public protocol ExternalStateViewModifier: ViewModifier {
     /// An observable reference to the presenting plugin, to know when we are in an external state
@@ -164,16 +172,18 @@ public protocol ExternalStateViewModifier: ViewModifier {
     init(plugin: ExternalStateViewModifierPlugin<Self>)
 }
 
-/// A ViewModifier for the `ExternalStateViewModifierPlugin` that presents the external state with the `.sheet` modifier
+/// A ViewModifier for the `ExternalStateViewModifierPlugin` that presents the external state with
+/// the `.sheet` modifier
 public struct ExternalStateSheetModifier: ExternalStateViewModifier {
     @ObservedObject public var plugin: ExternalStateViewModifierPlugin<Self>
+
     /// Constructs this ViewModifier
     /// - parameters:
     ///    - plugin: The plugin presenting the external state
     public init(plugin: ExternalStateViewModifierPlugin<Self>) {
         self.plugin = plugin
     }
-    @ViewBuilder
+
     public func body(content: Content) -> some View {
         content.inspectableSheet(isPresented: $plugin.isExternalState, content: {
             plugin.content
@@ -182,20 +192,20 @@ public struct ExternalStateSheetModifier: ExternalStateViewModifier {
 }
 
 // MARK: ViewInspector
+
 extension View {
-    func inspectableSheet<Sheet>(
+    func inspectableSheet<Sheet: View>(
         isPresented: Binding<Bool>,
         onDismiss: (() -> Void)? = nil,
         @ViewBuilder content: @escaping () -> Sheet
-    ) -> some View where Sheet: View {
-        return self.modifier(
+    ) -> some View {
+        modifier(
             InspectableSheet(isPresented: isPresented, onDismiss: onDismiss, popupBuilder: content)
         )
     }
 }
 
-struct InspectableSheet<Sheet>: ViewModifier where Sheet: View {
-
+struct InspectableSheet<Sheet: View>: ViewModifier {
     let isPresented: Binding<Bool>
     let onDismiss: (() -> Void)?
     let popupBuilder: () -> Sheet

--- a/plugins/external-state/swiftui/Sources/ExternalStateViewModifierPlugin.swift
+++ b/plugins/external-state/swiftui/Sources/ExternalStateViewModifierPlugin.swift
@@ -56,7 +56,7 @@ open class ExternalStateViewModifierPlugin<ModifierType: ExternalStateViewModifi
         )
     }
 
-    open func apply<P: HeadlessPlayer>(player: P) {
+    open func apply(player: some HeadlessPlayer) {
         guard let player = player as? SwiftUIPlayer else { return }
         player.hooks?.view.tap(name: pluginName) { view -> AnyView in
             return AnyView(view.modifier(ModifierType(plugin: self)))
@@ -195,10 +195,10 @@ public struct ExternalStateSheetModifier: ExternalStateViewModifier {
 // MARK: ViewInspector
 
 extension View {
-    func inspectableSheet<Sheet: View>(
+    func inspectableSheet(
         isPresented: Binding<Bool>,
         onDismiss: (() -> Void)? = nil,
-        @ViewBuilder content: @escaping () -> Sheet
+        @ViewBuilder content: @escaping () -> some View
     ) -> some View {
         modifier(
             InspectableSheet(isPresented: isPresented, onDismiss: onDismiss, popupBuilder: content)

--- a/plugins/external-state/swiftui/ViewInspector/ExternalStateViewModifierPluginTests.swift
+++ b/plugins/external-state/swiftui/ViewInspector/ExternalStateViewModifierPluginTests.swift
@@ -5,24 +5,21 @@
 //  Created by Harris Borawski on 8/19/21.
 //  Copyright © 2021 Intuit. All rights reserved.
 //
-import Foundation
-import XCTest
-import JavaScriptCore
 import Combine
-import SwiftUI
-import ViewInspector
+import Foundation
+import JavaScriptCore
 @testable import PlayerUI
-@testable import PlayerUIInternalTestUtilities
-@testable import PlayerUISwiftUI
-@testable import PlayerUIReferenceAssets
 @testable import PlayerUIExternalStatePlugin
 @testable import PlayerUIExternalStateViewModifierPlugin
+@testable import PlayerUIInternalTestUtilities
+@testable import PlayerUIReferenceAssets
+@testable import PlayerUISwiftUI
+import SwiftUI
+import ViewInspector
+import XCTest
 
 // swiftlint:disable type_body_length force_try
 class ExternalStateViewModifierPluginTests: XCTestCase {
-    override func setUp() {
-        XCUIApplication().terminate()
-    }
     // swiftlint:disable:next function_body_length
     func testExternalStateHandling() throws {
         let json = """
@@ -63,7 +60,7 @@ class ExternalStateViewModifierPluginTests: XCTestCase {
         let plugin = ExternalStateViewModifierPlugin<ExternalStateSheetModifier>(handlers: [
             .init(
                 ref: "test-1",
-                handlerFunction: { (state, _, transition) in
+                handlerFunction: { state, _, transition in
                     XCTAssertEqual(state.transitions, ["Next": "END_FWD", "Prev": "END_BCK"])
                     XCTAssertEqual(state.ref, "test-1")
                     // Test out subscript fetching additional properties
@@ -80,7 +77,7 @@ class ExternalStateViewModifierPluginTests: XCTestCase {
                             }
                     )
                 }
-            )
+            ),
         ])
 
         let context = SwiftUIPlayer.Context()
@@ -88,7 +85,7 @@ class ExternalStateViewModifierPluginTests: XCTestCase {
         let player = SwiftUIPlayer(
             flow: json,
             plugins: [ReferenceAssetsPlugin(), plugin],
-            result: Binding(get: {nil}, set: { (result) in
+            result: Binding(get: { nil }, set: { result in
                 switch result {
                 case .success:
                     completionExpectation.fulfill()
@@ -103,8 +100,13 @@ class ExternalStateViewModifierPluginTests: XCTestCase {
         wait(for: [renderExpectation, handlerExpectation], timeout: 10)
 
         XCTAssertNotNil(plugin.state)
-        let content = try player.inspect().vStack().first?.anyView().anyView()
-            .modifier(ExternalStateSheetModifier.self).viewModifierContent()
+        let content = try player.inspect()
+            .vStack()
+            .first?
+            .anyView()
+            .anyView()
+            .modifier(ExternalStateSheetModifier.self)
+            .viewModifierContent()
         try content?.sheet().anyView().text().callOnDisappear()
 
         wait(for: [completionExpectation], timeout: 10)
@@ -167,7 +169,7 @@ class ExternalStateViewModifierPluginTests: XCTestCase {
         let plugin = ExternalStateViewModifierPlugin<ExternalStateSheetModifier>(handlers: [
             .init(
                 ref: "test-1",
-                handlerFunction: { (state, _, transition) in
+                handlerFunction: { state, _, _ in
                     XCTAssertEqual(state.transitions, ["Next": "VIEW_1", "Prev": "END_BCK"])
                     XCTAssertEqual(state.ref, "test-1")
                     // Test out subscript fetching additional properties
@@ -176,7 +178,7 @@ class ExternalStateViewModifierPluginTests: XCTestCase {
                     handlerExpectation.fulfill()
                     return AnyView(Text("External State").onAppear { renderExpectation.fulfill() })
                 }
-            )
+            ),
         ])
         class HasTransitionedPlugin: NativePlugin {
             var pluginName: String = "HasTransitioned"
@@ -190,8 +192,8 @@ class ExternalStateViewModifierPluginTests: XCTestCase {
                 self.expectation = expectation
             }
 
-            func apply<P>(player: P) where P: HeadlessPlayer {
-                player.hooks?.flowController.tap({ flowController in
+            func apply<P: HeadlessPlayer>(player: P) {
+                player.hooks?.flowController.tap { flowController in
                     flowController.hooks.flow.tap { flow in
                         flow.hooks.afterTransition.tap { [weak self] newFlow in
                             if newFlow.currentState?.value?.stateType == self?.expected {
@@ -199,7 +201,7 @@ class ExternalStateViewModifierPluginTests: XCTestCase {
                             }
                         }
                     }
-                })
+                }
             }
         }
 
@@ -212,24 +214,30 @@ class ExternalStateViewModifierPluginTests: XCTestCase {
             plugins: [
                 ReferenceAssetsPlugin(),
                 plugin,
-                HasTransitionedPlugin(expected: .view, expectation: viewTransition)
+                HasTransitionedPlugin(expected: .view, expectation: viewTransition),
             ],
-            result: Binding(get: {nil}, set: { (result) in
-            switch result {
-            case .success:
-                completionExpectation.fulfill()
-            default:
-                break
-            }
-        }), context: context, unloadOnDisappear: false)
+            result: Binding(get: { nil }, set: { result in
+                switch result {
+                case .success:
+                    completionExpectation.fulfill()
+                default:
+                    break
+                }
+            }), context: context, unloadOnDisappear: false
+        )
 
         ViewHosting.host(view: player)
 
         wait(for: [renderExpectation, handlerExpectation], timeout: 10)
 
         XCTAssertNotNil(plugin.state)
-        let content = try player.inspect().vStack().first?.anyView().anyView()
-            .modifier(ExternalStateSheetModifier.self).viewModifierContent()
+        let content = try player.inspect()
+            .vStack()
+            .first?
+            .anyView()
+            .anyView()
+            .modifier(ExternalStateSheetModifier.self)
+            .viewModifierContent()
         let value = try content?.sheet().anyView().text().string()
         XCTAssertEqual(value, "External State")
         try (player.state as? InProgressState)?.controllers?.flow.transition(with: "Next")
@@ -250,7 +258,7 @@ class ExternalStateViewModifierPluginTests: XCTestCase {
         ViewHosting.expel()
     }
 
-    func testExternalStateHandlingThrowsError() throws {
+    func testExternalStateHandlingThrowsError() {
         let json = """
         {
           "id": "test-flow",
@@ -288,11 +296,11 @@ class ExternalStateViewModifierPluginTests: XCTestCase {
         let plugin = ExternalStateViewModifierPlugin<ExternalStateSheetModifier>(handlers: [
             .init(
                 ref: "test-1",
-                handlerFunction: { (_, _, _) in
+                handlerFunction: { _, _, _ in
                     handlerExpectation.fulfill()
                     throw PlayerError.jsConversionFailure
                 }
-            )
+            ),
         ])
 
         let context = SwiftUIPlayer.Context()
@@ -300,7 +308,7 @@ class ExternalStateViewModifierPluginTests: XCTestCase {
         let player = SwiftUIPlayer(
             flow: json,
             plugins: [ReferenceAssetsPlugin(), plugin],
-            result: Binding(get: {nil}, set: { (result) in
+            result: Binding(get: { nil }, set: { result in
                 guard result != nil else { return }
                 switch result {
                 case .success:
@@ -352,7 +360,8 @@ class ExternalStateViewModifierPluginTests: XCTestCase {
         }
         """
 
-        let lessSpecificExpectation = XCTestExpectation(description: "less specific handler should not be called")
+        let lessSpecificExpectation =
+            XCTestExpectation(description: "less specific handler should not be called")
         lessSpecificExpectation.isInverted = true
         let moreSpecificExpectation = XCTestExpectation(description: "more specific handler called")
         let completionExpectation = XCTestExpectation(description: "flow completed")
@@ -362,7 +371,7 @@ class ExternalStateViewModifierPluginTests: XCTestCase {
             // Less specific - only matches ref
             .init(
                 ref: "test-1",
-                handlerFunction: { (_, _, transition) in
+                handlerFunction: { _, _, transition in
                     lessSpecificExpectation.fulfill()
                     return AnyView(
                         Text("Less Specific")
@@ -376,7 +385,7 @@ class ExternalStateViewModifierPluginTests: XCTestCase {
             .init(
                 ref: "test-1",
                 match: ["extraProperty": "extraValue"],
-                handlerFunction: { (_, _, transition) in
+                handlerFunction: { _, _, transition in
                     moreSpecificExpectation.fulfill()
                     return AnyView(
                         Text("More Specific")
@@ -388,7 +397,7 @@ class ExternalStateViewModifierPluginTests: XCTestCase {
                             }
                     )
                 }
-            )
+            ),
         ])
 
         let context = SwiftUIPlayer.Context()
@@ -396,10 +405,11 @@ class ExternalStateViewModifierPluginTests: XCTestCase {
         let player = SwiftUIPlayer(
             flow: json,
             plugins: [ReferenceAssetsPlugin(), plugin],
-            result: Binding(get: {nil}, set: { (result) in
+            result: Binding(get: { nil }, set: { result in
                 switch result {
-                case .success(let completed):
-                    // More specific handler should have been called, returning "Next" -> outcome "FWD"
+                case let .success(completed):
+                    // More specific handler should have been called, returning "Next" -> outcome
+                    // "FWD"
                     XCTAssertEqual(completed.endState?.outcome, "FWD")
                     completionExpectation.fulfill()
                 default:
@@ -413,8 +423,13 @@ class ExternalStateViewModifierPluginTests: XCTestCase {
         wait(for: [renderExpectation, moreSpecificExpectation], timeout: 10)
 
         XCTAssertNotNil(plugin.state)
-        let content = try player.inspect().vStack().first?.anyView().anyView()
-            .modifier(ExternalStateSheetModifier.self).viewModifierContent()
+        let content = try player.inspect()
+            .vStack()
+            .first?
+            .anyView()
+            .anyView()
+            .modifier(ExternalStateSheetModifier.self)
+            .viewModifierContent()
         try content?.sheet().anyView().text().callOnDisappear()
 
         wait(for: [lessSpecificExpectation, completionExpectation], timeout: 10)
@@ -432,9 +447,9 @@ class ExternalStateViewModifierPluginTests: XCTestCase {
         let player = SwiftUIPlayer(
             flow: .flowWithErrorTransitions,
             plugins: [ReferenceAssetsPlugin(), plugin],
-            result: Binding(get: {nil}, set: { (result) in
+            result: Binding(get: { nil }, set: { result in
                 switch result {
-                case .success(let completed):
+                case let .success(completed):
                     XCTAssertEqual(completed.endState?.outcome, "ERROR")
                     completionExpectation.fulfill()
                 case .failure:
@@ -457,18 +472,18 @@ class ExternalStateViewModifierPluginTests: XCTestCase {
         let plugin = ExternalStateViewModifierPlugin<ExternalStateSheetModifier>(handlers: [
             .init(
                 ref: "test-1",
-                handlerFunction: { (_, _, transition) in
-                    return AnyView(Text("External State").onAppear { transition("") })
+                handlerFunction: { _, _, transition in
+                    AnyView(Text("External State").onAppear { transition("") })
                 }
-            )
+            ),
         ])
 
         let player = SwiftUIPlayer(
             flow: .flowWithErrorTransitions,
             plugins: [ReferenceAssetsPlugin(), plugin],
-            result: Binding(get: {nil}, set: { (result) in
+            result: Binding(get: { nil }, set: { result in
                 switch result {
-                case .success(let completed):
+                case let .success(completed):
                     XCTAssertEqual(completed.endState?.outcome, "ERROR")
                     completionExpectation.fulfill()
                 case .failure:
@@ -504,7 +519,7 @@ class ExternalStateViewModifierPluginTests: XCTestCase {
         let player = SwiftUIPlayer(
             flow: .basic,
             plugins: [ReferenceAssetsPlugin(), plugin, observer],
-            result: Binding(get: {nil}, set: { _ in }),
+            result: Binding(get: { nil }, set: { _ in }),
             context: .init(), unloadOnDisappear: false
         )
 
@@ -520,10 +535,10 @@ class ExternalStateViewModifierPluginTests: XCTestCase {
         let plugin = ExternalStateViewModifierPlugin<ExternalStateSheetModifier>(handlers: [
             .init(
                 ref: "test-1",
-                handlerFunction: { (_, _, transition) in
-                    return AnyView(Text("External State").onAppear { transition("") })
+                handlerFunction: { _, _, transition in
+                    AnyView(Text("External State").onAppear { transition("") })
                 }
-            )
+            ),
         ])
 
         let observer = TestPlugin { errorInfo in
@@ -533,11 +548,11 @@ class ExternalStateViewModifierPluginTests: XCTestCase {
             onErrorCalled.fulfill()
             return true // suppress default navigation
         }
-        
+
         let player = SwiftUIPlayer(
             flow: .basic,
             plugins: [ReferenceAssetsPlugin(), plugin, observer],
-            result: Binding(get: {nil}, set: { _ in }),
+            result: Binding(get: { nil }, set: { _ in }),
             context: .init(), unloadOnDisappear: false
         )
 
@@ -547,6 +562,10 @@ class ExternalStateViewModifierPluginTests: XCTestCase {
 
         ViewHosting.expel()
     }
+
+    override func setUp() {
+        XCUIApplication().terminate()
+    }
 }
 
 /// Registers an onError tap during `apply(player:)`, which runs before `SwiftUIPlayer`
@@ -554,13 +573,14 @@ class ExternalStateViewModifierPluginTests: XCTestCase {
 /// construction is too late — the hook has already fired.
 private final class TestPlugin: NativePlugin {
     let pluginName = "OnErrorObserver"
+
     private let onError: (JSValueError) -> Bool
 
     init(onError: @escaping (JSValueError) -> Bool) {
         self.onError = onError
     }
 
-    func apply<P>(player: P) where P: HeadlessPlayer {
+    func apply<P: HeadlessPlayer>(player: P) {
         player.hooks?.errorController.tap { [onError] errorController in
             errorController.hooks.onError.tap { errorInfo in
                 onError(errorInfo)
@@ -570,7 +590,7 @@ private final class TestPlugin: NativePlugin {
 }
 
 private extension String {
-    // Use the basic externalFlow (no errorTransitions); the onError tap suppresses navigation.
+    /// Use the basic externalFlow (no errorTransitions); the onError tap suppresses navigation.
     static let basic = """
     {
       "id": "test-flow",
@@ -630,4 +650,4 @@ private extension String {
 }
 
 extension InspectableSheet: @retroactive PopupPresenter {}
-extension Inspection: InspectionEmissary { }
+extension Inspection: InspectionEmissary {}

--- a/plugins/external-state/swiftui/ViewInspector/ExternalStateViewModifierPluginTests.swift
+++ b/plugins/external-state/swiftui/ViewInspector/ExternalStateViewModifierPluginTests.swift
@@ -192,7 +192,7 @@ class ExternalStateViewModifierPluginTests: XCTestCase {
                 self.expectation = expectation
             }
 
-            func apply<P: HeadlessPlayer>(player: P) {
+            func apply(player: some HeadlessPlayer) {
                 player.hooks?.flowController.tap { flowController in
                     flowController.hooks.flow.tap { flow in
                         flow.hooks.afterTransition.tap { [weak self] newFlow in
@@ -580,7 +580,7 @@ private final class TestPlugin: NativePlugin {
         self.onError = onError
     }
 
-    func apply<P: HeadlessPlayer>(player: P) {
+    func apply(player: some HeadlessPlayer) {
         player.hooks?.errorController.tap { [onError] errorController in
             errorController.hooks.onError.tap { errorInfo in
                 onError(errorInfo)

--- a/plugins/metrics/swiftui/Sources/MetricsPlugin.swift
+++ b/plugins/metrics/swiftui/Sources/MetricsPlugin.swift
@@ -10,22 +10,23 @@ import JavaScriptCore
 import SwiftUI
 
 #if SWIFT_PACKAGE
-import PlayerUI
-import PlayerUISwiftUI
+    import PlayerUI
+    import PlayerUISwiftUI
 #endif
 
 /// A Plugin that provides request time data to `MetricsPlugin`
 public class RequestTimePlugin: NativePlugin {
     public var pluginName: String = "RequestTime"
+
     private let requestTimeWebPlugin: RequestTimeWebPlugin
 
     /// Construct a `RequestTimePlugin`
     /// - Parameter getRequestTime: A callback to retrieve the time the last request took
     public init(_ getRequestTime: @escaping () -> Int) {
-        self.requestTimeWebPlugin = RequestTimeWebPlugin(getRequestTime)
+        requestTimeWebPlugin = RequestTimeWebPlugin(getRequestTime)
     }
 
-    public func apply<P>(player: P) where P: HeadlessPlayer {
+    public func apply<P: HeadlessPlayer>(player: P) {
         requestTimeWebPlugin.context = player.jsPlayerReference?.context
         player.applyTo(MetricsPlugin.self) { [weak self] plugin in
             self?.requestTimeWebPlugin.pluginRef?.invokeMethod("apply", withArguments: [plugin])
@@ -35,42 +36,43 @@ public class RequestTimePlugin: NativePlugin {
 
 class RequestTimeWebPlugin: JSBasePlugin {
     private var getRequestTime: () -> Int = { 0 }
-    public convenience init(_ getRequestTime: @escaping () -> Int) {
-        self.init(fileName: "MetricsPlugin.native", pluginName: "MetricsPlugin.RequestTimeWebPlugin")
+
+    convenience init(_ getRequestTime: @escaping () -> Int) {
+        self.init(
+            fileName: "MetricsPlugin.native",
+            pluginName: "MetricsPlugin.RequestTimeWebPlugin"
+        )
         self.getRequestTime = getRequestTime
     }
 
-    public override func getArguments() -> [Any] {
+    override open func getUrlForFile(fileName: String) -> URL? {
+        #if SWIFT_PACKAGE
+            ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
+        #else
+            ResourceUtilities.urlForFile(
+                name: fileName,
+                ext: "js",
+                bundle: Bundle(for: MetricsPlugin.self),
+                pathComponent: "PlayerUI_MetricsPlugin.bundle"
+            )
+        #endif
+    }
+
+    override func getArguments() -> [Any] {
         let handler: @convention(block) () -> Int = {
             self.getRequestTime()
         }
         return [JSValue(object: handler, in: context) as Any]
     }
-
-    override open func getUrlForFile(fileName: String) -> URL? {
-        #if SWIFT_PACKAGE
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
-        #else
-        ResourceUtilities.urlForFile(
-            name: fileName,
-            ext: "js",
-            bundle: Bundle(for: MetricsPlugin.self),
-            pathComponent: "PlayerUI_MetricsPlugin.bundle"
-        )
-        #endif
-    }
 }
-/**
- Plugin for capturing metrics
- */
+
+/// Plugin for capturing metrics
 public class MetricsPlugin: JSBasePlugin, NativePlugin, WithSymbol {
     public static let symbol = "MetricsPlugin.MetricsCorePluginSymbol"
-    public typealias RenderEndHandler = (MetricsTiming?, NodeRenderMetrics?, PlayerFlowMetrics?) -> Void
-    private var trackRenderTime: Bool = true
-
-    var onRenderEnd: RenderEndHandler?
 
     public var hooks: MetricsHooks?
+
+    var onRenderEnd: RenderEndHandler?
 
     var onRenderEndJSHandler: @convention(block) (JSValue?, JSValue?, JSValue?) -> Void {
         { [weak self] timing, nodeMetrics, flowMetrics in
@@ -83,62 +85,67 @@ public class MetricsPlugin: JSBasePlugin, NativePlugin, WithSymbol {
         }
     }
 
-    override public func setup(context: JSContext) {
-        super.setup(context: context)
+    private var trackRenderTime: Bool = true
 
-        if let pluginRef = pluginRef {
-            self.hooks = MetricsHooks(onRenderEnd: Hook3Decode(baseValue: pluginRef, name: "onRenderEnd"), onFlowBegin: HookDecode(baseValue: pluginRef, name: "onFlowBegin"), onFlowEnd: HookDecode(baseValue: pluginRef, name: "onFlowEnd"))
-        }
-    }
-
-    public func apply<P>(player: P) where P: HeadlessPlayer {
-        guard trackRenderTime, let player = player as? SwiftUIPlayer else { return }
-        let renderEnd = self.renderEnd
-        player.hooks?.view.tap(name: pluginName, { (view) -> AnyView in
-            AnyView(view.onAppear {
-                renderEnd()
-            })
-        })
-    }
-
-    /**
-     Constructs the MetricsPlugin
-     - parameters:
-        - trackRenderTime: Whether or not to track render times
-        - handler: A handler to receive events when rendering has finished
-     */
+    /// Constructs the MetricsPlugin
+    /// - parameters:
+    ///   - trackRenderTime: Whether or not to track render times
+    ///   - handler: A handler to receive events when rendering has finished
     public convenience init(trackRenderTime: Bool = true, handler: RenderEndHandler? = nil) {
         self.init(fileName: "MetricsPlugin.native", pluginName: "MetricsPlugin.MetricsCorePlugin")
         self.trackRenderTime = trackRenderTime
-        self.onRenderEnd = handler
+        onRenderEnd = handler
     }
 
-    public override func getArguments() -> [Any] {
-        return [[
-            "trackRenderTime": trackRenderTime,
-            "onRenderEnd": JSValue(object: onRenderEndJSHandler, in: context) as Any
-        ]]
+    public func apply<P: HeadlessPlayer>(player: P) {
+        guard trackRenderTime, let player = player as? SwiftUIPlayer else { return }
+        let renderEnd = renderEnd
+        player.hooks?.view.tap(name: pluginName) { view -> AnyView in
+            AnyView(view.onAppear {
+                renderEnd()
+            })
+        }
+    }
+
+    /// Called when the UI has finished rendering
+    public func renderEnd() {
+        pluginRef?.invokeMethod("renderEnd", withArguments: [])
     }
 
     override open func getUrlForFile(fileName: String) -> URL? {
         #if SWIFT_PACKAGE
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
+            ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
         #else
-        ResourceUtilities.urlForFile(
-            name: fileName,
-            ext: "js",
-            bundle: Bundle(for: MetricsPlugin.self),
-            pathComponent: "PlayerUI_MetricsPlugin.bundle"
-        )
+            ResourceUtilities.urlForFile(
+                name: fileName,
+                ext: "js",
+                bundle: Bundle(for: MetricsPlugin.self),
+                pathComponent: "PlayerUI_MetricsPlugin.bundle"
+            )
         #endif
     }
 
-    /**
-     Called when the UI has finished rendering
-     */
-    public func renderEnd() {
-        pluginRef?.invokeMethod("renderEnd", withArguments: [])
+    override public func setup(context: JSContext) {
+        super.setup(context: context)
+
+        if let pluginRef {
+            hooks = MetricsHooks(
+                onRenderEnd: Hook3Decode(baseValue: pluginRef, name: "onRenderEnd"),
+                onFlowBegin: HookDecode(baseValue: pluginRef, name: "onFlowBegin"),
+                onFlowEnd: HookDecode(baseValue: pluginRef, name: "onFlowEnd")
+            )
+        }
     }
+
+    override public func getArguments() -> [Any] {
+        [[
+            "trackRenderTime": trackRenderTime,
+            "onRenderEnd": JSValue(object: onRenderEndJSHandler, in: context) as Any,
+        ]]
+    }
+
+    public typealias RenderEndHandler = (MetricsTiming?, NodeRenderMetrics?, PlayerFlowMetrics?)
+        -> Void
 }
 
 public struct MetricsHooks {
@@ -146,7 +153,7 @@ public struct MetricsHooks {
     public let onRenderEnd: Hook3Decode<MetricsTiming, NodeRenderMetrics, PlayerFlowMetrics>
     /// Called when a flow starts
     public let onFlowBegin: HookDecode<PlayerFlowMetrics>
-    /// Called when a flow ends 
+    /// Called when a flow ends
     public let onFlowEnd: HookDecode<PlayerFlowMetrics>
 }
 

--- a/plugins/metrics/swiftui/Sources/MetricsPlugin.swift
+++ b/plugins/metrics/swiftui/Sources/MetricsPlugin.swift
@@ -23,7 +23,7 @@ public class RequestTimePlugin: NativePlugin {
         requestTimeWebPlugin = RequestTimeWebPlugin(getRequestTime)
     }
 
-    public func apply<P: HeadlessPlayer>(player: P) {
+    public func apply(player: some HeadlessPlayer) {
         requestTimeWebPlugin.context = player.jsPlayerReference?.context
         player.applyTo(MetricsPlugin.self) { [weak self] plugin in
             self?.requestTimeWebPlugin.pluginRef?.invokeMethod("apply", withArguments: [plugin])
@@ -85,7 +85,7 @@ public class MetricsPlugin: JSBasePlugin, NativePlugin, WithSymbol {
         onRenderEnd = handler
     }
 
-    public func apply<P: HeadlessPlayer>(player: P) {
+    public func apply(player: some HeadlessPlayer) {
         guard trackRenderTime, let player = player as? SwiftUIPlayer else { return }
         let renderEnd = renderEnd
         player.hooks?.view.tap(name: pluginName) { view -> AnyView in

--- a/plugins/metrics/swiftui/Sources/MetricsPlugin.swift
+++ b/plugins/metrics/swiftui/Sources/MetricsPlugin.swift
@@ -7,23 +7,23 @@
 
 import Foundation
 import JavaScriptCore
-import SwiftUI
-
 import PlayerUI
 import PlayerUISwiftUI
+import SwiftUI
 
 /// A Plugin that provides request time data to `MetricsPlugin`
 public class RequestTimePlugin: NativePlugin {
     public var pluginName: String = "RequestTime"
+
     private let requestTimeWebPlugin: RequestTimeWebPlugin
 
     /// Construct a `RequestTimePlugin`
     /// - Parameter getRequestTime: A callback to retrieve the time the last request took
     public init(_ getRequestTime: @escaping () -> Int) {
-        self.requestTimeWebPlugin = RequestTimeWebPlugin(getRequestTime)
+        requestTimeWebPlugin = RequestTimeWebPlugin(getRequestTime)
     }
 
-    public func apply<P>(player: P) where P: HeadlessPlayer {
+    public func apply<P: HeadlessPlayer>(player: P) {
         requestTimeWebPlugin.context = player.jsPlayerReference?.context
         player.applyTo(MetricsPlugin.self) { [weak self] plugin in
             self?.requestTimeWebPlugin.pluginRef?.invokeMethod("apply", withArguments: [plugin])
@@ -33,33 +33,34 @@ public class RequestTimePlugin: NativePlugin {
 
 class RequestTimeWebPlugin: JSBasePlugin {
     private var getRequestTime: () -> Int = { 0 }
-    public convenience init(_ getRequestTime: @escaping () -> Int) {
-        self.init(fileName: "MetricsPlugin.native", pluginName: "MetricsPlugin.RequestTimeWebPlugin")
-        self.getRequestTime = getRequestTime
-    }
 
-    public override func getArguments() -> [Any] {
-        let handler: @convention(block) () -> Int = {
-            self.getRequestTime()
-        }
-        return [JSValue(object: handler, in: context) as Any]
+    convenience init(_ getRequestTime: @escaping () -> Int) {
+        self.init(
+            fileName: "MetricsPlugin.native",
+            pluginName: "MetricsPlugin.RequestTimeWebPlugin"
+        )
+        self.getRequestTime = getRequestTime
     }
 
     override open func getUrlForFile(fileName: String) -> URL? {
         ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
     }
+
+    override func getArguments() -> [Any] {
+        let handler: @convention(block) () -> Int = {
+            self.getRequestTime()
+        }
+        return [JSValue(object: handler, in: context) as Any]
+    }
 }
-/**
- Plugin for capturing metrics
- */
+
+/// Plugin for capturing metrics
 public class MetricsPlugin: JSBasePlugin, NativePlugin, WithSymbol {
     public static let symbol = "MetricsPlugin.MetricsCorePluginSymbol"
-    public typealias RenderEndHandler = (MetricsTiming?, NodeRenderMetrics?, PlayerFlowMetrics?) -> Void
-    private var trackRenderTime: Bool = true
-
-    var onRenderEnd: RenderEndHandler?
 
     public var hooks: MetricsHooks?
+
+    var onRenderEnd: RenderEndHandler?
 
     var onRenderEndJSHandler: @convention(block) (JSValue?, JSValue?, JSValue?) -> Void {
         { [weak self] timing, nodeMetrics, flowMetrics in
@@ -72,53 +73,58 @@ public class MetricsPlugin: JSBasePlugin, NativePlugin, WithSymbol {
         }
     }
 
-    override public func setup(context: JSContext) {
-        super.setup(context: context)
+    private var trackRenderTime: Bool = true
 
-        if let pluginRef = pluginRef {
-            self.hooks = MetricsHooks(onRenderEnd: Hook3Decode(baseValue: pluginRef, name: "onRenderEnd"), onFlowBegin: HookDecode(baseValue: pluginRef, name: "onFlowBegin"), onFlowEnd: HookDecode(baseValue: pluginRef, name: "onFlowEnd"))
-        }
-    }
-
-    public func apply<P>(player: P) where P: HeadlessPlayer {
-        guard trackRenderTime, let player = player as? SwiftUIPlayer else { return }
-        let renderEnd = self.renderEnd
-        player.hooks?.view.tap(name: pluginName, { (view) -> AnyView in
-            AnyView(view.onAppear {
-                renderEnd()
-            })
-        })
-    }
-
-    /**
-     Constructs the MetricsPlugin
-     - parameters:
-        - trackRenderTime: Whether or not to track render times
-        - handler: A handler to receive events when rendering has finished
-     */
+    /// Constructs the MetricsPlugin
+    /// - parameters:
+    ///   - trackRenderTime: Whether or not to track render times
+    ///   - handler: A handler to receive events when rendering has finished
     public convenience init(trackRenderTime: Bool = true, handler: RenderEndHandler? = nil) {
         self.init(fileName: "MetricsPlugin.native", pluginName: "MetricsPlugin.MetricsCorePlugin")
         self.trackRenderTime = trackRenderTime
-        self.onRenderEnd = handler
+        onRenderEnd = handler
     }
 
-    public override func getArguments() -> [Any] {
-        return [[
-            "trackRenderTime": trackRenderTime,
-            "onRenderEnd": JSValue(object: onRenderEndJSHandler, in: context) as Any
-        ]]
+    public func apply<P: HeadlessPlayer>(player: P) {
+        guard trackRenderTime, let player = player as? SwiftUIPlayer else { return }
+        let renderEnd = renderEnd
+        player.hooks?.view.tap(name: pluginName) { view -> AnyView in
+            AnyView(view.onAppear {
+                renderEnd()
+            })
+        }
+    }
+
+    /// Called when the UI has finished rendering
+    public func renderEnd() {
+        pluginRef?.invokeMethod("renderEnd", withArguments: [])
     }
 
     override open func getUrlForFile(fileName: String) -> URL? {
         ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
     }
 
-    /**
-     Called when the UI has finished rendering
-     */
-    public func renderEnd() {
-        pluginRef?.invokeMethod("renderEnd", withArguments: [])
+    override public func setup(context: JSContext) {
+        super.setup(context: context)
+
+        if let pluginRef {
+            hooks = MetricsHooks(
+                onRenderEnd: Hook3Decode(baseValue: pluginRef, name: "onRenderEnd"),
+                onFlowBegin: HookDecode(baseValue: pluginRef, name: "onFlowBegin"),
+                onFlowEnd: HookDecode(baseValue: pluginRef, name: "onFlowEnd")
+            )
+        }
     }
+
+    override public func getArguments() -> [Any] {
+        [[
+            "trackRenderTime": trackRenderTime,
+            "onRenderEnd": JSValue(object: onRenderEndJSHandler, in: context) as Any,
+        ]]
+    }
+
+    public typealias RenderEndHandler = (MetricsTiming?, NodeRenderMetrics?, PlayerFlowMetrics?)
+        -> Void
 }
 
 public struct MetricsHooks {
@@ -126,7 +132,7 @@ public struct MetricsHooks {
     public let onRenderEnd: Hook3Decode<MetricsTiming, NodeRenderMetrics, PlayerFlowMetrics>
     /// Called when a flow starts
     public let onFlowBegin: HookDecode<PlayerFlowMetrics>
-    /// Called when a flow ends 
+    /// Called when a flow ends
     public let onFlowEnd: HookDecode<PlayerFlowMetrics>
 }
 

--- a/plugins/metrics/swiftui/ViewInspector/MetricsPluginTests.swift
+++ b/plugins/metrics/swiftui/ViewInspector/MetricsPluginTests.swift
@@ -7,27 +7,29 @@
 //
 
 import Foundation
-import XCTest
 import JavaScriptCore
-import ViewInspector
 @testable import PlayerUI
 @testable import PlayerUIInternalTestUtilities
-@testable import PlayerUITestUtilitiesCore
-@testable import PlayerUISwiftUI
 @testable import PlayerUIMetricsPlugin
 @testable import PlayerUIReferenceAssets
+@testable import PlayerUISwiftUI
+@testable import PlayerUITestUtilitiesCore
+import ViewInspector
+import XCTest
 
 class TapCounterPlugin: NativePlugin {
     var pluginName: String = "TapCounter"
     var count = 0
-    func apply<P>(player: P) where P: HeadlessPlayer {
+
+    func apply<P: HeadlessPlayer>(player: P) {
         guard let player = player as? SwiftUIPlayer else { return }
-        player.hooks?.view.interceptRegister({ info in
+        player.hooks?.view.interceptRegister { info in
             self.count += 1
             return info
-        })
+        }
     }
 }
+
 class MetricsPluginTests: XCTestCase {
     func testConstruction() {
         let context = JSContext()
@@ -37,7 +39,7 @@ class MetricsPluginTests: XCTestCase {
         XCTAssertNotNil(plugin.pluginRef)
     }
 
-    func testRenderTimeTracking() {
+    func testRenderTimeTracking() throws {
         let renderEndCalled = XCTestExpectation(description: "renderEnd called")
         let callback: @convention(block) () -> Void = {
             renderEndCalled.fulfill()
@@ -45,9 +47,12 @@ class MetricsPluginTests: XCTestCase {
         let plugin = MetricsPlugin()
         let counter = TapCounterPlugin()
 
-        let player = SwiftUIPlayer(flow: FlowData.COUNTER, plugins: [counter, plugin, ReferenceAssetsPlugin()])
+        let player = SwiftUIPlayer(
+            flow: FlowData.COUNTER,
+            plugins: [counter, plugin, ReferenceAssetsPlugin()]
+        )
 
-        let jscallback = JSValue(object: callback, in: plugin.pluginRef!.context)
+        let jscallback = try JSValue(object: callback, in: XCTUnwrap(plugin.pluginRef?.context))
         plugin.pluginRef?.setValue(jscallback, forProperty: "renderEnd")
 
         XCTAssertEqual(counter.count, 1)
@@ -59,12 +64,15 @@ class MetricsPluginTests: XCTestCase {
 
     func testNoRenderTimeTracking() {
         let counter = TapCounterPlugin()
-        let player = SwiftUIPlayer(flow: FlowData.COUNTER, plugins: [counter, MetricsPlugin(trackRenderTime: false)])
+        let player = SwiftUIPlayer(
+            flow: FlowData.COUNTER,
+            plugins: [counter, MetricsPlugin(trackRenderTime: false)]
+        )
 
         XCTAssertEqual(counter.count, 0)
     }
 
-    func testHandler() throws {
+    func testHandler() {
         let calledBack = expectation(description: "RenderEnd handler called")
         let player = SwiftUIPlayer(
             flow: FlowData.COUNTER,
@@ -75,7 +83,7 @@ class MetricsPluginTests: XCTestCase {
                     XCTAssertNotNil(nodeMetrics)
                     XCTAssertNotNil(flowMetrics)
                     calledBack.fulfill()
-                }
+                },
             ]
         )
 
@@ -84,7 +92,7 @@ class MetricsPluginTests: XCTestCase {
         wait(for: [calledBack], timeout: 2)
     }
 
-    func testOnRenderEndHook() throws {
+    func testOnRenderEndHook() {
         let calledBackExpectation = expectation(description: "RenderEnd handler called")
         let hookExpectation = XCTestExpectation(description: "onRenderEnd hook called")
         let jsContext = JSContext()
@@ -109,7 +117,8 @@ class MetricsPluginTests: XCTestCase {
         }
 
         let player = SwiftUIPlayer(
-            flow: FlowData.COUNTER, plugins: [ReferenceAssetsPlugin(), plugin], context: context)
+            flow: FlowData.COUNTER, plugins: [ReferenceAssetsPlugin(), plugin], context: context
+        )
 
         ViewHosting.host(view: player)
 
@@ -126,7 +135,10 @@ class MetricsPluginTests: XCTestCase {
 
         XCTAssertNotNil(plugin.context)
 
-        let player = HeadlessPlayerImpl(plugins: [ReferenceAssetsPlugin(), plugin], context: context ?? JSContext())
+        let player = HeadlessPlayerImpl(
+            plugins: [ReferenceAssetsPlugin(), plugin],
+            context: context ?? JSContext()
+        )
 
         plugin.hooks?.onFlowBegin.tap { flow in
             XCTAssertEqual(flow.flow.completed, false)
@@ -140,7 +152,7 @@ class MetricsPluginTests: XCTestCase {
             handlerExpectationFlowEnd.fulfill()
         }
 
-        player.start(flow: FlowData.COUNTER, completion: {_ in})
+        player.start(flow: FlowData.COUNTER, completion: { _ in })
 
         wait(for: [handlerExpectationFlowBegin], timeout: 5)
 
@@ -157,7 +169,7 @@ class MetricsPluginTests: XCTestCase {
 class RequestTimePluginTests: XCTestCase {
     func testRequestTimeTracking() {
         let renderEndCalled = XCTestExpectation(description: "renderEnd handler called")
-        let plugin = MetricsPlugin { (_, _, flow) in
+        let plugin = MetricsPlugin { _, _, flow in
             guard let req = flow?.flow.requestTime else { return }
             XCTAssertEqual(req, 5)
             renderEndCalled.fulfill()
@@ -171,7 +183,7 @@ class RequestTimePluginTests: XCTestCase {
                 counter,
                 plugin,
                 RequestTimePlugin { 5 },
-                ReferenceAssetsPlugin()
+                ReferenceAssetsPlugin(),
             ]
         )
 

--- a/plugins/metrics/swiftui/ViewInspector/MetricsPluginTests.swift
+++ b/plugins/metrics/swiftui/ViewInspector/MetricsPluginTests.swift
@@ -21,7 +21,7 @@ class TapCounterPlugin: NativePlugin {
     var pluginName: String = "TapCounter"
     var count = 0
 
-    func apply<P: HeadlessPlayer>(player: P) {
+    func apply(player: some HeadlessPlayer) {
         guard let player = player as? SwiftUIPlayer else { return }
         player.hooks?.view.interceptRegister { info in
             self.count += 1

--- a/plugins/pending-transaction/swiftui/Sources/SwiftUIPendingTransactionPlugin.swift
+++ b/plugins/pending-transaction/swiftui/Sources/SwiftUIPendingTransactionPlugin.swift
@@ -9,72 +9,76 @@ import Foundation
 import SwiftUI
 
 #if SWIFT_PACKAGE
-import PlayerUI
-import PlayerUISwiftUI
+    import PlayerUI
+    import PlayerUISwiftUI
 #endif
 
-/**
- A plugin that allows TransactionContext objects to be registered into the decoder's userInfo that is used to decode the view updates.
- Allows for handling pending transactions on the assets side so users can decide when and where to add new callbacks and commit them
- */
-public class SwiftUIPendingTransactionPlugin<T>: NativePlugin where T: Identifiable, T: Hashable {
+/// A plugin that allows TransactionContext objects to be registered into the decoder's userInfo
+/// that is used to decode the view updates.
+/// Allows for handling pending transactions on the assets side so users can decide when and where
+/// to add new callbacks and commit them
+public class SwiftUIPendingTransactionPlugin<T: Identifiable & Hashable>: NativePlugin {
     public var pluginName: String = "SwiftUIPendingTransactionPlugin"
 
-    /**
-     Constructs the SwiftUIPendingTransactionPlugin
-     - parameters:
-        - keypath: Takes a keypath from the EnvironmentValues extension with generics of the TransactionContext<T> matching a user defined object,
-                   `\.transactionContext` which uses TransactionContext<PendingTransactionPhases> is the default.
-     */
+    let keyPath: WritableKeyPath<EnvironmentValues, TransactionContext<T>>
+
+    private let transactionContext: TransactionContext<T> = .init()
+
+    /// Constructs the SwiftUIPendingTransactionPlugin
+    /// - parameters:
+    ///   - keypath: Takes a keypath from the EnvironmentValues extension with generics of the
+    /// TransactionContext<T> matching a user defined object,
+    ///              `\.transactionContext` which uses TransactionContext<PendingTransactionPhases>
+    /// is the default.
     public init(keyPath: WritableKeyPath<EnvironmentValues, TransactionContext<T>>) {
         self.keyPath = keyPath
     }
 
-    private let transactionContext = TransactionContext<T>()
-
-    let keyPath: WritableKeyPath<EnvironmentValues, TransactionContext<T>>
-
-    public func apply<P>(player: P) where P: HeadlessPlayer {
+    public func apply<P: HeadlessPlayer>(player: P) {
         guard let player = player as? SwiftUIPlayer else { return }
 
         // transactionContext should attach to decoder prior to decoding a view
         player.assetRegistry.decoder.setPendingTransaction(transactionContext)
 
-        player.hooks?.view.tap(name: "SwiftUIPendingTransactionPlugin", { view in
+        player.hooks?.view.tap(name: "SwiftUIPendingTransactionPlugin") { view in
             let keyPath = self.keyPath
             return AnyView(view.environment(keyPath, self.transactionContext))
-        })
+        }
     }
 }
 
-// typealias which uses default PendingTransactionPhases as the generic
-public typealias PendingTransactionPhasesPlugin = SwiftUIPendingTransactionPlugin<PendingTransactionPhases>
+/// typealias which uses default PendingTransactionPhases as the generic
+public typealias PendingTransactionPhasesPlugin =
+    SwiftUIPendingTransactionPlugin<PendingTransactionPhases>
 
-extension SwiftUIPendingTransactionPlugin where T == PendingTransactionPhases {
-    /**
-     Convenience init which takes no parameters and uses the \.transactionContext keypath as default if user would like to use PendingTransactionPhases as the Namespace for TransactionContext
-     */
-    public convenience init() {
+public extension SwiftUIPendingTransactionPlugin where T == PendingTransactionPhases {
+    /// Convenience init which takes no parameters and uses the \.transactionContext keypath as
+    /// default if user would like to use PendingTransactionPhases as the Namespace for
+    /// TransactionContext
+    convenience init() {
         self.init(keyPath: \.transactionContext)
     }
 }
 
-/// Represents a specific namespace which is a group of transactions that should be performed together.
+/// Represents a specific namespace which is a group of transactions that should be performed
+/// together.
 /// Extend this struct to add new PendingTransactionPhases
 public struct PendingTransactionPhases: RawRepresentable, Identifiable, Hashable {
-    public var id: Self { self }
     public var rawValue: String
+
+    public var id: Self {
+        self
+    }
 
     public init(rawValue: String) {
         self.rawValue = rawValue
     }
 }
 
-/**
- Context object that contains functions to get/set a pending transaction and to call the commit callbacks
- */
-public class TransactionContext<Namespace> where Namespace: Identifiable, Namespace: Hashable {
-    // Assumes each namespace can have multiple callbacks
+/// Context object that contains functions to get/set a pending transaction and to call the commit
+/// callbacks
+public class TransactionContext<Namespace: Identifiable & Hashable> {
+    /// Assumes each namespace can have multiple callbacks
     public var callbacks: [Namespace: [() -> Void]] = [:]
 
     /// Register a pending transaction to the namespace
@@ -100,19 +104,19 @@ public class TransactionContext<Namespace> where Namespace: Identifiable, Namesp
 
     /// Clear transactions belonging to the namespace
     public func clear(_ namespace: Namespace) {
-       callbacks.removeValue(forKey: namespace)
+        callbacks.removeValue(forKey: namespace)
     }
 
     /// Clear transactions belonging to the namespaces
     public func clear(_ namespaces: [Namespace]) {
-        namespaces.forEach {callbacks.removeValue(forKey: $0)}
+        namespaces.forEach { callbacks.removeValue(forKey: $0) }
     }
 }
 
 /// EnvironmentKey for setting a `TransactionContextKey`
-internal struct TransactionContextKey: EnvironmentKey {
+struct TransactionContextKey: EnvironmentKey {
     /// Default value for this key
-    public static let defaultValue: TransactionContext<PendingTransactionPhases> = .init()
+    static let defaultValue: TransactionContext<PendingTransactionPhases> = .init()
 }
 
 /// EnvironmentValue for `TransactionContext` for the `SwiftUIPendingTransactionPlugin`
@@ -129,12 +133,14 @@ public typealias CallbackHandler = () -> Void
 /// Callback structure used to preserve registration order in callbacks
 public struct Callback {
     public var id: String
+
     let callback: CallbackHandler
 }
 
 public extension CodingUserInfoKey {
     /// A `CodingUserInfoKey` to fetch the pendingTransactionContext for this decoder
-    static let pendingTransactionContext: CodingUserInfoKey! = CodingUserInfoKey(rawValue: "pendingTransactionContext")
+    static let pendingTransactionContext: CodingUserInfoKey! =
+        CodingUserInfoKey(rawValue: "pendingTransactionContext")
 }
 
 extension JSONDecoder {

--- a/plugins/pending-transaction/swiftui/Sources/SwiftUIPendingTransactionPlugin.swift
+++ b/plugins/pending-transaction/swiftui/Sources/SwiftUIPendingTransactionPlugin.swift
@@ -6,73 +6,76 @@
 //
 
 import Foundation
-import SwiftUI
-
 import PlayerUI
 import PlayerUISwiftUI
+import SwiftUI
 
-/**
- A plugin that allows TransactionContext objects to be registered into the decoder's userInfo that is used to decode the view updates.
- Allows for handling pending transactions on the assets side so users can decide when and where to add new callbacks and commit them
- */
-public class SwiftUIPendingTransactionPlugin<T>: NativePlugin where T: Identifiable, T: Hashable {
+/// A plugin that allows TransactionContext objects to be registered into the decoder's userInfo
+/// that is used to decode the view updates.
+/// Allows for handling pending transactions on the assets side so users can decide when and where
+/// to add new callbacks and commit them
+public class SwiftUIPendingTransactionPlugin<T: Identifiable & Hashable>: NativePlugin {
     public var pluginName: String = "SwiftUIPendingTransactionPlugin"
 
-    /**
-     Constructs the SwiftUIPendingTransactionPlugin
-     - parameters:
-        - keypath: Takes a keypath from the EnvironmentValues extension with generics of the TransactionContext<T> matching a user defined object,
-                   `\.transactionContext` which uses TransactionContext<PendingTransactionPhases> is the default.
-     */
+    let keyPath: WritableKeyPath<EnvironmentValues, TransactionContext<T>>
+
+    private let transactionContext: TransactionContext<T> = .init()
+
+    /// Constructs the SwiftUIPendingTransactionPlugin
+    /// - parameters:
+    ///   - keypath: Takes a keypath from the EnvironmentValues extension with generics of the
+    /// TransactionContext<T> matching a user defined object,
+    ///              `\.transactionContext` which uses TransactionContext<PendingTransactionPhases>
+    /// is the default.
     public init(keyPath: WritableKeyPath<EnvironmentValues, TransactionContext<T>>) {
         self.keyPath = keyPath
     }
 
-    private let transactionContext = TransactionContext<T>()
-
-    let keyPath: WritableKeyPath<EnvironmentValues, TransactionContext<T>>
-
-    public func apply<P>(player: P) where P: HeadlessPlayer {
+    public func apply<P: HeadlessPlayer>(player: P) {
         guard let player = player as? SwiftUIPlayer else { return }
 
         // transactionContext should attach to decoder prior to decoding a view
         player.assetRegistry.decoder.setPendingTransaction(transactionContext)
 
-        player.hooks?.view.tap(name: "SwiftUIPendingTransactionPlugin", { view in
+        player.hooks?.view.tap(name: "SwiftUIPendingTransactionPlugin") { view in
             let keyPath = self.keyPath
             return AnyView(view.environment(keyPath, self.transactionContext))
-        })
+        }
     }
 }
 
-// typealias which uses default PendingTransactionPhases as the generic
-public typealias PendingTransactionPhasesPlugin = SwiftUIPendingTransactionPlugin<PendingTransactionPhases>
+/// typealias which uses default PendingTransactionPhases as the generic
+public typealias PendingTransactionPhasesPlugin =
+    SwiftUIPendingTransactionPlugin<PendingTransactionPhases>
 
-extension SwiftUIPendingTransactionPlugin where T == PendingTransactionPhases {
-    /**
-     Convenience init which takes no parameters and uses the \.transactionContext keypath as default if user would like to use PendingTransactionPhases as the Namespace for TransactionContext
-     */
-    public convenience init() {
+public extension SwiftUIPendingTransactionPlugin where T == PendingTransactionPhases {
+    /// Convenience init which takes no parameters and uses the \.transactionContext keypath as
+    /// default if user would like to use PendingTransactionPhases as the Namespace for
+    /// TransactionContext
+    convenience init() {
         self.init(keyPath: \.transactionContext)
     }
 }
 
-/// Represents a specific namespace which is a group of transactions that should be performed together.
+/// Represents a specific namespace which is a group of transactions that should be performed
+/// together.
 /// Extend this struct to add new PendingTransactionPhases
 public struct PendingTransactionPhases: RawRepresentable, Identifiable, Hashable {
-    public var id: Self { self }
     public var rawValue: String
+
+    public var id: Self {
+        self
+    }
 
     public init(rawValue: String) {
         self.rawValue = rawValue
     }
 }
 
-/**
- Context object that contains functions to get/set a pending transaction and to call the commit callbacks
- */
-public class TransactionContext<Namespace> where Namespace: Identifiable, Namespace: Hashable {
-    // Assumes each namespace can have multiple callbacks
+/// Context object that contains functions to get/set a pending transaction and to call the commit
+/// callbacks
+public class TransactionContext<Namespace: Identifiable & Hashable> {
+    /// Assumes each namespace can have multiple callbacks
     public var callbacks: [Namespace: [() -> Void]] = [:]
 
     /// Register a pending transaction to the namespace
@@ -98,19 +101,19 @@ public class TransactionContext<Namespace> where Namespace: Identifiable, Namesp
 
     /// Clear transactions belonging to the namespace
     public func clear(_ namespace: Namespace) {
-       callbacks.removeValue(forKey: namespace)
+        callbacks.removeValue(forKey: namespace)
     }
 
     /// Clear transactions belonging to the namespaces
     public func clear(_ namespaces: [Namespace]) {
-        namespaces.forEach {callbacks.removeValue(forKey: $0)}
+        namespaces.forEach { callbacks.removeValue(forKey: $0) }
     }
 }
 
 /// EnvironmentKey for setting a `TransactionContextKey`
-internal struct TransactionContextKey: EnvironmentKey {
+struct TransactionContextKey: EnvironmentKey {
     /// Default value for this key
-    public static let defaultValue: TransactionContext<PendingTransactionPhases> = .init()
+    static let defaultValue: TransactionContext<PendingTransactionPhases> = .init()
 }
 
 /// EnvironmentValue for `TransactionContext` for the `SwiftUIPendingTransactionPlugin`
@@ -127,12 +130,14 @@ public typealias CallbackHandler = () -> Void
 /// Callback structure used to preserve registration order in callbacks
 public struct Callback {
     public var id: String
+
     let callback: CallbackHandler
 }
 
 public extension CodingUserInfoKey {
     /// A `CodingUserInfoKey` to fetch the pendingTransactionContext for this decoder
-    static let pendingTransactionContext: CodingUserInfoKey! = CodingUserInfoKey(rawValue: "pendingTransactionContext")
+    static let pendingTransactionContext: CodingUserInfoKey! =
+        CodingUserInfoKey(rawValue: "pendingTransactionContext")
 }
 
 extension JSONDecoder {

--- a/plugins/pending-transaction/swiftui/Sources/SwiftUIPendingTransactionPlugin.swift
+++ b/plugins/pending-transaction/swiftui/Sources/SwiftUIPendingTransactionPlugin.swift
@@ -31,7 +31,7 @@ public class SwiftUIPendingTransactionPlugin<T: Identifiable & Hashable>: Native
         self.keyPath = keyPath
     }
 
-    public func apply<P: HeadlessPlayer>(player: P) {
+    public func apply(player: some HeadlessPlayer) {
         guard let player = player as? SwiftUIPlayer else { return }
 
         // transactionContext should attach to decoder prior to decoding a view
@@ -142,7 +142,7 @@ public extension CodingUserInfoKey {
 
 extension JSONDecoder {
     /// Sets the TransactionContext for the user info on the decoder
-    func setPendingTransaction<T>(_ transaction: TransactionContext<T>?) {
+    func setPendingTransaction(_ transaction: TransactionContext<some Any>?) {
         userInfo[.pendingTransactionContext] = transaction
     }
 }

--- a/plugins/pending-transaction/swiftui/ViewInspector/SwiftUIPendingTransactionPlugin.swift
+++ b/plugins/pending-transaction/swiftui/ViewInspector/SwiftUIPendingTransactionPlugin.swift
@@ -1,21 +1,24 @@
 //
-//  SwiftUIPendingTransactionPluginTests.swift
+//  SwiftUIPendingTransactionPlugin.swift
 //  iOSPlayer
 //
 //  Created by Zhao Xia Wu on 2023-09-28.
 //
 
 import Foundation
-import XCTest
-import SwiftUI
-import ViewInspector
 @testable import PlayerUI
 @testable import PlayerUISwiftUI
 @testable import PlayerUISwiftUIPendingTransactionPlugin
+import SwiftUI
+import ViewInspector
+import XCTest
 
 class SwiftUIPendingTransactionPluginTests: XCTestCase {
     func testContextAttachment() throws {
-        let player = SwiftUIPlayer(flow: "", plugins: [SwiftUIPendingTransactionPlugin(keyPath: \.transactionContext)])
+        let player = SwiftUIPlayer(
+            flow: "",
+            plugins: [SwiftUIPendingTransactionPlugin(keyPath: \.transactionContext)]
+        )
 
         guard let view: AnyView = player.hooks?.view.call(AnyView(TestButtons())) else {
             return XCTFail("no view returned from hook")
@@ -25,7 +28,7 @@ class SwiftUIPendingTransactionPluginTests: XCTestCase {
         _ = try view.inspect().anyView().anyView().view(TestButtons.self)
     }
 
-    func testAddPendingTransactionAndCallCommitCallbackSingleNamespace() throws {
+    func testAddPendingTransactionAndCallCommitCallbackSingleNamespace() {
         var tree = TestButtons()
 
         let appear = tree.on(\.didAppear) { view in
@@ -51,7 +54,7 @@ class SwiftUIPendingTransactionPluginTests: XCTestCase {
         wait(for: [appear], timeout: 2)
     }
 
-    func testAddPendingTransactionAndCallCommitCallbackMultipleNamespaces() throws {
+    func testAddPendingTransactionAndCallCommitCallbackMultipleNamespaces() {
         var tree = TestButtons2()
 
         let appear = tree.on(\.didAppear) { view in
@@ -91,7 +94,8 @@ private struct TestButtons: View {
 
     @State var button1Text = "Button 1"
 
-    internal var didAppear: ((Self) -> Void)?
+    var didAppear: ((Self) -> Void)?
+
     var body: some View {
         VStack {
             Button(action: {
@@ -101,13 +105,13 @@ private struct TestButtons: View {
 
                 button1Text = "Button 1 Transaction Registered"
 
-            }, label: {Text(button1Text)}).id("button-1")
+            }, label: { Text(button1Text) }).id("button-1")
 
             Button(action: {
                 // clicking second button will trigger callback registered in first button
                 transactionContext.commit(.button1)
                 transactionContext.clear(.button1)
-            }, label: {Text("Button 2")}).id("button-2")
+            }, label: { Text("Button 2") }).id("button-2")
         }
         .onAppear { didAppear?(self) }
     }
@@ -119,7 +123,8 @@ private struct TestButtons2: View {
     @State var button1Text = "Button 1"
     @State var button2Text = "Button 2"
 
-    internal var didAppear: ((Self) -> Void)?
+    var didAppear: ((Self) -> Void)?
+
     var body: some View {
         VStack {
             Button(action: {
@@ -133,7 +138,7 @@ private struct TestButtons2: View {
 
                 button1Text = "Button 1 Transaction Registered"
 
-            }, label: {Text(button1Text)}).id("button-1")
+            }, label: { Text(button1Text) }).id("button-1")
 
             Button(action: {
                 transactionContext.register(.button2) {
@@ -142,19 +147,19 @@ private struct TestButtons2: View {
 
                 button2Text = "Button 2 Transaction Registered"
 
-            }, label: {Text(button2Text)}).id("button-2")
+            }, label: { Text(button2Text) }).id("button-2")
 
             Button(action: {
                 // clicking button 3 will commit transactions registered in button 1 and button 2
                 transactionContext.commit([.button1, .button2])
                 transactionContext.clear([.button1, .button2])
-            }, label: {Text("Button 3")}).id("button3")
+            }, label: { Text("Button 3") }).id("button3")
         }
         .onAppear { didAppear?(self) }
     }
 }
 
-extension PendingTransactionPhases {
-    public static let button1 = PendingTransactionPhases(rawValue: "button1")
-    public static let button2 = PendingTransactionPhases(rawValue: "button2")
+public extension PendingTransactionPhases {
+    static let button1: PendingTransactionPhases = .init(rawValue: "button1")
+    static let button2: PendingTransactionPhases = .init(rawValue: "button2")
 }

--- a/plugins/pubsub/ios/Sources/PubSubPlugin.swift
+++ b/plugins/pubsub/ios/Sources/PubSubPlugin.swift
@@ -1,5 +1,5 @@
 //
-//  PubsubPlugin.swift
+//  PubSubPlugin.swift
 //  PlayerUI
 //
 //  Created by Borawski, Harris on 4/17/20.
@@ -9,29 +9,23 @@ import Foundation
 import JavaScriptCore
 
 #if SWIFT_PACKAGE
-import PlayerUI
+    import PlayerUI
 #endif
 
-/**
- Additional options for `PubSubPlugin`
- */
+/// Additional options for `PubSubPlugin`
 public struct PubSubPluginOptions: Codable {
     /// A custom expression name to register
     let expressionName: String?
 
-    /**
-     Constructs the options object
-     - parameters:
-        - expressionName: An optional name to use as the publish expression
-     */
+    /// Constructs the options object
+    /// - parameters:
+    ///   - expressionName: An optional name to use as the publish expression
     public init(expressionName: String?) {
         self.expressionName = expressionName
     }
 }
 
-/**
- A plugin to register custom publish expressions and handlers
- */
+/// A plugin to register custom publish expressions and handlers
 public class PubSubPlugin: JSBasePlugin, NativePlugin {
     /// Array of subscriptions to subscribe once setup is complete
     private var eventSubscriptions: [PubSubSubscription] = []
@@ -39,65 +33,50 @@ public class PubSubPlugin: JSBasePlugin, NativePlugin {
     /// Additional options for the PubSubPlugin
     private var options: PubSubPluginOptions?
 
-    /**
-     Constructs a PubSubPlugin
-     - parameters:
-        - eventNames: The event names to subscribe to
-        - eventReceived: A callback to receive events
-     */
-    public convenience init(_ subscriptions: [PubSubSubscription], options: PubSubPluginOptions? = nil) {
+    /// Constructs a PubSubPlugin
+    /// - parameters:
+    ///   - eventNames: The event names to subscribe to
+    ///   - eventReceived: A callback to receive events
+    public convenience init(
+        _ subscriptions: [PubSubSubscription],
+        options: PubSubPluginOptions? = nil
+    ) {
         self.init(fileName: "PubSubPlugin.native", pluginName: "PubSubPlugin.PubSubPlugin")
         eventSubscriptions = subscriptions
         self.options = options
     }
 
-    /**
-    Constructs the PubSub Plugin in the given context
-    - parameters:
-       - context: The context to load the plugin into
-    */
-    override public func setup(context: JSContext) {
-        super.setup(context: context)
-        for subscription in eventSubscriptions {
-            subscribe(eventName: subscription.0, callback: subscription.1)
-        }
+    /// Publish an event through the plugin
+    /// - parameters:
+    ///   - eventName: The name of the event
+    ///   - eventData: Arbitrary data associated with the event
+    public func publish(eventName: String, eventData: AnyType) {
+        guard
+            let data = try? JSONEncoder().encode(eventData),
+            let dataString = String(data: data, encoding: .utf8),
+            let dataObject = pluginRef?.context.evaluateScript("(\(dataString))")
+        else { return }
+        pluginRef?.invokeMethod("publish", withArguments: [eventName, dataObject])
     }
 
-    public override func getArguments() -> [Any] {
-        guard let name = self.options?.expressionName else { return [] }
-        return [["expressionName": name]]
-    }
-
-    override open func getUrlForFile(fileName: String) -> URL? {
-        #if SWIFT_PACKAGE
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
-        #else
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle(for: PubSubPlugin.self), pathComponent: "PlayerUI_PubSubPlugin.bundle")
-        #endif
-    }
-
-    /**
-     Subscribe to an event
-     - parameters:
-        - eventName: The name of the event to attach a handler to
-        - callback: The handler to call when the event is received
-     */
+    /// Subscribe to an event
+    /// - parameters:
+    ///   - eventName: The name of the event to attach a handler to
+    ///   - callback: The handler to call when the event is received
     private func subscribe(eventName: String, callback: @escaping (String, AnyType?) -> Void) {
-        guard let pluginRef = pluginRef else { return }
-        let callback: @convention(block) (JSValue?, JSValue?) -> Void = { (event, data) in
+        guard let pluginRef else { return }
+        let callback: @convention(block) (JSValue?, JSValue?) -> Void = { event, data in
             guard let name = event?.toString() else { return }
             if
                 let isString = data?.isString, isString,
-                let objectString = data?.toString()
-            {
+                let objectString = data?.toString() {
                 callback(name, .string(data: objectString))
             } else if
                 let object = data?.toObject(),
                 let objectData = try? JSONSerialization.data(withJSONObject: object),
                 let eventData = try? AnyTypeDecodingContext(rawData: objectData)
-                    .inject(to: JSONDecoder())
-                    .decode(AnyType.self, from: objectData)
-            {
+                .inject(to: JSONDecoder())
+                .decode(AnyType.self, from: objectData) {
                 callback(name, eventData)
             } else {
                 callback(name, nil)
@@ -107,20 +86,32 @@ public class PubSubPlugin: JSBasePlugin, NativePlugin {
         pluginRef.invokeMethod("subscribe", withArguments: [eventName, jsCallback])
     }
 
-    /**
-     Publish an event through the plugin
-     - parameters:
-        - eventName: The name of the event
-        - eventData: Arbitrary data associated with the event
-     */
-    public func publish(eventName: String, eventData: AnyType) {
-        guard
-            let data = try? JSONEncoder().encode(eventData),
-            let dataString = String(data: data, encoding: .utf8),
-            let dataObject = pluginRef?.context.evaluateScript("(\(dataString))")
-        else { return }
-        pluginRef?.invokeMethod("publish", withArguments: [eventName, dataObject])
+    override open func getUrlForFile(fileName: String) -> URL? {
+        #if SWIFT_PACKAGE
+            ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
+        #else
+            ResourceUtilities.urlForFile(
+                name: fileName,
+                ext: "js",
+                bundle: Bundle(for: PubSubPlugin.self),
+                pathComponent: "PlayerUI_PubSubPlugin.bundle"
+            )
+        #endif
+    }
 
+    /// Constructs the PubSub Plugin in the given context
+    /// - parameters:
+    ///   - context: The context to load the plugin into
+    override public func setup(context: JSContext) {
+        super.setup(context: context)
+        for subscription in eventSubscriptions {
+            subscribe(eventName: subscription.0, callback: subscription.1)
+        }
+    }
+
+    override public func getArguments() -> [Any] {
+        guard let name = options?.expressionName else { return [] }
+        return [["expressionName": name]]
     }
 }
 

--- a/plugins/pubsub/ios/Sources/PubSubPlugin.swift
+++ b/plugins/pubsub/ios/Sources/PubSubPlugin.swift
@@ -1,5 +1,5 @@
 //
-//  PubsubPlugin.swift
+//  PubSubPlugin.swift
 //  PlayerUI
 //
 //  Created by Borawski, Harris on 4/17/20.
@@ -7,29 +7,22 @@
 
 import Foundation
 import JavaScriptCore
-
 import PlayerUI
 
-/**
- Additional options for `PubSubPlugin`
- */
+/// Additional options for `PubSubPlugin`
 public struct PubSubPluginOptions: Codable {
     /// A custom expression name to register
     let expressionName: String?
 
-    /**
-     Constructs the options object
-     - parameters:
-        - expressionName: An optional name to use as the publish expression
-     */
+    /// Constructs the options object
+    /// - parameters:
+    ///   - expressionName: An optional name to use as the publish expression
     public init(expressionName: String?) {
         self.expressionName = expressionName
     }
 }
 
-/**
- A plugin to register custom publish expressions and handlers
- */
+/// A plugin to register custom publish expressions and handlers
 public class PubSubPlugin: JSBasePlugin, NativePlugin {
     /// Array of subscriptions to subscribe once setup is complete
     private var eventSubscriptions: [PubSubSubscription] = []
@@ -37,61 +30,50 @@ public class PubSubPlugin: JSBasePlugin, NativePlugin {
     /// Additional options for the PubSubPlugin
     private var options: PubSubPluginOptions?
 
-    /**
-     Constructs a PubSubPlugin
-     - parameters:
-        - eventNames: The event names to subscribe to
-        - eventReceived: A callback to receive events
-     */
-    public convenience init(_ subscriptions: [PubSubSubscription], options: PubSubPluginOptions? = nil) {
+    /// Constructs a PubSubPlugin
+    /// - parameters:
+    ///   - eventNames: The event names to subscribe to
+    ///   - eventReceived: A callback to receive events
+    public convenience init(
+        _ subscriptions: [PubSubSubscription],
+        options: PubSubPluginOptions? = nil
+    ) {
         self.init(fileName: "PubSubPlugin.native", pluginName: "PubSubPlugin.PubSubPlugin")
         eventSubscriptions = subscriptions
         self.options = options
     }
 
-    /**
-    Constructs the PubSub Plugin in the given context
-    - parameters:
-       - context: The context to load the plugin into
-    */
-    override public func setup(context: JSContext) {
-        super.setup(context: context)
-        for subscription in eventSubscriptions {
-            subscribe(eventName: subscription.0, callback: subscription.1)
-        }
+    /// Publish an event through the plugin
+    /// - parameters:
+    ///   - eventName: The name of the event
+    ///   - eventData: Arbitrary data associated with the event
+    public func publish(eventName: String, eventData: AnyType) {
+        guard
+            let data = try? JSONEncoder().encode(eventData),
+            let dataString = String(data: data, encoding: .utf8),
+            let dataObject = pluginRef?.context.evaluateScript("(\(dataString))")
+        else { return }
+        pluginRef?.invokeMethod("publish", withArguments: [eventName, dataObject])
     }
 
-    public override func getArguments() -> [Any] {
-        guard let name = self.options?.expressionName else { return [] }
-        return [["expressionName": name]]
-    }
-
-    override open func getUrlForFile(fileName: String) -> URL? {
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
-    }
-
-    /**
-     Subscribe to an event
-     - parameters:
-        - eventName: The name of the event to attach a handler to
-        - callback: The handler to call when the event is received
-     */
+    /// Subscribe to an event
+    /// - parameters:
+    ///   - eventName: The name of the event to attach a handler to
+    ///   - callback: The handler to call when the event is received
     private func subscribe(eventName: String, callback: @escaping (String, AnyType?) -> Void) {
-        guard let pluginRef = pluginRef else { return }
-        let callback: @convention(block) (JSValue?, JSValue?) -> Void = { (event, data) in
+        guard let pluginRef else { return }
+        let callback: @convention(block) (JSValue?, JSValue?) -> Void = { event, data in
             guard let name = event?.toString() else { return }
             if
                 let isString = data?.isString, isString,
-                let objectString = data?.toString()
-            {
+                let objectString = data?.toString() {
                 callback(name, .string(data: objectString))
             } else if
                 let object = data?.toObject(),
                 let objectData = try? JSONSerialization.data(withJSONObject: object),
                 let eventData = try? AnyTypeDecodingContext(rawData: objectData)
-                    .inject(to: JSONDecoder())
-                    .decode(AnyType.self, from: objectData)
-            {
+                .inject(to: JSONDecoder())
+                .decode(AnyType.self, from: objectData) {
                 callback(name, eventData)
             } else {
                 callback(name, nil)
@@ -101,20 +83,23 @@ public class PubSubPlugin: JSBasePlugin, NativePlugin {
         pluginRef.invokeMethod("subscribe", withArguments: [eventName, jsCallback])
     }
 
-    /**
-     Publish an event through the plugin
-     - parameters:
-        - eventName: The name of the event
-        - eventData: Arbitrary data associated with the event
-     */
-    public func publish(eventName: String, eventData: AnyType) {
-        guard
-            let data = try? JSONEncoder().encode(eventData),
-            let dataString = String(data: data, encoding: .utf8),
-            let dataObject = pluginRef?.context.evaluateScript("(\(dataString))")
-        else { return }
-        pluginRef?.invokeMethod("publish", withArguments: [eventName, dataObject])
+    override open func getUrlForFile(fileName: String) -> URL? {
+        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
+    }
 
+    /// Constructs the PubSub Plugin in the given context
+    /// - parameters:
+    ///   - context: The context to load the plugin into
+    override public func setup(context: JSContext) {
+        super.setup(context: context)
+        for subscription in eventSubscriptions {
+            subscribe(eventName: subscription.0, callback: subscription.1)
+        }
+    }
+
+    override public func getArguments() -> [Any] {
+        guard let name = options?.expressionName else { return [] }
+        return [["expressionName": name]]
     }
 }
 

--- a/plugins/pubsub/ios/Tests/PubSubPluginTests.swift
+++ b/plugins/pubsub/ios/Tests/PubSubPluginTests.swift
@@ -7,11 +7,11 @@
 //
 
 import Foundation
-import XCTest
 import JavaScriptCore
 @testable import PlayerUI
-@testable import PlayerUITestUtilitiesCore
 @testable import PlayerUIPubSubPlugin
+@testable import PlayerUITestUtilitiesCore
+import XCTest
 
 class PubSubPluginTests: XCTestCase {
     func testPubSubPluginFromContent() {
@@ -44,10 +44,10 @@ class PubSubPluginTests: XCTestCase {
         """
 
         let expectation = XCTestExpectation(description: "publish callback called")
-        let subscription: PubSubSubscription = ("test", { (_, data) in
+        let subscription: PubSubSubscription = ("test", { _, data in
             guard let eventData = data else { return XCTFail("data did not exist") }
             switch eventData {
-            case .string(let result):
+            case let .string(result):
                 XCTAssertEqual(result, "example")
             default:
                 XCTFail("data was not a string")
@@ -57,7 +57,7 @@ class PubSubPluginTests: XCTestCase {
 
         let plugin = PubSubPlugin([subscription])
         let player = HeadlessPlayerImpl(plugins: [plugin])
-        player.start(flow: flow, completion: {_ in})
+        player.start(flow: flow, completion: { _ in })
         wait(for: [expectation], timeout: 3)
     }
 
@@ -91,10 +91,10 @@ class PubSubPluginTests: XCTestCase {
         """
 
         let expectation = XCTestExpectation(description: "publish callback called")
-        let subscription: PubSubSubscription = ("test", { (_, data) in
+        let subscription: PubSubSubscription = ("test", { _, data in
             guard let eventData = data else { return XCTFail("data did not exist") }
             switch eventData {
-            case .string(let result):
+            case let .string(result):
                 XCTAssertEqual(result, "example")
             default:
                 XCTFail("data was not a string")
@@ -102,20 +102,24 @@ class PubSubPluginTests: XCTestCase {
             expectation.fulfill()
         })
 
-        let plugin = PubSubPlugin([subscription], options: PubSubPluginOptions(expressionName: "customPublish"))
+        let plugin = PubSubPlugin(
+            [subscription],
+            options: PubSubPluginOptions(expressionName: "customPublish")
+        )
         let player = HeadlessPlayerImpl(plugins: [plugin])
-        player.start(flow: flow, completion: {_ in})
+        player.start(flow: flow, completion: { _ in })
         wait(for: [expectation], timeout: 3)
     }
-    func testPubSubPluginStringData() {
-        let context = JSContext()!
+
+    func testPubSubPluginStringData() throws {
+        let context = try XCTUnwrap(JSContext())
         JSUtilities.polyfill(context)
 
         let expectation = XCTestExpectation(description: "beacon callback called")
-        let subscription: PubSubSubscription = ("test", { (_, data) in
+        let subscription: PubSubSubscription = ("test", { _, data in
             guard let eventData = data else { return XCTFail("data did not exist") }
             switch eventData {
-            case .string(let result):
+            case let .string(result):
                 XCTAssertEqual(result, "example")
             default:
                 XCTFail("data was not a string")
@@ -130,15 +134,15 @@ class PubSubPluginTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
 
-    func testPubSubPluginArrayData() {
-        let context = JSContext()!
+    func testPubSubPluginArrayData() throws {
+        let context = try XCTUnwrap(JSContext())
         JSUtilities.polyfill(context)
 
         let expectation = XCTestExpectation(description: "beacon callback called")
-        let subscription: PubSubSubscription = ("test", { (_, data) in
+        let subscription: PubSubSubscription = ("test", { _, data in
             guard let eventData = data else { return XCTFail("data did not exist") }
             switch eventData {
-            case .array(let result):
+            case let .array(result):
                 XCTAssertEqual(result, ["example", "data"])
             default:
                 XCTFail("data was not an array")
@@ -153,15 +157,15 @@ class PubSubPluginTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
 
-    func testPubSubPluginDictionaryData() {
-        let context = JSContext()!
+    func testPubSubPluginDictionaryData() throws {
+        let context = try XCTUnwrap(JSContext())
         JSUtilities.polyfill(context)
 
         let expectation = XCTestExpectation(description: "beacon callback called")
-        let subscription: PubSubSubscription = ("test", { (_, data) in
+        let subscription: PubSubSubscription = ("test", { _, data in
             guard let eventData = data else { return XCTFail("data did not exist") }
             switch eventData {
-            case .dictionary(let result):
+            case let .dictionary(result):
                 XCTAssertEqual(result, ["example": "data"])
             default:
                 XCTFail("data was not a dictionary")
@@ -176,15 +180,15 @@ class PubSubPluginTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
 
-    func testPubSubPluginAnyDictionaryData() {
-        let context = JSContext()!
+    func testPubSubPluginAnyDictionaryData() throws {
+        let context = try XCTUnwrap(JSContext())
         JSUtilities.polyfill(context)
 
         let expectation = XCTestExpectation(description: "beacon callback called")
-        let subscription: PubSubSubscription = ("test", { (_, data) in
+        let subscription: PubSubSubscription = ("test", { _, data in
             guard let eventData = data else { return XCTFail("data did not exist") }
             switch eventData {
-            case .anyDictionary(let dict):
+            case let .anyDictionary(dict):
                 XCTAssertEqual(2, dict.keys.count)
                 XCTAssertEqual("example", dict["data"] as? String)
                 XCTAssertEqual(3, dict["value"] as? Double)
@@ -197,7 +201,10 @@ class PubSubPluginTests: XCTestCase {
         let plugin = PubSubPlugin([subscription])
         plugin.context = context
 
-        plugin.publish(eventName: "test", eventData: .anyDictionary(data: ["data": "example", "value": 3]))
+        plugin.publish(
+            eventName: "test",
+            eventData: .anyDictionary(data: ["data": "example", "value": 3])
+        )
         wait(for: [expectation], timeout: 2)
     }
 }

--- a/plugins/pubsub/ios/Tests/PubSubPluginTests.swift
+++ b/plugins/pubsub/ios/Tests/PubSubPluginTests.swift
@@ -7,11 +7,11 @@
 //
 
 import Foundation
-import XCTest
 import JavaScriptCore
 @testable import PlayerUI
-@testable import PlayerUITestUtilitiesCore
 @testable import PlayerUIPubSubPlugin
+@testable import PlayerUITestUtilitiesCore
+import XCTest
 
 class PubSubPluginTests: XCTestCase {
     func testPubSubPluginFromContent() {
@@ -44,10 +44,10 @@ class PubSubPluginTests: XCTestCase {
         """
 
         let expectation = XCTestExpectation(description: "publish callback called")
-        let subscription: PubSubSubscription = ("test", { (_, data) in
+        let subscription: PubSubSubscription = ("test", { _, data in
             guard let eventData = data else { return XCTFail("data did not exist") }
             switch eventData {
-            case .string(let result):
+            case let .string(result):
                 XCTAssertEqual(result, "example")
             default:
                 XCTFail("data was not a string")
@@ -57,7 +57,7 @@ class PubSubPluginTests: XCTestCase {
 
         let plugin = PubSubPlugin([subscription])
         let player = HeadlessPlayerImpl(plugins: [plugin])
-        player.start(flow: flow, completion: {_ in})
+        player.start(flow: flow, completion: { _ in })
         wait(for: [expectation], timeout: 3)
     }
 
@@ -91,10 +91,10 @@ class PubSubPluginTests: XCTestCase {
         """
 
         let expectation = XCTestExpectation(description: "publish callback called")
-        let subscription: PubSubSubscription = ("test", { (_, data) in
+        let subscription: PubSubSubscription = ("test", { _, data in
             guard let eventData = data else { return XCTFail("data did not exist") }
             switch eventData {
-            case .string(let result):
+            case let .string(result):
                 XCTAssertEqual(result, "example")
             default:
                 XCTFail("data was not a string")
@@ -102,20 +102,24 @@ class PubSubPluginTests: XCTestCase {
             expectation.fulfill()
         })
 
-        let plugin = PubSubPlugin([subscription], options: PubSubPluginOptions(expressionName: "customPublish"))
+        let plugin = PubSubPlugin(
+            [subscription],
+            options: PubSubPluginOptions(expressionName: "customPublish")
+        )
         let player = HeadlessPlayerImpl(plugins: [plugin])
-        player.start(flow: flow, completion: {_ in})
+        player.start(flow: flow, completion: { _ in })
         wait(for: [expectation], timeout: 3)
     }
-    func testPubSubPluginStringData() {
-        let context = JSContext()!
+
+    func testPubSubPluginStringData() throws {
+        let context = try XCTUnwrap(JSContext())
         JSUtilities.polyfill(context)
 
         let expectation = XCTestExpectation(description: "beacon callback called")
-        let subscription: PubSubSubscription = ("test", { (_, data) in
+        let subscription: PubSubSubscription = ("test", { _, data in
             guard let eventData = data else { return XCTFail("data did not exist") }
             switch eventData {
-            case .string(let result):
+            case let .string(result):
                 XCTAssertEqual(result, "example")
             default:
                 XCTFail("data was not a string")
@@ -130,15 +134,15 @@ class PubSubPluginTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
 
-    func testPubSubPluginArrayData() {
-        let context = JSContext()!
+    func testPubSubPluginArrayData() throws {
+        let context = try XCTUnwrap(JSContext())
         JSUtilities.polyfill(context)
 
         let expectation = XCTestExpectation(description: "beacon callback called")
-        let subscription: PubSubSubscription = ("test", { (_, data) in
+        let subscription: PubSubSubscription = ("test", { _, data in
             guard let eventData = data else { return XCTFail("data did not exist") }
             switch eventData {
-            case .array(let result):
+            case let .array(result):
                 XCTAssertEqual(result, ["example", "data"])
             default:
                 XCTFail("data was not an array")
@@ -153,15 +157,15 @@ class PubSubPluginTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
 
-    func testPubSubPluginDictionaryData() {
-        let context = JSContext()!
+    func testPubSubPluginDictionaryData() throws {
+        let context = try XCTUnwrap(JSContext())
         JSUtilities.polyfill(context)
 
         let expectation = XCTestExpectation(description: "beacon callback called")
-        let subscription: PubSubSubscription = ("test", { (_, data) in
+        let subscription: PubSubSubscription = ("test", { _, data in
             guard let eventData = data else { return XCTFail("data did not exist") }
             switch eventData {
-            case .dictionary(let result):
+            case let .dictionary(result):
                 XCTAssertEqual(result, ["example": "data"])
             default:
                 XCTFail("data was not a dictionary")
@@ -176,22 +180,22 @@ class PubSubPluginTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
 
-    func testPubSubPluginAnyDictionaryData() {
-        let context = JSContext()!
+    func testPubSubPluginAnyDictionaryData() throws {
+        let context = try XCTUnwrap(JSContext())
         JSUtilities.polyfill(context)
 
         let expectation = XCTestExpectation(description: "beacon callback called")
-        let subscription: PubSubSubscription = ("test", { (_, data) in
+        let subscription: PubSubSubscription = ("test", { _, data in
             guard let eventData = data else { return XCTFail("data did not exist") }
             switch eventData {
-            case .anyDictionary(let dict):
+            case let .anyDictionary(dict):
                 XCTAssertEqual(2, dict.keys.count)
-                if case .string(let dataValue) = dict["data"] {
+                if case let .string(dataValue) = dict["data"] {
                     XCTAssertEqual("example", dataValue)
                 } else {
                     XCTFail("data was not a string")
                 }
-                if case .number(let valueNum) = dict["value"] {
+                if case let .number(valueNum) = dict["value"] {
                     XCTAssertEqual(3, valueNum)
                 } else {
                     XCTFail("value was not a number")
@@ -205,7 +209,13 @@ class PubSubPluginTests: XCTestCase {
         let plugin = PubSubPlugin([subscription])
         plugin.context = context
 
-        plugin.publish(eventName: "test", eventData: .anyDictionary(data: ["data": .string(data: "example"), "value": .number(data: 3)]))
+        plugin.publish(
+            eventName: "test",
+            eventData: .anyDictionary(data: [
+                "data": .string(data: "example"),
+                "value": .number(data: 3),
+            ])
+        )
         wait(for: [expectation], timeout: 2)
     }
 }

--- a/plugins/reference-assets/swiftui/Sources/ReferenceAssetsPlugin.swift
+++ b/plugins/reference-assets/swiftui/Sources/ReferenceAssetsPlugin.swift
@@ -1,20 +1,24 @@
 import SwiftUI
 
 #if SWIFT_PACKAGE
-import PlayerUI
-import PlayerUISwiftUI
+    import PlayerUI
+    import PlayerUISwiftUI
 #endif
 
-/**
- Reference Assets for the `SwiftUIPlayer`
- */
+/// Reference Assets for the `SwiftUIPlayer`
 public class ReferenceAssetsPlugin: JSBasePlugin, NativePlugin {
-    /**
-    Tap into `Player` hooks during player creation
-    - parameters:
-       - player: The `HeadlessPlayer` that is applying this plugin
-    */
-    public func apply<P>(player: P) where P: HeadlessPlayer {
+    /// Constructs the SwiftUIReferenceAssetsPlugin
+    public convenience init() {
+        self.init(
+            fileName: "ReferenceAssetsPlugin.native",
+            pluginName: "ReferenceAssetsPlugin.ReferenceAssetsPlugin"
+        )
+    }
+
+    /// Tap into `Player` hooks during player creation
+    /// - parameters:
+    ///   - player: The `HeadlessPlayer` that is applying this plugin
+    public func apply<P: HeadlessPlayer>(player: P) {
         if let registry = player.assetRegistry as? SwiftUIRegistry {
             registry.register("action", asset: ActionAsset.self)
             registry.register("text", asset: TextAsset.self)
@@ -23,24 +27,21 @@ public class ReferenceAssetsPlugin: JSBasePlugin, NativePlugin {
             registry.register("info", asset: InfoAsset.self)
         }
     }
-    /**
-     Constructs the SwiftUIReferenceAssetsPlugin
-     */
-    public convenience init() {
-        self.init(fileName: "ReferenceAssetsPlugin.native", pluginName: "ReferenceAssetsPlugin.ReferenceAssetsPlugin")
-    }
 
-    /**
-     Retrieve the transforms from the JS bundle
-     - parameters:
-        - fileName: The name of the file to fetch
-     - returns: A URL if it exists in the bundle
-     */
+    /// Retrieve the transforms from the JS bundle
+    /// - parameters:
+    ///   - fileName: The name of the file to fetch
+    /// - returns: A URL if it exists in the bundle
     override open func getUrlForFile(fileName: String) -> URL? {
         #if SWIFT_PACKAGE
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
+            ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
         #else
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle(for: ReferenceAssetsPlugin.self), pathComponent: "PlayerUI_ReferenceAssets.bundle")
+            ResourceUtilities.urlForFile(
+                name: fileName,
+                ext: "js",
+                bundle: Bundle(for: ReferenceAssetsPlugin.self),
+                pathComponent: "PlayerUI_ReferenceAssets.bundle"
+            )
         #endif
     }
 }

--- a/plugins/reference-assets/swiftui/Sources/ReferenceAssetsPlugin.swift
+++ b/plugins/reference-assets/swiftui/Sources/ReferenceAssetsPlugin.swift
@@ -1,18 +1,21 @@
-import SwiftUI
-
 import PlayerUI
 import PlayerUISwiftUI
+import SwiftUI
 
-/**
- Reference Assets for the `SwiftUIPlayer`
- */
+/// Reference Assets for the `SwiftUIPlayer`
 public class ReferenceAssetsPlugin: JSBasePlugin, NativePlugin {
-    /**
-    Tap into `Player` hooks during player creation
-    - parameters:
-       - player: The `HeadlessPlayer` that is applying this plugin
-    */
-    public func apply<P>(player: P) where P: HeadlessPlayer {
+    /// Constructs the SwiftUIReferenceAssetsPlugin
+    public convenience init() {
+        self.init(
+            fileName: "ReferenceAssetsPlugin.native",
+            pluginName: "ReferenceAssetsPlugin.ReferenceAssetsPlugin"
+        )
+    }
+
+    /// Tap into `Player` hooks during player creation
+    /// - parameters:
+    ///   - player: The `HeadlessPlayer` that is applying this plugin
+    public func apply<P: HeadlessPlayer>(player: P) {
         if let registry = player.assetRegistry as? SwiftUIRegistry {
             registry.register("action", asset: ActionAsset.self)
             registry.register("text", asset: TextAsset.self)
@@ -21,19 +24,11 @@ public class ReferenceAssetsPlugin: JSBasePlugin, NativePlugin {
             registry.register("info", asset: InfoAsset.self)
         }
     }
-    /**
-     Constructs the SwiftUIReferenceAssetsPlugin
-     */
-    public convenience init() {
-        self.init(fileName: "ReferenceAssetsPlugin.native", pluginName: "ReferenceAssetsPlugin.ReferenceAssetsPlugin")
-    }
 
-    /**
-     Retrieve the transforms from the JS bundle
-     - parameters:
-        - fileName: The name of the file to fetch
-     - returns: A URL if it exists in the bundle
-     */
+    /// Retrieve the transforms from the JS bundle
+    /// - parameters:
+    ///   - fileName: The name of the file to fetch
+    /// - returns: A URL if it exists in the bundle
     override open func getUrlForFile(fileName: String) -> URL? {
         ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
     }

--- a/plugins/reference-assets/swiftui/Sources/ReferenceAssetsPlugin.swift
+++ b/plugins/reference-assets/swiftui/Sources/ReferenceAssetsPlugin.swift
@@ -15,7 +15,7 @@ public class ReferenceAssetsPlugin: JSBasePlugin, NativePlugin {
     /// Tap into `Player` hooks during player creation
     /// - parameters:
     ///   - player: The `HeadlessPlayer` that is applying this plugin
-    public func apply<P: HeadlessPlayer>(player: P) {
+    public func apply(player: some HeadlessPlayer) {
         if let registry = player.assetRegistry as? SwiftUIRegistry {
             registry.register("action", asset: ActionAsset.self)
             registry.register("text", asset: TextAsset.self)

--- a/plugins/reference-assets/swiftui/Sources/SwiftUI/ActionAsset.swift
+++ b/plugins/reference-assets/swiftui/Sources/SwiftUI/ActionAsset.swift
@@ -1,16 +1,14 @@
-import SwiftUI
 import Combine
+import SwiftUI
 
 #if SWIFT_PACKAGE
-import PlayerUI
-import PlayerUISwiftUI
-import PlayerUISwiftUIPendingTransactionPlugin
-import PlayerUIBeaconPlugin
+    import PlayerUI
+    import PlayerUIBeaconPlugin
+    import PlayerUISwiftUI
+    import PlayerUISwiftUIPendingTransactionPlugin
 #endif
 
-/**
- Data Decoded by Player for `ActionAsset`
- */
+/// Data Decoded by Player for `ActionAsset`
 struct ActionData: AssetData {
     /// The ID of the asset
     var id: String
@@ -25,17 +23,15 @@ struct ActionData: AssetData {
     var metaData: MetaData?
 }
 
-/**
- Wrapper class to tie `ActionData` to a SwiftUI `View`
- */
+/// Wrapper class to tie `ActionData` to a SwiftUI `View`
 final class ActionAsset: UncontrolledAsset<ActionData> {
     /// A type erased view object
-    public override var view: AnyView { AnyView(ActionAssetView(model: model)) }
+    override var view: AnyView {
+        AnyView(ActionAssetView(model: model))
+    }
 }
 
-/**
- View implementation for `ActionAsset`
- */
+/// View implementation for `ActionAsset`
 public struct ActionAssetView: View {
     /// The viewModel with decoded data, supplied by `ActionAsset`
     @ObservedObject var model: AssetViewModel<ActionData>
@@ -43,24 +39,32 @@ public struct ActionAssetView: View {
     /// The `BeaconContext` if the `SwiftUIBeaconPlugin` is used in this player instance
     @Environment(\.beaconContext) var beaconContext
 
-    /// The `TransactionContext` if the `SwiftUIPendingTransactionPlugin` is used in this player instance
+    /// For Testing Purposes
+    var didAppear: ((Self) -> Void)?
+
+    /// The `TransactionContext` if the `SwiftUIPendingTransactionPlugin` is used in this player
+    /// instance
     @Environment(\.transactionContext) private var transactionContext
 
-    // For Testing Purposes
-    internal var didAppear: ((Self) -> Void)?
-
-    @ViewBuilder
     public var body: some View {
         Button(
             action: {
-                beaconContext?.beacon(action: "clicked", element: "button", id: model.data.id, metaData: model.data.metaData)
+                beaconContext?.beacon(
+                    action: "clicked",
+                    element: "button",
+                    id: model.data.id,
+                    metaData: model.data.metaData
+                )
 
-                // commit the pendingTransactionContext input callbacks before running the wrapped function
+                // commit the pendingTransactionContext input callbacks before running the wrapped
+                // function
                 model.data.run?.commitCallbacksThenCall()
             },
             label: {
                 if let label = model.data.label?.asset {
-                    label.view.foregroundColor(.white).padding()
+                    label.view
+                        .foregroundColor(.white)
+                        .padding()
                         .frame(maxWidth: .infinity, maxHeight: 44)
                         .background(
                             Rectangle()
@@ -73,14 +77,15 @@ public struct ActionAssetView: View {
             }
         )
         .accessibility(identifier: model.data.id)
-        .onAppear { self.didAppear?(self) }
+        .onAppear { didAppear?(self) }
     }
 }
 
-extension WrappedFunction {
+public extension WrappedFunction {
     ///  commits the pendingTransactionContext callbacks before running the wrapped function
-    public func commitCallbacksThenCall(_ args: Any...) {
-        let pendingTransactions = userInfo?[.pendingTransactionContext] as? TransactionContext<PendingTransactionPhases>
+    func commitCallbacksThenCall(_ args: Any...) {
+        let pendingTransactions =
+            userInfo?[.pendingTransactionContext] as? TransactionContext<PendingTransactionPhases>
         pendingTransactions?.commit(.input)
 
         guard let jsValue = rawValue else { return }

--- a/plugins/reference-assets/swiftui/Sources/SwiftUI/ActionAsset.swift
+++ b/plugins/reference-assets/swiftui/Sources/SwiftUI/ActionAsset.swift
@@ -1,14 +1,11 @@
-import SwiftUI
 import Combine
-
 import PlayerUI
+import PlayerUIBeaconPlugin
 import PlayerUISwiftUI
 import PlayerUISwiftUIPendingTransactionPlugin
-import PlayerUIBeaconPlugin
+import SwiftUI
 
-/**
- Data Decoded by Player for `ActionAsset`
- */
+/// Data Decoded by Player for `ActionAsset`
 struct ActionData: AssetData {
     /// The ID of the asset
     var id: String
@@ -23,17 +20,15 @@ struct ActionData: AssetData {
     var metaData: MetaData?
 }
 
-/**
- Wrapper class to tie `ActionData` to a SwiftUI `View`
- */
+/// Wrapper class to tie `ActionData` to a SwiftUI `View`
 final class ActionAsset: UncontrolledAsset<ActionData> {
     /// A type erased view object
-    public override var view: AnyView { AnyView(ActionAssetView(model: model)) }
+    override var view: AnyView {
+        AnyView(ActionAssetView(model: model))
+    }
 }
 
-/**
- View implementation for `ActionAsset`
- */
+/// View implementation for `ActionAsset`
 public struct ActionAssetView: View {
     /// The viewModel with decoded data, supplied by `ActionAsset`
     @ObservedObject var model: AssetViewModel<ActionData>
@@ -41,24 +36,32 @@ public struct ActionAssetView: View {
     /// The `BeaconContext` if the `SwiftUIBeaconPlugin` is used in this player instance
     @Environment(\.beaconContext) var beaconContext
 
-    /// The `TransactionContext` if the `SwiftUIPendingTransactionPlugin` is used in this player instance
+    /// For Testing Purposes
+    var didAppear: ((Self) -> Void)?
+
+    /// The `TransactionContext` if the `SwiftUIPendingTransactionPlugin` is used in this player
+    /// instance
     @Environment(\.transactionContext) private var transactionContext
 
-    // For Testing Purposes
-    internal var didAppear: ((Self) -> Void)?
-
-    @ViewBuilder
     public var body: some View {
         Button(
             action: {
-                beaconContext?.beacon(action: "clicked", element: "button", id: model.data.id, metaData: model.data.metaData)
+                beaconContext?.beacon(
+                    action: "clicked",
+                    element: "button",
+                    id: model.data.id,
+                    metaData: model.data.metaData
+                )
 
-                // commit the pendingTransactionContext input callbacks before running the wrapped function
+                // commit the pendingTransactionContext input callbacks before running the wrapped
+                // function
                 model.data.run?.commitCallbacksThenCall()
             },
             label: {
                 if let label = model.data.label?.asset {
-                    label.view.foregroundColor(.white).padding()
+                    label.view
+                        .foregroundColor(.white)
+                        .padding()
                         .frame(maxWidth: .infinity, maxHeight: 44)
                         .background(
                             Rectangle()
@@ -71,14 +74,15 @@ public struct ActionAssetView: View {
             }
         )
         .accessibility(identifier: model.data.id)
-        .onAppear { self.didAppear?(self) }
+        .onAppear { didAppear?(self) }
     }
 }
 
-extension WrappedFunction {
+public extension WrappedFunction {
     ///  commits the pendingTransactionContext callbacks before running the wrapped function
-    public func commitCallbacksThenCall(_ args: Any...) {
-        let pendingTransactions = userInfo?[.pendingTransactionContext] as? TransactionContext<PendingTransactionPhases>
+    func commitCallbacksThenCall(_ args: Any...) {
+        let pendingTransactions =
+            userInfo?[.pendingTransactionContext] as? TransactionContext<PendingTransactionPhases>
         pendingTransactions?.commit(.input)
 
         guard let jsValue = rawValue else { return }

--- a/plugins/reference-assets/swiftui/Sources/SwiftUI/CollectionAsset.swift
+++ b/plugins/reference-assets/swiftui/Sources/SwiftUI/CollectionAsset.swift
@@ -1,14 +1,12 @@
-import SwiftUI
 import Combine
+import SwiftUI
 
 #if SWIFT_PACKAGE
-import PlayerUI
-import PlayerUISwiftUI
+    import PlayerUI
+    import PlayerUISwiftUI
 #endif
 
-/**
- Data Decoded by Player for `CollectionAsset`
- */
+/// Data Decoded by Player for `CollectionAsset`
 struct CollectionData: AssetData {
     /// The ID of the asset
     var id: String
@@ -20,22 +18,19 @@ struct CollectionData: AssetData {
     var values: [WrappedAsset?]
 }
 
-/**
- Wrapper class to tie `CollectionData` to a SwiftUI `View`
- */
+/// Wrapper class to tie `CollectionData` to a SwiftUI `View`
 final class CollectionAsset: UncontrolledAsset<CollectionData> {
     /// A type erased view object
-    public override var view: AnyView { AnyView(CollectionAssetView(model: model)) }
+    override var view: AnyView {
+        AnyView(CollectionAssetView(model: model))
+    }
 }
 
-/**
- View implementation for `CollectionAsset`
- */
+/// View implementation for `CollectionAsset`
 struct CollectionAssetView: View {
     /// The viewModel with decoded data, supplied by `CollectionAsset`
     @ObservedObject var model: AssetViewModel<CollectionData>
 
-    @ViewBuilder
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             if let asset = model.data.label?.asset {
@@ -43,8 +38,8 @@ struct CollectionAssetView: View {
                     .font(.headline)
                     .padding(.vertical, 12)
             }
-            ForEach(model.data.values.compactMap({ $0?.asset })) { asset in
-                    asset.view
+            ForEach(model.data.values.compactMap { $0?.asset }) { asset in
+                asset.view
                     .font(.body)
             }
         }

--- a/plugins/reference-assets/swiftui/Sources/SwiftUI/CollectionAsset.swift
+++ b/plugins/reference-assets/swiftui/Sources/SwiftUI/CollectionAsset.swift
@@ -1,12 +1,9 @@
-import SwiftUI
 import Combine
-
 import PlayerUI
 import PlayerUISwiftUI
+import SwiftUI
 
-/**
- Data Decoded by Player for `CollectionAsset`
- */
+/// Data Decoded by Player for `CollectionAsset`
 struct CollectionData: AssetData {
     /// The ID of the asset
     var id: String
@@ -18,22 +15,19 @@ struct CollectionData: AssetData {
     var values: [WrappedAsset?]
 }
 
-/**
- Wrapper class to tie `CollectionData` to a SwiftUI `View`
- */
+/// Wrapper class to tie `CollectionData` to a SwiftUI `View`
 final class CollectionAsset: UncontrolledAsset<CollectionData> {
     /// A type erased view object
-    public override var view: AnyView { AnyView(CollectionAssetView(model: model)) }
+    override var view: AnyView {
+        AnyView(CollectionAssetView(model: model))
+    }
 }
 
-/**
- View implementation for `CollectionAsset`
- */
+/// View implementation for `CollectionAsset`
 struct CollectionAssetView: View {
     /// The viewModel with decoded data, supplied by `CollectionAsset`
     @ObservedObject var model: AssetViewModel<CollectionData>
 
-    @ViewBuilder
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             if let asset = model.data.label?.asset {
@@ -41,8 +35,8 @@ struct CollectionAssetView: View {
                     .font(.headline)
                     .padding(.vertical, 12)
             }
-            ForEach(model.data.values.compactMap({ $0?.asset })) { asset in
-                    asset.view
+            ForEach(model.data.values.compactMap { $0?.asset }) { asset in
+                asset.view
                     .font(.body)
             }
         }

--- a/plugins/reference-assets/swiftui/Sources/SwiftUI/InfoAsset.swift
+++ b/plugins/reference-assets/swiftui/Sources/SwiftUI/InfoAsset.swift
@@ -1,13 +1,11 @@
 import SwiftUI
 
 #if SWIFT_PACKAGE
-import PlayerUI
-import PlayerUISwiftUI
+    import PlayerUI
+    import PlayerUISwiftUI
 #endif
 
-/**
- Data Decoded by Player for `InfoAsset`
- */
+/// Data Decoded by Player for `InfoAsset`
 struct InfoData: AssetData {
     /// The ID of the asset
     var id: String
@@ -25,28 +23,25 @@ struct InfoData: AssetData {
     var footer: WrappedAsset?
 }
 
-/**
- Wrapper class to tie `InfoData` to a SwiftUI `View`
- */
+/// Wrapper class to tie `InfoData` to a SwiftUI `View`
 class InfoAsset: UncontrolledAsset<InfoData> {
     /// A type erased view object
-    override var view: AnyView { AnyView(InfoAssetView(model: model)) }
+    override var view: AnyView {
+        AnyView(InfoAssetView(model: model))
+    }
 }
 
-/**
- View implementation for `InfoAsset`
- */
+/// View implementation for `InfoAsset`
 struct InfoAssetView: View {
     /// The viewModel with decoded data, supplied by `InfoAsset`
     @ObservedObject var model: AssetViewModel<InfoData>
 
-    @ViewBuilder
     var body: some View {
         VStack {
             model.data.title?.asset?.view.font(.title).padding(.bottom, 40)
             model.data.subTitle?.asset?.view.font(.subheadline).padding(.bottom, 40)
             model.data.primaryInfo?.asset?.view
-            if let actions = model.data.actions?.compactMap({ $0.asset }) {
+            if let actions = model.data.actions?.compactMap(\.asset) {
                 ForEach(actions) { action in
                     action.view
                 }

--- a/plugins/reference-assets/swiftui/Sources/SwiftUI/InfoAsset.swift
+++ b/plugins/reference-assets/swiftui/Sources/SwiftUI/InfoAsset.swift
@@ -1,11 +1,8 @@
-import SwiftUI
-
 import PlayerUI
 import PlayerUISwiftUI
+import SwiftUI
 
-/**
- Data Decoded by Player for `InfoAsset`
- */
+/// Data Decoded by Player for `InfoAsset`
 struct InfoData: AssetData {
     /// The ID of the asset
     var id: String
@@ -23,28 +20,25 @@ struct InfoData: AssetData {
     var footer: WrappedAsset?
 }
 
-/**
- Wrapper class to tie `InfoData` to a SwiftUI `View`
- */
+/// Wrapper class to tie `InfoData` to a SwiftUI `View`
 class InfoAsset: UncontrolledAsset<InfoData> {
     /// A type erased view object
-    override var view: AnyView { AnyView(InfoAssetView(model: model)) }
+    override var view: AnyView {
+        AnyView(InfoAssetView(model: model))
+    }
 }
 
-/**
- View implementation for `InfoAsset`
- */
+/// View implementation for `InfoAsset`
 struct InfoAssetView: View {
     /// The viewModel with decoded data, supplied by `InfoAsset`
     @ObservedObject var model: AssetViewModel<InfoData>
 
-    @ViewBuilder
     var body: some View {
         VStack {
             model.data.title?.asset?.view.font(.title).padding(.bottom, 40)
             model.data.subTitle?.asset?.view.font(.subheadline).padding(.bottom, 40)
             model.data.primaryInfo?.asset?.view
-            if let actions = model.data.actions?.compactMap({ $0.asset }) {
+            if let actions = model.data.actions?.compactMap(\.asset) {
                 ForEach(actions) { action in
                     action.view
                 }

--- a/plugins/reference-assets/swiftui/Sources/SwiftUI/InputAsset.swift
+++ b/plugins/reference-assets/swiftui/Sources/SwiftUI/InputAsset.swift
@@ -1,34 +1,29 @@
-import SwiftUI
 import Combine
+import SwiftUI
 
 #if SWIFT_PACKAGE
-import PlayerUI
-import PlayerUISwiftUI
-import PlayerUISwiftUIPendingTransactionPlugin
+    import PlayerUI
+    import PlayerUISwiftUI
+    import PlayerUISwiftUIPendingTransactionPlugin
 #endif
 
-/**
- Represents a DataType that is associated with the asset
- */
+/// Represents a DataType that is associated with the asset
 public struct DataType: Decodable, Hashable {
     /// The type of data for this DataType (IntegerType for example)
     public let type: String
 }
 
-/**
- Data Decoded by Player for `InputAsset`
- */
+/// Data Decoded by Player for `InputAsset`
 public struct InputData: AssetData, Equatable {
     /// The ID of the asset
     public var id: String
     /// The Type of the asset
     public var type: String
+
     /// A string to use as a placeholder when there is no value
     var placeholder: String?
-    /**
-     The value of the asset, as a `ModelReference` so it can be pulled as a string
-     in case the primitive type in the data model was a number something else
-     */
+    /// The value of the asset, as a `ModelReference` so it can be pulled as a string
+    /// in case the primitive type in the data model was a number something else
     var value: ModelReference?
     /// An asset to use as a label for this asset
     var label: WrappedAsset?
@@ -42,63 +37,57 @@ public struct InputData: AssetData, Equatable {
     var note: WrappedAsset?
 }
 
-/**
- An extended `AssetViewModel` to allow for custom behavior
- */
+/// An extended `AssetViewModel` to allow for custom behavior
 open class InputAssetViewModel: AssetViewModel<InputData> {
     /// The current string value of the asset
     @Published var text: String = ""
 
-    /**
-     Constructs the `InputAssetViewModel`
-     - parameters:
-        - data: The `InputData` decoded from the core player
-        - userInfo: The `userInfo` from the decoder
-     */
+    /// Constructs the `InputAssetViewModel`
+    /// - parameters:
+    ///   - data: The `InputData` decoded from the core player
+    ///   - userInfo: The `userInfo` from the decoder
     public required init(_ data: InputData, userInfo: [CodingUserInfoKey: Any]) {
         super.init(data, userInfo: userInfo)
-        $data.sink { [weak self] (newData) in
+        $data.sink { [weak self] newData in
             (newData.value?.stringValue).map { self?.text = $0 }
-        }.store(in: &bag)
+        }
+        .store(in: &bag)
     }
 
-    /**
-     Sets the current text into the data model in the core player
-     */
+    /// Sets the current text into the data model in the core player
     public func set() {
         data.set?(text)
     }
 }
 
-/**
- Wrapper class to tie `InputData` to a SwiftUI `View`
- */
+/// Wrapper class to tie `InputData` to a SwiftUI `View`
 class InputAsset: ControlledAsset<InputData, InputAssetViewModel> {
     /// A type erased view object
-    public override var view: AnyView { AnyView(InputAssetView(model: model)) }
+    override var view: AnyView {
+        AnyView(InputAssetView(model: model))
+    }
 }
 
-/**
- View implementation for `InputAsset`
- */
+/// View implementation for `InputAsset`
 struct InputAssetView: View {
     /// The viewModel with decoded data, supplied by `InputAsset`
     @ObservedObject var model: InputAssetViewModel
 
     @Environment(\.transactionContext) private var transactionContext
 
-    /// The color to use for the stroke around the field
-    var strokeColor: Color {
-        if let validation = model.data.validation {
-            return validation.severity.color
-        }
-        return Color(red: 0.729, green: 0.745, blue: 0.773)
-    }
-
-    @ViewBuilder
     var body: some View {
         VStack(alignment: .leading) {
-            model.data.label?.asset?.view.foregroundColor(Color(red: 0.102, green: 0.125, blue: 0.173)).padding(.bottom, 8).font(.headline)
+            model.data
+                .label?
+                .asset?
+                .view
+                .foregroundColor(Color(
+                    red: 0.102,
+                    green: 0.125,
+                    blue: 0.173
+                ))
+                .padding(.bottom, 8)
+                .font(.headline)
             TextField(
                 model.data.placeholder ?? "",
                 text: $model.text,
@@ -108,35 +97,57 @@ struct InputAssetView: View {
             .background(
                 RoundedRectangle(cornerRadius: 4)
                     .stroke(lineWidth: 1)
-                    .background(model.data.validation == nil ? Color.clear : strokeColor.opacity(0.1))
+                    .background(model.data.validation == nil ? Color.clear : strokeColor
+                        .opacity(0.1))
                     .foregroundColor(strokeColor)
             )
             .accessibility(identifier: model.data.id)
             if let data = model.data.validation {
-                let dismissFunction: (() -> Void)? = data.dismiss == nil ? nil : {data.dismiss?()}
-                ValidationView(message: data.message, severity: data.severity, dismiss: dismissFunction)
-                    .accessibility(identifier: "\(model.data.id)-validation")
+                let dismissFunction: (() -> Void)? = data.dismiss == nil ? nil : { data.dismiss?() }
+                ValidationView(
+                    message: data.message,
+                    severity: data.severity,
+                    dismiss: dismissFunction
+                )
+                .accessibility(identifier: "\(model.data.id)-validation")
             }
-            model.data.note?.asset?.view.foregroundColor(Color(red: 0.729, green: 0.745, blue: 0.773)).padding(.top, 8).font(.subheadline)
+            model.data
+                .note?
+                .asset?
+                .view
+                .foregroundColor(Color(
+                    red: 0.729,
+                    green: 0.745,
+                    blue: 0.773
+                ))
+                .padding(.top, 8)
+                .font(.subheadline)
         }
+    }
+
+    /// The color to use for the stroke around the field
+    var strokeColor: Color {
+        if let validation = model.data.validation {
+            return validation.severity.color
+        }
+        return Color(red: 0.729, green: 0.745, blue: 0.773)
     }
 
     func onEditingChanged(_ editing: Bool) {
         guard !editing else {
             transactionContext.register(.input) {
-                self.model.set()
+                model.set()
             }
             return
         }
-        self.model.set()
+        model.set()
         // remove the transaction once editing ends
         transactionContext.clear(.input)
     }
 }
 
-/**
- Extensions for PendingTransactionPhases of TransactionContext to create a new Phase for Input callbacks
- */
-extension PendingTransactionPhases {
-    public static let input = PendingTransactionPhases(rawValue: "input")
+/// Extensions for PendingTransactionPhases of TransactionContext to create a new Phase for Input
+/// callbacks
+public extension PendingTransactionPhases {
+    static let input: PendingTransactionPhases = .init(rawValue: "input")
 }

--- a/plugins/reference-assets/swiftui/Sources/SwiftUI/InputAsset.swift
+++ b/plugins/reference-assets/swiftui/Sources/SwiftUI/InputAsset.swift
@@ -1,32 +1,26 @@
-import SwiftUI
 import Combine
-
 import PlayerUI
 import PlayerUISwiftUI
 import PlayerUISwiftUIPendingTransactionPlugin
+import SwiftUI
 
-/**
- Represents a DataType that is associated with the asset
- */
+/// Represents a DataType that is associated with the asset
 public struct DataType: Decodable, Hashable {
     /// The type of data for this DataType (IntegerType for example)
     public let type: String
 }
 
-/**
- Data Decoded by Player for `InputAsset`
- */
+/// Data Decoded by Player for `InputAsset`
 public struct InputData: AssetData, Equatable {
     /// The ID of the asset
     public var id: String
     /// The Type of the asset
     public var type: String
+
     /// A string to use as a placeholder when there is no value
     var placeholder: String?
-    /**
-     The value of the asset, as a `ModelReference` so it can be pulled as a string
-     in case the primitive type in the data model was a number something else
-     */
+    /// The value of the asset, as a `ModelReference` so it can be pulled as a string
+    /// in case the primitive type in the data model was a number something else
     var value: ModelReference?
     /// An asset to use as a label for this asset
     var label: WrappedAsset?
@@ -40,63 +34,57 @@ public struct InputData: AssetData, Equatable {
     var note: WrappedAsset?
 }
 
-/**
- An extended `AssetViewModel` to allow for custom behavior
- */
+/// An extended `AssetViewModel` to allow for custom behavior
 open class InputAssetViewModel: AssetViewModel<InputData> {
     /// The current string value of the asset
     @Published var text: String = ""
 
-    /**
-     Constructs the `InputAssetViewModel`
-     - parameters:
-        - data: The `InputData` decoded from the core player
-        - userInfo: The `userInfo` from the decoder
-     */
+    /// Constructs the `InputAssetViewModel`
+    /// - parameters:
+    ///   - data: The `InputData` decoded from the core player
+    ///   - userInfo: The `userInfo` from the decoder
     public required init(_ data: InputData, userInfo: [CodingUserInfoKey: Any]) {
         super.init(data, userInfo: userInfo)
-        $data.sink { [weak self] (newData) in
+        $data.sink { [weak self] newData in
             (newData.value?.stringValue).map { self?.text = $0 }
-        }.store(in: &bag)
+        }
+        .store(in: &bag)
     }
 
-    /**
-     Sets the current text into the data model in the core player
-     */
+    /// Sets the current text into the data model in the core player
     public func set() {
         data.set?(text)
     }
 }
 
-/**
- Wrapper class to tie `InputData` to a SwiftUI `View`
- */
+/// Wrapper class to tie `InputData` to a SwiftUI `View`
 class InputAsset: ControlledAsset<InputData, InputAssetViewModel> {
     /// A type erased view object
-    public override var view: AnyView { AnyView(InputAssetView(model: model)) }
+    override var view: AnyView {
+        AnyView(InputAssetView(model: model))
+    }
 }
 
-/**
- View implementation for `InputAsset`
- */
+/// View implementation for `InputAsset`
 struct InputAssetView: View {
     /// The viewModel with decoded data, supplied by `InputAsset`
     @ObservedObject var model: InputAssetViewModel
 
     @Environment(\.transactionContext) private var transactionContext
 
-    /// The color to use for the stroke around the field
-    var strokeColor: Color {
-        if let validation = model.data.validation {
-            return validation.severity.color
-        }
-        return Color(red: 0.729, green: 0.745, blue: 0.773)
-    }
-
-    @ViewBuilder
     var body: some View {
         VStack(alignment: .leading) {
-            model.data.label?.asset?.view.foregroundColor(Color(red: 0.102, green: 0.125, blue: 0.173)).padding(.bottom, 8).font(.headline)
+            model.data
+                .label?
+                .asset?
+                .view
+                .foregroundColor(Color(
+                    red: 0.102,
+                    green: 0.125,
+                    blue: 0.173
+                ))
+                .padding(.bottom, 8)
+                .font(.headline)
             TextField(
                 model.data.placeholder ?? "",
                 text: $model.text,
@@ -106,35 +94,57 @@ struct InputAssetView: View {
             .background(
                 RoundedRectangle(cornerRadius: 4)
                     .stroke(lineWidth: 1)
-                    .background(model.data.validation == nil ? Color.clear : strokeColor.opacity(0.1))
+                    .background(model.data.validation == nil ? Color.clear : strokeColor
+                        .opacity(0.1))
                     .foregroundColor(strokeColor)
             )
             .accessibility(identifier: model.data.id)
             if let data = model.data.validation {
-                let dismissFunction: (() -> Void)? = data.dismiss == nil ? nil : {data.dismiss?()}
-                ValidationView(message: data.message, severity: data.severity, dismiss: dismissFunction)
-                    .accessibility(identifier: "\(model.data.id)-validation")
+                let dismissFunction: (() -> Void)? = data.dismiss == nil ? nil : { data.dismiss?() }
+                ValidationView(
+                    message: data.message,
+                    severity: data.severity,
+                    dismiss: dismissFunction
+                )
+                .accessibility(identifier: "\(model.data.id)-validation")
             }
-            model.data.note?.asset?.view.foregroundColor(Color(red: 0.729, green: 0.745, blue: 0.773)).padding(.top, 8).font(.subheadline)
+            model.data
+                .note?
+                .asset?
+                .view
+                .foregroundColor(Color(
+                    red: 0.729,
+                    green: 0.745,
+                    blue: 0.773
+                ))
+                .padding(.top, 8)
+                .font(.subheadline)
         }
+    }
+
+    /// The color to use for the stroke around the field
+    var strokeColor: Color {
+        if let validation = model.data.validation {
+            return validation.severity.color
+        }
+        return Color(red: 0.729, green: 0.745, blue: 0.773)
     }
 
     func onEditingChanged(_ editing: Bool) {
         guard !editing else {
             transactionContext.register(.input) {
-                self.model.set()
+                model.set()
             }
             return
         }
-        self.model.set()
+        model.set()
         // remove the transaction once editing ends
         transactionContext.clear(.input)
     }
 }
 
-/**
- Extensions for PendingTransactionPhases of TransactionContext to create a new Phase for Input callbacks
- */
-extension PendingTransactionPhases {
-    public static let input = PendingTransactionPhases(rawValue: "input")
+/// Extensions for PendingTransactionPhases of TransactionContext to create a new Phase for Input
+/// callbacks
+public extension PendingTransactionPhases {
+    static let input: PendingTransactionPhases = .init(rawValue: "input")
 }

--- a/plugins/reference-assets/swiftui/Sources/SwiftUI/TextAsset.swift
+++ b/plugins/reference-assets/swiftui/Sources/SwiftUI/TextAsset.swift
@@ -1,13 +1,11 @@
 import SwiftUI
 
 #if SWIFT_PACKAGE
-import PlayerUI
-import PlayerUISwiftUI
+    import PlayerUI
+    import PlayerUISwiftUI
 #endif
 
-/**
- Data Decoded by Player for `TextAsset`
- */
+/// Data Decoded by Player for `TextAsset`
 struct TextData: AssetData, Equatable {
     /// The ID of the asset
     var id: String
@@ -18,42 +16,39 @@ struct TextData: AssetData, Equatable {
     var modifiers: [Modifier]?
 }
 
-/**
- Wrapper class to tie `TextData` to a SwiftUI `View`
- */
+/// Wrapper class to tie `TextData` to a SwiftUI `View`
 class TextAsset: UncontrolledAsset<TextData> {
     /// A type erased view object
-    public override var view: AnyView { AnyView(TextAssetView(model: model)) }
+    override var view: AnyView {
+        AnyView(TextAssetView(model: model))
+    }
 }
 
-/**
- View implementation for `TextAsset`
- */
+/// View implementation for `TextAsset`
 struct TextAssetView: View {
     /// The viewModel with decoded data, supplied by `TextAsset`
     @ObservedObject var model: AssetViewModel<TextData>
 
-    @ViewBuilder
     var body: some View {
         if let link = model.data.modifiers?.first(where: { $0.type == "link" })?.metaData?.ref {
-            Text(model.data.value.stringValue ?? "").bold().modifier(LinkModifier(link)).accessibility(identifier: model.data.id)
+            Text(model.data.value.stringValue ?? "")
+                .bold()
+                .modifier(LinkModifier(link))
+                .accessibility(identifier: model.data.id)
         } else {
             Text(model.data.value.stringValue ?? "").accessibility(identifier: model.data.id)
         }
     }
 }
 
-/**
- A `ViewModifier` to make a `View` open a string URL
- */
+/// A `ViewModifier` to make a `View` open a string URL
 struct LinkModifier: ViewModifier {
     /// The URL location to visit
     let destination: URL
-    /**
-     Constructs a `LinkModifier` with a string destination
-     - parameters:
-        - destination: A string URL destination
-     */
+
+    /// Constructs a `LinkModifier` with a string destination
+    /// - parameters:
+    ///   - destination: A string URL destination
     init(_ destination: String) {
         self.destination = URL(string: destination)!
     }

--- a/plugins/reference-assets/swiftui/Sources/SwiftUI/TextAsset.swift
+++ b/plugins/reference-assets/swiftui/Sources/SwiftUI/TextAsset.swift
@@ -50,6 +50,7 @@ struct LinkModifier: ViewModifier {
     /// - parameters:
     ///   - destination: A string URL destination
     init(_ destination: String) {
+        // swiftlint:disable:next force_unwrapping
         self.destination = URL(string: destination)!
     }
 

--- a/plugins/reference-assets/swiftui/Sources/SwiftUI/TextAsset.swift
+++ b/plugins/reference-assets/swiftui/Sources/SwiftUI/TextAsset.swift
@@ -48,6 +48,9 @@ struct LinkModifier: ViewModifier {
     ///   - destination: A string URL destination
     init(_ destination: String) {
         self.destination = URL(string: destination)
+        if self.destination == nil {
+            print("Error: Link has no destination. URL is nil.")
+        }
     }
 
     func body(content: Content) -> some View {

--- a/plugins/reference-assets/swiftui/Sources/SwiftUI/TextAsset.swift
+++ b/plugins/reference-assets/swiftui/Sources/SwiftUI/TextAsset.swift
@@ -41,19 +41,21 @@ struct TextAssetView: View {
 /// A `ViewModifier` to make a `View` open a string URL
 struct LinkModifier: ViewModifier {
     /// The URL location to visit
-    let destination: URL
+    let destination: URL?
 
     /// Constructs a `LinkModifier` with a string destination
     /// - parameters:
     ///   - destination: A string URL destination
     init(_ destination: String) {
-        self.destination = URL(string: destination)!
+        self.destination = URL(string: destination)
     }
 
     func body(content: Content) -> some View {
         content
             .onTapGesture {
-                UIApplication.shared.open(destination)
+                if let destination {
+                    UIApplication.shared.open(destination)
+                }
             }
             .foregroundColor(Color(red: 0.000, green: 0.467, blue: 0.773))
     }

--- a/plugins/reference-assets/swiftui/Sources/SwiftUI/TextAsset.swift
+++ b/plugins/reference-assets/swiftui/Sources/SwiftUI/TextAsset.swift
@@ -1,11 +1,8 @@
-import SwiftUI
-
 import PlayerUI
 import PlayerUISwiftUI
+import SwiftUI
 
-/**
- Data Decoded by Player for `TextAsset`
- */
+/// Data Decoded by Player for `TextAsset`
 struct TextData: AssetData, Equatable {
     /// The ID of the asset
     var id: String
@@ -16,42 +13,39 @@ struct TextData: AssetData, Equatable {
     var modifiers: [Modifier]?
 }
 
-/**
- Wrapper class to tie `TextData` to a SwiftUI `View`
- */
+/// Wrapper class to tie `TextData` to a SwiftUI `View`
 class TextAsset: UncontrolledAsset<TextData> {
     /// A type erased view object
-    public override var view: AnyView { AnyView(TextAssetView(model: model)) }
+    override var view: AnyView {
+        AnyView(TextAssetView(model: model))
+    }
 }
 
-/**
- View implementation for `TextAsset`
- */
+/// View implementation for `TextAsset`
 struct TextAssetView: View {
     /// The viewModel with decoded data, supplied by `TextAsset`
     @ObservedObject var model: AssetViewModel<TextData>
 
-    @ViewBuilder
     var body: some View {
         if let link = model.data.modifiers?.first(where: { $0.type == "link" })?.metaData?.ref {
-            Text(model.data.value.stringValue ?? "").bold().modifier(LinkModifier(link)).accessibility(identifier: model.data.id)
+            Text(model.data.value.stringValue ?? "")
+                .bold()
+                .modifier(LinkModifier(link))
+                .accessibility(identifier: model.data.id)
         } else {
             Text(model.data.value.stringValue ?? "").accessibility(identifier: model.data.id)
         }
     }
 }
 
-/**
- A `ViewModifier` to make a `View` open a string URL
- */
+/// A `ViewModifier` to make a `View` open a string URL
 struct LinkModifier: ViewModifier {
     /// The URL location to visit
     let destination: URL
-    /**
-     Constructs a `LinkModifier` with a string destination
-     - parameters:
-        - destination: A string URL destination
-     */
+
+    /// Constructs a `LinkModifier` with a string destination
+    /// - parameters:
+    ///   - destination: A string URL destination
     init(_ destination: String) {
         self.destination = URL(string: destination)!
     }

--- a/plugins/reference-assets/swiftui/Sources/SwiftUI/ValidationView.swift
+++ b/plugins/reference-assets/swiftui/Sources/SwiftUI/ValidationView.swift
@@ -8,13 +8,11 @@
 import SwiftUI
 
 #if SWIFT_PACKAGE
-import PlayerUI
-import PlayerUISwiftUI
+    import PlayerUI
+    import PlayerUISwiftUI
 #endif
 
-/**
- The severity of a validation object
- */
+/// The severity of a validation object
 public enum ValidationSeverity: String, Decodable {
     /// The validation was an error
     case error
@@ -23,12 +21,10 @@ public enum ValidationSeverity: String, Decodable {
     case warning
 }
 
-/**
- Extension for ValidationSeverity for associated colors and images with severity levels
- */
-extension ValidationSeverity {
+/// Extension for ValidationSeverity for associated colors and images with severity levels
+public extension ValidationSeverity {
     /// The color of this severity
-    public var color: Color {
+    var color: Color {
         switch self {
         case .warning:
             return Color(red: 0.976, green: 0.341, blue: 0.000)
@@ -38,7 +34,7 @@ extension ValidationSeverity {
     }
 
     /// The text color of this severity
-    public var textColor: Color {
+    var textColor: Color {
         switch self {
         case .warning:
             return Color(red: 0.000, green: 0.000, blue: 0.000)
@@ -48,44 +44,43 @@ extension ValidationSeverity {
     }
 
     /// The icon of this severity
-    public var icon: UIImage? {
-        return InternalAssets.getSVGOfSize(
-            name: self.rawValue,
+    var icon: UIImage? {
+        InternalAssets.getSVGOfSize(
+            name: rawValue,
             size: CGSize(width: 16, height: 16)
         )
     }
 }
 
-/**
- Decodable class that represents a validation object
- */
+/// Decodable class that represents a validation object
 struct ValidationData: Decodable, Hashable {
     /// The severity of this validation
-    public var severity: ValidationSeverity
+    var severity: ValidationSeverity
 
     /// The message associated with this validation
-    public var message: String
+    var message: String
 
     /// A function to dismiss the validation if it's allowed
-    public var dismiss: WrappedFunction<Void>?
+    var dismiss: WrappedFunction<Void>?
 }
 
-/**
- Shows a validation message
- */
+/// Shows a validation message
 struct ValidationView: View {
     /// The message to show
     var message: String
-    // The severity of the message
+    /// The severity of the message
     var severity: ValidationSeverity
     /// A dismiss function if it should be dismissable
     var dismiss: (() -> Void)?
 
-    @ViewBuilder
     var body: some View {
         HStack {
             Image(uiImage: severity.icon ?? UIImage()).foregroundColor(severity.color)
-            Text(message).foregroundColor(severity.textColor).font(.system(size: 14)).italic().bold()
+            Text(message)
+                .foregroundColor(severity.textColor)
+                .font(.system(size: 14))
+                .italic()
+                .bold()
             if let dismissAction = dismiss {
                 Spacer()
                 Button("Dismiss", action: dismissAction).foregroundColor(.blue)

--- a/plugins/reference-assets/swiftui/Sources/SwiftUI/ValidationView.swift
+++ b/plugins/reference-assets/swiftui/Sources/SwiftUI/ValidationView.swift
@@ -24,9 +24,9 @@ public extension ValidationSeverity {
     var color: Color {
         switch self {
         case .warning:
-            return Color(red: 0.976, green: 0.341, blue: 0.000)
+            Color(red: 0.976, green: 0.341, blue: 0.000)
         default:
-            return Color(red: 0.835, green: 0.169, blue: 0.118)
+            Color(red: 0.835, green: 0.169, blue: 0.118)
         }
     }
 
@@ -34,9 +34,9 @@ public extension ValidationSeverity {
     var textColor: Color {
         switch self {
         case .warning:
-            return Color(red: 0.000, green: 0.000, blue: 0.000)
+            Color(red: 0.000, green: 0.000, blue: 0.000)
         default:
-            return Color(red: 0.835, green: 0.169, blue: 0.118)
+            Color(red: 0.835, green: 0.169, blue: 0.118)
         }
     }
 

--- a/plugins/reference-assets/swiftui/Sources/SwiftUI/ValidationView.swift
+++ b/plugins/reference-assets/swiftui/Sources/SwiftUI/ValidationView.swift
@@ -5,14 +5,11 @@
 //  Created by Harris Borawski on 3/4/21.
 //
 
-import SwiftUI
-
 import PlayerUI
 import PlayerUISwiftUI
+import SwiftUI
 
-/**
- The severity of a validation object
- */
+/// The severity of a validation object
 public enum ValidationSeverity: String, Decodable {
     /// The validation was an error
     case error
@@ -21,12 +18,10 @@ public enum ValidationSeverity: String, Decodable {
     case warning
 }
 
-/**
- Extension for ValidationSeverity for associated colors and images with severity levels
- */
-extension ValidationSeverity {
+/// Extension for ValidationSeverity for associated colors and images with severity levels
+public extension ValidationSeverity {
     /// The color of this severity
-    public var color: Color {
+    var color: Color {
         switch self {
         case .warning:
             return Color(red: 0.976, green: 0.341, blue: 0.000)
@@ -36,7 +31,7 @@ extension ValidationSeverity {
     }
 
     /// The text color of this severity
-    public var textColor: Color {
+    var textColor: Color {
         switch self {
         case .warning:
             return Color(red: 0.000, green: 0.000, blue: 0.000)
@@ -46,44 +41,43 @@ extension ValidationSeverity {
     }
 
     /// The icon of this severity
-    public var icon: UIImage? {
-        return InternalAssets.getSVGOfSize(
-            name: self.rawValue,
+    var icon: UIImage? {
+        InternalAssets.getSVGOfSize(
+            name: rawValue,
             size: CGSize(width: 16, height: 16)
         )
     }
 }
 
-/**
- Decodable class that represents a validation object
- */
+/// Decodable class that represents a validation object
 struct ValidationData: Decodable, Hashable {
     /// The severity of this validation
-    public var severity: ValidationSeverity
+    var severity: ValidationSeverity
 
     /// The message associated with this validation
-    public var message: String
+    var message: String
 
     /// A function to dismiss the validation if it's allowed
-    public var dismiss: WrappedFunction<Void>?
+    var dismiss: WrappedFunction<Void>?
 }
 
-/**
- Shows a validation message
- */
+/// Shows a validation message
 struct ValidationView: View {
     /// The message to show
     var message: String
-    // The severity of the message
+    /// The severity of the message
     var severity: ValidationSeverity
     /// A dismiss function if it should be dismissable
     var dismiss: (() -> Void)?
 
-    @ViewBuilder
     var body: some View {
         HStack {
             Image(uiImage: severity.icon ?? UIImage()).foregroundColor(severity.color)
-            Text(message).foregroundColor(severity.textColor).font(.system(size: 14)).italic().bold()
+            Text(message)
+                .foregroundColor(severity.textColor)
+                .font(.system(size: 14))
+                .italic()
+                .bold()
             if let dismissAction = dismiss {
                 Spacer()
                 Button("Dismiss", action: dismissAction).foregroundColor(.blue)

--- a/plugins/reference-assets/swiftui/Sources/Utilities/InternalAssets.swift
+++ b/plugins/reference-assets/swiftui/Sources/Utilities/InternalAssets.swift
@@ -8,25 +8,30 @@
 import Foundation
 import UIKit
 
-/**
- Assets that are used internally for rendering ReferenceAssets
- */
+/// Assets that are used internally for rendering ReferenceAssets
 class InternalAssets {
-
-    /**
-     An image used for the dismiss button
-     */
+    /// An image used for the dismiss button
     static var dismissIcon: UIImage? {
-        return InternalAssets.getSVGOfSize(name: "dismiss")
+        InternalAssets.getSVGOfSize(name: "dismiss")
     }
 
-    /**
-     Helper method to get and resize bundled SVGs
-     - parameters:
-        - name: The name of the svg icon
-        - size: The size to resize the SVG to if desired
-     - returns: A resized UIImage from the SVG
-     */
+    #if SWIFT_PACKAGE
+        static var bundleURL: URL? {
+            Bundle.module.resourceURL
+        }
+    #else
+        static var bundleURL: URL? {
+            Bundle(for: InternalAssets.self)
+                .resourceURL?
+                .appendingPathComponent("ReferenceAssets.bundle")
+        }
+    #endif
+
+    /// Helper method to get and resize bundled SVGs
+    /// - parameters:
+    ///   - name: The name of the svg icon
+    ///   - size: The size to resize the SVG to if desired
+    /// - returns: A resized UIImage from the SVG
     static func getSVGOfSize(name: String, size: CGSize? = nil) -> UIImage? {
         guard
             let url = InternalAssets.bundleURL,
@@ -34,25 +39,19 @@ class InternalAssets {
 
         let image = UIImage(named: name, in: bundle, with: .none)
 
-        if let size = size {
+        if let size {
             return image?.resize(to: size).withRenderingMode(.alwaysTemplate)
         }
 
         return image?.withRenderingMode(.alwaysTemplate)
     }
-
-    #if SWIFT_PACKAGE
-    static var bundleURL: URL? { Bundle.module.resourceURL }
-    #else
-    static var bundleURL: URL? { Bundle(for: InternalAssets.self).resourceURL?.appendingPathComponent("ReferenceAssets.bundle") }
-    #endif
 }
 
 extension UIImage {
     func resize(to newSize: CGSize) -> UIImage {
         let rect = CGRect(origin: CGPoint(x: 0, y: 0), size: newSize)
         UIGraphicsBeginImageContext(newSize)
-        self.draw(in: rect)
+        draw(in: rect)
         guard let newImage = UIGraphicsGetImageFromCurrentImageContext() else { return self }
         UIGraphicsEndImageContext()
         return newImage

--- a/plugins/reference-assets/swiftui/Sources/Utilities/InternalAssets.swift
+++ b/plugins/reference-assets/swiftui/Sources/Utilities/InternalAssets.swift
@@ -8,25 +8,22 @@
 import Foundation
 import UIKit
 
-/**
- Assets that are used internally for rendering ReferenceAssets
- */
+/// Assets that are used internally for rendering ReferenceAssets
 class InternalAssets {
-
-    /**
-     An image used for the dismiss button
-     */
+    /// An image used for the dismiss button
     static var dismissIcon: UIImage? {
-        return InternalAssets.getSVGOfSize(name: "dismiss")
+        InternalAssets.getSVGOfSize(name: "dismiss")
     }
 
-    /**
-     Helper method to get and resize bundled SVGs
-     - parameters:
-        - name: The name of the svg icon
-        - size: The size to resize the SVG to if desired
-     - returns: A resized UIImage from the SVG
-     */
+    static var bundleURL: URL? {
+        Bundle.module.resourceURL
+    }
+
+    /// Helper method to get and resize bundled SVGs
+    /// - parameters:
+    ///   - name: The name of the svg icon
+    ///   - size: The size to resize the SVG to if desired
+    /// - returns: A resized UIImage from the SVG
     static func getSVGOfSize(name: String, size: CGSize? = nil) -> UIImage? {
         guard
             let url = InternalAssets.bundleURL,
@@ -34,21 +31,19 @@ class InternalAssets {
 
         let image = UIImage(named: name, in: bundle, with: .none)
 
-        if let size = size {
+        if let size {
             return image?.resize(to: size).withRenderingMode(.alwaysTemplate)
         }
 
         return image?.withRenderingMode(.alwaysTemplate)
     }
-
-    static var bundleURL: URL? { Bundle.module.resourceURL }
 }
 
 extension UIImage {
     func resize(to newSize: CGSize) -> UIImage {
         let rect = CGRect(origin: CGPoint(x: 0, y: 0), size: newSize)
         UIGraphicsBeginImageContext(newSize)
-        self.draw(in: rect)
+        draw(in: rect)
         guard let newImage = UIGraphicsGetImageFromCurrentImageContext() else { return self }
         UIGraphicsEndImageContext()
         return newImage

--- a/plugins/reference-assets/swiftui/UITests/ActionAssetUITests.swift
+++ b/plugins/reference-assets/swiftui/UITests/ActionAssetUITests.swift
@@ -23,7 +23,11 @@ class ActionAssetUITests: BaseTestCase {
 
         XCTAssertTrue(app.alerts["Flow Finished"].exists)
 
-        XCTAssertTrue(app.alerts["Flow Finished"].staticTexts.element(boundBy: 1).label.contains("done"))
+        XCTAssertTrue(app.alerts["Flow Finished"]
+            .staticTexts
+            .element(boundBy: 1)
+            .label
+            .contains("done"))
     }
 
     func testActionTransitionError() {
@@ -36,6 +40,10 @@ class ActionAssetUITests: BaseTestCase {
 
         XCTAssertTrue(app.alerts["Flow Finished"].exists)
 
-        XCTAssertTrue(app.alerts["Flow Finished"].staticTexts.element(boundBy: 1).label.contains("Unclosed brace"))
+        XCTAssertTrue(app.alerts["Flow Finished"]
+            .staticTexts
+            .element(boundBy: 1)
+            .label
+            .contains("Unclosed brace"))
     }
 }

--- a/plugins/reference-assets/swiftui/UITests/BaseTestCase.swift
+++ b/plugins/reference-assets/swiftui/UITests/BaseTestCase.swift
@@ -6,15 +6,15 @@
 //  Copyright © 2020 CocoaPods. All rights reserved.
 //
 
+import Combine
 import Foundation
-import XCTest
 import PlayerUI
 import PlayerUITestUtilities
 import PlayerUITestUtilitiesCore
-import Combine
+import XCTest
 
 class BaseTestCase: AssetUITestCase {
-    // AssetCollectionView uses a List which wont register elements if they aren't on screen
+    /// AssetCollectionView uses a List which wont register elements if they aren't on screen
     override func openFlow(_ mockName: String) {
         guard !app.buttons[mockName].exists else { return super.openFlow(mockName) }
         var attempts = 0

--- a/plugins/reference-assets/swiftui/UITests/BaseTestCase.swift
+++ b/plugins/reference-assets/swiftui/UITests/BaseTestCase.swift
@@ -6,15 +6,15 @@
 //  Copyright © 2020 Intuit. All rights reserved.
 //
 
+import Combine
 import Foundation
-import XCTest
 import PlayerUI
 import PlayerUITestUtilities
 import PlayerUITestUtilitiesCore
-import Combine
+import XCTest
 
 class BaseTestCase: AssetUITestCase {
-    // AssetCollectionView uses a List which wont register elements if they aren't on screen
+    /// AssetCollectionView uses a List which wont register elements if they aren't on screen
     override func openFlow(_ mockName: String) {
         guard !app.buttons[mockName].exists else { return super.openFlow(mockName) }
         var attempts = 0

--- a/plugins/reference-assets/swiftui/UITests/BeaconPluginUITest.swift
+++ b/plugins/reference-assets/swiftui/UITests/BeaconPluginUITest.swift
@@ -2,10 +2,6 @@ import Foundation
 import XCTest
 
 class BeaconPluginUITests: BaseTestCase {
-    override func navigateToAssetCollection() {
-        app.otherElements.buttons["Plugins + Managed Player"].firstMatch.tap()
-    }
-
     func testBeaconPluginAction() {
         openFlow("beacon action")
         XCTAssertTrue(app.alerts["Info"].staticTexts.element(boundBy: 1).label.contains("action"))
@@ -15,6 +11,14 @@ class BeaconPluginUITests: BaseTestCase {
         waitFor(button)
         button.tap()
 
-        XCTAssertTrue(app.alerts["Info"].staticTexts.element(boundBy: 1).label.contains("some-data"))
+        XCTAssertTrue(app.alerts["Info"]
+            .staticTexts
+            .element(boundBy: 1)
+            .label
+            .contains("some-data"))
+    }
+
+    override func navigateToAssetCollection() {
+        app.otherElements.buttons["Plugins + Managed Player"].firstMatch.tap()
     }
 }

--- a/plugins/reference-assets/swiftui/UITests/ChatMessageAssetUITests.swift
+++ b/plugins/reference-assets/swiftui/UITests/ChatMessageAssetUITests.swift
@@ -1,11 +1,11 @@
- import XCTest
+import XCTest
 
- class ChatMessageAssetUITests: BaseTestCase {
-     func testChatMessage() {
-         openFlow("chat message basic")
-         waitFor(app.otherElements["collection-async-1"])
-         let value1 = app.staticTexts["text"].label
+class ChatMessageAssetUITests: BaseTestCase {
+    func testChatMessage() {
+        openFlow("chat message basic")
+        waitFor(app.otherElements["collection-async-1"])
+        let value1 = app.staticTexts["text"].label
 
-         XCTAssertEqual(value1, "chat message")
-     }
- }
+        XCTAssertEqual(value1, "chat message")
+    }
+}

--- a/plugins/reference-assets/swiftui/UITests/ExternalActionUITests.swift
+++ b/plugins/reference-assets/swiftui/UITests/ExternalActionUITests.swift
@@ -2,14 +2,14 @@ import Foundation
 import XCTest
 
 class ExternalActionUITests: BaseTestCase {
-    override func navigateToAssetCollection() {
-        app.otherElements.buttons["Plugins + Managed Player"].firstMatch.tap()
-    }
-
     func testExternalAction() {
         openFlow("external-action external-action")
         let alert = app.alerts["FlowCompleted"]
         waitFor(alert)
         XCTAssertTrue(alert.staticTexts.element(boundBy: 1).label.contains("FWD"))
+    }
+
+    override func navigateToAssetCollection() {
+        app.otherElements.buttons["Plugins + Managed Player"].firstMatch.tap()
     }
 }

--- a/plugins/reference-assets/swiftui/UITests/ExternalStateUITests.swift
+++ b/plugins/reference-assets/swiftui/UITests/ExternalStateUITests.swift
@@ -2,14 +2,14 @@ import Foundation
 import XCTest
 
 class ExternalStateUITests: BaseTestCase {
-    override func navigateToAssetCollection() {
-        app.otherElements.buttons["Plugins + Managed Player"].firstMatch.tap()
-    }
-
     func testExternalState() {
         openFlow("external-state external-state")
         let alert = app.alerts["FlowCompleted"]
         waitFor(alert)
         XCTAssertTrue(alert.staticTexts.element(boundBy: 1).label.contains("FWD"))
+    }
+
+    override func navigateToAssetCollection() {
+        app.otherElements.buttons["Plugins + Managed Player"].firstMatch.tap()
     }
 }

--- a/plugins/reference-assets/swiftui/UITests/InfoAssetUITests.swift
+++ b/plugins/reference-assets/swiftui/UITests/InfoAssetUITests.swift
@@ -10,7 +10,10 @@ class InfoAssetUITests: BaseTestCase {
 
         XCTAssertTrue(app.alerts["Flow Finished"].exists)
 
-        XCTAssertTrue(app.alerts["Flow Finished"].staticTexts.element(boundBy: 1).label.contains("done"))
-
+        XCTAssertTrue(app.alerts["Flow Finished"]
+            .staticTexts
+            .element(boundBy: 1)
+            .label
+            .contains("done"))
     }
 }

--- a/plugins/reference-assets/swiftui/UITests/ManagedPlayerUITests.swift
+++ b/plugins/reference-assets/swiftui/UITests/ManagedPlayerUITests.swift
@@ -2,32 +2,6 @@ import Foundation
 import XCTest
 
 class ManagedPlayerUITests: BaseTestCase {
-    override func navigateToAssetCollection() {
-        app.otherElements.buttons["Plugins + Managed Player"].firstMatch.tap()
-    }
-
-    /// Taps the element and verifies the expected outcome appears. If the tap has no effect
-    /// (e.g., the JS action handler isn't wired yet due to async SwiftUI binding), retries the tap.
-    private func tapAndAssertElementAppears(
-        _ element: XCUIElement,
-        expectedOutcome: XCUIElement,
-        timeout: TimeInterval = 3,
-        retries: Int = 3
-    ) {
-        for _ in 0..<retries {
-            // If the expected outcome already appeared (from a previous tap that was slow to produce results),
-            // stop immediately instead of tapping again.
-            if expectedOutcome.exists { return }
-            // If the tappable element is gone (a previous tap successfully navigated away),
-            // stop retrying instead of crashing on a missing element.
-            guard element.exists else { break }
-            element.tap()
-            if expectedOutcome.waitForExistence(timeout: timeout) {
-                return
-            }
-        }
-    }
-
     func testSimpleFlow() {
         openFlow("Simple Flows")
         let button1 = app.buttons["first_view"].firstMatch
@@ -41,7 +15,6 @@ class ManagedPlayerUITests: BaseTestCase {
         tapAndAssertElementAppears(button2, expectedOutcome: completedText)
     }
 
-    
     func testErrorContentFlow() {
         openFlow("Error Content Flow")
 
@@ -55,7 +28,8 @@ class ManagedPlayerUITests: BaseTestCase {
         let retryButton = app.buttons["Retry"].firstMatch
         tapAndAssertElementAppears(button2, expectedOutcome: retryButton, timeout: 5)
 
-        let errorText = app.staticTexts["Unclosed brace after \"foo.bar..}\" at character 12"].firstMatch
+        let errorText = app.staticTexts["Unclosed brace after \"foo.bar..}\" at character 12"]
+            .firstMatch
         XCTAssert(errorText.exists, "Error message did not appear")
     }
 
@@ -65,7 +39,8 @@ class ManagedPlayerUITests: BaseTestCase {
         waitFor(button1)
         button1.tap()
 
-        let errorText = app.staticTexts["PlayerUI.DecodingError.typeNotRegistered(type: \"error\")"].firstMatch
+        let errorText = app.staticTexts["PlayerUI.DecodingError.typeNotRegistered(type: \"error\")"]
+            .firstMatch
         waitFor(errorText)
 
         let resetButton = app.buttons["Reset"]
@@ -83,5 +58,32 @@ class ManagedPlayerUITests: BaseTestCase {
 
         // the same view should reload properly
         waitFor(button1)
+    }
+
+    /// Taps the element and verifies the expected outcome appears. If the tap has no effect
+    /// (e.g., the JS action handler isn't wired yet due to async SwiftUI binding), retries the tap.
+    private func tapAndAssertElementAppears(
+        _ element: XCUIElement,
+        expectedOutcome: XCUIElement,
+        timeout: TimeInterval = 3,
+        retries: Int = 3
+    ) {
+        for _ in 0 ..< retries {
+            // If the expected outcome already appeared (from a previous tap that was slow to
+            // produce results),
+            // stop immediately instead of tapping again.
+            if expectedOutcome.exists { return }
+            // If the tappable element is gone (a previous tap successfully navigated away),
+            // stop retrying instead of crashing on a missing element.
+            guard element.exists else { break }
+            element.tap()
+            if expectedOutcome.waitForExistence(timeout: timeout) {
+                return
+            }
+        }
+    }
+
+    override func navigateToAssetCollection() {
+        app.otherElements.buttons["Plugins + Managed Player"].firstMatch.tap()
     }
 }

--- a/plugins/reference-assets/swiftui/UITests/ManagedPlayerUITests.swift
+++ b/plugins/reference-assets/swiftui/UITests/ManagedPlayerUITests.swift
@@ -2,10 +2,6 @@ import Foundation
 import XCTest
 
 class ManagedPlayerUITests: BaseTestCase {
-    override func navigateToAssetCollection() {
-        app.otherElements.buttons["Plugins + Managed Player"].firstMatch.tap()
-    }
-
     func testSimpleFlow() {
         openFlow("Simple Flows")
         let button1 = app.buttons["first_view"].firstMatch
@@ -19,7 +15,6 @@ class ManagedPlayerUITests: BaseTestCase {
         tapAndAssertElementAppears(button2, expectedOutcome: completedText)
     }
 
-    
     func testErrorContentFlow() {
         openFlow("Error Content Flow")
 
@@ -33,7 +28,8 @@ class ManagedPlayerUITests: BaseTestCase {
         let retryButton = app.buttons["Retry"].firstMatch
         tapAndAssertElementAppears(button2, expectedOutcome: retryButton, timeout: 5)
 
-        let errorText = app.staticTexts["Unclosed brace after \"foo.bar..}\" at character 12"].firstMatch
+        let errorText = app.staticTexts["Unclosed brace after \"foo.bar..}\" at character 12"]
+            .firstMatch
         XCTAssert(errorText.exists, "Error message did not appear")
     }
 
@@ -43,7 +39,8 @@ class ManagedPlayerUITests: BaseTestCase {
         waitFor(button1)
         button1.tap()
 
-        let errorText = app.staticTexts["PlayerUI.DecodingError.typeNotRegistered(type: \"error\")"].firstMatch
+        let errorText = app.staticTexts["PlayerUI.DecodingError.typeNotRegistered(type: \"error\")"]
+            .firstMatch
         waitFor(errorText)
 
         let resetButton = app.buttons["Reset"]
@@ -61,5 +58,9 @@ class ManagedPlayerUITests: BaseTestCase {
 
         // the same view should reload properly
         waitFor(button1)
+    }
+
+    override func navigateToAssetCollection() {
+        app.otherElements.buttons["Plugins + Managed Player"].firstMatch.tap()
     }
 }

--- a/plugins/reference-assets/swiftui/UITests/PubsubUITests.swift
+++ b/plugins/reference-assets/swiftui/UITests/PubsubUITests.swift
@@ -2,10 +2,6 @@ import Foundation
 import XCTest
 
 class PubSubUITests: BaseTestCase {
-    override func navigateToAssetCollection() {
-        app.otherElements.buttons["Plugins + Managed Player"].firstMatch.tap()
-    }
-
     func testPubsubPluginAction() {
         openFlow("pub sub basic")
         XCTAssertTrue(app.alerts["Info"].staticTexts.element(boundBy: 1).label.contains("action"))
@@ -16,8 +12,20 @@ class PubSubUITests: BaseTestCase {
         waitFor(button)
         button.tap()
 
-        XCTAssertTrue(app.alerts["Info"].staticTexts.element(boundBy: 1).label.contains("Published: `some-event`"))
+        XCTAssertTrue(app.alerts["Info"]
+            .staticTexts
+            .element(boundBy: 1)
+            .label
+            .contains("Published: `some-event`"))
 
-        XCTAssertTrue(app.alerts["Info"].staticTexts.element(boundBy: 1).label.contains("event published message"))
+        XCTAssertTrue(app.alerts["Info"]
+            .staticTexts
+            .element(boundBy: 1)
+            .label
+            .contains("event published message"))
+    }
+
+    override func navigateToAssetCollection() {
+        app.otherElements.buttons["Plugins + Managed Player"].firstMatch.tap()
     }
 }

--- a/plugins/reference-assets/swiftui/UITests/SwiftUIPendingTransactionPluginUITests.swift
+++ b/plugins/reference-assets/swiftui/UITests/SwiftUIPendingTransactionPluginUITests.swift
@@ -2,10 +2,6 @@ import Foundation
 import XCTest
 
 class SwiftUIPendingTransactionPluginUITests: BaseTestCase {
-    override func navigateToAssetCollection() {
-        app.otherElements.buttons["Plugins + Managed Player"].firstMatch.tap()
-    }
-
     func testInputAssetPendingTransaction() {
         openFlow("input asset pending transaction")
 
@@ -40,5 +36,9 @@ class SwiftUIPendingTransactionPluginUITests: BaseTestCase {
 
         app.buttons["OK"].firstMatch.tap()
         XCTAssertTrue(app.staticTexts["You made it!"].firstMatch.exists)
+    }
+
+    override func navigateToAssetCollection() {
+        app.otherElements.buttons["Plugins + Managed Player"].firstMatch.tap()
     }
 }

--- a/plugins/reference-assets/swiftui/ViewInspector/ReferenceAssetsPluginTests.swift
+++ b/plugins/reference-assets/swiftui/ViewInspector/ReferenceAssetsPluginTests.swift
@@ -7,16 +7,16 @@
 //
 
 import Foundation
-import XCTest
 import JavaScriptCore
 @testable import PlayerUI
-@testable import PlayerUITestUtilities
 @testable import PlayerUIReferenceAssets
 @testable import PlayerUISwiftUI
+@testable import PlayerUITestUtilities
+import XCTest
 
 class SwiftUIReferenceAssetsPluginTests: XCTestCase {
-    func testReferenceAssetsPluginConstructs() {
-        let context = JSContext()!
+    func testReferenceAssetsPluginConstructs() throws {
+        let context = try XCTUnwrap(JSContext())
 
         let plugin = ReferenceAssetsPlugin()
         plugin.context = context

--- a/plugins/reference-assets/swiftui/ViewInspector/SwiftUI/ActionAssetTests.swift
+++ b/plugins/reference-assets/swiftui/ViewInspector/SwiftUI/ActionAssetTests.swift
@@ -7,20 +7,17 @@
 //
 
 import Foundation
-import XCTest
-import SwiftUI
-import ViewInspector
-
 @testable import PlayerUI
-@testable import PlayerUITestUtilities
+@testable import PlayerUIBeaconPlugin
 @testable import PlayerUIReferenceAssets
 @testable import PlayerUISwiftUI
-@testable import PlayerUIBeaconPlugin
+@testable import PlayerUITestUtilities
+import SwiftUI
+import ViewInspector
+import XCTest
 
 @MainActor
 class ActionAssetTests: SwiftUIAssetUnitTestCase {
-    override open func plugins() -> [NativePlugin] { [ReferenceAssetsPlugin()] }
-
     func setup() {
         XCUIApplication().terminate()
     }
@@ -46,8 +43,8 @@ class ActionAssetTests: SwiftUIAssetUnitTestCase {
         }
 
         _ = try action.view.inspect().find(ActionAssetView.self).button()
-
     }
+
     func testViewNoLabel() throws {
         let data = ActionData(id: "id", type: "action", label: nil, run: nil)
 
@@ -63,7 +60,12 @@ class ActionAssetTests: SwiftUIAssetUnitTestCase {
         {"id": "text", "type": "text", "value":"hello world"}
         """)
         else { return XCTFail("unable to get asset") }
-        let data = ActionData(id: "id", type: "action", label: WrappedAsset(forAsset: text), run: nil)
+        let data = ActionData(
+            id: "id",
+            type: "action",
+            label: WrappedAsset(forAsset: text),
+            run: nil
+        )
 
         let model = AssetViewModel<ActionData>(data)
 
@@ -76,9 +78,10 @@ class ActionAssetTests: SwiftUIAssetUnitTestCase {
         XCTAssertEqual("hello world", try label.string())
     }
 
-    func testRunsFunction() throws {
+    func testRunsFunction() {
         let runExpect = expectation(description: "Beacon Called")
-        guard let run: WrappedFunction<Void> = getWrappedFunction(completion: { runExpect.fulfill() }) else {
+        guard let run: WrappedFunction<Void> =
+            getWrappedFunction(completion: { runExpect.fulfill() }) else {
             return XCTFail("unable to get function")
         }
         let data = ActionData(id: "id", type: "action", label: nil, run: run)
@@ -96,7 +99,7 @@ class ActionAssetTests: SwiftUIAssetUnitTestCase {
         wait(for: [appear, runExpect], timeout: 5)
     }
 
-    func testSendsBeacon() throws {
+    func testSendsBeacon() {
         let data = ActionData(id: "id", type: "action", label: nil, run: nil)
 
         let model = AssetViewModel<ActionData>(data)
@@ -109,10 +112,14 @@ class ActionAssetTests: SwiftUIAssetUnitTestCase {
             try view.button().tap()
         }
 
-        ViewHosting.host(view: view.environment(\.beaconContext, BeaconContext({ _ in
+        ViewHosting.host(view: view.environment(\.beaconContext, BeaconContext { _ in
             expect.fulfill()
-        })))
+        }))
 
         wait(for: [appear, expect], timeout: 5)
+    }
+
+    override open func plugins() -> [NativePlugin] {
+        [ReferenceAssetsPlugin()]
     }
 }

--- a/plugins/reference-assets/swiftui/ViewInspector/SwiftUI/CollectionAssetTests.swift
+++ b/plugins/reference-assets/swiftui/ViewInspector/SwiftUI/CollectionAssetTests.swift
@@ -7,19 +7,16 @@
 //
 
 import Foundation
-import XCTest
-import ViewInspector
-import SwiftUI
-
 @testable import PlayerUI
-@testable import PlayerUITestUtilities
 @testable import PlayerUIReferenceAssets
 @testable import PlayerUISwiftUI
+@testable import PlayerUITestUtilities
+import SwiftUI
+import ViewInspector
+import XCTest
 
 @MainActor
 class CollectionAssetTests: SwiftUIAssetUnitTestCase {
-    override open func plugins() -> [NativePlugin] { [ReferenceAssetsPlugin()] }
-
     func testDecoding() async throws {
         let json = """
         {
@@ -44,7 +41,8 @@ class CollectionAssetTests: SwiftUIAssetUnitTestCase {
         }
         """
 
-        guard let collection: CollectionAsset = await getAsset(json) else { return XCTFail("could not get asset") }
+        guard let collection: CollectionAsset = await getAsset(json)
+        else { return XCTFail("could not get asset") }
 
         _ = try collection.view.inspect().find(CollectionAssetView.self).vStack()
     }
@@ -82,7 +80,8 @@ class CollectionAssetTests: SwiftUIAssetUnitTestCase {
         }
         """
 
-        guard let collection: CollectionAsset = await getAsset(json) else { return XCTFail("could not get asset") }
+        guard let collection: CollectionAsset = await getAsset(json)
+        else { return XCTFail("could not get asset") }
 
         let stack = try collection.view.inspect().find(CollectionAssetView.self).vStack()
         // Verify the label is present in the view hierarchy
@@ -94,8 +93,10 @@ class CollectionAssetTests: SwiftUIAssetUnitTestCase {
 
     func testView() async throws {
         guard
-            let text1: TextAsset = await getAsset("{\"id\": \"text\", \"type\": \"text\", \"value\":\"hello world\"}"),
-            let text2: TextAsset = await getAsset("{\"id\": \"text2\", \"type\": \"text\", \"value\":\"goodbye world\"}")
+            let text1: TextAsset =
+            await getAsset("{\"id\": \"text\", \"type\": \"text\", \"value\":\"hello world\"}"),
+            let text2: TextAsset =
+            await getAsset("{\"id\": \"text2\", \"type\": \"text\", \"value\":\"goodbye world\"}")
         else { return XCTFail("could not get assets") }
         let model = AssetViewModel<CollectionData>(
             CollectionData(
@@ -103,7 +104,7 @@ class CollectionAssetTests: SwiftUIAssetUnitTestCase {
                 type: "collection",
                 values: [
                     WrappedAsset(forAsset: text1),
-                    WrappedAsset(forAsset: text2)
+                    WrappedAsset(forAsset: text2),
                 ]
             )
         )
@@ -122,9 +123,14 @@ class CollectionAssetTests: SwiftUIAssetUnitTestCase {
     /// when a label is provided in the model data.
     func testViewWithLabel() async throws {
         guard
-            let label: TextAsset = await getAsset("{\"id\": \"label\", \"type\": \"text\", \"value\":\"My Collection\"}"),
-            let text1: TextAsset = await getAsset("{\"id\": \"text\", \"type\": \"text\", \"value\":\"hello world\"}"),
-            let text2: TextAsset = await getAsset("{\"id\": \"text2\", \"type\": \"text\", \"value\":\"goodbye world\"}")
+            let label: TextAsset =
+            await getAsset(
+                "{\"id\": \"label\", \"type\": \"text\", \"value\":\"My Collection\"}"
+            ),
+            let text1: TextAsset =
+            await getAsset("{\"id\": \"text\", \"type\": \"text\", \"value\":\"hello world\"}"),
+            let text2: TextAsset =
+            await getAsset("{\"id\": \"text2\", \"type\": \"text\", \"value\":\"goodbye world\"}")
         else { return XCTFail("could not get assets") }
         let model = AssetViewModel<CollectionData>(
             CollectionData(
@@ -133,7 +139,7 @@ class CollectionAssetTests: SwiftUIAssetUnitTestCase {
                 label: WrappedAsset(forAsset: label),
                 values: [
                     WrappedAsset(forAsset: text1),
-                    WrappedAsset(forAsset: text2)
+                    WrappedAsset(forAsset: text2),
                 ]
             )
         )
@@ -150,5 +156,9 @@ class CollectionAssetTests: SwiftUIAssetUnitTestCase {
         // Verify each value's text content
         _ = try stack.find(text: "hello world")
         _ = try stack.find(text: "goodbye world")
+    }
+
+    override open func plugins() -> [NativePlugin] {
+        [ReferenceAssetsPlugin()]
     }
 }

--- a/plugins/reference-assets/swiftui/ViewInspector/SwiftUI/InfoAssetTests.swift
+++ b/plugins/reference-assets/swiftui/ViewInspector/SwiftUI/InfoAssetTests.swift
@@ -7,19 +7,16 @@
 //
 
 import Foundation
+@testable import PlayerUI
+@testable import PlayerUIReferenceAssets
+@testable import PlayerUISwiftUI
+@testable import PlayerUITestUtilities
 import SwiftUI
 import ViewInspector
 import XCTest
 
-@testable import PlayerUI
-@testable import PlayerUITestUtilities
-@testable import PlayerUIReferenceAssets
-@testable import PlayerUISwiftUI
-
 @MainActor
 class InfoAssetTests: SwiftUIAssetUnitTestCase {
-    override open func plugins() -> [NativePlugin] { [ReferenceAssetsPlugin()] }
-
     func testDecoding() async throws {
         let json = """
         {
@@ -51,16 +48,20 @@ class InfoAssetTests: SwiftUIAssetUnitTestCase {
         }
         """
 
-        guard let info: InfoAsset = await getAsset(json) else { return XCTFail("could not get asset") }
+        guard let info: InfoAsset = await getAsset(json)
+        else { return XCTFail("could not get asset") }
 
         _ = try info.view.inspect().find(InfoAssetView.self)
     }
 
     func testView() async throws {
         guard
-            let title: TextAsset = await getAsset("{\"id\": \"text\", \"type\": \"text\", \"value\":\"hello world\"}"),
-            let action1: ActionAsset = await getAsset("{\"id\": \"action1\", \"type\": \"action\", \"value\":\"next\"}"),
-            let action2: ActionAsset = await getAsset("{\"id\": \"action2\", \"type\": \"action\", \"value\":\"prev\"}")
+            let title: TextAsset =
+            await getAsset("{\"id\": \"text\", \"type\": \"text\", \"value\":\"hello world\"}"),
+            let action1: ActionAsset =
+            await getAsset("{\"id\": \"action1\", \"type\": \"action\", \"value\":\"next\"}"),
+            let action2: ActionAsset =
+            await getAsset("{\"id\": \"action2\", \"type\": \"action\", \"value\":\"prev\"}")
         else { return XCTFail("could not get assets") }
 
         let data = InfoData(
@@ -69,7 +70,7 @@ class InfoAssetTests: SwiftUIAssetUnitTestCase {
             title: WrappedAsset(forAsset: title),
             actions: [
                 WrappedAsset(forAsset: action1),
-                WrappedAsset(forAsset: action2)
+                WrappedAsset(forAsset: action2),
             ]
         )
         let model = AssetViewModel<InfoData>(data)
@@ -84,5 +85,9 @@ class InfoAssetTests: SwiftUIAssetUnitTestCase {
         XCTAssertEqual(forEach.count, 2)
 
         _ = try forEach.anyView(0).find(ActionAssetView.self).button()
+    }
+
+    override open func plugins() -> [NativePlugin] {
+        [ReferenceAssetsPlugin()]
     }
 }

--- a/plugins/reference-assets/swiftui/ViewInspector/SwiftUI/InputAssetTests.swift
+++ b/plugins/reference-assets/swiftui/ViewInspector/SwiftUI/InputAssetTests.swift
@@ -6,22 +6,19 @@
 //  Copyright © 2021 CocoaPods. All rights reserved.
 //
 
-import Foundation
 import Combine
+import Foundation
+import JavaScriptCore
+@testable import PlayerUI
+@testable import PlayerUIReferenceAssets
+@testable import PlayerUISwiftUI
+@testable import PlayerUITestUtilities
 import SwiftUI
 import ViewInspector
 import XCTest
-import JavaScriptCore
-
-@testable import PlayerUI
-@testable import PlayerUITestUtilities
-@testable import PlayerUIReferenceAssets
-@testable import PlayerUISwiftUI
 
 @MainActor
 class InputAssetTests: SwiftUIAssetUnitTestCase {
-    override open func plugins() -> [NativePlugin] { [ReferenceAssetsPlugin()] }
-
     func testDecoding() async throws {
         let json = """
         {
@@ -39,7 +36,8 @@ class InputAssetTests: SwiftUIAssetUnitTestCase {
         }
         """
 
-        guard let input: InputAsset = await getAsset(json) else { return XCTFail("could not get asset") }
+        guard let input: InputAsset = await getAsset(json)
+        else { return XCTFail("could not get asset") }
 
         _ = try input.view.inspect().find(InputAssetView.self).vStack().textField(1)
     }
@@ -51,7 +49,8 @@ class InputAssetTests: SwiftUIAssetUnitTestCase {
 
         let setExpectation = expectation(description: "Model Set called")
         guard
-            let wrapper: WrappedFunction<Void> = getWrappedFunction(completion: { setExpectation.fulfill() })
+            let wrapper: WrappedFunction<Void> =
+            getWrappedFunction(completion: { setExpectation.fulfill() })
         else { return XCTFail("could not create function") }
 
         let data = InputData(
@@ -67,10 +66,12 @@ class InputAssetTests: SwiftUIAssetUnitTestCase {
 
         let model = InputAssetViewModel(data, userInfo: [:])
         let update1expect = expectation(description: "Initial value")
-        model.$data.sink { (data) in
-            guard data.value?.stringValue == "a" else { return }
-            update1expect.fulfill()
-        }.store(in: &bag)
+        model.$data
+            .sink { data in
+                guard data.value?.stringValue == "a" else { return }
+                update1expect.fulfill()
+            }
+            .store(in: &bag)
 
         wait(for: [update1expect], timeout: 3)
 
@@ -91,10 +92,12 @@ class InputAssetTests: SwiftUIAssetUnitTestCase {
         model.data = newData
 
         let update2expect = expectation(description: "Updated value")
-        model.$data.sink { (data) in
-            guard data.value?.stringValue == "b" else { return }
-            update2expect.fulfill()
-        }.store(in: &bag)
+        model.$data
+            .sink { data in
+                guard data.value?.stringValue == "b" else { return }
+                update2expect.fulfill()
+            }
+            .store(in: &bag)
 
         wait(for: [update2expect], timeout: 3)
 
@@ -106,7 +109,16 @@ class InputAssetTests: SwiftUIAssetUnitTestCase {
     func testViewNoLabel() throws {
         let val = context.evaluateScript("('a')")
         let modelRef = ModelReference(rawValue: val)
-        let data = InputData(id: "input", type: "input", placeholder: nil, value: modelRef, label: nil, set: nil, dataType: nil, validation: nil)
+        let data = InputData(
+            id: "input",
+            type: "input",
+            placeholder: nil,
+            value: modelRef,
+            label: nil,
+            set: nil,
+            dataType: nil,
+            validation: nil
+        )
 
         let model = InputAssetViewModel(data, userInfo: [:])
 
@@ -118,12 +130,16 @@ class InputAssetTests: SwiftUIAssetUnitTestCase {
 
         let background = try field.background()
 
-        XCTAssertEqual(Color(red: 0.729, green: 0.745, blue: 0.773), try background.foregroundColor())
+        XCTAssertEqual(
+            Color(red: 0.729, green: 0.745, blue: 0.773),
+            try background.foregroundColor()
+        )
     }
 
     func testViewWithLabel() async throws {
         guard
-            let label: TextAsset = await getAsset("{\"id\": \"text\", \"type\": \"text\", \"value\":\"hello world\"}")
+            let label: TextAsset =
+            await getAsset("{\"id\": \"text\", \"type\": \"text\", \"value\":\"hello world\"}")
         else { return XCTFail("could not get asset") }
         let val = context.evaluateScript("('a')")
         let modelRef = ModelReference(rawValue: val)
@@ -156,7 +172,8 @@ class InputAssetTests: SwiftUIAssetUnitTestCase {
             let validationObject = context.evaluateScript("(\(validationDataString))")
         else { return XCTFail("could not get validation object") }
 
-        let validation = try JSONDecoder().decode(ValidationData.self, from: validationObject)
+        let validation = try JSONDecoder()
+            .decode(ValidationData.self, from: validationObject)
             .withDismiss(context: context, dismiss: {
                 dismissExpectation.fulfill()
             })
@@ -197,10 +214,20 @@ class InputAssetTests: SwiftUIAssetUnitTestCase {
     func testTextfieldEditingFalse() throws {
         let setExpectation = expectation(description: "Model Set called")
         guard
-            let wrapper: WrappedFunction<Void> = getWrappedFunction(completion: { setExpectation.fulfill() })
+            let wrapper: WrappedFunction<Void> =
+            getWrappedFunction(completion: { setExpectation.fulfill() })
         else { return XCTFail("could not create function") }
 
-        let data = InputData(id: "input", type: "input", placeholder: nil, value: nil, label: nil, set: wrapper, dataType: nil, validation: nil)
+        let data = InputData(
+            id: "input",
+            type: "input",
+            placeholder: nil,
+            value: nil,
+            label: nil,
+            set: wrapper,
+            dataType: nil,
+            validation: nil
+        )
 
         let model = InputAssetViewModel(data, userInfo: [:])
 
@@ -219,10 +246,20 @@ class InputAssetTests: SwiftUIAssetUnitTestCase {
     func testTextfieldCommit() throws {
         let setExpectation = expectation(description: "Model Set called")
         guard
-            let wrapper: WrappedFunction<Void> = getWrappedFunction(completion: { setExpectation.fulfill() })
+            let wrapper: WrappedFunction<Void> =
+            getWrappedFunction(completion: { setExpectation.fulfill() })
         else { return XCTFail("could not create function") }
 
-        let data = InputData(id: "input", type: "input", placeholder: nil, value: nil, label: nil, set: wrapper, dataType: nil, validation: nil)
+        let data = InputData(
+            id: "input",
+            type: "input",
+            placeholder: nil,
+            value: nil,
+            label: nil,
+            set: wrapper,
+            dataType: nil,
+            validation: nil
+        )
 
         let model = InputAssetViewModel(data, userInfo: [:])
 
@@ -239,6 +276,10 @@ class InputAssetTests: SwiftUIAssetUnitTestCase {
 
         wait(for: [setExpectation], timeout: 1)
     }
+
+    override open func plugins() -> [NativePlugin] {
+        [ReferenceAssetsPlugin()]
+    }
 }
 
 extension ValidationData {
@@ -248,6 +289,10 @@ extension ValidationData {
             return value
         }
         let jsDismiss = JSValue(object: dismissCallback, in: context)
-        return ValidationData(severity: severity, message: message, dismiss: WrappedFunction(rawValue: jsDismiss))
+        return ValidationData(
+            severity: severity,
+            message: message,
+            dismiss: WrappedFunction(rawValue: jsDismiss)
+        )
     }
 }

--- a/plugins/reference-assets/swiftui/ViewInspector/SwiftUI/InputAssetTests.swift
+++ b/plugins/reference-assets/swiftui/ViewInspector/SwiftUI/InputAssetTests.swift
@@ -6,22 +6,19 @@
 //  Copyright © 2021 Intuit. All rights reserved.
 //
 
-import Foundation
 import Combine
+import Foundation
+import JavaScriptCore
+@testable import PlayerUI
+@testable import PlayerUIReferenceAssets
+@testable import PlayerUISwiftUI
+@testable import PlayerUITestUtilities
 import SwiftUI
 import ViewInspector
 import XCTest
-import JavaScriptCore
-
-@testable import PlayerUI
-@testable import PlayerUITestUtilities
-@testable import PlayerUIReferenceAssets
-@testable import PlayerUISwiftUI
 
 @MainActor
 class InputAssetTests: SwiftUIAssetUnitTestCase {
-    override open func plugins() -> [NativePlugin] { [ReferenceAssetsPlugin()] }
-
     func testDecoding() async throws {
         let json = """
         {
@@ -39,7 +36,8 @@ class InputAssetTests: SwiftUIAssetUnitTestCase {
         }
         """
 
-        guard let input: InputAsset = await getAsset(json) else { return XCTFail("could not get asset") }
+        guard let input: InputAsset = await getAsset(json)
+        else { return XCTFail("could not get asset") }
 
         _ = try input.view.inspect().find(InputAssetView.self).vStack().textField(1)
     }
@@ -51,7 +49,8 @@ class InputAssetTests: SwiftUIAssetUnitTestCase {
 
         let setExpectation = expectation(description: "Model Set called")
         guard
-            let wrapper: WrappedFunction<Void> = getWrappedFunction(completion: { setExpectation.fulfill() })
+            let wrapper: WrappedFunction<Void> =
+            getWrappedFunction(completion: { setExpectation.fulfill() })
         else { return XCTFail("could not create function") }
 
         let data = InputData(
@@ -67,10 +66,12 @@ class InputAssetTests: SwiftUIAssetUnitTestCase {
 
         let model = InputAssetViewModel(data, userInfo: [:])
         let update1expect = expectation(description: "Initial value")
-        model.$data.sink { (data) in
-            guard data.value?.stringValue == "a" else { return }
-            update1expect.fulfill()
-        }.store(in: &bag)
+        model.$data
+            .sink { data in
+                guard data.value?.stringValue == "a" else { return }
+                update1expect.fulfill()
+            }
+            .store(in: &bag)
 
         wait(for: [update1expect], timeout: 3)
 
@@ -91,10 +92,12 @@ class InputAssetTests: SwiftUIAssetUnitTestCase {
         model.data = newData
 
         let update2expect = expectation(description: "Updated value")
-        model.$data.sink { (data) in
-            guard data.value?.stringValue == "b" else { return }
-            update2expect.fulfill()
-        }.store(in: &bag)
+        model.$data
+            .sink { data in
+                guard data.value?.stringValue == "b" else { return }
+                update2expect.fulfill()
+            }
+            .store(in: &bag)
 
         wait(for: [update2expect], timeout: 3)
 
@@ -106,7 +109,16 @@ class InputAssetTests: SwiftUIAssetUnitTestCase {
     func testViewNoLabel() throws {
         let val = context.evaluateScript("('a')")
         let modelRef = ModelReference(rawValue: val)
-        let data = InputData(id: "input", type: "input", placeholder: nil, value: modelRef, label: nil, set: nil, dataType: nil, validation: nil)
+        let data = InputData(
+            id: "input",
+            type: "input",
+            placeholder: nil,
+            value: modelRef,
+            label: nil,
+            set: nil,
+            dataType: nil,
+            validation: nil
+        )
 
         let model = InputAssetViewModel(data, userInfo: [:])
 
@@ -118,12 +130,16 @@ class InputAssetTests: SwiftUIAssetUnitTestCase {
 
         let background = try field.background()
 
-        XCTAssertEqual(Color(red: 0.729, green: 0.745, blue: 0.773), try background.foregroundColor())
+        XCTAssertEqual(
+            Color(red: 0.729, green: 0.745, blue: 0.773),
+            try background.foregroundColor()
+        )
     }
 
     func testViewWithLabel() async throws {
         guard
-            let label: TextAsset = await getAsset("{\"id\": \"text\", \"type\": \"text\", \"value\":\"hello world\"}")
+            let label: TextAsset =
+            await getAsset("{\"id\": \"text\", \"type\": \"text\", \"value\":\"hello world\"}")
         else { return XCTFail("could not get asset") }
         let val = context.evaluateScript("('a')")
         let modelRef = ModelReference(rawValue: val)
@@ -156,7 +172,8 @@ class InputAssetTests: SwiftUIAssetUnitTestCase {
             let validationObject = context.evaluateScript("(\(validationDataString))")
         else { return XCTFail("could not get validation object") }
 
-        let validation = try JSONDecoder().decode(ValidationData.self, from: validationObject)
+        let validation = try JSONDecoder()
+            .decode(ValidationData.self, from: validationObject)
             .withDismiss(context: context, dismiss: {
                 dismissExpectation.fulfill()
             })
@@ -197,10 +214,20 @@ class InputAssetTests: SwiftUIAssetUnitTestCase {
     func testTextfieldEditingFalse() throws {
         let setExpectation = expectation(description: "Model Set called")
         guard
-            let wrapper: WrappedFunction<Void> = getWrappedFunction(completion: { setExpectation.fulfill() })
+            let wrapper: WrappedFunction<Void> =
+            getWrappedFunction(completion: { setExpectation.fulfill() })
         else { return XCTFail("could not create function") }
 
-        let data = InputData(id: "input", type: "input", placeholder: nil, value: nil, label: nil, set: wrapper, dataType: nil, validation: nil)
+        let data = InputData(
+            id: "input",
+            type: "input",
+            placeholder: nil,
+            value: nil,
+            label: nil,
+            set: wrapper,
+            dataType: nil,
+            validation: nil
+        )
 
         let model = InputAssetViewModel(data, userInfo: [:])
 
@@ -219,10 +246,20 @@ class InputAssetTests: SwiftUIAssetUnitTestCase {
     func testTextfieldCommit() throws {
         let setExpectation = expectation(description: "Model Set called")
         guard
-            let wrapper: WrappedFunction<Void> = getWrappedFunction(completion: { setExpectation.fulfill() })
+            let wrapper: WrappedFunction<Void> =
+            getWrappedFunction(completion: { setExpectation.fulfill() })
         else { return XCTFail("could not create function") }
 
-        let data = InputData(id: "input", type: "input", placeholder: nil, value: nil, label: nil, set: wrapper, dataType: nil, validation: nil)
+        let data = InputData(
+            id: "input",
+            type: "input",
+            placeholder: nil,
+            value: nil,
+            label: nil,
+            set: wrapper,
+            dataType: nil,
+            validation: nil
+        )
 
         let model = InputAssetViewModel(data, userInfo: [:])
 
@@ -239,6 +276,10 @@ class InputAssetTests: SwiftUIAssetUnitTestCase {
 
         wait(for: [setExpectation], timeout: 1)
     }
+
+    override open func plugins() -> [NativePlugin] {
+        [ReferenceAssetsPlugin()]
+    }
 }
 
 extension ValidationData {
@@ -248,6 +289,10 @@ extension ValidationData {
             return value
         }
         let jsDismiss = JSValue(object: dismissCallback, in: context)
-        return ValidationData(severity: severity, message: message, dismiss: WrappedFunction(rawValue: jsDismiss))
+        return ValidationData(
+            severity: severity,
+            message: message,
+            dismiss: WrappedFunction(rawValue: jsDismiss)
+        )
     }
 }

--- a/plugins/reference-assets/swiftui/ViewInspector/SwiftUI/TextAssetTests.swift
+++ b/plugins/reference-assets/swiftui/ViewInspector/SwiftUI/TextAssetTests.swift
@@ -7,18 +7,16 @@
 //
 
 import Foundation
-import XCTest
-import ViewInspector
-import SwiftUI
 @testable import PlayerUI
 @testable import PlayerUIReferenceAssets
 @testable import PlayerUISwiftUI
 @testable import PlayerUITestUtilities
+import SwiftUI
+import ViewInspector
+import XCTest
 
 @MainActor
 class TextAssetTests: SwiftUIAssetUnitTestCase {
-    override open func plugins() -> [NativePlugin] { [ReferenceAssetsPlugin()] }
-
     func testAssetDecoding() async throws {
         let json = """
         {
@@ -28,10 +26,10 @@ class TextAssetTests: SwiftUIAssetUnitTestCase {
         }
         """
 
-        guard let text: TextAsset = await getAsset(json) else { return XCTFail("could not get asset") }
+        guard let text: TextAsset = await getAsset(json)
+        else { return XCTFail("could not get asset") }
 
         _ = try text.view.inspect().find(TextAssetView.self).text()
-
     }
 
     func testView() throws {
@@ -60,7 +58,7 @@ class TextAssetTests: SwiftUIAssetUnitTestCase {
                         value: nil,
                         name: nil,
                         metaData: ModifierMetaData(ref: "https://intuit.com")
-                    )
+                    ),
                 ]
             )
         )
@@ -74,5 +72,9 @@ class TextAssetTests: SwiftUIAssetUnitTestCase {
         let modifier = try text.modifier(LinkModifier.self)
         XCTAssertEqual(Color(red: 0.000, green: 0.467, blue: 0.773), try modifier.foregroundColor())
         try text.callOnTapGesture()
+    }
+
+    override open func plugins() -> [NativePlugin] {
+        [ReferenceAssetsPlugin()]
     }
 }

--- a/plugins/reference-assets/swiftui/ViewInspector/Utilities/ValidationTests.swift
+++ b/plugins/reference-assets/swiftui/ViewInspector/Utilities/ValidationTests.swift
@@ -7,16 +7,16 @@
 //
 
 import Foundation
-import XCTest
 import JavaScriptCore
-import SwiftUI
 @testable import PlayerUI
-@testable import PlayerUITestUtilities
 @testable import PlayerUIReferenceAssets
 @testable import PlayerUISwiftUI
+@testable import PlayerUITestUtilities
+import SwiftUI
+import XCTest
 
 class ValidationTests: SwiftUIAssetUnitTestCase {
-    func testErrorValidation() {
+    func testErrorValidation() throws {
         let validation = """
         {
           "type": "required",
@@ -25,7 +25,10 @@ class ValidationTests: SwiftUIAssetUnitTestCase {
         }
         """
 
-        guard let val = try? JSONDecoder().decode(ValidationData.self, from: validation.data(using: .utf8)!) else {
+        guard let val = try? JSONDecoder().decode(
+            ValidationData.self,
+            from: try XCTUnwrap(validation.data(using: .utf8))
+        ) else {
             return XCTFail("could not get validation")
         }
         XCTAssertEqual(val.severity, ValidationSeverity.error)
@@ -33,7 +36,7 @@ class ValidationTests: SwiftUIAssetUnitTestCase {
         XCTAssertEqual(val.severity.color, Color(red: 0.835, green: 0.169, blue: 0.118))
     }
 
-    func testWarningValidation() {
+    func testWarningValidation() throws {
         let validation = """
         {
           "type": "required",
@@ -43,7 +46,10 @@ class ValidationTests: SwiftUIAssetUnitTestCase {
         """
         let dismissExpect = XCTestExpectation(description: "dismiss called")
 
-        guard var val = try? JSONDecoder().decode(ValidationData.self, from: validation.data(using: .utf8)!) else {
+        guard var val = try? JSONDecoder().decode(
+            ValidationData.self,
+            from: try XCTUnwrap(validation.data(using: .utf8))
+        ) else {
             return XCTFail("could not get validation")
         }
         val.dismiss = getWrappedFunction {

--- a/plugins/stage-revert-data/ios/Sources/StageRevertDataPlugin.swift
+++ b/plugins/stage-revert-data/ios/Sources/StageRevertDataPlugin.swift
@@ -2,25 +2,29 @@ import Foundation
 import JavaScriptCore
 
 #if SWIFT_PACKAGE
-import PlayerUI
+    import PlayerUI
 #endif
 
-/**
- Plugin to stage data changes until an approved transition is made
- */
+/// Plugin to stage data changes until an approved transition is made
 public class StageRevertDataPlugin: JSBasePlugin, NativePlugin {
-    /**
-     Constructs the StageRevertDataPlugin
-     */
+    /// Constructs the StageRevertDataPlugin
     public convenience init() {
-        self.init(fileName: "StageRevertDataPlugin.native", pluginName: "StageRevertDataPlugin.StageRevertDataPlugin")
+        self.init(
+            fileName: "StageRevertDataPlugin.native",
+            pluginName: "StageRevertDataPlugin.StageRevertDataPlugin"
+        )
     }
 
     override open func getUrlForFile(fileName: String) -> URL? {
         #if SWIFT_PACKAGE
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
+            ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
         #else
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle(for: StageRevertDataPlugin.self), pathComponent: "PlayerUI_StageRevertDataPlugin.bundle")
+            ResourceUtilities.urlForFile(
+                name: fileName,
+                ext: "js",
+                bundle: Bundle(for: StageRevertDataPlugin.self),
+                pathComponent: "PlayerUI_StageRevertDataPlugin.bundle"
+            )
         #endif
     }
 }

--- a/plugins/stage-revert-data/ios/Tests/StageRevertDataPluginTests.swift
+++ b/plugins/stage-revert-data/ios/Tests/StageRevertDataPluginTests.swift
@@ -1,11 +1,11 @@
 import Foundation
-import XCTest
 @testable import PlayerUI
-@testable import PlayerUITestUtilitiesCore
 @testable import PlayerUIStageRevertDataPlugin
+@testable import PlayerUITestUtilitiesCore
+import XCTest
 
 class StageRevertDataPluginTests: XCTestCase {
-    let json = """
+    private let json = """
     {
       "id": "minimal",
       "views": [
@@ -63,7 +63,7 @@ class StageRevertDataPluginTests: XCTestCase {
       }
     }
     """
-    
+
     func testStageRevertDataPluginStagesData() {
         let expected = XCTestExpectation(description: "data did not change")
         let player = HeadlessPlayerImpl(plugins: [StageRevertDataPlugin()])
@@ -83,11 +83,13 @@ class StageRevertDataPluginTests: XCTestCase {
             }
         }
 
-        player.hooks?.flowController.tap({ flowController in
+        player.hooks?.flowController.tap { flowController in
             flowController.hooks.flow.tap { flow in
                 flow.hooks.afterTransition.tap { flowInstance in
                     guard flowInstance.currentState?.name == "VIEW_3" else {
-                        (player.state as? InProgressState)?.controllers?.data.set(transaction: ["name": "Test"])
+                        (player.state as? InProgressState)?.controllers?
+                            .data
+                            .set(transaction: ["name": "Test"])
                         do {
                             try flowController.transition(with: "clear")
                         } catch {
@@ -97,9 +99,9 @@ class StageRevertDataPluginTests: XCTestCase {
                     }
                 }
             }
-        })
+        }
 
-        player.start(flow: json, completion: {_ in})
+        player.start(flow: json, completion: { _ in })
         wait(for: [expected], timeout: 1)
     }
 
@@ -122,11 +124,13 @@ class StageRevertDataPluginTests: XCTestCase {
             }
         }
 
-        player.hooks?.flowController.tap({ flowController in
+        player.hooks?.flowController.tap { flowController in
             flowController.hooks.flow.tap { flow in
                 flow.hooks.afterTransition.tap { flowInstance in
                     guard flowInstance.currentState?.name == "VIEW_2" else {
-                        (player.state as? InProgressState)?.controllers?.data.set(transaction: ["name": "Test"])
+                        (player.state as? InProgressState)?.controllers?
+                            .data
+                            .set(transaction: ["name": "Test"])
                         do {
                             try flowController.transition(with: "commit")
                         } catch {
@@ -136,9 +140,9 @@ class StageRevertDataPluginTests: XCTestCase {
                     }
                 }
             }
-        })
+        }
 
-        player.start(flow: json, completion: {_ in})
+        player.start(flow: json, completion: { _ in })
         wait(for: [expected], timeout: 1)
     }
 }

--- a/plugins/transition/swiftui/Sources/TransitionPlugin.swift
+++ b/plugins/transition/swiftui/Sources/TransitionPlugin.swift
@@ -1,15 +1,13 @@
 import Combine
-import SwiftUI
 import SwiftHooks
+import SwiftUI
 
 #if SWIFT_PACKAGE
-import PlayerUI
-import PlayerUISwiftUI
+    import PlayerUI
+    import PlayerUISwiftUI
 #endif
 
-/**
- A plugin to supply transition animations for initial flow load and between views in a flow
- */
+/// A plugin to supply transition animations for initial flow load and between views in a flow
 public class TransitionPlugin: NativePlugin, ManagedPlayerPlugin {
     public var pluginName: String = "TransitionPlugin"
 
@@ -19,14 +17,12 @@ public class TransitionPlugin: NativePlugin, ManagedPlayerPlugin {
     private let pushTransition: PlayerViewTransition
     private let popTransition: PlayerViewTransition
 
-    /**
-     Initializes a `TransitionPlugin` with transition information.
-    
-     - parameters:
-        - stateTransition: The transition to use when the loaded state of managed player changes
-        - pushTransition:  The transition to use when views are pushed in the same flow
-        - popTransition:   The transition to use when views are popped in the same flow
-     */
+    /// Initializes a `TransitionPlugin` with transition information.
+    ///
+    /// - parameters:
+    ///   - stateTransition: The transition to use when the loaded state of managed player changes
+    ///   - pushTransition:  The transition to use when views are pushed in the same flow
+    ///   - popTransition:   The transition to use when views are popped in the same flow
     public init(
         stateTransition: PlayerViewTransition = .fadeInSlideOut,
         pushTransition: PlayerViewTransition = .push,
@@ -37,10 +33,10 @@ public class TransitionPlugin: NativePlugin, ManagedPlayerPlugin {
         self.popTransition = popTransition
     }
 
-    public func apply<P>(player: P) where P: HeadlessPlayer {
+    public func apply<P: HeadlessPlayer>(player: P) {
         guard let player = player as? SwiftUIPlayer else { return }
-        let pushTransition = self.pushTransition
-        let popTransition = self.popTransition
+        let pushTransition = pushTransition
+        let popTransition = popTransition
         player.hooks?.transition.tapNavigationStack(
             name: pluginName,
             player: player,
@@ -50,20 +46,26 @@ public class TransitionPlugin: NativePlugin, ManagedPlayerPlugin {
     }
 
     public func apply(_ model: ManagedPlayerViewModel) {
-        let stateTransition = self.stateTransition
+        let stateTransition = stateTransition
         model.stateTransition.tap(name: pluginName, id: tapId) { .bail(stateTransition) }
     }
 }
 
 private extension SyncBailHook where Parameters == Void, ReturnType == PlayerViewTransition {
-    /// Taps a standard navigation stack transition onto the supplied player. This will maintain a list of view
+    /// Taps a standard navigation stack transition onto the supplied player. This will maintain a
+    /// list of view
     /// identifiers and apply push/pop transitions based on the navigation stack.
-    func tapNavigationStack(name: String, player: SwiftUIPlayer, push: PlayerViewTransition = .push, pop: PlayerViewTransition = .pop) {
+    func tapNavigationStack(
+        name: String,
+        player: SwiftUIPlayer,
+        push: PlayerViewTransition = .push,
+        pop: PlayerViewTransition = .pop
+    ) {
         // keep track of the root view ids we navigate through
         var navStack: [String] = (player.assetRegistry.root?.id).map { [$0] } ?? []
 
-        // updates the navigation stack and returns a transtion appropriate for
-        // the push/pop/none operation that is occurring
+        /// updates the navigation stack and returns a transtion appropriate for
+        /// the push/pop/none operation that is occurring
         func updateNavStack(_ currentId: String?) -> PlayerViewTransition {
             // if there's no id currently clear the stack and return a pop
             guard let id = currentId else {
@@ -91,7 +93,8 @@ private extension SyncBailHook where Parameters == Void, ReturnType == PlayerVie
 }
 
 public extension PlayerViewTransition {
-    /// Transition that slides views in from the trailing edge and out from to the leading edge of the screen
+    /// Transition that slides views in from the trailing edge and out from to the leading edge of
+    /// the screen
     static let slideInSlideOut: PlayerViewTransition = push
 
     /// Transition that slides views in from the trailing edge and fades out views on removal
@@ -102,36 +105,44 @@ public extension PlayerViewTransition {
     )
 
     /// Transition that fades views in and slides out to the leading edge of the screen on removal
-    static let fadeInSlideOut = PlayerViewTransition(
+    static let fadeInSlideOut: PlayerViewTransition = .init(
         name: .fadeInSlideOut,
         transition: .asymmetric(insertion: .opacity, removal: .move(edge: .leading)),
         animationCurve: .inoutDefault
     )
 
     /// A standard navigation push transition
-    static let push = PlayerViewTransition(name: .push, transition: .push, animationCurve: .inoutDefault)
+    static let push: PlayerViewTransition = .init(
+        name: .push,
+        transition: .push,
+        animationCurve: .inoutDefault
+    )
 
     /// A standard navigation pop transition
-    static let pop = PlayerViewTransition(name: .pop, transition: .pop, animationCurve: .inoutDefault)
+    static let pop: PlayerViewTransition = .init(
+        name: .pop,
+        transition: .pop,
+        animationCurve: .inoutDefault
+    )
 }
 
 public extension PlayerViewTransition.Name {
-    static let slideInFadeOut = Self(rawValue: "slideInFadeOut")
-    static let fadeInSlideOut = Self(rawValue: "fadeInSlideOut")
-    static let push = Self(rawValue: "push")
-    static let pop = Self(rawValue: "pop")
+    static let slideInFadeOut: Self = .init(rawValue: "slideInFadeOut")
+    static let fadeInSlideOut: Self = .init(rawValue: "fadeInSlideOut")
+    static let push: Self = .init(rawValue: "push")
+    static let pop: Self = .init(rawValue: "pop")
 }
 
 private extension Animation {
-    static let inoutDefault = Animation.easeInOut(duration: 0.3)
+    static let inoutDefault: Animation = .easeInOut(duration: 0.3)
 }
 
 extension AnyTransition {
-    static let push = AnyTransition.asymmetric(
+    static let push: AnyTransition = .asymmetric(
         insertion: .move(edge: .trailing),
         removal: .move(edge: .leading)
     )
-    static let pop  = AnyTransition.asymmetric(
+    static let pop: AnyTransition = .asymmetric(
         insertion: .move(edge: .leading),
         removal: .move(edge: .trailing)
     )

--- a/plugins/transition/swiftui/Sources/TransitionPlugin.swift
+++ b/plugins/transition/swiftui/Sources/TransitionPlugin.swift
@@ -1,13 +1,10 @@
 import Combine
-import SwiftUI
-import SwiftHooks
-
 import PlayerUI
 import PlayerUISwiftUI
+import SwiftHooks
+import SwiftUI
 
-/**
- A plugin to supply transition animations for initial flow load and between views in a flow
- */
+/// A plugin to supply transition animations for initial flow load and between views in a flow
 public class TransitionPlugin: NativePlugin, ManagedPlayerPlugin {
     public var pluginName: String = "TransitionPlugin"
 
@@ -17,14 +14,12 @@ public class TransitionPlugin: NativePlugin, ManagedPlayerPlugin {
     private let pushTransition: PlayerViewTransition
     private let popTransition: PlayerViewTransition
 
-    /**
-     Initializes a `TransitionPlugin` with transition information.
-    
-     - parameters:
-        - stateTransition: The transition to use when the loaded state of managed player changes
-        - pushTransition:  The transition to use when views are pushed in the same flow
-        - popTransition:   The transition to use when views are popped in the same flow
-     */
+    /// Initializes a `TransitionPlugin` with transition information.
+    ///
+    /// - parameters:
+    ///   - stateTransition: The transition to use when the loaded state of managed player changes
+    ///   - pushTransition:  The transition to use when views are pushed in the same flow
+    ///   - popTransition:   The transition to use when views are popped in the same flow
     public init(
         stateTransition: PlayerViewTransition = .fadeInSlideOut,
         pushTransition: PlayerViewTransition = .push,
@@ -35,10 +30,10 @@ public class TransitionPlugin: NativePlugin, ManagedPlayerPlugin {
         self.popTransition = popTransition
     }
 
-    public func apply<P>(player: P) where P: HeadlessPlayer {
+    public func apply<P: HeadlessPlayer>(player: P) {
         guard let player = player as? SwiftUIPlayer else { return }
-        let pushTransition = self.pushTransition
-        let popTransition = self.popTransition
+        let pushTransition = pushTransition
+        let popTransition = popTransition
         player.hooks?.transition.tapNavigationStack(
             name: pluginName,
             player: player,
@@ -48,20 +43,26 @@ public class TransitionPlugin: NativePlugin, ManagedPlayerPlugin {
     }
 
     public func apply(_ model: ManagedPlayerViewModel) {
-        let stateTransition = self.stateTransition
+        let stateTransition = stateTransition
         model.stateTransition.tap(name: pluginName, id: tapId) { .bail(stateTransition) }
     }
 }
 
 private extension SyncBailHook where Parameters == Void, ReturnType == PlayerViewTransition {
-    /// Taps a standard navigation stack transition onto the supplied player. This will maintain a list of view
+    /// Taps a standard navigation stack transition onto the supplied player. This will maintain a
+    /// list of view
     /// identifiers and apply push/pop transitions based on the navigation stack.
-    func tapNavigationStack(name: String, player: SwiftUIPlayer, push: PlayerViewTransition = .push, pop: PlayerViewTransition = .pop) {
+    func tapNavigationStack(
+        name: String,
+        player: SwiftUIPlayer,
+        push: PlayerViewTransition = .push,
+        pop: PlayerViewTransition = .pop
+    ) {
         // keep track of the root view ids we navigate through
         var navStack: [String] = (player.assetRegistry.root?.id).map { [$0] } ?? []
 
-        // updates the navigation stack and returns a transtion appropriate for
-        // the push/pop/none operation that is occurring
+        /// updates the navigation stack and returns a transtion appropriate for
+        /// the push/pop/none operation that is occurring
         func updateNavStack(_ currentId: String?) -> PlayerViewTransition {
             // if there's no id currently clear the stack and return a pop
             guard let id = currentId else {
@@ -89,7 +90,8 @@ private extension SyncBailHook where Parameters == Void, ReturnType == PlayerVie
 }
 
 public extension PlayerViewTransition {
-    /// Transition that slides views in from the trailing edge and out from to the leading edge of the screen
+    /// Transition that slides views in from the trailing edge and out from to the leading edge of
+    /// the screen
     static let slideInSlideOut: PlayerViewTransition = push
 
     /// Transition that slides views in from the trailing edge and fades out views on removal
@@ -100,36 +102,44 @@ public extension PlayerViewTransition {
     )
 
     /// Transition that fades views in and slides out to the leading edge of the screen on removal
-    static let fadeInSlideOut = PlayerViewTransition(
+    static let fadeInSlideOut: PlayerViewTransition = .init(
         name: .fadeInSlideOut,
         transition: .asymmetric(insertion: .opacity, removal: .move(edge: .leading)),
         animationCurve: .inoutDefault
     )
 
     /// A standard navigation push transition
-    static let push = PlayerViewTransition(name: .push, transition: .push, animationCurve: .inoutDefault)
+    static let push: PlayerViewTransition = .init(
+        name: .push,
+        transition: .push,
+        animationCurve: .inoutDefault
+    )
 
     /// A standard navigation pop transition
-    static let pop = PlayerViewTransition(name: .pop, transition: .pop, animationCurve: .inoutDefault)
+    static let pop: PlayerViewTransition = .init(
+        name: .pop,
+        transition: .pop,
+        animationCurve: .inoutDefault
+    )
 }
 
 public extension PlayerViewTransition.Name {
-    static let slideInFadeOut = Self(rawValue: "slideInFadeOut")
-    static let fadeInSlideOut = Self(rawValue: "fadeInSlideOut")
-    static let push = Self(rawValue: "push")
-    static let pop = Self(rawValue: "pop")
+    static let slideInFadeOut: Self = .init(rawValue: "slideInFadeOut")
+    static let fadeInSlideOut: Self = .init(rawValue: "fadeInSlideOut")
+    static let push: Self = .init(rawValue: "push")
+    static let pop: Self = .init(rawValue: "pop")
 }
 
 private extension Animation {
-    static let inoutDefault = Animation.easeInOut(duration: 0.3)
+    static let inoutDefault: Animation = .easeInOut(duration: 0.3)
 }
 
 extension AnyTransition {
-    static let push = AnyTransition.asymmetric(
+    static let push: AnyTransition = .asymmetric(
         insertion: .move(edge: .trailing),
         removal: .move(edge: .leading)
     )
-    static let pop  = AnyTransition.asymmetric(
+    static let pop: AnyTransition = .asymmetric(
         insertion: .move(edge: .leading),
         removal: .move(edge: .trailing)
     )

--- a/plugins/transition/swiftui/Sources/TransitionPlugin.swift
+++ b/plugins/transition/swiftui/Sources/TransitionPlugin.swift
@@ -30,7 +30,7 @@ public class TransitionPlugin: NativePlugin, ManagedPlayerPlugin {
         self.popTransition = popTransition
     }
 
-    public func apply<P: HeadlessPlayer>(player: P) {
+    public func apply(player: some HeadlessPlayer) {
         guard let player = player as? SwiftUIPlayer else { return }
         let pushTransition = pushTransition
         let popTransition = popTransition

--- a/plugins/transition/swiftui/ViewInspector/TransitionPluginTests.swift
+++ b/plugins/transition/swiftui/ViewInspector/TransitionPluginTests.swift
@@ -6,23 +6,18 @@
 //  Copyright © 2021 CocoaPods. All rights reserved.
 //
 
-import Foundation
-import XCTest
-import SwiftUI
-import ViewInspector
 import Combine
-
+import Foundation
 @testable import PlayerUI
 @testable import PlayerUIInternalTestUtilities
 @testable import PlayerUIReferenceAssets
 @testable import PlayerUISwiftUI
 @testable import PlayerUITransitionPlugin
+import SwiftUI
+import ViewInspector
+import XCTest
 
 class TransitionPluginTests: XCTestCase {
-    open override func setUp() {
-        XCUIApplication().terminate()
-    }
-
     func testTransitionPluginStateTransitions() {
         let flow = TestFlowManager()
         let model = ManagedPlayerViewModel(manager: flow) { _ in }
@@ -33,25 +28,33 @@ class TransitionPluginTests: XCTestCase {
 
     func testTransitionPluginDefaultTransitions() throws {
         let plugin = TransitionPlugin(pushTransition: .test1, popTransition: .test2)
-        let player = SwiftUIPlayer(flow: FlowData.MULTIPAGE, plugins: [ReferenceAssetsPlugin(), plugin])
+        let player = SwiftUIPlayer(
+            flow: FlowData.MULTIPAGE,
+            plugins: [ReferenceAssetsPlugin(), plugin]
+        )
 
         ViewHosting.host(view: player)
 
-        func callTransitionAndAssert(expectedTransition: PlayerViewTransition, description: String) {
+        func callTransitionAndAssert(expectedTransition: PlayerViewTransition,
+                                     description: String) {
             let transitionExpectation = XCTestExpectation(description: "Waiting for \(description)")
             var capturedTransition: PlayerViewTransition?
 
-            DispatchQueue.main.async {
-                capturedTransition = player.hooks?.transition.call()
-                // Delay the assertion to allow for any post-call processing
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                    XCTAssertEqual(capturedTransition, expectedTransition, "Transition for \(description) should be \(expectedTransition)")
-                    transitionExpectation.fulfill()
+            DispatchQueue.main
+                .async {
+                    capturedTransition = player.hooks?.transition.call()
+                    // Delay the assertion to allow for any post-call processing
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                        XCTAssertEqual(
+                            capturedTransition,
+                            expectedTransition,
+                            "Transition for \(description) should be \(expectedTransition)"
+                        )
+                        transitionExpectation.fulfill()
+                    }
                 }
-            }
             wait(for: [transitionExpectation], timeout: 3.0)
         }
-
 
         // Check initial transition
         callTransitionAndAssert(expectedTransition: .identity, description: "initial state")
@@ -77,14 +80,26 @@ class TransitionPluginTests: XCTestCase {
         ViewHosting.expel()
     }
 
+    override open func setUp() {
+        XCUIApplication().terminate()
+    }
+
     struct TestFlowManager: FlowManager {
-        func next(_ result: CompletedState?) async throws -> NextState {
-            return .flow("")
+        func next(_: CompletedState?) async throws -> NextState {
+            .flow("")
         }
     }
 }
 
 private extension PlayerViewTransition {
-    static let test1 = PlayerViewTransition(name: Name(rawValue: "test1"), transition: .opacity, animationCurve: .default)
-    static let test2 = PlayerViewTransition(name: Name(rawValue: "test2"), transition: .identity, animationCurve: .default)
+    static let test1: PlayerViewTransition = .init(
+        name: Name(rawValue: "test1"),
+        transition: .opacity,
+        animationCurve: .default
+    )
+    static let test2: PlayerViewTransition = .init(
+        name: Name(rawValue: "test2"),
+        transition: .identity,
+        animationCurve: .default
+    )
 }

--- a/plugins/transition/swiftui/ViewInspector/TransitionPluginTests.swift
+++ b/plugins/transition/swiftui/ViewInspector/TransitionPluginTests.swift
@@ -6,23 +6,18 @@
 //  Copyright © 2021 Intuit. All rights reserved.
 //
 
-import Foundation
-import XCTest
-import SwiftUI
-import ViewInspector
 import Combine
-
+import Foundation
 @testable import PlayerUI
 @testable import PlayerUIInternalTestUtilities
 @testable import PlayerUIReferenceAssets
 @testable import PlayerUISwiftUI
 @testable import PlayerUITransitionPlugin
+import SwiftUI
+import ViewInspector
+import XCTest
 
 class TransitionPluginTests: XCTestCase {
-    open override func setUp() {
-        XCUIApplication().terminate()
-    }
-
     func testTransitionPluginStateTransitions() {
         let flow = TestFlowManager()
         let model = ManagedPlayerViewModel(manager: flow) { _ in }
@@ -33,25 +28,33 @@ class TransitionPluginTests: XCTestCase {
 
     func testTransitionPluginDefaultTransitions() throws {
         let plugin = TransitionPlugin(pushTransition: .test1, popTransition: .test2)
-        let player = SwiftUIPlayer(flow: FlowData.MULTIPAGE, plugins: [ReferenceAssetsPlugin(), plugin])
+        let player = SwiftUIPlayer(
+            flow: FlowData.MULTIPAGE,
+            plugins: [ReferenceAssetsPlugin(), plugin]
+        )
 
         ViewHosting.host(view: player)
 
-        func callTransitionAndAssert(expectedTransition: PlayerViewTransition, description: String) {
+        func callTransitionAndAssert(expectedTransition: PlayerViewTransition,
+                                     description: String) {
             let transitionExpectation = XCTestExpectation(description: "Waiting for \(description)")
             var capturedTransition: PlayerViewTransition?
 
-            DispatchQueue.main.async {
-                capturedTransition = player.hooks?.transition.call()
-                // Delay the assertion to allow for any post-call processing
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                    XCTAssertEqual(capturedTransition, expectedTransition, "Transition for \(description) should be \(expectedTransition)")
-                    transitionExpectation.fulfill()
+            DispatchQueue.main
+                .async {
+                    capturedTransition = player.hooks?.transition.call()
+                    // Delay the assertion to allow for any post-call processing
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                        XCTAssertEqual(
+                            capturedTransition,
+                            expectedTransition,
+                            "Transition for \(description) should be \(expectedTransition)"
+                        )
+                        transitionExpectation.fulfill()
+                    }
                 }
-            }
             wait(for: [transitionExpectation], timeout: 3.0)
         }
-
 
         // Check initial transition
         callTransitionAndAssert(expectedTransition: .identity, description: "initial state")
@@ -77,14 +80,26 @@ class TransitionPluginTests: XCTestCase {
         ViewHosting.expel()
     }
 
+    override open func setUp() {
+        XCUIApplication().terminate()
+    }
+
     struct TestFlowManager: FlowManager {
-        func next(result: CompletedState?) async throws -> String? {
-            return ""
+        func next(result _: CompletedState?) async throws -> String? {
+            ""
         }
     }
 }
 
 private extension PlayerViewTransition {
-    static let test1 = PlayerViewTransition(name: Name(rawValue: "test1"), transition: .opacity, animationCurve: .default)
-    static let test2 = PlayerViewTransition(name: Name(rawValue: "test2"), transition: .identity, animationCurve: .default)
+    static let test1: PlayerViewTransition = .init(
+        name: Name(rawValue: "test1"),
+        transition: .opacity,
+        animationCurve: .default
+    )
+    static let test2: PlayerViewTransition = .init(
+        name: Name(rawValue: "test2"),
+        transition: .identity,
+        animationCurve: .default
+    )
 }

--- a/plugins/types-provider/ios/Sources/Types/CustomType.swift
+++ b/plugins/types-provider/ios/Sources/Types/CustomType.swift
@@ -1,40 +1,31 @@
-/**
- A Custom type to register with Player, with pre-determined validations and formatters
- */
+/// A Custom type to register with Player, with pre-determined validations and formatters
 public struct CustomType {
     /// The Type to register this CustomType as
     let type: String
 
-    /**
-     Any additional validations that are associated with this property
-     These will add to any base validations associated with the "type"
-    */
+    /// Any additional validations that are associated with this property
+    /// These will add to any base validations associated with the "type"
     let validation: [ValidationReference]
 
-    /**
-     A reference to a specific data format to use.
-     If none is specified, will fallback to that of the base type
-    */
+    /// A reference to a specific data format to use.
+    /// If none is specified, will fallback to that of the base type
     let format: FormatReference?
 
     /// The referenced object represents an array rather than an object
     let isArray: Bool
 
-    /**
-     A default value for this property.
-     Any reads for this property will result in this default value being written to the model.
-    */
+    /// A default value for this property.
+    /// Any reads for this property will result in this default value being written to the model.
     let defaultValue: Any?
 
-    /**
-     Creates a CustomType definition
-     - parameters:
-        - type: The type to register this as
-        - validation: A list of validations to run for this type
-        - format: A formatter to run for this type
-        - isArray: Whether or not this is an Array type
-        - defaultValue: A default value to use for this type if the value is undefined in the data model
-     */
+    /// Creates a CustomType definition
+    /// - parameters:
+    ///   - type: The type to register this as
+    ///   - validation: A list of validations to run for this type
+    ///   - format: A formatter to run for this type
+    ///   - isArray: Whether or not this is an Array type
+    ///   - defaultValue: A default value to use for this type if the value is undefined in the data
+    /// model
     public init(
         type: String,
         validation: [ValidationReference] = [],

--- a/plugins/types-provider/ios/Sources/Types/FormatDeclaration.swift
+++ b/plugins/types-provider/ios/Sources/Types/FormatDeclaration.swift
@@ -1,31 +1,21 @@
-/**
- A declaration of a new formatter
- This can have format and deformat, or either
- */
+/// A declaration of a new formatter
+/// This can have format and deformat, or either
 public struct FormatDeclaration {
-    /**
-     The name of the formatter.
-     This corresponds to the 'type' format property when creating a DataType
-    */
+    /// The name of the formatter.
+    /// This corresponds to the 'type' format property when creating a DataType
     public let name: String
-    /**
-     An optional function to format data for display to the user.
-     This goes from dataModel -> UI display
-    */
+    /// An optional function to format data for display to the user.
+    /// This goes from dataModel -> UI display
     public let format: ((Any, [String: Any]) -> Any)?
-    /**
-     An optional function for undo the action of a format function for storage.
-     This goes from UI -> dataModel
-    */
+    /// An optional function for undo the action of a format function for storage.
+    /// This goes from UI -> dataModel
     public let deformat: ((Any, [String: Any]) -> Any)?
 
-    /**
-     Constructs a new formatter/deformatter
-     - parameters:
-        - name: The name of the formatter
-        - format: A function to run for formatting
-        - deformat: A function to run for deformatting
-     */
+    /// Constructs a new formatter/deformatter
+    /// - parameters:
+    ///   - name: The name of the formatter
+    ///   - format: A function to run for formatting
+    ///   - deformat: A function to run for deformatting
     public init(
         name: String,
         format: ((Any, [String: Any]) -> Any)? = nil,

--- a/plugins/types-provider/ios/Sources/Types/FormatReference.swift
+++ b/plugins/types-provider/ios/Sources/Types/FormatReference.swift
@@ -1,6 +1,4 @@
-/**
- A reference to a format to associate with a type
- */
+/// A reference to a format to associate with a type
 public struct FormatReference {
     /// The name of the formatter (and de-formatter) to use
     public let type: String
@@ -8,12 +6,10 @@ public struct FormatReference {
     /// Any additional properties will be passed as options to the formatter function
     public let options: [String: Any]
 
-    /**
-     Construct a FormatReference object. Used for referencing a formatter in a `CustomType`
-     - parameters:
-        - type: The format type
-        - options: Additional options to pass to the formatter
-     */
+    /// Construct a FormatReference object. Used for referencing a formatter in a `CustomType`
+    /// - parameters:
+    ///   - type: The format type
+    ///   - options: Additional options to pass to the formatter
     public init(type: String, options: [String: Any]? = nil) {
         self.type = type
         self.options = options ?? [:]

--- a/plugins/types-provider/ios/Sources/Types/ValidationDeclaration.swift
+++ b/plugins/types-provider/ios/Sources/Types/ValidationDeclaration.swift
@@ -1,6 +1,4 @@
-/**
- A declaration of a new Validation
- */
+/// A declaration of a new Validation
 public struct ValidationDeclaration {
     /// The Type to register this validation as
     public let type: String
@@ -8,12 +6,10 @@ public struct ValidationDeclaration {
     /// A function to run for validation, taking parameters (context, value, options)
     public let handler: (Any, Any, [String: Any]) -> Any?
 
-    /**
-     Constructs a new validation function
-     - parameters:
-        - type: The type to register this validation as
-        - handler: The function to run as the validation function
-     */
+    /// Constructs a new validation function
+    /// - parameters:
+    ///   - type: The type to register this validation as
+    ///   - handler: The function to run as the validation function
     public init(type: String, handler: @escaping (Any, Any, [String: Any]) -> Any?) {
         self.type = type
         self.handler = handler

--- a/plugins/types-provider/ios/Sources/Types/ValidationReference.swift
+++ b/plugins/types-provider/ios/Sources/Types/ValidationReference.swift
@@ -1,11 +1,7 @@
-/**
- A reference to a validation, to associate with a type
- */
+/// A reference to a validation, to associate with a type
 public struct ValidationReference {
-    /**
-     The name of the referenced validation type
-     This will be used to lookup the proper handler
-    */
+    /// The name of the referenced validation type
+    /// This will be used to lookup the proper handler
     public let type: String
 
     /// An optional means of overriding the default message if the validation is triggered
@@ -20,15 +16,13 @@ public struct ValidationReference {
     /// Additional props to send down to a Validator
     public let options: [String: Any]?
 
-    /**
-     Construct a ValidationReference object, used for referencing a validation in a `CustomType`
-     - parameters:
-        - type: The type of validation
-        - message: An optional message to use for the validation
-        - severity: An optional severity to use for this validation
-        - trigger: An optional trigger for the validation
-        - options: Additional options passed to the validation function
-     */
+    /// Construct a ValidationReference object, used for referencing a validation in a `CustomType`
+    /// - parameters:
+    ///   - type: The type of validation
+    ///   - message: An optional message to use for the validation
+    ///   - severity: An optional severity to use for this validation
+    ///   - trigger: An optional trigger for the validation
+    ///   - options: Additional options passed to the validation function
     public init(
         type: String,
         message: String? = nil,

--- a/plugins/types-provider/ios/Sources/TypesProviderPlugin.swift
+++ b/plugins/types-provider/ios/Sources/TypesProviderPlugin.swift
@@ -9,12 +9,10 @@ import Foundation
 import JavaScriptCore
 
 #if SWIFT_PACKAGE
-import PlayerUI
+    import PlayerUI
 #endif
 
-/**
- Plugin for registering custom types Player
- */
+/// Plugin for registering custom types Player
 public class TypesProviderPlugin: JSBasePlugin, NativePlugin {
     /// The types to register
     private var types: [CustomType] = []
@@ -25,14 +23,17 @@ public class TypesProviderPlugin: JSBasePlugin, NativePlugin {
     /// The formatters to register
     private var formats: [FormatDeclaration] = []
 
-    /**
-     Constructs the TypesProviderPlugin
-     - parameters:
-        - types: The new Types to register, these can reference existing, or new custom validators/formatters
-        - validators: The new validation functions to register
-        - formats: The new formatters/deformatters to register
-     */
-    public convenience init(types: [CustomType], validators: [ValidationDeclaration], formats: [FormatDeclaration]) {
+    /// Constructs the TypesProviderPlugin
+    /// - parameters:
+    ///   - types: The new Types to register, these can reference existing, or new custom
+    /// validators/formatters
+    ///   - validators: The new validation functions to register
+    ///   - formats: The new formatters/deformatters to register
+    public convenience init(
+        types: [CustomType],
+        validators: [ValidationDeclaration],
+        formats: [FormatDeclaration]
+    ) {
         self.init(
             fileName: "TypesProviderPlugin.native",
             pluginName: "TypesProviderPlugin.TypesProviderPlugin"
@@ -42,39 +43,16 @@ public class TypesProviderPlugin: JSBasePlugin, NativePlugin {
         self.formats = formats
     }
 
-    override open func getUrlForFile(fileName: String) -> URL? {
-        #if SWIFT_PACKAGE
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
-        #else
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle(for: TypesProviderPlugin.self), pathComponent: "PlayerUI_TypesProviderPlugin.bundle")
-        #endif
-    }
-
-    /**
-     Gets the arguments for constructing the JS plugin
-     - returns: An array of arguments for construction
-     */
-    override public func getArguments() -> [Any] {
-        let constructionObj: [String: Any] = [
-            "types": self.types.map(typeToJs(_:)),
-            "formats": self.formats.compactMap(formatToJs(_:)),
-            "validators": self.validators.compactMap(validatorToJs(_:))
-        ]
-        return [constructionObj]
-    }
-
-    /**
-     Converts a CustomType to the appropriate dictionary format to pass to the JS plugin
-     - parameters:
-        - type: The CustomType to convert
-     - returns: A formatted dictionary
-     */
+    /// Converts a CustomType to the appropriate dictionary format to pass to the JS plugin
+    /// - parameters:
+    ///   - type: The CustomType to convert
+    /// - returns: A formatted dictionary
     public func typeToJs(_ type: CustomType) -> [String: Any] {
         var typeObj: [String: Any] = [
             "type": type.type,
             "validation": type.validation.map(valRefToDict(_:)),
             "format": formatRefToDict(type.format),
-            "isArray": type.isArray
+            "isArray": type.isArray,
         ]
         if let def = type.defaultValue {
             typeObj["defaultValue"] = def
@@ -82,25 +60,21 @@ public class TypesProviderPlugin: JSBasePlugin, NativePlugin {
         return typeObj
     }
 
-    /**
-     Converts a FormatReference to the appropriate dicionary format to pass to the JS plugin
-     - parameters:
-        - ref: The FormatReference to convert
-     - returns: A formatted dictionary
-     */
+    /// Converts a FormatReference to the appropriate dicionary format to pass to the JS plugin
+    /// - parameters:
+    ///   - ref: The FormatReference to convert
+    /// - returns: A formatted dictionary
     public func formatRefToDict(_ ref: FormatReference?) -> [String: Any] {
-        guard let ref = ref else { return [:] }
+        guard let ref else { return [:] }
         return ref.options.merging([
-            "type": ref.type
-        ], uniquingKeysWith: {$1})
+            "type": ref.type,
+        ], uniquingKeysWith: { $1 })
     }
 
-    /**
-    Converts a ValidationReference to the appropriate dicionary format to pass to the JS plugin
-    - parameters:
-       - ref: The ValidationReference to convert
-    - returns: A formatted dictionary
-    */
+    /// Converts a ValidationReference to the appropriate dicionary format to pass to the JS plugin
+    /// - parameters:
+    ///   - ref: The ValidationReference to convert
+    /// - returns: A formatted dictionary
     public func valRefToDict(_ ref: ValidationReference) -> [String: Any] {
         var valRef = (ref.options ?? [:])
         valRef["type"] = ref.type
@@ -116,49 +90,83 @@ public class TypesProviderPlugin: JSBasePlugin, NativePlugin {
         return valRef
     }
 
-    /**
-     Converts a ValidationDeclaration to a JSValue with the handler bound into a callable JS Block
-     - parameters:
-        - dec: The ValidationDeclaration to convert
-     - returns: JSValue representing an array with the type at index 0, and the handler function at index 1
-     */
+    /// Converts a ValidationDeclaration to a JSValue with the handler bound into a callable JS
+    /// Block
+    /// - parameters:
+    ///   - dec: The ValidationDeclaration to convert
+    /// - returns: JSValue representing an array with the type at index 0, and the handler function
+    /// at index 1
     public func validatorToJs(_ dec: ValidationDeclaration) -> JSValue? {
         let arr = JSValue(newArrayIn: context)
         arr?.setObject(dec.type, atIndexedSubscript: 0)
-        let callback: @convention(block) (JSValue, JSValue, JSValue) -> JSValue? = { (context, value, options) in
-            let castedOptions = options.toObject() as? [String: Any] ?? [:]
-            return JSValue(
-                object: dec.handler(context.toObject() as Any, value.toObject() as Any, castedOptions),
-                in: self.context
-            )
-        }
+        let callback: @convention(block) (JSValue, JSValue, JSValue)
+            -> JSValue? = { context, value, options in
+                let castedOptions = options.toObject() as? [String: Any] ?? [:]
+                return JSValue(
+                    object: dec.handler(
+                        context.toObject() as Any,
+                        value.toObject() as Any,
+                        castedOptions
+                    ),
+                    in: self.context
+                )
+            }
         arr?.setObject(callback, atIndexedSubscript: 1)
         return arr
     }
 
-    /**
-    Converts a FormatDeclaration to a JSValue with format/deformat bound into a callable JS Blocks
-    - parameters:
-       - dec: The FormatDeclaration to convert
-    - returns: JSValue representing an object with a name, format, and deformat properties
-    */
+    /// Converts a FormatDeclaration to a JSValue with format/deformat bound into a callable JS
+    /// Blocks
+    /// - parameters:
+    ///   - dec: The FormatDeclaration to convert
+    /// - returns: JSValue representing an object with a name, format, and deformat properties
     public func formatToJs(_ dec: FormatDeclaration) -> JSValue? {
         let val = JSValue(newObjectIn: context)
         val?.setValue(dec.name, forProperty: "name")
         if let format = dec.format {
-            let callback: @convention(block) (JSValue, JSValue) -> JSValue? = { (value, options) in
+            let callback: @convention(block) (JSValue, JSValue) -> JSValue? = { value, options in
                 let castedOptions = options.toObject() as? [String: Any] ?? [:]
-                return JSValue(object: format(value.toObject() as Any, castedOptions), in: self.context)
+                return JSValue(
+                    object: format(value.toObject() as Any, castedOptions),
+                    in: self.context
+                )
             }
             val?.setObject(callback, forKeyedSubscript: "format")
         }
         if let deformat = dec.deformat {
-            let callback: @convention(block) (JSValue, JSValue) -> JSValue? = { (value, options) in
+            let callback: @convention(block) (JSValue, JSValue) -> JSValue? = { value, options in
                 let castedOptions = options.toObject() as? [String: Any] ?? [:]
-                return JSValue(object: deformat(value.toObject() as Any, castedOptions), in: self.context)
+                return JSValue(
+                    object: deformat(value.toObject() as Any, castedOptions),
+                    in: self.context
+                )
             }
             val?.setObject(callback, forKeyedSubscript: "deformat")
         }
         return val
+    }
+
+    override open func getUrlForFile(fileName: String) -> URL? {
+        #if SWIFT_PACKAGE
+            ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
+        #else
+            ResourceUtilities.urlForFile(
+                name: fileName,
+                ext: "js",
+                bundle: Bundle(for: TypesProviderPlugin.self),
+                pathComponent: "PlayerUI_TypesProviderPlugin.bundle"
+            )
+        #endif
+    }
+
+    /// Gets the arguments for constructing the JS plugin
+    /// - returns: An array of arguments for construction
+    override public func getArguments() -> [Any] {
+        let constructionObj: [String: Any] = [
+            "types": types.map(typeToJs(_:)),
+            "formats": formats.compactMap(formatToJs(_:)),
+            "validators": validators.compactMap(validatorToJs(_:)),
+        ]
+        return [constructionObj]
     }
 }

--- a/plugins/types-provider/ios/Sources/TypesProviderPlugin.swift
+++ b/plugins/types-provider/ios/Sources/TypesProviderPlugin.swift
@@ -7,12 +7,9 @@
 
 import Foundation
 import JavaScriptCore
-
 import PlayerUI
 
-/**
- Plugin for registering custom types Player
- */
+/// Plugin for registering custom types Player
 public class TypesProviderPlugin: JSBasePlugin, NativePlugin {
     /// The types to register
     private var types: [CustomType] = []
@@ -23,14 +20,17 @@ public class TypesProviderPlugin: JSBasePlugin, NativePlugin {
     /// The formatters to register
     private var formats: [FormatDeclaration] = []
 
-    /**
-     Constructs the TypesProviderPlugin
-     - parameters:
-        - types: The new Types to register, these can reference existing, or new custom validators/formatters
-        - validators: The new validation functions to register
-        - formats: The new formatters/deformatters to register
-     */
-    public convenience init(types: [CustomType], validators: [ValidationDeclaration], formats: [FormatDeclaration]) {
+    /// Constructs the TypesProviderPlugin
+    /// - parameters:
+    ///   - types: The new Types to register, these can reference existing, or new custom
+    /// validators/formatters
+    ///   - validators: The new validation functions to register
+    ///   - formats: The new formatters/deformatters to register
+    public convenience init(
+        types: [CustomType],
+        validators: [ValidationDeclaration],
+        formats: [FormatDeclaration]
+    ) {
         self.init(
             fileName: "TypesProviderPlugin.native",
             pluginName: "TypesProviderPlugin.TypesProviderPlugin"
@@ -40,35 +40,16 @@ public class TypesProviderPlugin: JSBasePlugin, NativePlugin {
         self.formats = formats
     }
 
-    override open func getUrlForFile(fileName: String) -> URL? {
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
-    }
-
-    /**
-     Gets the arguments for constructing the JS plugin
-     - returns: An array of arguments for construction
-     */
-    override public func getArguments() -> [Any] {
-        let constructionObj: [String: Any] = [
-            "types": self.types.map(typeToJs(_:)),
-            "formats": self.formats.compactMap(formatToJs(_:)),
-            "validators": self.validators.compactMap(validatorToJs(_:))
-        ]
-        return [constructionObj]
-    }
-
-    /**
-     Converts a CustomType to the appropriate dictionary format to pass to the JS plugin
-     - parameters:
-        - type: The CustomType to convert
-     - returns: A formatted dictionary
-     */
+    /// Converts a CustomType to the appropriate dictionary format to pass to the JS plugin
+    /// - parameters:
+    ///   - type: The CustomType to convert
+    /// - returns: A formatted dictionary
     public func typeToJs(_ type: CustomType) -> [String: Any] {
         var typeObj: [String: Any] = [
             "type": type.type,
             "validation": type.validation.map(valRefToDict(_:)),
             "format": formatRefToDict(type.format),
-            "isArray": type.isArray
+            "isArray": type.isArray,
         ]
         if let def = type.defaultValue {
             typeObj["defaultValue"] = def
@@ -76,25 +57,21 @@ public class TypesProviderPlugin: JSBasePlugin, NativePlugin {
         return typeObj
     }
 
-    /**
-     Converts a FormatReference to the appropriate dicionary format to pass to the JS plugin
-     - parameters:
-        - ref: The FormatReference to convert
-     - returns: A formatted dictionary
-     */
+    /// Converts a FormatReference to the appropriate dicionary format to pass to the JS plugin
+    /// - parameters:
+    ///   - ref: The FormatReference to convert
+    /// - returns: A formatted dictionary
     public func formatRefToDict(_ ref: FormatReference?) -> [String: Any] {
-        guard let ref = ref else { return [:] }
+        guard let ref else { return [:] }
         return ref.options.merging([
-            "type": ref.type
-        ], uniquingKeysWith: {$1})
+            "type": ref.type,
+        ], uniquingKeysWith: { $1 })
     }
 
-    /**
-    Converts a ValidationReference to the appropriate dicionary format to pass to the JS plugin
-    - parameters:
-       - ref: The ValidationReference to convert
-    - returns: A formatted dictionary
-    */
+    /// Converts a ValidationReference to the appropriate dicionary format to pass to the JS plugin
+    /// - parameters:
+    ///   - ref: The ValidationReference to convert
+    /// - returns: A formatted dictionary
     public func valRefToDict(_ ref: ValidationReference) -> [String: Any] {
         var valRef = (ref.options ?? [:])
         valRef["type"] = ref.type
@@ -110,49 +87,74 @@ public class TypesProviderPlugin: JSBasePlugin, NativePlugin {
         return valRef
     }
 
-    /**
-     Converts a ValidationDeclaration to a JSValue with the handler bound into a callable JS Block
-     - parameters:
-        - dec: The ValidationDeclaration to convert
-     - returns: JSValue representing an array with the type at index 0, and the handler function at index 1
-     */
+    /// Converts a ValidationDeclaration to a JSValue with the handler bound into a callable JS
+    /// Block
+    /// - parameters:
+    ///   - dec: The ValidationDeclaration to convert
+    /// - returns: JSValue representing an array with the type at index 0, and the handler function
+    /// at index 1
     public func validatorToJs(_ dec: ValidationDeclaration) -> JSValue? {
         let arr = JSValue(newArrayIn: context)
         arr?.setObject(dec.type, atIndexedSubscript: 0)
-        let callback: @convention(block) (JSValue, JSValue, JSValue) -> JSValue? = { (context, value, options) in
-            let castedOptions = options.toObject() as? [String: Any] ?? [:]
-            return JSValue(
-                object: dec.handler(context.toObject() as Any, value.toObject() as Any, castedOptions),
-                in: self.context
-            )
-        }
+        let callback: @convention(block) (JSValue, JSValue, JSValue)
+            -> JSValue? = { context, value, options in
+                let castedOptions = options.toObject() as? [String: Any] ?? [:]
+                return JSValue(
+                    object: dec.handler(
+                        context.toObject() as Any,
+                        value.toObject() as Any,
+                        castedOptions
+                    ),
+                    in: self.context
+                )
+            }
         arr?.setObject(callback, atIndexedSubscript: 1)
         return arr
     }
 
-    /**
-    Converts a FormatDeclaration to a JSValue with format/deformat bound into a callable JS Blocks
-    - parameters:
-       - dec: The FormatDeclaration to convert
-    - returns: JSValue representing an object with a name, format, and deformat properties
-    */
+    /// Converts a FormatDeclaration to a JSValue with format/deformat bound into a callable JS
+    /// Blocks
+    /// - parameters:
+    ///   - dec: The FormatDeclaration to convert
+    /// - returns: JSValue representing an object with a name, format, and deformat properties
     public func formatToJs(_ dec: FormatDeclaration) -> JSValue? {
         let val = JSValue(newObjectIn: context)
         val?.setValue(dec.name, forProperty: "name")
         if let format = dec.format {
-            let callback: @convention(block) (JSValue, JSValue) -> JSValue? = { (value, options) in
+            let callback: @convention(block) (JSValue, JSValue) -> JSValue? = { value, options in
                 let castedOptions = options.toObject() as? [String: Any] ?? [:]
-                return JSValue(object: format(value.toObject() as Any, castedOptions), in: self.context)
+                return JSValue(
+                    object: format(value.toObject() as Any, castedOptions),
+                    in: self.context
+                )
             }
             val?.setObject(callback, forKeyedSubscript: "format")
         }
         if let deformat = dec.deformat {
-            let callback: @convention(block) (JSValue, JSValue) -> JSValue? = { (value, options) in
+            let callback: @convention(block) (JSValue, JSValue) -> JSValue? = { value, options in
                 let castedOptions = options.toObject() as? [String: Any] ?? [:]
-                return JSValue(object: deformat(value.toObject() as Any, castedOptions), in: self.context)
+                return JSValue(
+                    object: deformat(value.toObject() as Any, castedOptions),
+                    in: self.context
+                )
             }
             val?.setObject(callback, forKeyedSubscript: "deformat")
         }
         return val
+    }
+
+    override open func getUrlForFile(fileName: String) -> URL? {
+        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
+    }
+
+    /// Gets the arguments for constructing the JS plugin
+    /// - returns: An array of arguments for construction
+    override public func getArguments() -> [Any] {
+        let constructionObj: [String: Any] = [
+            "types": types.map(typeToJs(_:)),
+            "formats": formats.compactMap(formatToJs(_:)),
+            "validators": validators.compactMap(validatorToJs(_:)),
+        ]
+        return [constructionObj]
     }
 }

--- a/plugins/types-provider/ios/Tests/TypesProviderPluginTests.swift
+++ b/plugins/types-provider/ios/Tests/TypesProviderPluginTests.swift
@@ -7,10 +7,10 @@
 //
 
 import Foundation
-import XCTest
 import JavaScriptCore
 @testable import PlayerUI
 @testable import PlayerUITypesProviderPlugin
+import XCTest
 
 class TypesProviderPluginTests: XCTestCase {
     func testFormatReferenceConversion() {
@@ -20,7 +20,7 @@ class TypesProviderPluginTests: XCTestCase {
         let formatRef = FormatReference(type: "test", options: ["someOption": "someValue"])
         XCTAssertEqual(
             Set(["type", "someOption"]),
-            Set(plugin.formatRefToDict(formatRef).keys.map {$0})
+            Set(plugin.formatRefToDict(formatRef).keys.map { $0 })
         )
     }
 
@@ -31,7 +31,7 @@ class TypesProviderPluginTests: XCTestCase {
         let formatRef = FormatReference(type: "test")
         XCTAssertEqual(
             Set(["type"]),
-            Set(plugin.formatRefToDict(formatRef).keys.map {$0})
+            Set(plugin.formatRefToDict(formatRef).keys.map { $0 })
         )
     }
 
@@ -39,19 +39,25 @@ class TypesProviderPluginTests: XCTestCase {
         let plugin = TypesProviderPlugin(types: [], validators: [], formats: [])
         plugin.context = JSContext()
 
-        let validationRef = ValidationReference(type: "test", message: "Bad Value", severity: "error", trigger: "start", options: ["someOption": "someValue"])
+        let validationRef = ValidationReference(
+            type: "test",
+            message: "Bad Value",
+            severity: "error",
+            trigger: "start",
+            options: ["someOption": "someValue"]
+        )
 
         let validationRefExpect = Set([
             "type",
             "message",
             "severity",
             "trigger",
-            "someOption"
+            "someOption",
         ])
 
         XCTAssertEqual(
             validationRefExpect,
-            Set(plugin.valRefToDict(validationRef).keys.map {$0})
+            Set(plugin.valRefToDict(validationRef).keys.map { $0 })
         )
     }
 
@@ -59,18 +65,24 @@ class TypesProviderPluginTests: XCTestCase {
         let plugin = TypesProviderPlugin(types: [], validators: [], formats: [])
         plugin.context = JSContext()
 
-        let customType = CustomType(type: "", validation: [], format: nil, isArray: false, defaultValue: 1)
+        let customType = CustomType(
+            type: "",
+            validation: [],
+            format: nil,
+            isArray: false,
+            defaultValue: 1
+        )
         let customTypeExpect = Set([
             "type",
             "validation",
             "format",
             "isArray",
-            "defaultValue"
+            "defaultValue",
         ])
 
         XCTAssertEqual(
             customTypeExpect,
-            Set(plugin.typeToJs(customType).keys.map {$0})
+            Set(plugin.typeToJs(customType).keys.map { $0 })
         )
     }
 
@@ -79,7 +91,7 @@ class TypesProviderPluginTests: XCTestCase {
         plugin.context = JSContext()
 
         let validationExpectation = XCTestExpectation(description: "Validation Called")
-        let validation = ValidationDeclaration(type: "test", handler: {_, _, _ in
+        let validation = ValidationDeclaration(type: "test", handler: { _, _, _ in
             validationExpectation.fulfill()
         })
 
@@ -97,9 +109,9 @@ class TypesProviderPluginTests: XCTestCase {
 
         let formatDec = FormatDeclaration(
             name: "test",
-            format: {_, _ in
+            format: { _, _ in
                 formatExpectation.fulfill()
-            }, deformat: {_, _ in
+            }, deformat: { _, _ in
                 deformatExpectation.fulfill()
             }
         )

--- a/xcode/Package.resolved
+++ b/xcode/Package.resolved
@@ -1,39 +1,48 @@
 {
   "pins" : [
     {
-      "identity" : "mint",
+      "identity" : "collectionconcurrencykit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/yonaskolb/Mint.git",
+      "location" : "https://github.com/JohnSundell/CollectionConcurrencyKit.git",
       "state" : {
-        "revision" : "7bc67a0b925b949c8becc327bc08f56eeadc0051",
-        "version" : "0.18.0"
+        "revision" : "b4f23e24b5a1bff301efc5e70871083ca029ff95",
+        "version" : "0.2.0"
       }
     },
     {
-      "identity" : "pathkit",
+      "identity" : "cryptoswift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/kylef/PathKit.git",
+      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
       "state" : {
-        "revision" : "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
-        "version" : "1.0.1"
+        "revision" : "f2a627b84c1ff96f21ac2fcb623ab36142dd5512",
+        "version" : "1.10.0"
       }
     },
     {
-      "identity" : "rainbow",
+      "identity" : "sourcekitten",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/onevcat/Rainbow.git",
+      "location" : "https://github.com/jpsim/SourceKitten.git",
       "state" : {
-        "revision" : "cdf146ae671b2624917648b61c908d1244b98ca1",
-        "version" : "4.2.1"
+        "revision" : "6529c17fe80dd94843a3df7ed3e6a239790d5c91",
+        "version" : "0.37.3"
       }
     },
     {
-      "identity" : "spectre",
+      "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/kylef/Spectre.git",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "26cc5e9ae0947092c7139ef7ba612e34646086c7",
-        "version" : "0.10.1"
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    },
+    {
+      "identity" : "swift-filename-matcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ileitch/swift-filename-matcher",
+      "state" : {
+        "revision" : "eef5ac0b6b3cdc64b3039b037bed2def8a1edaeb",
+        "version" : "2.0.1"
       }
     },
     {
@@ -46,21 +55,48 @@
       }
     },
     {
-      "identity" : "swiftcli",
+      "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jakeheis/SwiftCLI.git",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "2e949055d9797c1a6bddcda0e58dada16cc8e970",
-        "version" : "6.0.3"
+        "revision" : "65b02a90ad2cc213e09309faeb7f6909e0a8577a",
+        "version" : "604.0.0-prerelease-2026-01-20"
       }
     },
     {
-      "identity" : "version",
+      "identity" : "swiftformat",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mxcl/Version.git",
+      "location" : "https://github.com/nicklockwood/SwiftFormat.git",
       "state" : {
-        "revision" : "3043fcd2a50375db76d89ff206a612471833d1c2",
-        "version" : "2.2.1"
+        "revision" : "397309e73621d6355d3a7fb832ca233ac9dd5254",
+        "version" : "0.61.0"
+      }
+    },
+    {
+      "identity" : "swiftlint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/SwiftLint.git",
+      "state" : {
+        "revision" : "88952528a590ed366c6f76f6bfb980b5ebdcefc1",
+        "version" : "0.63.2"
+      }
+    },
+    {
+      "identity" : "swiftytexttable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/scottrhoyt/SwiftyTextTable.git",
+      "state" : {
+        "revision" : "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "swxmlhash",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/drmohundro/SWXMLHash.git",
+      "state" : {
+        "revision" : "a853604c9e9a83ad9954c7e3d2a565273982471f",
+        "version" : "7.0.2"
       }
     },
     {
@@ -70,6 +106,15 @@
       "state" : {
         "revision" : "e9a06346499a3a889165647e3f23f8a7b2609a1c",
         "version" : "0.10.3"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "a27b21e0c81c5bf42049b897a62aaf387e80f279",
+        "version" : "6.2.2"
       }
     }
   ],

--- a/xcode/Package.resolved
+++ b/xcode/Package.resolved
@@ -1,48 +1,39 @@
 {
   "pins" : [
     {
-      "identity" : "collectionconcurrencykit",
+      "identity" : "mint",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/JohnSundell/CollectionConcurrencyKit.git",
+      "location" : "https://github.com/yonaskolb/Mint.git",
       "state" : {
-        "revision" : "b4f23e24b5a1bff301efc5e70871083ca029ff95",
-        "version" : "0.2.0"
+        "revision" : "7bc67a0b925b949c8becc327bc08f56eeadc0051",
+        "version" : "0.18.0"
       }
     },
     {
-      "identity" : "cryptoswift",
+      "identity" : "pathkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
+      "location" : "https://github.com/kylef/PathKit.git",
       "state" : {
-        "revision" : "e45a26384239e028ec87fbcc788f513b67e10d8f",
-        "version" : "1.9.0"
+        "revision" : "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
+        "version" : "1.0.1"
       }
     },
     {
-      "identity" : "sourcekitten",
+      "identity" : "rainbow",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jpsim/SourceKitten.git",
+      "location" : "https://github.com/onevcat/Rainbow.git",
       "state" : {
-        "revision" : "6529c17fe80dd94843a3df7ed3e6a239790d5c91",
-        "version" : "0.37.3"
+        "revision" : "cdf146ae671b2624917648b61c908d1244b98ca1",
+        "version" : "4.2.1"
       }
     },
     {
-      "identity" : "swift-argument-parser",
+      "identity" : "spectre",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "location" : "https://github.com/kylef/Spectre.git",
       "state" : {
-        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
-        "version" : "1.7.1"
-      }
-    },
-    {
-      "identity" : "swift-filename-matcher",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ileitch/swift-filename-matcher",
-      "state" : {
-        "revision" : "eef5ac0b6b3cdc64b3039b037bed2def8a1edaeb",
-        "version" : "2.0.1"
+        "revision" : "26cc5e9ae0947092c7139ef7ba612e34646086c7",
+        "version" : "0.10.1"
       }
     },
     {
@@ -55,39 +46,21 @@
       }
     },
     {
-      "identity" : "swift-syntax",
+      "identity" : "swiftcli",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "location" : "https://github.com/jakeheis/SwiftCLI.git",
       "state" : {
-        "revision" : "65b02a90ad2cc213e09309faeb7f6909e0a8577a",
-        "version" : "604.0.0-prerelease-2026-01-20"
+        "revision" : "2e949055d9797c1a6bddcda0e58dada16cc8e970",
+        "version" : "6.0.3"
       }
     },
     {
-      "identity" : "swiftlint",
+      "identity" : "version",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/realm/SwiftLint.git",
+      "location" : "https://github.com/mxcl/Version.git",
       "state" : {
-        "revision" : "88952528a590ed366c6f76f6bfb980b5ebdcefc1",
-        "version" : "0.63.2"
-      }
-    },
-    {
-      "identity" : "swiftytexttable",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/scottrhoyt/SwiftyTextTable.git",
-      "state" : {
-        "revision" : "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
-        "version" : "0.9.0"
-      }
-    },
-    {
-      "identity" : "swxmlhash",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/drmohundro/SWXMLHash.git",
-      "state" : {
-        "revision" : "a853604c9e9a83ad9954c7e3d2a565273982471f",
-        "version" : "7.0.2"
+        "revision" : "3043fcd2a50375db76d89ff206a612471833d1c2",
+        "version" : "2.2.1"
       }
     },
     {
@@ -97,15 +70,6 @@
       "state" : {
         "revision" : "e9a06346499a3a889165647e3f23f8a7b2609a1c",
         "version" : "0.10.3"
-      }
-    },
-    {
-      "identity" : "yams",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jpsim/Yams.git",
-      "state" : {
-        "revision" : "deaf82e867fa2cbd3cd865978b079bfcf384ac28",
-        "version" : "6.2.1"
       }
     }
   ],

--- a/xcode/Package.swift
+++ b/xcode/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -9,26 +9,31 @@ import PackageDescription
 // bazel mod tidy
 // ⚠️⚠️⚠️⚠️⚠️⚠️⚠️ //
 
-// SPM doesn't isolate dependencies that are not used by products
-// So relying on a tool, like SwiftLint, a consuming user will still need to resolve that
-// even though they would not use it
-// this can cause conflicts for packages not used by the product at runtime
-//
-// So this file is used to generate dependencies for bazel so we can keep the actual Package.swift clean
-// since the spm rules for bazel only work from a Package.swift
+/// SPM doesn't isolate dependencies that are not used by products
+/// So relying on a tool, like SwiftLint, a consuming user will still need to resolve that
+/// even though they would not use it
+/// this can cause conflicts for packages not used by the product at runtime
+///
+/// So this file is used to generate dependencies for bazel so we can keep the actual Package.swift clean
+/// since the spm rules for bazel only work from a Package.swift
 let package = Package(
     name: "PlayerUIBazelDependencies",
     platforms: [
-        .macOS(.v11)
+        .macOS(.v11),
     ],
     products: [],
     dependencies: [
         // Actual Dependencies
         .package(url: "https://github.com/intuit/swift-hooks.git", .upToNextMajor(from: "0.1.0")),
-        .package(url: "https://github.com/realm/SwiftLint.git", .upToNextMajor(from: "0.54.0")),
+
+        // Used to manage SwiftLint and SwiftFormat
+        .package(url: "https://github.com/yonaskolb/Mint.git", exact: "0.18.0"),
 
         // Testing Dependencies
-        .package(url: "https://github.com/nalexn/viewinspector.git", .upToNextMajor(from: "0.10.3"))
+        .package(
+            url: "https://github.com/nalexn/viewinspector.git",
+            .upToNextMajor(from: "0.10.3")
+        ),
     ],
     targets: []
 )

--- a/xcode/Package.swift
+++ b/xcode/Package.swift
@@ -14,7 +14,8 @@ import PackageDescription
 /// even though they would not use it
 /// this can cause conflicts for packages not used by the product at runtime
 ///
-/// So this file is used to generate dependencies for bazel so we can keep the actual Package.swift clean
+/// So this file is used to generate dependencies for bazel so we can keep the actual Package.swift
+/// clean
 /// since the spm rules for bazel only work from a Package.swift
 let package = Package(
     name: "PlayerUIBazelDependencies",
@@ -26,8 +27,9 @@ let package = Package(
         // Actual Dependencies
         .package(url: "https://github.com/intuit/swift-hooks.git", .upToNextMajor(from: "0.1.0")),
 
-        // Used to manage SwiftLint and SwiftFormat
-        .package(url: "https://github.com/yonaskolb/Mint.git", exact: "0.18.0"),
+        // Linters
+        .package(url: "https://github.com/realm/SwiftLint.git", exact: "0.63.2"),
+        .package(url: "https://github.com/nicklockwood/SwiftFormat.git", exact: "0.61.0"),
 
         // Testing Dependencies
         .package(


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

## What

> [!NOTE]
> Update: this now uses `SwiftLint` and `SwiftFormat` directly via Swift Package Manager.

Resolves https://github.com/player-ui/player/issues/849.

Automatic formatting will be enforced for `.swift` files using a combination of `SwiftLint` and `SwiftFormat`. Here is the developer flow:

1. Local: Run formatting locally with `just format-ios`
2. Pre-commit: When a dev commits any Swift files, formatting will be run via a husky pre-commit hook
3. CI/CD: CI/CD will run a lint check and fail if there are any issues

## Why

We would like to enable automatic formatting to catch some basic ios issues before review. This will reduce PR review burden.

Specifically, we chose to go with a mix of `SwiftLint` and `SwiftFormat` to leverage each one's specialties. `SwiftLint` is better at catching logic issues that cannot be automatically fixed, like force unwrapping, while `SwiftFormat` is better at fixing things automatically.

## Other Options Considered

- [`rules_swiftformat`](https://github.com/cgrindel/rules_swiftformat):
    - Pros: This is hermetic (does not require SwiftFormat on the machine). This is actually the recommended way according to the SwiftFormat github repo with Bazel, [link](https://github.com/nicklockwood/SwiftFormat#bazel-build)
    - Cons: has not been maintained by a human since 2022. It does get some dependabot updates though
    - Blocking Problem: not in the bazel registry, doesn't appear to work with new MODULE-based Bazel
- Fork `rules_swiftformat`:
    - Pros: hermetic
    - Cons: We would have to maintain this, including adding it to the bazel registry
- [`rules_lint`](https://github.com/aspect-build/rules_lint) (replacement for [`bazel-super-formatter`](https://github.com/aspect-build/bazel-super-formatter):
    - Pros: Actively maintained (last commit 3 weeks ago).
    - Cons: non-hermetic (depends on local SwiftFormat). Using local SwiftFormat means we'll all probably have different linters running
- Use the `SwiftFormat` Swift package ([link](https://github.com/nicklockwood/SwiftFormat#swift-package-manager-plugin)) and have a rules_player rule leverage it:
    - Pros: Easy way to align on the same version across machines
    - Cons: non-hermetic.
    - Blocking Problem: We apparently might need to reference the binary directly. Referencing the binary directly increases the rule complexity a lot
- Use `swift-format` via Xcode
    - Pros: Built into Xcode, is a standard
    - Cons: Not-hermetic. Formatting will vary across different Xcode versions, even minor versions. Hard to align on versions across devs---doesn't fit our current development style well.


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
- [x] `N/A`


### Does your PR have any documentation updates?
- [x] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->