### PR TITLE
Moved tapAndAssertElementAppears to AssetUITestCase

### DIFF
--- a/ios/test-utils/Sources/ui-test/AssetUITestCase.swift
+++ b/ios/test-utils/Sources/ui-test/AssetUITestCase.swift
@@ -88,4 +88,28 @@ open class AssetUITestCase: XCTestCase {
         let expectation = self.expectation(for: predicate, evaluatedWith: nil, handler: nil)
         wait(for: [expectation], timeout: timeout)
     }
+
+    /**
+     Taps an element and verifies the expected outcome appears. Retries the tap if the
+     outcome doesn't show up (e.g. the JS action handler isn't wired yet due to async
+     SwiftUI binding).
+     - parameters:
+        - element: The XCUIElement to tap
+        - expectedOutcome: The XCUIElement expected to appear after a successful tap
+        - timeout: How long to wait for the outcome after each tap
+        - retries: Maximum number of tap attempts
+     */
+    public func tapAndAssertElementAppears(
+        _ element: XCUIElement,
+        expectedOutcome: XCUIElement,
+        timeout: TimeInterval = 3,
+        retries: Int = 3
+    ) {
+        for _ in 0..<retries {
+            if expectedOutcome.exists { return }
+            guard element.exists else { break }
+            element.tap()
+            if expectedOutcome.waitForExistence(timeout: timeout) { return }
+        }
+    }
 }

--- a/ios/test-utils/Sources/ui-test/AssetUITestCase.swift
+++ b/ios/test-utils/Sources/ui-test/AssetUITestCase.swift
@@ -89,16 +89,14 @@ open class AssetUITestCase: XCTestCase {
         wait(for: [expectation], timeout: timeout)
     }
 
-    /**
-     Taps an element and verifies the expected outcome appears. Retries the tap if the
-     outcome doesn't show up (e.g. the JS action handler isn't wired yet due to async
-     SwiftUI binding).
-     - parameters:
-        - element: The XCUIElement to tap
-        - expectedOutcome: The XCUIElement expected to appear after a successful tap
-        - timeout: How long to wait for the outcome after each tap
-        - retries: Maximum number of tap attempts
-     */
+    /// Taps an element and verifies the expected outcome appears. Retries the tap if the
+    /// outcome doesn't show up (e.g. the JS action handler isn't wired yet due to async
+    /// SwiftUI binding).
+    /// - parameters:
+    ///    - element: The XCUIElement to tap
+    ///    - expectedOutcome: The XCUIElement expected to appear after a successful tap
+    ///    - timeout: How long to wait for the outcome after each tap
+    ///    - retries: Maximum number of tap attempts
     public func tapAndAssertElementAppears(
         _ element: XCUIElement,
         expectedOutcome: XCUIElement,

--- a/plugins/reference-assets/swiftui/UITests/ManagedPlayerUITests.swift
+++ b/plugins/reference-assets/swiftui/UITests/ManagedPlayerUITests.swift
@@ -6,28 +6,6 @@ class ManagedPlayerUITests: BaseTestCase {
         app.otherElements.buttons["Plugins + Managed Player"].firstMatch.tap()
     }
 
-    /// Taps the element and verifies the expected outcome appears. If the tap has no effect
-    /// (e.g., the JS action handler isn't wired yet due to async SwiftUI binding), retries the tap.
-    private func tapAndAssertElementAppears(
-        _ element: XCUIElement,
-        expectedOutcome: XCUIElement,
-        timeout: TimeInterval = 3,
-        retries: Int = 3
-    ) {
-        for _ in 0..<retries {
-            // If the expected outcome already appeared (from a previous tap that was slow to produce results),
-            // stop immediately instead of tapping again.
-            if expectedOutcome.exists { return }
-            // If the tappable element is gone (a previous tap successfully navigated away),
-            // stop retrying instead of crashing on a missing element.
-            guard element.exists else { break }
-            element.tap()
-            if expectedOutcome.waitForExistence(timeout: timeout) {
-                return
-            }
-        }
-    }
-
     func testSimpleFlow() {
         openFlow("Simple Flows")
         let button1 = app.buttons["first_view"].firstMatch


### PR DESCRIPTION
tapAndAssertElementAppears solves a generic UI-test race (tap before async SwiftUI/JS binding wires up) — not something specific to managed-player tests. Keeping it private forces other UI tests to copy or reinvent it. Moving it to the shared AssetUITestCase (next to waitFor/waitAndTap/tap) gives every UI test one canonical, public helper with no extra imports.

<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [x] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->