### PR TITLE
Revert the removal of clearExceptionHandler method

### DIFF
--- a/docs/site/src/content/docs/announcements/player-one-dot-0.mdx
+++ b/docs/site/src/content/docs/announcements/player-one-dot-0.mdx
@@ -288,21 +288,6 @@ corresponding docs:
 - [Computed Properties Plugin](../../plugins/core/computed-properties)
 - [Stage Revert Data Plugin](../../plugins/core/stage-revert-data)
 
-### (iOS) `SwiftUIPlayer.clearExceptionHandler()` removed
-
-As part of the JSContext memory leak fix ([#855](https://github.com/player-ui/player/pull/855)), `unload()` was enhanced to fully break all retain cycles — including clearing the `exceptionHandler`. This made the standalone `clearExceptionHandler()` method redundant, so it has been removed.
-
-#### Migration
-
-Remove any calls to `clearExceptionHandler()`. No replacement is needed; `unload()` handles this cleanup automatically when `ManagedPlayer` tears down.
-
-```swift
-// Before
-player.clearExceptionHandler()
-
-// After — remove the call; unload() clears it automatically
-```
-
 ### (iOS) Dropped CocoaPods Support
 
 Since CocoaPods is in maintenance mode, we are dropping support in favour of using Swift Package Manager (SPM) only. Please leverage the Swift Package, e.g.

--- a/ios/swiftui/Sources/SwiftUIPlayer.swift
+++ b/ios/swiftui/Sources/SwiftUIPlayer.swift
@@ -129,6 +129,12 @@ public struct SwiftUIPlayer: View, HeadlessPlayer {
             registry.resetView()
         }
 
+        /// Clear the exceptionHandler of the context to remove reference to the logger
+        /// should be called when ManagedPlayer gets tore down
+        public func clearExceptionHandler() {
+            player?.context.exceptionHandler = nil
+        }
+
         /// Returns `player` but asserts that it is not nil. Used from methods that should not be called
         /// when we are unloaded.
         private var expectedPlayer: JSValue? {


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->
Restores `SwiftUIPlayer.clearExceptionHandler()` on iOS, which was removed in #864 as part of the unused-methods cleanup. This method will still be used. 

### Change Type (required)
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
- [x] `N/A`

### Does your PR have any documentation updates?
- [x] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs

<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->