### PR TITLE
Fixed: avoid destructive unload on ManagedPlayer onDisappear

### DIFF
--- a/ios/swiftui/Sources/ManagedPlayer/ManagedPlayer.swift
+++ b/ios/swiftui/Sources/ManagedPlayer/ManagedPlayer.swift
@@ -150,7 +150,7 @@ internal struct ManagedPlayer14<Loading: View, Fallback: View>: View {
     public var body: some View {
         bodyContent(viewModel.stateTransition.call() ?? .identity)
             .onDisappear {
-                context.unload()
+                context.clearExceptionHandler()
             }
     }
 


### PR DESCRIPTION
ManagedPlayer.body.onDisappear now calls clearExceptionHandler() instead of unload(), restoring 0.15.2 dismissal semantics. The aggressive unload() introduced in #855 (synchronous JSGarbageCollect on main, JS export nil-ing, registry resetView) ran during SwiftUI's dismissal animation and could hang exit on flows with many delay() expressions.
unload() still runs from onChange(loadingState == .loading) for flow-to-flow transitions, so the cross-runtime retain cycle fix from #855 is preserved. Standalone SwiftUIPlayer.onDisappear is unchanged.

<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [x] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->