### PR TITLE
Fix Benchmark Updating on `main`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -374,7 +374,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/player
-
+      - setup_auth
       - run:
           name: Run benchmarks
           command: |
@@ -608,17 +608,18 @@ workflows:
       - build_and_test_ios:
           requires:
             - build
+            - test
 
       - android_test:
           context:
             - Build
           requires:
             - build
+            - test
 
       - test:
           requires:
             - build
-            - build_and_test_ios
 
       - upload_coverage:
           requires:


### PR DESCRIPTION
Switch core and iOS/Android test order on main. Configure git for main benchmark runs

<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
- [x] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [x] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->