### PR TITLE
implement android a2ui assets

### DIFF
--- a/android/demo/BUILD
+++ b/android/demo/BUILD
@@ -7,6 +7,7 @@ main_deps = [
     "//jvm/hermes:hermes-android",
     "//jvm/utils",
     "//plugins/reference-assets/android",
+    "//plugins/a2ui/android",
     "//plugins/common-types/jvm",
     "//tools/mocks:jar",
 

--- a/android/demo/src/main/kotlin/com/intuit/playerui/android/reference/demo/lifecycle/DemoPlayerViewModel.kt
+++ b/android/demo/src/main/kotlin/com/intuit/playerui/android/reference/demo/lifecycle/DemoPlayerViewModel.kt
@@ -2,12 +2,14 @@ package com.intuit.playerui.android.reference.demo.lifecycle
 
 import com.intuit.playerui.android.AndroidPlayer
 import com.intuit.playerui.android.AndroidPlayer.Config
+import com.intuit.playerui.android.a2ui.A2UIAndroidPlugin
 import com.intuit.playerui.android.asset.SuspendableAsset.AsyncHydrationTrackerPlugin
 import com.intuit.playerui.android.asset.asyncHydrationTrackerPlugin
 import com.intuit.playerui.android.lifecycle.PlayerViewModel
 import com.intuit.playerui.android.reference.assets.ReferenceAssetsPlugin
 import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
 import com.intuit.playerui.core.managed.AsyncFlowIterator
+import com.intuit.playerui.core.player.StartOptions
 import com.intuit.playerui.core.player.state.PlayerFlowState
 import com.intuit.playerui.plugins.transactions.PendingTransactionPlugin
 import com.intuit.playerui.plugins.types.CommonTypesPlugin
@@ -17,13 +19,18 @@ import kotlinx.coroutines.flow.asStateFlow
 
 class DemoPlayerViewModel(
     iterator: AsyncFlowIterator,
+    private val format: String? = null,
 ) : PlayerViewModel(iterator) {
     override val plugins = listOf(
         CommonTypesPlugin(),
         ReferenceAssetsPlugin(),
+        A2UIAndroidPlugin(),
         PendingTransactionPlugin(),
         AsyncHydrationTrackerPlugin(),
     )
+
+    /** Non-Player content (e.g. A2UI snapshots) is started with its declared format. */
+    override val startOptions: StartOptions? = format?.let { StartOptions(format = it) }
 
     public val isDebug = false
 

--- a/android/demo/src/main/kotlin/com/intuit/playerui/android/reference/demo/ui/base/BasePlayerFragment.kt
+++ b/android/demo/src/main/kotlin/com/intuit/playerui/android/reference/demo/ui/base/BasePlayerFragment.kt
@@ -19,8 +19,13 @@ import kotlinx.coroutines.launch
 abstract class BasePlayerFragment : PlayerFragment() {
     abstract val flow: String
 
+    /** Optional content format (e.g. `"a2ui"`) for non-Player flows. */
+    open val format: String? = null
+
     override val playerViewModel by viewModels<DemoPlayerViewModel> {
-        PlayerViewModel.Factory(AsyncFlowIterator(flow), ::DemoPlayerViewModel)
+        PlayerViewModel.Factory(AsyncFlowIterator(flow)) { iterator ->
+            DemoPlayerViewModel(iterator, format)
+        }
     }
 
     private val currentPlayerCanvas get() = binding.playerCanvas.getChildAt(0)

--- a/android/demo/src/main/kotlin/com/intuit/playerui/android/reference/demo/ui/main/MainActivity.kt
+++ b/android/demo/src/main/kotlin/com/intuit/playerui/android/reference/demo/ui/main/MainActivity.kt
@@ -25,11 +25,13 @@ import com.intuit.playerui.android.reference.demo.R
 import com.intuit.playerui.android.reference.demo.model.AssetMock
 import com.intuit.playerui.android.reference.demo.model.StringMock
 import com.intuit.playerui.android.ui.PlayerFragment
+import com.intuit.playerui.utils.makeFlow
 import com.intuit.playerui.utils.mocks.ClassLoaderMock
 import com.intuit.playerui.utils.mocks.Mock
-import com.intuit.playerui.utils.mocks.getFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
 
 class MainActivity : AppCompatActivity() {
     private lateinit var drawerLayout: DrawerLayout
@@ -98,23 +100,44 @@ class MainActivity : AppCompatActivity() {
         json?.let { viewModel.launch(json) }
     }
 
-    private fun startFlow(mock: Mock<*>) = launchFlow(
-        when (mock) {
-            is ClassLoaderMock -> mock.getFlow(this.classLoader)
-            is AssetMock -> mock.getFlow(this.assets)
-            is StringMock -> mock.getFlow("")
+    private fun startFlow(mock: Mock<*>) {
+        val raw = when (mock) {
+            is ClassLoaderMock -> mock.read(this.classLoader)
+            is AssetMock -> mock.read(this.assets)
+            is StringMock -> mock.read("")
             else -> throw IllegalArgumentException("mock of type ${mock::class}[$mock] not supported")
-        },
-        mock.name,
-    )
+        }
 
-    private fun launchFlow(flow: String, name: String?) {
+        // A2UI snapshots are not Player flows — they're translated by the A2UI
+        // content plugin when started with `format = "a2ui"`. Detect them by their
+        // structural signature and pass the raw content through untouched. Player
+        // flows continue to be normalized via `makeFlow`.
+        if (isA2UISnapshot(raw)) {
+            launchFlow(raw, mock.name, format = "a2ui")
+        } else {
+            launchFlow(makeFlow(raw).toString(), mock.name)
+        }
+    }
+
+    private fun launchFlow(
+        flow: String,
+        name: String?,
+        format: String? = null,
+    ) {
         drawerLayout.closeDrawer(GravityCompat.START)
         navController.navigate(
             R.id.action_launch_player,
-            name?.let {
-                bundleOf("name" to name, "flow" to flow)
-            } ?: bundleOf("flow" to flow),
+            bundleOf("flow" to flow).apply {
+                name?.let { putString("name", it) }
+                format?.let { putString("format", it) }
+            },
         )
+    }
+
+    private fun isA2UISnapshot(raw: String): Boolean = try {
+        val json = Json.parseToJsonElement(raw).jsonObject
+        json.containsKey("surfaceId") && json.containsKey("components") && !json.containsKey("views")
+    } catch (e: Exception) {
+        false
     }
 }

--- a/android/demo/src/main/kotlin/com/intuit/playerui/android/reference/demo/ui/player/DemoPlayerFragment.kt
+++ b/android/demo/src/main/kotlin/com/intuit/playerui/android/reference/demo/ui/player/DemoPlayerFragment.kt
@@ -4,4 +4,5 @@ import com.intuit.playerui.android.reference.demo.ui.base.BasePlayerFragment
 
 class DemoPlayerFragment : BasePlayerFragment() {
     override val flow: String get() = arguments?.getString("flow")!!
+    override val format: String? get() = arguments?.getString("format")
 }

--- a/android/player/src/main/kotlin/com/intuit/playerui/android/AndroidPlayer.kt
+++ b/android/player/src/main/kotlin/com/intuit/playerui/android/AndroidPlayer.kt
@@ -26,6 +26,7 @@ import com.intuit.playerui.core.logger.TapableLogger
 import com.intuit.playerui.core.player.HeadlessPlayer
 import com.intuit.playerui.core.player.Player
 import com.intuit.playerui.core.player.PlayerException
+import com.intuit.playerui.core.player.StartOptions
 import com.intuit.playerui.core.player.state.CompletedState
 import com.intuit.playerui.core.player.state.PlayerFlowState
 import com.intuit.playerui.core.player.state.inProgressState
@@ -144,7 +145,7 @@ public class AndroidPlayer private constructor(
 
     override val scope: CoroutineScope by player::scope
 
-    override fun start(flow: String): Completable<CompletedState> = player.start(flow)
+    override fun start(flow: String, options: StartOptions?): Completable<CompletedState> = player.start(flow, options)
 
     private val assetSerializer = RenderableAsset.Serializer(this)
 

--- a/android/player/src/main/kotlin/com/intuit/playerui/android/lifecycle/PlayerViewModel.kt
+++ b/android/player/src/main/kotlin/com/intuit/playerui/android/lifecycle/PlayerViewModel.kt
@@ -13,6 +13,7 @@ import com.intuit.playerui.core.managed.AsyncFlowIterator
 import com.intuit.playerui.core.managed.AsyncIterationManager
 import com.intuit.playerui.core.managed.FlowManager
 import com.intuit.playerui.core.player.PlayerException
+import com.intuit.playerui.core.player.StartOptions
 import com.intuit.playerui.core.player.state.CompletedState
 import com.intuit.playerui.core.player.state.ErrorState
 import com.intuit.playerui.core.player.state.InProgressState
@@ -68,6 +69,14 @@ public open class PlayerViewModel(
 
     protected open val config: AndroidPlayer.Config = AndroidPlayer.Config()
 
+    /**
+     * Optional [StartOptions] describing the content emitted by the flow
+     * iterator. When the content is not already a Player flow (e.g. an A2UI
+     * snapshot), override this to declare its `format` so the matching content
+     * plugin can transform it. Defaults to `null` (content is a Player flow).
+     */
+    protected open val startOptions: StartOptions? = null
+
     @ExperimentalPlayerApi
     public val deferredPlayer: Deferred<AndroidPlayer> = viewModelScope.async(Dispatchers.Default) {
         // this is unfortunate, but is essentially for ensuring view model has completely initialized
@@ -117,7 +126,7 @@ public open class PlayerViewModel(
         }
     }
 
-    private fun start(flow: String) = player.start(flow) {
+    private fun start(flow: String) = player.start(flow, startOptions) {
         when {
             it.isSuccess -> player.logger.info(
                 "Flow completed successfully!",

--- a/jvm/core/BUILD
+++ b/jvm/core/BUILD
@@ -23,6 +23,7 @@ main_resources = [
 # Test dependencies
 test_deps = [
     "//jvm/testutils:with-runtimes",
+    "//plugins/a2ui/jvm",
     "//plugins/beacon/jvm",
     "//plugins/common-types/jvm",
     "//plugins/reference-assets/jvm",

--- a/jvm/core/src/main/kotlin/com/intuit/playerui/core/player/HeadlessPlayer.kt
+++ b/jvm/core/src/main/kotlin/com/intuit/playerui/core/player/HeadlessPlayer.kt
@@ -13,6 +13,7 @@ import com.intuit.playerui.core.bridge.runtime.ScriptContext
 import com.intuit.playerui.core.bridge.runtime.add
 import com.intuit.playerui.core.bridge.runtime.runtimeContainers
 import com.intuit.playerui.core.bridge.runtime.runtimeFactory
+import com.intuit.playerui.core.bridge.runtime.serialize
 import com.intuit.playerui.core.bridge.serialization.serializers.NodeSerializableField
 import com.intuit.playerui.core.constants.ConstantsController
 import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
@@ -32,6 +33,7 @@ import com.intuit.playerui.core.plugins.logging.loggers
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.serialization.builtins.nullable
 import java.net.URL
 
 /**
@@ -177,15 +179,15 @@ public class HeadlessPlayer @ExperimentalPlayerApi @JvmOverloads public construc
             .onEach { it.apply(this) }
     }
 
-    override fun start(flow: String): Completable<CompletedState> = try {
-        start(runtime.execute("($flow)") as Node)
+    override fun start(flow: String, options: StartOptions?): Completable<CompletedState> = try {
+        start(runtime.execute("($flow)") as Node, options)
     } catch (exception: Exception) {
         val wrapped = PlayerException("Could not load Player content", exception)
         inProgressState?.fail(wrapped) ?: hooks.state.call(hashMapOf(), arrayOf(ErrorState.from(wrapped)))
         PlayerCompletable(Promise.reject(wrapped))
     }
 
-    public fun start(flow: Node): Completable<CompletedState> = PlayerCompletable(player.getInvokable<Node>("start")!!.invoke(flow))
+    public fun start(flow: Node, options: StartOptions? = null): Completable<CompletedState> = PlayerCompletable(player.getInvokable<Node>("start")!!.invoke(flow, options))
 
     /** Start a [flow] and subscribe to the result */
     public fun start(flow: Node, onComplete: (Result<CompletedState>) -> Unit): Completable<CompletedState> = start(flow).apply {

--- a/jvm/core/src/main/kotlin/com/intuit/playerui/core/player/Player.kt
+++ b/jvm/core/src/main/kotlin/com/intuit/playerui/core/player/Player.kt
@@ -109,8 +109,13 @@ public abstract class Player : Pluggable {
      * Asynchronously [start] the [flow] represented as a [String]. The
      * [FlowResult] can be obtained by subscribing the the [Completable.onComplete]
      * or by blocking on [Completable.await].
+     *
+     * The optional [options] describe the shape of the supplied content so a
+     * content plugin can transform it into a Player flow before it's started
+     * (e.g. `StartOptions(format = "a2ui")`). When omitted, the content is
+     * assumed to already be a Player flow.
      */
-    public abstract fun start(flow: String): Completable<CompletedState>
+    public abstract fun start(flow: String, options: StartOptions? = null): Completable<CompletedState>
 
     /**
      * Release any resources being used by the [Player] instance and
@@ -141,7 +146,33 @@ public abstract class Player : Pluggable {
     public fun start(flow: String, onComplete: (Result<CompletedState>) -> Unit): Completable<CompletedState> = start(flow).apply {
         onComplete(onComplete)
     }
+
+    /**
+     * [ExperimentalPlayerApi] utility method to [start] a non-Player [flow]
+     * described by [options] while subscribing to the [FlowResult] in the
+     * same call.
+     */
+    @ExperimentalPlayerApi
+    public fun start(
+        flow: String,
+        options: StartOptions?,
+        onComplete: (Result<CompletedState>) -> Unit,
+    ): Completable<CompletedState> = start(flow, options).apply {
+        onComplete(onComplete)
+    }
 }
+
+/**
+ * Options describing the content passed to [Player.start], mirroring the core
+ * `StartOptions`. [format] identifies the input content's format (`"player"`
+ * means it's already a Player flow); [version] is an optional, free-form
+ * content-format version a content plugin can dispatch on.
+ */
+@Serializable
+public data class StartOptions(
+    val format: String? = null,
+    val version: String? = null,
+)
 
 /**
  * Create a child [CoroutineScope] of the [Player.scope], such that it'll inherit the [CoroutineContext],

--- a/jvm/core/src/test/kotlin/com/intuit/playerui/core/player/A2UIContentIntegrationTest.kt
+++ b/jvm/core/src/test/kotlin/com/intuit/playerui/core/player/A2UIContentIntegrationTest.kt
@@ -1,0 +1,57 @@
+package com.intuit.playerui.core.player
+
+import com.intuit.playerui.core.asset.Asset
+import com.intuit.playerui.core.player.state.InProgressState
+import com.intuit.playerui.core.player.state.lastViewUpdate
+import com.intuit.playerui.core.plugins.Plugin
+import com.intuit.playerui.plugins.a2ui.A2UIPlugin
+import com.intuit.playerui.plugins.types.CommonTypesPlugin
+import com.intuit.playerui.utils.test.PlayerTest
+import com.intuit.playerui.utils.test.runBlockingTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.TestTemplate
+
+/**
+ * End-to-end check that the JVM [A2UIPlugin] bundle translates an A2UI snapshot
+ * into a render-ready Player flow when started with `format = "a2ui"`.
+ *
+ * This exercises the full chain: [Player.start] forwards the content meta to the
+ * JS player, whose `transformContent` hook (tapped by the bundled A2UI content
+ * plugin) runs `adaptA2UIToFlow` to produce a Player flow that resolves into the
+ * expected nested asset tree.
+ */
+internal class A2UIContentIntegrationTest : PlayerTest() {
+    override val plugins: List<Plugin> = listOf(A2UIPlugin(), CommonTypesPlugin())
+
+    // A2UI snapshot: a Button whose child is a Text label. Flat component list
+    // linked by id, rooted at "root" — adaptA2UIToFlow inlines this into a tree.
+    private val buttonSnapshot =
+        """
+        {
+          "surfaceId": "button-basic",
+          "components": [
+            { "id": "root", "component": "Button", "child": "lbl", "variant": "primary" },
+            { "id": "lbl", "component": "Text", "text": "Click me" }
+          ]
+        }
+        """.trimIndent()
+
+    @TestTemplate
+    fun `a2ui snapshot is translated into a renderable flow`() = runBlockingTest {
+        player.start(buttonSnapshot, StartOptions(format = "a2ui"))
+
+        val state = player.state
+        assertTrue(state is InProgressState) { "Expected A2UI snapshot to start, but was $state" }
+        state as InProgressState
+
+        val root: Asset? = state.lastViewUpdate
+        assertNotNull(root, "Expected a resolved view for the translated A2UI flow")
+        assertEquals("Button", root!!.type)
+
+        // The Button's Text child should be inlined as a nested {asset: ...} node.
+        val childAsset = root.getAsset("child")?.asset
+        assertEquals("Text", childAsset?.type)
+    }
+}

--- a/jvm/core/src/test/kotlin/com/intuit/playerui/core/player/A2UIContentIntegrationTest.kt
+++ b/jvm/core/src/test/kotlin/com/intuit/playerui/core/player/A2UIContentIntegrationTest.kt
@@ -38,6 +38,31 @@ internal class A2UIContentIntegrationTest : PlayerTest() {
         }
         """.trimIndent()
 
+    // A2UI snapshot exercising the Intl-backed `formatCurrency` expression. On
+    // Hermes (no `Intl` global) this previously threw `ReferenceError: Property
+    // 'Intl' doesn't exist`; the core format handlers now fall back to pure JS.
+    private val currencySnapshot =
+        """
+        {
+          "surfaceId": "expressions-currency",
+          "data": { "order": { "subtotal": 1299.5 } },
+          "components": [
+            {
+              "id": "root",
+              "component": "Text",
+              "text": {
+                "call": "formatCurrency",
+                "args": {
+                  "value": { "path": "/order/subtotal" },
+                  "currency": "USD",
+                  "locale": "en-US"
+                }
+              }
+            }
+          ]
+        }
+        """.trimIndent()
+
     @TestTemplate
     fun `a2ui snapshot is translated into a renderable flow`() = runBlockingTest {
         player.start(buttonSnapshot, StartOptions(format = "a2ui"))
@@ -53,5 +78,20 @@ internal class A2UIContentIntegrationTest : PlayerTest() {
         // The Button's Text child should be inlined as a nested {asset: ...} node.
         val childAsset = root.getAsset("child")?.asset
         assertEquals("Text", childAsset?.type)
+    }
+
+    @TestTemplate
+    fun `formatCurrency expression resolves without Intl`() = runBlockingTest {
+        player.start(currencySnapshot, StartOptions(format = "a2ui"))
+
+        val state = player.state
+        assertTrue(state is InProgressState) { "Expected currency snapshot to start, but was $state" }
+        state as InProgressState
+
+        val root: Asset? = state.lastViewUpdate
+        assertNotNull(root, "Expected a resolved view for the currency A2UI flow")
+        assertEquals("Text", root!!.type)
+        // Hermes fallback yields "$1,299.50"; full-Intl runtimes yield the same en-US output.
+        assertEquals("\$1,299.50", root.getString("text"))
     }
 }

--- a/jvm/core/src/test/kotlin/com/intuit/playerui/core/player/StartContentMetaTest.kt
+++ b/jvm/core/src/test/kotlin/com/intuit/playerui/core/player/StartContentMetaTest.kt
@@ -1,0 +1,56 @@
+package com.intuit.playerui.core.player
+
+import com.intuit.playerui.core.plugins.JSScriptPluginWrapper
+import com.intuit.playerui.core.plugins.Plugin
+import com.intuit.playerui.utils.test.PlayerTest
+import com.intuit.playerui.utils.test.runBlockingTest
+import com.intuit.playerui.utils.test.simpleFlowString
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.TestTemplate
+
+/**
+ * Verifies that the JVM [Player.start] overload forwards the optional content
+ * [format]/[version] meta through to the JS player's `transformContent` hook.
+ *
+ * A tiny inline JS content plugin taps `transformContent` and records the
+ * `meta.format` it observed on a runtime global. If the meta were dropped (the
+ * previous behavior, where `start` invoked the JS player with only the flow
+ * node), the hook would observe the default `"player"` format instead.
+ */
+internal class StartContentMetaTest : PlayerTest() {
+    private val contentPlugin = JSScriptPluginWrapper.from(
+        name = "TestContentPlugin",
+        script =
+            """
+            globalThis.__observedFormat = null;
+            var TestContentPlugin = (function () {
+                function TestContentPlugin() {}
+                TestContentPlugin.prototype.apply = function (player) {
+                    player.hooks.transformContent.tap('test-content', function (content, meta) {
+                        globalThis.__observedFormat = meta && meta.format;
+                        return content;
+                    });
+                };
+                return TestContentPlugin;
+            })();
+            """.trimIndent(),
+    )
+
+    override val plugins: List<Plugin> = listOf(contentPlugin)
+
+    private fun lastObservedFormat(): String? = runtime.execute("globalThis.__observedFormat") as? String
+
+    @TestTemplate
+    fun `start forwards explicit format to transformContent hook`() = runBlockingTest {
+        player.start(simpleFlowString, StartOptions(format = "a2ui"))
+
+        assertEquals("a2ui", lastObservedFormat())
+    }
+
+    @TestTemplate
+    fun `start without format defaults to player format`() = runBlockingTest {
+        player.start(simpleFlowString)
+
+        assertEquals("player", lastObservedFormat())
+    }
+}

--- a/plugins/a2ui/android/BUILD
+++ b/plugins/a2ui/android/BUILD
@@ -7,6 +7,7 @@ main_exports = [
 
 main_deps = main_exports + [
     "//plugins/a2ui/jvm",
+    "//plugins/pending-transaction/jvm",
     artifact("androidx.compose.material:material"),
     artifact("androidx.compose.material:material-icons-core"),
 ]

--- a/plugins/a2ui/android/BUILD
+++ b/plugins/a2ui/android/BUILD
@@ -1,0 +1,27 @@
+load("@rules_jvm_external//:defs.bzl", "artifact")
+load("//android:defs.bzl", "kt_android")
+
+main_exports = [
+    "//android/player",
+]
+
+main_deps = main_exports + [
+    "//plugins/a2ui/jvm",
+    artifact("androidx.compose.material:material"),
+    artifact("androidx.compose.material:material-icons-core"),
+]
+
+instrumented_test_deps = [
+    "//android/testutils:with-runtime",
+    "//plugins/common-types/jvm",
+]
+
+kt_android(
+    name = "a2ui-android",
+    instrumented_test_deps = instrumented_test_deps,
+    main_deps = main_deps,
+    main_exports = main_exports,
+    # Disable explicit API mode for reference module
+    main_opts = "//jvm:test_options",
+    plugins = ["//android:jetpack_compose_compiler_plugin"],
+)

--- a/plugins/a2ui/android/src/androidTest/kotlin/com/intuit/playerui/android/a2ui/A2UIAndroidPluginTest.kt
+++ b/plugins/a2ui/android/src/androidTest/kotlin/com/intuit/playerui/android/a2ui/A2UIAndroidPluginTest.kt
@@ -1,0 +1,121 @@
+package com.intuit.playerui.android.a2ui
+
+import androidx.test.runner.AndroidJUnit4
+import com.intuit.playerui.android.AndroidPlayer
+import com.intuit.playerui.android.asset.RenderableAsset
+import com.intuit.playerui.android.testutils.asset.shouldBeAsset
+import com.intuit.playerui.android.testutils.asset.shouldBeAtState
+import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
+import com.intuit.playerui.core.player.StartOptions
+import com.intuit.playerui.core.player.state.InProgressState
+import com.intuit.playerui.core.plugins.Plugin
+import com.intuit.playerui.plugins.types.CommonTypesPlugin
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Robolectric checks that the [A2UIAndroidPlugin] loads the A2UI bundle, that
+ * starting with `format = "a2ui"` translates a snapshot into a Player flow, and
+ * that the resolved asset tree is built from the registered Compose renderers.
+ */
+@RunWith(AndroidJUnit4::class)
+@OptIn(ExperimentalPlayerApi::class)
+class A2UIAndroidPluginTest {
+    private val plugins: List<Plugin> = listOf(A2UIAndroidPlugin(), CommonTypesPlugin())
+
+    private val player: AndroidPlayer by lazy {
+        AndroidPlayer(plugins).also { it.onUpdate { asset, _ -> tree = asset } }
+    }
+
+    private var tree: RenderableAsset? = null
+
+    private fun start(snapshot: String) {
+        player.start(snapshot, StartOptions(format = "a2ui")).onComplete { it.exceptionOrNull()?.printStackTrace() }
+    }
+
+    @Test
+    fun `button snapshot resolves to A2UIButton with a Text child`() {
+        start(
+            """
+            {
+              "surfaceId": "button-basic",
+              "components": [
+                { "id": "root", "component": "Button", "child": "lbl", "variant": "primary" },
+                { "id": "lbl", "component": "Text", "text": "Click me" }
+              ]
+            }
+            """.trimIndent(),
+        )
+
+        player.shouldBeAtState<InProgressState> {}
+        runTest {
+            tree.shouldBeAsset<A2UIButton> {
+                val data = getData()
+                assertEquals("primary", data.variant)
+                assertNotNull(data.child)
+                data.child.shouldBeAsset<A2UIText> {
+                    assertEquals("Click me", getData().text)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `column snapshot resolves to A2UIColumn with children`() {
+        start(
+            """
+            {
+              "surfaceId": "column-basic",
+              "components": [
+                { "id": "root", "component": "Column", "children": ["a", "b"], "justify": "center" },
+                { "id": "a", "component": "Text", "text": "First" },
+                { "id": "b", "component": "Text", "text": "Second" }
+              ]
+            }
+            """.trimIndent(),
+        )
+
+        player.shouldBeAtState<InProgressState> {}
+        runTest {
+            tree.shouldBeAsset<A2UIColumn> {
+                val data = getData()
+                assertEquals("center", data.justify)
+                assertEquals(2, data.children.size)
+                data.children[0].shouldBeAsset<A2UIText> { assertEquals("First", getData().text) }
+                data.children[1].shouldBeAsset<A2UIText> { assertEquals("Second", getData().text) }
+            }
+        }
+    }
+
+    @Test
+    fun `common A2UICommon fields round-trip onto asset data`() {
+        start(
+            """
+            {
+              "surfaceId": "text-common",
+              "components": [
+                {
+                  "id": "root",
+                  "component": "Text",
+                  "text": "Hi",
+                  "accessibility": "Greeting label",
+                  "weight": 2
+                }
+              ]
+            }
+            """.trimIndent(),
+        )
+
+        player.shouldBeAtState<InProgressState> {}
+        runTest {
+            tree.shouldBeAsset<A2UIText> {
+                val data = getData()
+                assertEquals("Greeting label", data.accessibility)
+                assertEquals(2.0, data.weight)
+            }
+        }
+    }
+}

--- a/plugins/a2ui/android/src/androidTest/kotlin/com/intuit/playerui/android/a2ui/A2UIAndroidPluginTest.kt
+++ b/plugins/a2ui/android/src/androidTest/kotlin/com/intuit/playerui/android/a2ui/A2UIAndroidPluginTest.kt
@@ -91,6 +91,109 @@ class A2UIAndroidPluginTest {
     }
 
     @Test
+    fun `button secondary and destructive variants round-trip onto asset data`() {
+        start(
+            """
+            {
+              "surfaceId": "button-variants",
+              "components": [
+                { "id": "root", "component": "Row", "children": ["s", "d"] },
+                { "id": "s", "component": "Button", "child": "sl", "variant": "secondary" },
+                { "id": "sl", "component": "Text", "text": "Secondary" },
+                { "id": "d", "component": "Button", "child": "dl", "variant": "destructive" },
+                { "id": "dl", "component": "Text", "text": "Delete" }
+              ]
+            }
+            """.trimIndent(),
+        )
+
+        player.shouldBeAtState<InProgressState> {}
+        runTest {
+            tree.shouldBeAsset<A2UIRow> {
+                val children = getData().children
+                children[0].shouldBeAsset<A2UIButton> { assertEquals("secondary", getData().variant) }
+                children[1].shouldBeAsset<A2UIButton> { assertEquals("destructive", getData().variant) }
+            }
+        }
+    }
+
+    @Test
+    fun `textField date type round-trips onto asset data`() {
+        start(
+            """
+            {
+              "surfaceId": "textfield-date",
+              "components": [
+                { "id": "root", "component": "TextField", "textFieldType": "date", "label": "When" }
+              ]
+            }
+            """.trimIndent(),
+        )
+
+        player.shouldBeAtState<InProgressState> {}
+        runTest {
+            tree.shouldBeAsset<A2UITextField> {
+                assertEquals("date", getData().textFieldType)
+            }
+        }
+    }
+
+    @Test
+    fun `bound textField reads its current value from the model`() {
+        start(
+            """
+            {
+              "surfaceId": "textfield-bound",
+              "data": { "user": { "name": "Ada" } },
+              "components": [
+                {
+                  "id": "root",
+                  "component": "TextField",
+                  "label": "Name",
+                  "value": { "path": "/user/name" },
+                  "textFieldType": "shortText"
+                }
+              ]
+            }
+            """.trimIndent(),
+        )
+
+        player.shouldBeAtState<InProgressState> {}
+        runTest {
+            tree.shouldBeAsset<A2UITextField> {
+                // currentValue is wired through the core transform from the bound model path.
+                assertEquals("Ada", getData().currentValue)
+            }
+        }
+    }
+
+    @Test
+    fun `row child weight is readable from the child node`() {
+        start(
+            """
+            {
+              "surfaceId": "row-weight",
+              "components": [
+                { "id": "root", "component": "Row", "children": ["a", "b"] },
+                { "id": "a", "component": "Text", "text": "Grow", "weight": 3 },
+                { "id": "b", "component": "Text", "text": "Fixed" }
+              ]
+            }
+            """.trimIndent(),
+        )
+
+        player.shouldBeAtState<InProgressState> {}
+        runTest {
+            tree.shouldBeAsset<A2UIRow> {
+                val children = getData().children
+                // childLayout reads weight from the raw child node (React applies it per-child).
+                assertEquals(3.0, children[0].a2uiWeight)
+                assertEquals(null, children[1].a2uiWeight)
+            }
+        }
+    }
+
+    @Test
     fun `common A2UICommon fields round-trip onto asset data`() {
         start(
             """

--- a/plugins/a2ui/android/src/main/AndroidManifest.xml
+++ b/plugins/a2ui/android/src/main/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<manifest package="com.intuit.playerui.android.a2ui"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-sdk android:minSdkVersion="24" />
+
+    <!-- Resolve a conflict issue while building with Bazel. -->
+    <application>
+    <provider
+        android:name="androidx.startup.InitializationProvider"
+        android:authorities="${applicationId}.androidx-startup"
+        tools:node="remove" />
+    </application>
+</manifest>

--- a/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIAndroidPlugin.kt
+++ b/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIAndroidPlugin.kt
@@ -1,0 +1,50 @@
+package com.intuit.playerui.android.a2ui
+
+import com.intuit.playerui.android.AndroidPlayer
+import com.intuit.playerui.android.AndroidPlayerPlugin
+import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
+import com.intuit.playerui.core.player.Player
+import com.intuit.playerui.core.plugins.JSPluginWrapper
+import com.intuit.playerui.core.plugins.findPlugin
+import com.intuit.playerui.plugins.a2ui.A2UIPlugin
+
+/**
+ * Registers Jetpack Compose renderers for the A2UI v0.9 reference assets and
+ * loads the platform-agnostic A2UI core bundle (which taps `transformContent`
+ * and registers the asset transforms + expression functions) by delegating to
+ * the generated JVM [A2UIPlugin] wrapper.
+ *
+ * Hosts opt into A2UI content by starting with an A2UI [StartOptions]:
+ * ```
+ * androidPlayer.start(snapshotJson, StartOptions(format = "a2ui"))
+ * ```
+ */
+@OptIn(ExperimentalPlayerApi::class)
+public class A2UIAndroidPlugin :
+    AndroidPlayerPlugin,
+    JSPluginWrapper by A2UIPlugin() {
+    override fun apply(androidPlayer: AndroidPlayer) {
+        // Asset type names are the verbatim A2UI component identifiers so that
+        // snapshots adapted via adaptA2UIToFlow resolve directly.
+        androidPlayer.registerAsset("Row", ::A2UIRow)
+        androidPlayer.registerAsset("Column", ::A2UIColumn)
+        androidPlayer.registerAsset("List", ::A2UIList)
+        androidPlayer.registerAsset("Text", ::A2UIText)
+        androidPlayer.registerAsset("Image", ::A2UIImage)
+        androidPlayer.registerAsset("Icon", ::A2UIIcon)
+        androidPlayer.registerAsset("Divider", ::A2UIDivider)
+        androidPlayer.registerAsset("Button", ::A2UIButton)
+        androidPlayer.registerAsset("TextField", ::A2UITextField)
+        androidPlayer.registerAsset("CheckBox", ::A2UICheckBox)
+        androidPlayer.registerAsset("Slider", ::A2UISlider)
+        androidPlayer.registerAsset("DateTimeInput", ::A2UIDateTimeInput)
+        androidPlayer.registerAsset("ChoicePicker", ::A2UIChoicePicker)
+        androidPlayer.registerAsset("Card", ::A2UICard)
+        androidPlayer.registerAsset("Modal", ::A2UIModal)
+        androidPlayer.registerAsset("Tabs", ::A2UITabs)
+    }
+
+    public companion object {
+        public val Player.a2uiAndroidPlugin: A2UIAndroidPlugin get() = findPlugin()!!
+    }
+}

--- a/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIButton.kt
+++ b/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIButton.kt
@@ -2,6 +2,8 @@ package com.intuit.playerui.android.a2ui
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedButton
 import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
@@ -45,6 +47,16 @@ internal class A2UIButton(
         when (data.variant) {
             "outline" -> OutlinedButton(onClick = onClick, modifier = modifier) { data.child?.compose() }
             "ghost" -> TextButton(onClick = onClick, modifier = modifier) { data.child?.compose() }
+            "secondary" -> Button(
+                onClick = onClick,
+                modifier = modifier,
+                colors = ButtonDefaults.buttonColors(backgroundColor = MaterialTheme.colors.secondary),
+            ) { data.child?.compose() }
+            "destructive" -> Button(
+                onClick = onClick,
+                modifier = modifier,
+                colors = ButtonDefaults.buttonColors(backgroundColor = MaterialTheme.colors.error),
+            ) { data.child?.compose() }
             else -> Button(onClick = onClick, modifier = modifier) { data.child?.compose() }
         }
     }

--- a/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIButton.kt
+++ b/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIButton.kt
@@ -1,0 +1,51 @@
+package com.intuit.playerui.android.a2ui
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.Button
+import androidx.compose.material.OutlinedButton
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import com.intuit.playerui.android.AssetContext
+import com.intuit.playerui.android.asset.RenderableAsset
+import com.intuit.playerui.android.compose.ComposableAsset
+import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+
+/**
+ * A2UI `Button` — renders its child (typically a Text) and, on click, fires the
+ * transform-provided `run()` helper which evaluates any expression and triggers
+ * the resolved transition.
+ */
+@OptIn(ExperimentalPlayerApi::class)
+internal class A2UIButton(
+    assetContext: AssetContext,
+) : ComposableAsset<A2UIButton.Data>(assetContext, Data.serializer()) {
+    @Serializable
+    data class Data(
+        val child: RenderableAsset? = null,
+        val variant: String? = null,
+        override val accessibility: String? = null,
+        override val weight: Double? = null,
+        private val run: () -> Unit = {},
+    ) : A2UICommon {
+        suspend fun run() = withContext(Dispatchers.Default) { run.invoke() }
+    }
+
+    @Composable
+    override fun content(data: Data) {
+        val scope = rememberCoroutineScope()
+        val onClick: () -> Unit = { scope.launch { data.run() } }
+        val modifier = Modifier.fillMaxWidth().a2uiCommon(data)
+
+        when (data.variant) {
+            "outline" -> OutlinedButton(onClick = onClick, modifier = modifier) { data.child?.compose() }
+            "ghost" -> TextButton(onClick = onClick, modifier = modifier) { data.child?.compose() }
+            else -> Button(onClick = onClick, modifier = modifier) { data.child?.compose() }
+        }
+    }
+}

--- a/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UICard.kt
+++ b/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UICard.kt
@@ -1,0 +1,36 @@
+package com.intuit.playerui.android.a2ui
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Card
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.intuit.playerui.android.AssetContext
+import com.intuit.playerui.android.asset.RenderableAsset
+import com.intuit.playerui.android.compose.ComposableAsset
+import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
+import kotlinx.serialization.Serializable
+
+/** A2UI `Card` — a surface container wrapping a single child. */
+@OptIn(ExperimentalPlayerApi::class)
+internal class A2UICard(
+    assetContext: AssetContext,
+) : ComposableAsset<A2UICard.Data>(assetContext, Data.serializer()) {
+    @Serializable
+    data class Data(
+        val child: RenderableAsset? = null,
+        override val accessibility: String? = null,
+        override val weight: Double? = null,
+    ) : A2UICommon
+
+    @Composable
+    override fun content(data: Data) {
+        Card(
+            modifier = Modifier.fillMaxWidth().a2uiCommon(data),
+            elevation = 2.dp,
+        ) {
+            data.child?.compose(modifier = Modifier.padding(16.dp))
+        }
+    }
+}

--- a/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UICheckBox.kt
+++ b/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UICheckBox.kt
@@ -1,0 +1,52 @@
+package com.intuit.playerui.android.a2ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.Checkbox
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.intuit.playerui.android.AssetContext
+import com.intuit.playerui.android.compose.ComposableAsset
+import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+
+/** A2UI `CheckBox` — a boolean toggle bound to the data model with an optional label. */
+@OptIn(ExperimentalPlayerApi::class)
+internal class A2UICheckBox(
+    assetContext: AssetContext,
+) : ComposableAsset<A2UICheckBox.Data>(assetContext, Data.serializer()) {
+    @Serializable
+    data class Data(
+        val label: String? = null,
+        val currentValue: Boolean = false,
+        override val accessibility: String? = null,
+        override val weight: Double? = null,
+        private val set: (Boolean) -> Unit = {},
+    ) : A2UICommon {
+        suspend fun set(value: Boolean) = withContext(Dispatchers.Default) { set.invoke(value) }
+    }
+
+    @Composable
+    override fun content(data: Data) {
+        val scope = rememberCoroutineScope()
+        Row(
+            modifier = Modifier.fillMaxWidth().a2uiCommon(data),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Checkbox(
+                checked = data.currentValue,
+                onCheckedChange = { checked -> scope.launch { data.set(checked) } },
+            )
+            data.label?.let { Text(it) }
+        }
+    }
+}

--- a/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIChoicePicker.kt
+++ b/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIChoicePicker.kt
@@ -1,0 +1,85 @@
+package com.intuit.playerui.android.a2ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.material.Checkbox
+import androidx.compose.material.RadioButton
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.intuit.playerui.android.AssetContext
+import com.intuit.playerui.android.compose.ComposableAsset
+import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+
+/**
+ * A2UI `ChoicePicker` — single-select (radio) when `maxAllowedSelections` is 1
+ * or omitted, otherwise multi-select (checkboxes). Selected values are stored as
+ * a string list in the data model via the transform `currentValue`/`set` helpers.
+ */
+@OptIn(ExperimentalPlayerApi::class)
+internal class A2UIChoicePicker(
+    assetContext: AssetContext,
+) : ComposableAsset<A2UIChoicePicker.Data>(assetContext, Data.serializer()) {
+    @Serializable
+    data class Option(
+        val label: String = "",
+        val value: String = "",
+    )
+
+    @Serializable
+    data class Data(
+        val options: List<Option> = emptyList(),
+        val maxAllowedSelections: Int? = null,
+        val currentValue: List<String> = emptyList(),
+        override val accessibility: String? = null,
+        override val weight: Double? = null,
+        private val set: (List<String>) -> Unit = {},
+    ) : A2UICommon {
+        suspend fun set(value: List<String>) = withContext(Dispatchers.Default) { set.invoke(value) }
+    }
+
+    @Composable
+    override fun content(data: Data) {
+        val scope = rememberCoroutineScope()
+        val multiSelect = (data.maxAllowedSelections ?: 1) > 1
+
+        Column(
+            modifier = Modifier.fillMaxWidth().a2uiCommon(data),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            data.options.forEach { option ->
+                val selected = data.currentValue.contains(option.value)
+                val onSelect: () -> Unit = {
+                    val next = if (multiSelect) {
+                        if (selected) data.currentValue - option.value else data.currentValue + option.value
+                    } else {
+                        listOf(option.value)
+                    }
+                    scope.launch { data.set(next) }
+                }
+                Row(
+                    modifier = Modifier.fillMaxWidth().selectable(selected = selected, onClick = onSelect),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    if (multiSelect) {
+                        Checkbox(checked = selected, onCheckedChange = { onSelect() })
+                    } else {
+                        RadioButton(selected = selected, onClick = onSelect)
+                    }
+                    Text(option.label)
+                }
+            }
+        }
+    }
+}

--- a/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIChoicePicker.kt
+++ b/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIChoicePicker.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.material.Checkbox
 import androidx.compose.material.RadioButton
 import androidx.compose.material.Text
@@ -12,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import com.intuit.playerui.android.AssetContext
 import com.intuit.playerui.android.compose.ComposableAsset
@@ -54,7 +56,9 @@ internal class A2UIChoicePicker(
         val multiSelect = (data.maxAllowedSelections ?: 1) > 1
 
         Column(
-            modifier = Modifier.fillMaxWidth().a2uiCommon(data),
+            // Mirror React's role="radiogroup"/"group" so assistive tech reads the
+            // options as a single selection group.
+            modifier = Modifier.fillMaxWidth().a2uiCommon(data).selectableGroup(),
             verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
             data.options.forEach { option ->
@@ -68,14 +72,20 @@ internal class A2UIChoicePicker(
                     scope.launch { data.set(next) }
                 }
                 Row(
-                    modifier = Modifier.fillMaxWidth().selectable(selected = selected, onClick = onSelect),
+                    modifier = Modifier.fillMaxWidth().selectable(
+                        selected = selected,
+                        onClick = onSelect,
+                        role = if (multiSelect) Role.Checkbox else Role.RadioButton,
+                    ),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
+                    // null callbacks: the parent Row handles selection/role so the
+                    // control isn't announced as a separate focusable target.
                     if (multiSelect) {
-                        Checkbox(checked = selected, onCheckedChange = { onSelect() })
+                        Checkbox(checked = selected, onCheckedChange = null)
                     } else {
-                        RadioButton(selected = selected, onClick = onSelect)
+                        RadioButton(selected = selected, onClick = null)
                     }
                     Text(option.label)
                 }

--- a/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIColumn.kt
+++ b/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIColumn.kt
@@ -1,0 +1,37 @@
+package com.intuit.playerui.android.a2ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.intuit.playerui.android.AssetContext
+import com.intuit.playerui.android.asset.RenderableAsset
+import com.intuit.playerui.android.compose.ComposableAsset
+import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
+import kotlinx.serialization.Serializable
+
+/** A2UI `Column` — lays children out vertically with `justify`/`align` arrangement. */
+@OptIn(ExperimentalPlayerApi::class)
+internal class A2UIColumn(
+    assetContext: AssetContext,
+) : ComposableAsset<A2UIColumn.Data>(assetContext, Data.serializer()) {
+    @Serializable
+    data class Data(
+        val children: List<RenderableAsset> = emptyList(),
+        val justify: String? = null,
+        val align: String? = null,
+        override val accessibility: String? = null,
+        override val weight: Double? = null,
+    ) : A2UICommon
+
+    @Composable
+    override fun content(data: Data) {
+        Column(
+            modifier = Modifier.fillMaxWidth().a2uiCommon(data),
+            verticalArrangement = Layout.verticalArrangement(data.justify),
+            horizontalAlignment = Layout.horizontalAlignment(data.align),
+        ) {
+            data.children.forEach { it.compose() }
+        }
+    }
+}

--- a/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIColumn.kt
+++ b/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIColumn.kt
@@ -31,7 +31,7 @@ internal class A2UIColumn(
             verticalArrangement = Layout.verticalArrangement(data.justify),
             horizontalAlignment = Layout.horizontalAlignment(data.align),
         ) {
-            data.children.forEach { it.compose() }
+            data.children.forEach { it.compose(modifier = childLayout(it, data.align)) }
         }
     }
 }

--- a/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UICommon.kt
+++ b/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UICommon.kt
@@ -1,8 +1,13 @@
 package com.intuit.playerui.android.a2ui
 
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import com.intuit.playerui.android.asset.RenderableAsset
 
 /**
  * Presentation hints shared by every A2UI asset, mirroring the core
@@ -24,4 +29,37 @@ internal interface A2UICommon {
 internal fun Modifier.a2uiCommon(common: A2UICommon): Modifier {
     val description = common.accessibility ?: return this
     return this.semantics { contentDescription = description }
+}
+
+/**
+ * The flex-grow [A2UICommon.weight] declared on a child asset, read from its raw
+ * node. A flex container reads this for each child (React applies `weight` on each
+ * component itself via `commonProps`; on Android the parent applies it in-scope).
+ */
+internal val RenderableAsset.a2uiWeight: Double? get() = asset.node.getDouble("weight")
+
+/**
+ * Per-child layout modifier applied by a [RowScope] container (Row, horizontal
+ * List). Mirrors React's `commonProps` flex handling: the child's [weight] maps to
+ * `Modifier.weight` (flex-grow), and `align="stretch"` on the parent makes children
+ * fill the cross axis (`fillMaxHeight` for a row).
+ */
+internal fun RowScope.childLayout(child: RenderableAsset, align: String?): Modifier {
+    var modifier: Modifier = Modifier
+    child.a2uiWeight?.let { if (it > 0) modifier = modifier.weight(it.toFloat()) }
+    if (align == "stretch") modifier = modifier.fillMaxHeight()
+    return modifier
+}
+
+/**
+ * Per-child layout modifier applied by a [ColumnScope] container (Column, vertical
+ * List). The child's [weight] maps to `Modifier.weight` (flex-grow), and
+ * `align="stretch"` on the parent makes children fill the cross axis
+ * (`fillMaxWidth` for a column).
+ */
+internal fun ColumnScope.childLayout(child: RenderableAsset, align: String?): Modifier {
+    var modifier: Modifier = Modifier
+    child.a2uiWeight?.let { if (it > 0) modifier = modifier.weight(it.toFloat()) }
+    if (align == "stretch") modifier = modifier.fillMaxWidth()
+    return modifier
 }

--- a/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UICommon.kt
+++ b/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UICommon.kt
@@ -1,0 +1,27 @@
+package com.intuit.playerui.android.a2ui
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+
+/**
+ * Presentation hints shared by every A2UI asset, mirroring the core
+ * `A2UICommon` interface (`plugins/a2ui/core/src/assets/common`). Each asset's
+ * `@Serializable data class Data` implements this and declares its own
+ * `accessibility`/`weight` properties (kotlinx serializes each class's declared
+ * fields), so the deserialized shape matches the core asset types 1:1.
+ *
+ * - [accessibility]: screen-reader description (DOM `aria-label` in React,
+ *   Compose `contentDescription` here).
+ * - [weight]: flex-grow hint honored by flex containers (Row/Column/List).
+ */
+internal interface A2UICommon {
+    val accessibility: String?
+    val weight: Double?
+}
+
+/** Apply the shared [A2UICommon.accessibility] hint as a Compose semantics description. */
+internal fun Modifier.a2uiCommon(common: A2UICommon): Modifier {
+    val description = common.accessibility ?: return this
+    return this.semantics { contentDescription = description }
+}

--- a/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIDateTimeInput.kt
+++ b/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIDateTimeInput.kt
@@ -1,0 +1,64 @@
+package com.intuit.playerui.android.a2ui
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import com.intuit.playerui.android.AssetContext
+import com.intuit.playerui.android.compose.ComposableAsset
+import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+
+/**
+ * A2UI `DateTimeInput` — a date/time entry bound to the data model as an ISO
+ * string. Rendered as a text input with a label hinting the enabled portions;
+ * `enableDate`/`enableTime` describe which parts the value carries.
+ */
+@OptIn(ExperimentalPlayerApi::class)
+internal class A2UIDateTimeInput(
+    assetContext: AssetContext,
+) : ComposableAsset<A2UIDateTimeInput.Data>(assetContext, Data.serializer()) {
+    @Serializable
+    data class Data(
+        val currentValue: String = "",
+        val enableDate: Boolean = true,
+        val enableTime: Boolean = false,
+        override val accessibility: String? = null,
+        override val weight: Double? = null,
+        private val set: (String) -> Unit = {},
+    ) : A2UICommon {
+        suspend fun set(value: String) = withContext(Dispatchers.Default) { set.invoke(value) }
+    }
+
+    @Composable
+    override fun content(data: Data) {
+        val scope = rememberCoroutineScope()
+        var text by remember(data.currentValue) { mutableStateOf(data.currentValue) }
+
+        val label = when {
+            data.enableDate && data.enableTime -> "Date & time"
+            data.enableTime -> "Time"
+            else -> "Date"
+        }
+
+        OutlinedTextField(
+            value = text,
+            onValueChange = { newValue ->
+                text = newValue
+                scope.launch { data.set(newValue) }
+            },
+            label = { Text(label) },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth().a2uiCommon(data),
+        )
+    }
+}

--- a/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIDateTimeInput.kt
+++ b/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIDateTimeInput.kt
@@ -1,5 +1,7 @@
 package com.intuit.playerui.android.a2ui
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
@@ -10,6 +12,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import com.intuit.playerui.android.AssetContext
 import com.intuit.playerui.android.compose.ComposableAsset
 import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
@@ -20,8 +23,9 @@ import kotlinx.serialization.Serializable
 
 /**
  * A2UI `DateTimeInput` — a date/time entry bound to the data model as an ISO
- * string. Rendered as a text input with a label hinting the enabled portions;
- * `enableDate`/`enableTime` describe which parts the value carries.
+ * string. Mirrors React's native `<input type="date|time|datetime-local">`:
+ * tapping the (read-only) field opens the native picker(s) selected by
+ * `enableDate`/`enableTime`, emitting an ISO value.
  */
 @OptIn(ExperimentalPlayerApi::class)
 internal class A2UIDateTimeInput(
@@ -42,6 +46,7 @@ internal class A2UIDateTimeInput(
     @Composable
     override fun content(data: Data) {
         val scope = rememberCoroutineScope()
+        val context = LocalContext.current
         var text by remember(data.currentValue) { mutableStateOf(data.currentValue) }
 
         val label = when {
@@ -50,15 +55,35 @@ internal class A2UIDateTimeInput(
             else -> "Date"
         }
 
-        OutlinedTextField(
-            value = text,
-            onValueChange = { newValue ->
-                text = newValue
-                scope.launch { data.set(newValue) }
-            },
-            label = { Text(label) },
-            singleLine = true,
-            modifier = Modifier.fillMaxWidth().a2uiCommon(data),
-        )
+        val commit: (String) -> Unit = { value ->
+            text = value
+            scope.launch { data.set(value) }
+        }
+
+        // Compose the enabled portions. When both are enabled, the date picker
+        // chains into the time picker and the parts are joined as `<date>T<time>`.
+        val openPicker: () -> Unit = {
+            when {
+                data.enableDate && data.enableTime -> DateTimePickers.showDatePicker(context, text) { date ->
+                    DateTimePickers.showTimePicker(context, text) { time -> commit("${date}T$time") }
+                }
+                data.enableTime -> DateTimePickers.showTimePicker(context, text, commit)
+                else -> DateTimePickers.showDatePicker(context, text, commit)
+            }
+        }
+
+        Box(modifier = Modifier.fillMaxWidth().a2uiCommon(data)) {
+            OutlinedTextField(
+                value = text,
+                onValueChange = {},
+                readOnly = true,
+                enabled = false,
+                label = { Text(label) },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            // Transparent overlay captures the tap (a disabled field won't).
+            Box(modifier = Modifier.matchParentSize().clickable { openPicker() })
+        }
     }
 }

--- a/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIDivider.kt
+++ b/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIDivider.kt
@@ -1,0 +1,35 @@
+package com.intuit.playerui.android.a2ui
+
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Divider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.intuit.playerui.android.AssetContext
+import com.intuit.playerui.android.compose.ComposableAsset
+import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
+import kotlinx.serialization.Serializable
+
+/** A2UI `Divider` — a horizontal or vertical separator line. */
+@OptIn(ExperimentalPlayerApi::class)
+internal class A2UIDivider(
+    assetContext: AssetContext,
+) : ComposableAsset<A2UIDivider.Data>(assetContext, Data.serializer()) {
+    @Serializable
+    data class Data(
+        val axis: String? = null,
+        override val accessibility: String? = null,
+        override val weight: Double? = null,
+    ) : A2UICommon
+
+    @Composable
+    override fun content(data: Data) {
+        if (data.axis == "vertical") {
+            Divider(modifier = Modifier.fillMaxHeight().width(1.dp).a2uiCommon(data))
+        } else {
+            Divider(modifier = Modifier.fillMaxWidth().a2uiCommon(data))
+        }
+    }
+}

--- a/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIIcon.kt
+++ b/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIIcon.kt
@@ -1,0 +1,74 @@
+package com.intuit.playerui.android.a2ui
+
+import androidx.compose.material.Icon
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowForward
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Done
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.runtime.Composable
+import com.intuit.playerui.android.AssetContext
+import com.intuit.playerui.android.compose.ComposableAsset
+import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
+import kotlinx.serialization.Serializable
+
+/**
+ * A2UI `Icon` — maps a (possibly kebab/camel-case) icon `name` onto a Material
+ * filled icon from `material-icons-core`. Unknown names fall back to an info
+ * glyph. A broader icon set would require `material-icons-extended` on the
+ * classpath.
+ */
+@OptIn(ExperimentalPlayerApi::class)
+internal class A2UIIcon(
+    assetContext: AssetContext,
+) : ComposableAsset<A2UIIcon.Data>(assetContext, Data.serializer()) {
+    @Serializable
+    data class Data(
+        val name: String? = null,
+        override val accessibility: String? = null,
+        override val weight: Double? = null,
+    ) : A2UICommon
+
+    @Composable
+    override fun content(data: Data) {
+        val normalized = data.name?.lowercase()?.replace(Regex("[-_ ]"), "")
+        val icon = when (normalized) {
+            "add", "plus" -> Icons.Filled.Add
+            "arrowback", "back" -> Icons.Filled.ArrowBack
+            "arrowforward", "forward", "next" -> Icons.Filled.ArrowForward
+            "check", "checkmark" -> Icons.Filled.Check
+            "clear" -> Icons.Filled.Clear
+            "close", "x" -> Icons.Filled.Close
+            "delete", "trash" -> Icons.Filled.Delete
+            "done" -> Icons.Filled.Done
+            "edit", "pencil" -> Icons.Filled.Edit
+            "email", "mail" -> Icons.Filled.Email
+            "favorite", "heart" -> Icons.Filled.Favorite
+            "home" -> Icons.Filled.Home
+            "info" -> Icons.Filled.Info
+            "menu" -> Icons.Filled.Menu
+            "person", "account", "user" -> Icons.Filled.AccountCircle
+            "search" -> Icons.Filled.Search
+            "settings", "gear" -> Icons.Filled.Settings
+            "star" -> Icons.Filled.Star
+            "warning", "alert" -> Icons.Filled.Warning
+            else -> Icons.Filled.Info
+        }
+        Icon(imageVector = icon, contentDescription = data.accessibility ?: data.name)
+    }
+}

--- a/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIImage.kt
+++ b/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIImage.kt
@@ -1,0 +1,51 @@
+package com.intuit.playerui.android.a2ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.Icon
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import com.intuit.playerui.android.AssetContext
+import com.intuit.playerui.android.compose.ComposableAsset
+import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
+import kotlinx.serialization.Serializable
+
+/**
+ * A2UI `Image` — renders a placeholder for the image at `url`. Network image
+ * loading requires an image-loading dependency (e.g. Coil), which is not yet on
+ * the classpath; this renders a sized placeholder carrying the URL as its
+ * content description so layout and accessibility are preserved.
+ */
+@OptIn(ExperimentalPlayerApi::class)
+internal class A2UIImage(
+    assetContext: AssetContext,
+) : ComposableAsset<A2UIImage.Data>(assetContext, Data.serializer()) {
+    @Serializable
+    data class Data(
+        val url: String? = null,
+        val fit: String? = null,
+        val variant: String? = null,
+        override val accessibility: String? = null,
+        override val weight: Double? = null,
+    ) : A2UICommon
+
+    @Composable
+    override fun content(data: Data) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(120.dp)
+                .semantics { contentDescription = data.accessibility ?: data.url ?: "image" },
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(imageVector = Icons.Filled.Person, contentDescription = null)
+        }
+    }
+}

--- a/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIList.kt
+++ b/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIList.kt
@@ -1,0 +1,50 @@
+package com.intuit.playerui.android.a2ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.intuit.playerui.android.AssetContext
+import com.intuit.playerui.android.asset.RenderableAsset
+import com.intuit.playerui.android.compose.ComposableAsset
+import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
+import kotlinx.serialization.Serializable
+
+/** A2UI `List` — renders children stacked vertically or horizontally with spacing. */
+@OptIn(ExperimentalPlayerApi::class)
+internal class A2UIList(
+    assetContext: AssetContext,
+) : ComposableAsset<A2UIList.Data>(assetContext, Data.serializer()) {
+    @Serializable
+    data class Data(
+        val children: List<RenderableAsset> = emptyList(),
+        val direction: String? = null,
+        val align: String? = null,
+        override val accessibility: String? = null,
+        override val weight: Double? = null,
+    ) : A2UICommon
+
+    @Composable
+    override fun content(data: Data) {
+        if (data.direction == "horizontal") {
+            Row(
+                modifier = Modifier.fillMaxWidth().a2uiCommon(data),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Layout.verticalAlignment(data.align),
+            ) {
+                data.children.forEach { it.compose() }
+            }
+        } else {
+            Column(
+                modifier = Modifier.fillMaxWidth().a2uiCommon(data),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                horizontalAlignment = Layout.horizontalAlignment(data.align),
+            ) {
+                data.children.forEach { it.compose() }
+            }
+        }
+    }
+}

--- a/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIList.kt
+++ b/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIList.kt
@@ -6,6 +6,9 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.CollectionInfo
+import androidx.compose.ui.semantics.collectionInfo
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.intuit.playerui.android.AssetContext
 import com.intuit.playerui.android.asset.RenderableAsset
@@ -29,21 +32,30 @@ internal class A2UIList(
 
     @Composable
     override fun content(data: Data) {
+        // Mirror React's role="list" via a single-axis collection (rowCount for a
+        // horizontal list, columnCount for a vertical one).
+        val listSemantics = Modifier.semantics {
+            collectionInfo = if (data.direction == "horizontal") {
+                CollectionInfo(rowCount = 1, columnCount = data.children.size)
+            } else {
+                CollectionInfo(rowCount = data.children.size, columnCount = 1)
+            }
+        }
         if (data.direction == "horizontal") {
             Row(
-                modifier = Modifier.fillMaxWidth().a2uiCommon(data),
+                modifier = Modifier.fillMaxWidth().a2uiCommon(data).then(listSemantics),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Layout.verticalAlignment(data.align),
             ) {
-                data.children.forEach { it.compose() }
+                data.children.forEach { it.compose(modifier = childLayout(it, data.align)) }
             }
         } else {
             Column(
-                modifier = Modifier.fillMaxWidth().a2uiCommon(data),
+                modifier = Modifier.fillMaxWidth().a2uiCommon(data).then(listSemantics),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
                 horizontalAlignment = Layout.horizontalAlignment(data.align),
             ) {
-                data.children.forEach { it.compose() }
+                data.children.forEach { it.compose(modifier = childLayout(it, data.align)) }
             }
         }
     }

--- a/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIModal.kt
+++ b/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIModal.kt
@@ -1,0 +1,55 @@
+package com.intuit.playerui.android.a2ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.intuit.playerui.android.AssetContext
+import com.intuit.playerui.android.asset.RenderableAsset
+import com.intuit.playerui.android.compose.ComposableAsset
+import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
+import kotlinx.serialization.Serializable
+
+/**
+ * A2UI `Modal` — renders the `entryPointChild` inline; tapping it opens a
+ * [Dialog] containing the `contentChild`. Dismissing the dialog (back/scrim)
+ * closes it.
+ */
+@OptIn(ExperimentalPlayerApi::class)
+internal class A2UIModal(
+    assetContext: AssetContext,
+) : ComposableAsset<A2UIModal.Data>(assetContext, Data.serializer()) {
+    @Serializable
+    data class Data(
+        val entryPointChild: RenderableAsset? = null,
+        val contentChild: RenderableAsset? = null,
+        override val accessibility: String? = null,
+        override val weight: Double? = null,
+    ) : A2UICommon
+
+    @Composable
+    override fun content(data: Data) {
+        var open by remember { mutableStateOf(false) }
+
+        Box(modifier = Modifier.clickable { open = true }.a2uiCommon(data)) {
+            data.entryPointChild?.compose()
+        }
+
+        if (open) {
+            Dialog(onDismissRequest = { open = false }) {
+                Surface(modifier = Modifier.fillMaxWidth()) {
+                    data.contentChild?.compose(modifier = Modifier.padding(16.dp))
+                }
+            }
+        }
+    }
+}

--- a/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIRow.kt
+++ b/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIRow.kt
@@ -1,0 +1,37 @@
+package com.intuit.playerui.android.a2ui
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.intuit.playerui.android.AssetContext
+import com.intuit.playerui.android.asset.RenderableAsset
+import com.intuit.playerui.android.compose.ComposableAsset
+import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
+import kotlinx.serialization.Serializable
+
+/** A2UI `Row` — lays children out horizontally with `justify`/`align` arrangement. */
+@OptIn(ExperimentalPlayerApi::class)
+internal class A2UIRow(
+    assetContext: AssetContext,
+) : ComposableAsset<A2UIRow.Data>(assetContext, Data.serializer()) {
+    @Serializable
+    data class Data(
+        val children: List<RenderableAsset> = emptyList(),
+        val justify: String? = null,
+        val align: String? = null,
+        override val accessibility: String? = null,
+        override val weight: Double? = null,
+    ) : A2UICommon
+
+    @Composable
+    override fun content(data: Data) {
+        Row(
+            modifier = Modifier.fillMaxWidth().a2uiCommon(data),
+            horizontalArrangement = Layout.horizontalArrangement(data.justify),
+            verticalAlignment = Layout.verticalAlignment(data.align),
+        ) {
+            data.children.forEach { it.compose() }
+        }
+    }
+}

--- a/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIRow.kt
+++ b/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIRow.kt
@@ -31,7 +31,7 @@ internal class A2UIRow(
             horizontalArrangement = Layout.horizontalArrangement(data.justify),
             verticalAlignment = Layout.verticalAlignment(data.align),
         ) {
-            data.children.forEach { it.compose() }
+            data.children.forEach { it.compose(modifier = childLayout(it, data.align)) }
         }
     }
 }

--- a/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UISlider.kt
+++ b/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UISlider.kt
@@ -1,0 +1,47 @@
+package com.intuit.playerui.android.a2ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.Slider
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import com.intuit.playerui.android.AssetContext
+import com.intuit.playerui.android.compose.ComposableAsset
+import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+
+/** A2UI `Slider` — a numeric range input bound to the data model. */
+@OptIn(ExperimentalPlayerApi::class)
+internal class A2UISlider(
+    assetContext: AssetContext,
+) : ComposableAsset<A2UISlider.Data>(assetContext, Data.serializer()) {
+    @Serializable
+    data class Data(
+        val currentValue: Double = 0.0,
+        val minValue: Double = 0.0,
+        val maxValue: Double = 100.0,
+        override val accessibility: String? = null,
+        override val weight: Double? = null,
+        private val set: (Double) -> Unit = {},
+    ) : A2UICommon {
+        suspend fun set(value: Double) = withContext(Dispatchers.Default) { set.invoke(value) }
+    }
+
+    @Composable
+    override fun content(data: Data) {
+        val scope = rememberCoroutineScope()
+        Column(modifier = Modifier.fillMaxWidth().a2uiCommon(data)) {
+            Slider(
+                value = data.currentValue.toFloat(),
+                onValueChange = { value -> scope.launch { data.set(value.toDouble()) } },
+                valueRange = data.minValue.toFloat()..data.maxValue.toFloat(),
+            )
+            Text(text = data.currentValue.toString())
+        }
+    }
+}

--- a/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UISlider.kt
+++ b/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UISlider.kt
@@ -5,7 +5,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.Slider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.intuit.playerui.android.AssetContext
 import com.intuit.playerui.android.compose.ComposableAsset
@@ -35,13 +39,18 @@ internal class A2UISlider(
     @Composable
     override fun content(data: Data) {
         val scope = rememberCoroutineScope()
+        // Track the drag locally so the thumb/label update live, but only write
+        // back to the model when the drag is released (onValueChangeFinished).
+        // Re-seed from the model when it changes externally.
+        var position by remember(data.currentValue) { mutableStateOf(data.currentValue.toFloat()) }
         Column(modifier = Modifier.fillMaxWidth().a2uiCommon(data)) {
             Slider(
-                value = data.currentValue.toFloat(),
-                onValueChange = { value -> scope.launch { data.set(value.toDouble()) } },
+                value = position,
+                onValueChange = { value -> position = value },
+                onValueChangeFinished = { scope.launch { data.set(position.toDouble()) } },
                 valueRange = data.minValue.toFloat()..data.maxValue.toFloat(),
             )
-            Text(text = data.currentValue.toString())
+            Text(text = position.toDouble().toString())
         }
     }
 }

--- a/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UITabs.kt
+++ b/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UITabs.kt
@@ -1,0 +1,59 @@
+package com.intuit.playerui.android.a2ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Tab
+import androidx.compose.material.TabRow
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.intuit.playerui.android.AssetContext
+import com.intuit.playerui.android.asset.RenderableAsset
+import com.intuit.playerui.android.compose.ComposableAsset
+import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
+import kotlinx.serialization.Serializable
+
+/** A2UI `Tabs` — a tab strip; the selected tab's child is rendered below. */
+@OptIn(ExperimentalPlayerApi::class)
+internal class A2UITabs(
+    assetContext: AssetContext,
+) : ComposableAsset<A2UITabs.Data>(assetContext, Data.serializer()) {
+    @Serializable
+    data class TabItem(
+        val title: String = "",
+        val child: RenderableAsset? = null,
+    )
+
+    @Serializable
+    data class Data(
+        val tabItems: List<TabItem> = emptyList(),
+        override val accessibility: String? = null,
+        override val weight: Double? = null,
+    ) : A2UICommon
+
+    @Composable
+    override fun content(data: Data) {
+        if (data.tabItems.isEmpty()) return
+        var selected by remember { mutableStateOf(0) }
+        val index = selected.coerceIn(0, data.tabItems.lastIndex)
+
+        Column(modifier = Modifier.fillMaxWidth().a2uiCommon(data)) {
+            TabRow(selectedTabIndex = index) {
+                data.tabItems.forEachIndexed { i, item ->
+                    Tab(
+                        selected = i == index,
+                        onClick = { selected = i },
+                        text = { Text(item.title) },
+                    )
+                }
+            }
+            data.tabItems[index].child?.compose(modifier = Modifier.padding(top = 8.dp))
+        }
+    }
+}

--- a/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIText.kt
+++ b/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIText.kt
@@ -1,0 +1,55 @@
+package com.intuit.playerui.android.a2ui
+
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import com.intuit.playerui.android.AssetContext
+import com.intuit.playerui.android.compose.ComposableAsset
+import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
+import kotlinx.serialization.Serializable
+
+/**
+ * A2UI `Text` — renders a string (already resolved from any model binding by the
+ * core text transform) with a typography `variant`.
+ */
+@OptIn(ExperimentalPlayerApi::class)
+internal class A2UIText(
+    assetContext: AssetContext,
+) : ComposableAsset<A2UIText.Data>(assetContext, Data.serializer()) {
+    @Serializable
+    data class Data(
+        val text: String? = null,
+        val variant: String? = null,
+        override val accessibility: String? = null,
+        override val weight: Double? = null,
+    ) : A2UICommon
+
+    @Composable
+    override fun content(data: Data) {
+        val typography = MaterialTheme.typography
+        val style = when (data.variant) {
+            "h1" -> typography.h1
+            "h2" -> typography.h2
+            "h3" -> typography.h3
+            "h4" -> typography.h4
+            "h5" -> typography.h5
+            "caption" -> typography.caption
+            else -> typography.body1
+        }
+        val fontWeight = when (data.variant) {
+            "h1", "h2", "h3" -> FontWeight.Bold
+            "h4", "h5" -> FontWeight.SemiBold
+            else -> null
+        }
+        Text(
+            text = data.text ?: "",
+            style = style,
+            fontWeight = fontWeight,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.a2uiCommon(data),
+        )
+    }
+}

--- a/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIText.kt
+++ b/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UIText.kt
@@ -5,7 +5,6 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import com.intuit.playerui.android.AssetContext
 import com.intuit.playerui.android.compose.ComposableAsset
 import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
@@ -48,7 +47,6 @@ internal class A2UIText(
             text = data.text ?: "",
             style = style,
             fontWeight = fontWeight,
-            overflow = TextOverflow.Ellipsis,
             modifier = Modifier.a2uiCommon(data),
         )
     }

--- a/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UITextField.kt
+++ b/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UITextField.kt
@@ -1,0 +1,100 @@
+package com.intuit.playerui.android.a2ui
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import com.intuit.playerui.android.AssetContext
+import com.intuit.playerui.android.compose.ComposableAsset
+import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+
+/**
+ * A2UI `TextField` — a single-line/multi-line text input bound to the data model
+ * through the transform-provided `currentValue`/`set` helpers. `textFieldType`
+ * selects the keyboard and obscuring behavior; `validationRegexp` is applied
+ * client-side to surface an inline error.
+ */
+@OptIn(ExperimentalPlayerApi::class)
+internal class A2UITextField(
+    assetContext: AssetContext,
+) : ComposableAsset<A2UITextField.Data>(assetContext, Data.serializer()) {
+    /** Mirrors the core `ValidationResponse` consumed by `TransformedTextField`. */
+    @Serializable
+    data class Validation(
+        val message: String? = null,
+        val severity: String? = null,
+    )
+
+    @Serializable
+    data class Data(
+        val label: String? = null,
+        val textFieldType: String? = null,
+        val validationRegexp: String? = null,
+        val currentValue: String? = null,
+        /** Validation result for the bound model location (from the transform). */
+        val validation: Validation? = null,
+        /** Schema data type discovered for the binding, if any. */
+        val dataType: String? = null,
+        override val accessibility: String? = null,
+        override val weight: Double? = null,
+        private val set: (String?) -> Unit = {},
+        private val format: (String?) -> String? = { it },
+    ) : A2UICommon {
+        suspend fun set(value: String?) = withContext(Dispatchers.Default) { set.invoke(value) }
+
+        /** Format a value through any schema-attached formatters (from the transform). */
+        suspend fun format(value: String?): String? = withContext(Dispatchers.Default) { format.invoke(value) }
+    }
+
+    @Composable
+    override fun content(data: Data) {
+        val scope = rememberCoroutineScope()
+        var text by remember(data.currentValue) { mutableStateOf(data.currentValue ?: "") }
+
+        val regexError = data.validationRegexp
+            ?.let { runCatching { Regex(it) }.getOrNull() }
+            ?.let { regex -> text.isNotEmpty() && !regex.matches(text) }
+            ?: false
+
+        // Mirror React: prefer the transform-provided validation message, else
+        // fall back to the client-side regex check.
+        val error = data.validation?.message ?: if (regexError) "Invalid value" else null
+
+        OutlinedTextField(
+            value = text,
+            onValueChange = { newValue ->
+                text = newValue
+                scope.launch { data.set(newValue) }
+            },
+            label = data.label?.let { { Text(it) } },
+            singleLine = data.textFieldType != "longText",
+            isError = error != null,
+            visualTransformation = if (data.textFieldType == "obscured") {
+                PasswordVisualTransformation()
+            } else {
+                androidx.compose.ui.text.input.VisualTransformation.None
+            },
+            keyboardOptions = KeyboardOptions(
+                keyboardType = when (data.textFieldType) {
+                    "number" -> KeyboardType.Number
+                    "obscured" -> KeyboardType.Password
+                    else -> KeyboardType.Text
+                },
+            ),
+            modifier = Modifier.fillMaxWidth().a2uiCommon(data),
+        )
+    }
+}

--- a/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UITextField.kt
+++ b/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/A2UITextField.kt
@@ -1,21 +1,32 @@
 package com.intuit.playerui.android.a2ui
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.TextFieldValue
 import com.intuit.playerui.android.AssetContext
 import com.intuit.playerui.android.compose.ComposableAsset
 import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
+import com.intuit.playerui.plugins.transactions.commitPendingTransaction
+import com.intuit.playerui.plugins.transactions.registerPendingTransaction
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -62,39 +73,114 @@ internal class A2UITextField(
     @Composable
     override fun content(data: Data) {
         val scope = rememberCoroutineScope()
-        var text by remember(data.currentValue) { mutableStateOf(data.currentValue ?: "") }
+        val context = LocalContext.current
+
+        // Hold a TextFieldValue so the caret/selection survives recomposition
+        // (mirrors the reference Input asset's setText + setSelection). Seeded from
+        // the model value, but only resynced when the model differs from the local
+        // edit — so an external model update doesn't reset the cursor mid-typing.
+        var field by remember { mutableStateOf(TextFieldValue(data.currentValue ?: "")) }
+        LaunchedEffect(data.currentValue) {
+            val modelValue = data.currentValue ?: ""
+            if (modelValue != field.text) {
+                field = TextFieldValue(modelValue, TextRange(modelValue.length))
+            }
+        }
 
         val regexError = data.validationRegexp
             ?.let { runCatching { Regex(it) }.getOrNull() }
-            ?.let { regex -> text.isNotEmpty() && !regex.matches(text) }
+            ?.let { regex -> field.text.isNotEmpty() && !regex.matches(field.text) }
             ?: false
 
         // Mirror React: prefer the transform-provided validation message, else
         // fall back to the client-side regex check.
         val error = data.validation?.message ?: if (regexError) "Invalid value" else null
 
-        OutlinedTextField(
-            value = text,
-            onValueChange = { newValue ->
-                text = newValue
-                scope.launch { data.set(newValue) }
-            },
-            label = data.label?.let { { Text(it) } },
-            singleLine = data.textFieldType != "longText",
-            isError = error != null,
-            visualTransformation = if (data.textFieldType == "obscured") {
-                PasswordVisualTransformation()
+        // Local edit. Like the reference Input asset, apply the transform's
+        // formatter in-place while the caret sits at the end (so reformatting
+        // doesn't fight the cursor); the model write is deferred to blur.
+        val onEdit: (TextFieldValue) -> Unit = { new ->
+            field = new
+            val atEnd = new.selection.collapsed && new.selection.end == new.text.length
+            if (atEnd) {
+                scope.launch {
+                    val formatted = data.format(new.text) ?: new.text
+                    if (formatted != new.text) {
+                        field = TextFieldValue(formatted, TextRange(formatted.length))
+                    }
+                }
+            }
+        }
+
+        // Commit on blur via the PendingTransactionPlugin, exactly like the
+        // reference Input asset: register the set() on focus, commit on blur.
+        // (These extensions are no-ops if the plugin isn't registered.)
+        val focusModifier = Modifier.onFocusChanged { focusState ->
+            if (focusState.isFocused) {
+                player.registerPendingTransaction {
+                    scope.launch { data.set(field.text) }
+                }
             } else {
-                androidx.compose.ui.text.input.VisualTransformation.None
-            },
-            keyboardOptions = KeyboardOptions(
-                keyboardType = when (data.textFieldType) {
-                    "number" -> KeyboardType.Number
-                    "obscured" -> KeyboardType.Password
-                    else -> KeyboardType.Text
-                },
-            ),
-            modifier = Modifier.fillMaxWidth().a2uiCommon(data),
-        )
+                player.commitPendingTransaction()
+            }
+        }
+
+        Column(modifier = Modifier.fillMaxWidth().a2uiCommon(data)) {
+            if (data.textFieldType == "date") {
+                // Mirror React's `<input type="date">`: a read-only field that opens
+                // a native picker, emitting an ISO date string. A picked date is a
+                // discrete commit, so write straight through (no focus/blur cycle).
+                Box {
+                    OutlinedTextField(
+                        value = field.text,
+                        onValueChange = {},
+                        readOnly = true,
+                        enabled = false,
+                        label = data.label?.let { { Text(it) } },
+                        singleLine = true,
+                        isError = error != null,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    Box(
+                        modifier = Modifier
+                            .matchParentSize()
+                            .clickable {
+                                DateTimePickers.showDatePicker(context, field.text) { picked ->
+                                    field = TextFieldValue(picked, TextRange(picked.length))
+                                    scope.launch { data.set(picked) }
+                                }
+                            },
+                    )
+                }
+            } else {
+                OutlinedTextField(
+                    value = field,
+                    onValueChange = onEdit,
+                    label = data.label?.let { { Text(it) } },
+                    singleLine = data.textFieldType != "longText",
+                    isError = error != null,
+                    visualTransformation = if (data.textFieldType == "obscured") {
+                        PasswordVisualTransformation()
+                    } else {
+                        androidx.compose.ui.text.input.VisualTransformation.None
+                    },
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = when (data.textFieldType) {
+                            "number" -> KeyboardType.Number
+                            "obscured" -> KeyboardType.Password
+                            else -> KeyboardType.Text
+                        },
+                    ),
+                    modifier = Modifier.fillMaxWidth().then(focusModifier),
+                )
+            }
+            if (error != null) {
+                Text(
+                    text = error,
+                    color = MaterialTheme.colors.error,
+                    style = MaterialTheme.typography.caption,
+                )
+            }
+        }
     }
 }

--- a/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/DateTimePickers.kt
+++ b/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/DateTimePickers.kt
@@ -1,0 +1,70 @@
+package com.intuit.playerui.android.a2ui
+
+import android.app.DatePickerDialog
+import android.app.TimePickerDialog
+import android.content.Context
+import java.util.Calendar
+
+/**
+ * Native date/time picker helpers shared by `A2UITextField` (date type) and
+ * `A2UIDateTimeInput`. Values are emitted as ISO-8601 strings to match the core
+ * transform's model representation (React relies on the browser's native pickers
+ * producing ISO values for `<input type="date">`/`time`/`datetime-local`).
+ */
+internal object DateTimePickers {
+    /** Opens a native date picker, emitting an ISO date (`yyyy-MM-dd`) on selection. */
+    fun showDatePicker(
+        context: Context,
+        current: String?,
+        onPicked: (String) -> Unit,
+    ) {
+        val cal = parseDate(current) ?: Calendar.getInstance()
+        DatePickerDialog(
+            context,
+            { _, year, month, day -> onPicked(formatDate(year, month, day)) },
+            cal.get(Calendar.YEAR),
+            cal.get(Calendar.MONTH),
+            cal.get(Calendar.DAY_OF_MONTH),
+        ).show()
+    }
+
+    /** Opens a native time picker, emitting an ISO time (`HH:mm`) on selection. */
+    fun showTimePicker(
+        context: Context,
+        current: String?,
+        onPicked: (String) -> Unit,
+    ) {
+        val cal = parseTime(current) ?: Calendar.getInstance()
+        TimePickerDialog(
+            context,
+            { _, hour, minute -> onPicked(formatTime(hour, minute)) },
+            cal.get(Calendar.HOUR_OF_DAY),
+            cal.get(Calendar.MINUTE),
+            true,
+        ).show()
+    }
+
+    private fun formatDate(
+        year: Int,
+        month: Int,
+        day: Int,
+    ): String = "%04d-%02d-%02d".format(year, month + 1, day)
+
+    private fun formatTime(hour: Int, minute: Int): String = "%02d:%02d".format(hour, minute)
+
+    private fun parseDate(value: String?): Calendar? {
+        // Accept a leading ISO date (optionally followed by a time component).
+        val match = value?.let { Regex("""(\d{4})-(\d{2})-(\d{2})""").find(it) } ?: return null
+        val (y, m, d) = match.destructured
+        return Calendar.getInstance().apply { set(y.toInt(), m.toInt() - 1, d.toInt()) }
+    }
+
+    private fun parseTime(value: String?): Calendar? {
+        val match = value?.let { Regex("""(\d{2}):(\d{2})""").find(it) } ?: return null
+        val (h, min) = match.destructured
+        return Calendar.getInstance().apply {
+            set(Calendar.HOUR_OF_DAY, h.toInt())
+            set(Calendar.MINUTE, min.toInt())
+        }
+    }
+}

--- a/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/Layout.kt
+++ b/plugins/a2ui/android/src/main/kotlin/com/intuit/playerui/android/a2ui/Layout.kt
@@ -1,0 +1,46 @@
+package com.intuit.playerui.android.a2ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.ui.Alignment
+
+/**
+ * Shared mappings from A2UI layout enums (`justify`/`align`) onto Compose
+ * [Arrangement] and [Alignment] values. A2UI uses the same enum names for Row
+ * and Column; the `justify` axis differs (horizontal for Row, vertical for
+ * Column) so it has axis-specific helpers.
+ */
+internal object Layout {
+    /** Maps an A2UI `justify` value to a Compose horizontal [Arrangement] (Row main axis). */
+    fun horizontalArrangement(justify: String?): Arrangement.Horizontal = when (justify) {
+        "center" -> Arrangement.Center
+        "end" -> Arrangement.End
+        "spaceBetween" -> Arrangement.SpaceBetween
+        "spaceAround" -> Arrangement.SpaceAround
+        "spaceEvenly" -> Arrangement.SpaceEvenly
+        else -> Arrangement.Start
+    }
+
+    /** Maps an A2UI `justify` value to a Compose vertical [Arrangement] (Column main axis). */
+    fun verticalArrangement(justify: String?): Arrangement.Vertical = when (justify) {
+        "center" -> Arrangement.Center
+        "end" -> Arrangement.Bottom
+        "spaceBetween" -> Arrangement.SpaceBetween
+        "spaceAround" -> Arrangement.SpaceAround
+        "spaceEvenly" -> Arrangement.SpaceEvenly
+        else -> Arrangement.Top
+    }
+
+    /** Maps an A2UI `align` value to a Compose vertical [Alignment] (Row cross axis). */
+    fun verticalAlignment(align: String?): Alignment.Vertical = when (align) {
+        "center" -> Alignment.CenterVertically
+        "end" -> Alignment.Bottom
+        else -> Alignment.Top
+    }
+
+    /** Maps an A2UI `align` value to a Compose horizontal [Alignment] (Column cross axis). */
+    fun horizontalAlignment(align: String?): Alignment.Horizontal = when (align) {
+        "center" -> Alignment.CenterHorizontally
+        "end" -> Alignment.End
+        else -> Alignment.Start
+    }
+}

--- a/plugins/a2ui/core/src/__tests__/expressions.test.ts
+++ b/plugins/a2ui/core/src/__tests__/expressions.test.ts
@@ -99,6 +99,56 @@ describe("a2ui expressions — format", () => {
   });
 });
 
+describe("a2ui expressions — format fallbacks (no Intl)", () => {
+  // The Hermes engine (JVM/Android) lacks `Intl`; exercise the pure-JS fallback
+  // by removing the global for the duration of each assertion.
+  const withoutIntl = (fn: () => void) => {
+    const realIntl = (globalThis as any).Intl;
+    (globalThis as any).Intl = undefined;
+    try {
+      fn();
+    } finally {
+      (globalThis as any).Intl = realIntl;
+    }
+  };
+
+  it("formatNumber groups en-US style", () => {
+    withoutIntl(() => {
+      expect(formatNumber(ctx, 1234.5, "en-US")).toBe("1,234.5");
+      expect(formatNumber(ctx, 1234567, "en-US")).toBe("1,234,567");
+      expect(formatNumber(ctx, 0.5, { style: "percent" })).toBe("50%");
+      expect(formatNumber(ctx, "not a number")).toBe("not a number");
+    });
+  });
+
+  it("formatCurrency prefixes a known symbol", () => {
+    withoutIntl(() => {
+      expect(formatCurrency(ctx, 1299.5, "USD", "en-US")).toBe("$1,299.50");
+      expect(formatCurrency(ctx, 9.99, "USD")).toBe("$9.99");
+      // Unmapped currency falls back to a code prefix.
+      expect(formatCurrency(ctx, 5, "ZZZ")).toBe("ZZZ 5.00");
+    });
+  });
+
+  it("formatDate renders a non-empty string", () => {
+    withoutIntl(() => {
+      const iso = "2024-01-15T00:00:00.000Z";
+      expect(formatDate(ctx, iso, "short")).toEqual(expect.any(String));
+      expect(formatDate(ctx, iso, "short").length).toBeGreaterThan(0);
+      expect(formatDate(ctx, "bogus")).toBe("bogus");
+    });
+  });
+
+  it("pluralize uses minimal English rule", () => {
+    withoutIntl(() => {
+      const opts = { one: "1 item", other: "{n} items" };
+      expect(pluralize(ctx, 1, opts)).toBe("1 item");
+      expect(pluralize(ctx, 2, opts)).toBe("{n} items");
+      expect(pluralize(ctx, 0, opts)).toBe("{n} items");
+    });
+  });
+});
+
 describe("a2ui expressions — logic", () => {
   it("and / or / not", () => {
     expect(and(ctx, true, true, 1)).toBe(true);

--- a/plugins/a2ui/core/src/expressions/format.ts
+++ b/plugins/a2ui/core/src/expressions/format.ts
@@ -23,6 +23,39 @@ function pickNumberLocaleAndOptions(
   return { locale: undefined, options: b };
 }
 
+/**
+ * The A2UI bundle runs on multiple JS engines. Browsers (React) and Node (tests)
+ * ship the full `Intl` API, but the Hermes engine used by the JVM/Android player
+ * is built without it. Each formatter below prefers the real `Intl` and falls
+ * back to a locale-light pure-JS implementation only when the relevant `Intl`
+ * constructor is missing. The fallbacks target readable en-US-style output — they
+ * intentionally do not reproduce per-locale separators/symbols (Hermes carries no
+ * locale data), but they never throw.
+ */
+const hasIntl = (ctor: keyof typeof Intl): boolean =>
+  typeof Intl !== "undefined" && typeof (Intl as never)[ctor] === "function";
+
+/** Group the integer part with `,` and join the fraction with `.` (en-US style). */
+function groupThousands(n: number, fractionDigits?: number): string {
+  const fixed =
+    fractionDigits === undefined ? String(n) : n.toFixed(fractionDigits);
+  const negative = fixed.startsWith("-");
+  const [intPart, fracPart] = (negative ? fixed.slice(1) : fixed).split(".");
+  const grouped = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  const out = fracPart ? `${grouped}.${fracPart}` : grouped;
+  return negative ? `-${out}` : out;
+}
+
+/** Minimal en-US currency symbols; unmapped codes fall back to `"<CODE> <amt>"`. */
+const CURRENCY_SYMBOLS: Record<string, string> = {
+  USD: "$",
+  EUR: "€",
+  GBP: "£",
+  JPY: "¥",
+  CAD: "$",
+  AUD: "$",
+};
+
 /** `Intl.NumberFormat` wrapper. 2nd arg can be a locale string OR options. */
 export const formatNumber: ExpressionHandler<
   [unknown, NumberFormatArg?, Intl.NumberFormatOptions?],
@@ -31,7 +64,18 @@ export const formatNumber: ExpressionHandler<
   const n = Number(value);
   if (Number.isNaN(n)) return String(value ?? "");
   const { locale, options } = pickNumberLocaleAndOptions(a, b);
-  return new Intl.NumberFormat(locale, options).format(n);
+  if (hasIntl("NumberFormat")) {
+    return new Intl.NumberFormat(locale, options).format(n);
+  }
+  // Fallback: en-US grouping, honoring percent style + fraction-digit bounds.
+  if (options?.style === "percent") {
+    const digits = options.maximumFractionDigits ?? 0;
+    return `${groupThousands(n * 100, digits)}%`;
+  }
+  const min = options?.minimumFractionDigits;
+  const max = options?.maximumFractionDigits;
+  const digits = max ?? min;
+  return groupThousands(n, digits);
 };
 
 /** `Intl.NumberFormat` in currency style. */
@@ -41,10 +85,16 @@ export const formatCurrency: ExpressionHandler<
 > = (_ctx, value, currency, locale) => {
   const n = Number(value);
   if (Number.isNaN(n) || !currency) return String(value ?? "");
-  return new Intl.NumberFormat(locale, {
-    style: "currency",
-    currency,
-  }).format(n);
+  if (hasIntl("NumberFormat")) {
+    return new Intl.NumberFormat(locale, {
+      style: "currency",
+      currency,
+    }).format(n);
+  }
+  // Fallback: en-US grouping to 2 decimals, prefixed with a known symbol.
+  const amount = groupThousands(n, 2);
+  const symbol = CURRENCY_SYMBOLS[currency];
+  return symbol ? `${symbol}${amount}` : `${currency} ${amount}`;
 };
 
 const DATE_STYLE_MAP: Record<string, Intl.DateTimeFormatOptions> = {
@@ -66,8 +116,45 @@ export const formatDate: ExpressionHandler<
     value instanceof Date ? value : new Date(value as string | number);
   if (Number.isNaN(date.getTime())) return String(value ?? "");
   const options = pattern ? DATE_STYLE_MAP[pattern] : undefined;
-  return new Intl.DateTimeFormat(locale, options).format(date);
+  if (hasIntl("DateTimeFormat")) {
+    return new Intl.DateTimeFormat(locale, options).format(date);
+  }
+  return formatDateFallback(date, pattern);
 };
+
+const MONTHS_SHORT = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+/** Locale-light date rendering for engines without `Intl.DateTimeFormat`. */
+function formatDateFallback(date: Date, pattern?: string): string {
+  const y = date.getFullYear();
+  const m = date.getMonth();
+  const d = date.getDate();
+  const pad = (v: number) => String(v).padStart(2, "0");
+  switch (pattern) {
+    case "short":
+      // en-US numeric: M/D/YYYY
+      return `${m + 1}/${d}/${y}`;
+    case "medium":
+    case "long":
+    case "full":
+      return `${MONTHS_SHORT[m]} ${d}, ${y}`;
+    default:
+      return `${y}-${pad(m + 1)}-${pad(d)}`;
+  }
+}
 
 type PluralOptions = Partial<
   Record<Intl.LDMLPluralRule | "default", string>
@@ -85,6 +172,11 @@ export const pluralize: ExpressionHandler<[unknown, PluralOptions], string> = (
 ) => {
   const n = Number(count);
   if (!options || typeof options !== "object" || Number.isNaN(n)) return "";
-  const category = new Intl.PluralRules(options.locale).select(n);
+  const category = hasIntl("PluralRules")
+    ? new Intl.PluralRules(options.locale).select(n)
+    : // Fallback: minimal English plural rule (Hermes has no PluralRules).
+      n === 1
+      ? "one"
+      : "other";
   return options[category] ?? options.other ?? options.default ?? "";
 };

--- a/plugins/a2ui/jvm/BUILD
+++ b/plugins/a2ui/jvm/BUILD
@@ -1,0 +1,9 @@
+load("//plugins:defs.bzl", "GROUP", "kt_player_plugin_wrapper")
+
+kt_player_plugin_wrapper(
+    name = "a2ui",
+    package = GROUP + ".a2ui",
+    plugin_name = "A2UIPlugin",
+    plugin_source = "plugins/a2ui/core/dist/A2UIPlugin.native.js",
+    resources = ["//plugins/a2ui/core:core_native_bundle"],
+)

--- a/plugins/a2ui/mocks/BUILD
+++ b/plugins/a2ui/mocks/BUILD
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@rules_player//javascript:defs.bzl", "js_pipeline")
 load("@rules_player//player:defs.bzl", "generate_mocks_manifest")
 load("@npm//:defs.bzl", "npm_link_all_packages")
@@ -10,11 +11,36 @@ tsup_config(name = "tsup_config")
 vitest_config(name = "vitest_config")
 
 # Raw snapshot JSONs — the canonical source. Exposed for cross-platform
-# consumers (iOS / Android) and for the top-level //tools/mocks aggregator.
+# consumers (iOS / Android).
 # Named `snapshots` (not `mocks`) because `js_pipeline` below auto-creates an
 # `npm_package` target named `mocks` from the bazel package directory name.
 filegroup(
     name = "snapshots",
     srcs = glob(["src/**/*.json"]),
+    visibility = ["//visibility:public"],
+)
+
+# Re-root the snapshots under `mocks/<group>/<file>.json`. The //tools/mocks
+# manifest generator derives each mock's classpath path from the last three
+# path segments, so the directory immediately above `<group>` must be `mocks`
+# (matching the compiled reference-asset mocks). Leaving them under `src/`
+# produces `./src/...` manifest paths that fail to resolve at runtime.
+_snapshots = glob(["src/**/*.json"])
+
+[
+    copy_file(
+        name = "rerooted_{}".format(f.removeprefix("src/").replace("/", "_").replace(".json", "")),
+        src = f,
+        out = "mocks/{}".format(f.removeprefix("src/")),
+    )
+    for f in _snapshots
+]
+
+filegroup(
+    name = "rerooted_mocks",
+    srcs = [
+        ":rerooted_{}".format(f.removeprefix("src/").replace("/", "_").replace(".json", ""))
+        for f in _snapshots
+    ],
     visibility = ["//visibility:public"],
 )

--- a/tools/mocks/BUILD
+++ b/tools/mocks/BUILD
@@ -13,8 +13,10 @@ filegroup(
     srcs = ["//plugins/{}/mocks".format(plugin) for plugin in PLUGIN_MOCKS] + [
         "//plugins/reference-assets/mocks:flow-manager",
         # a2ui mocks live alongside a js_pipeline so the directory-level
-        # `mocks` target is the npm_package; the raw JSONs are at `:snapshots`.
-        "//plugins/a2ui/mocks:snapshots",
+        # `mocks` target is the npm_package; the raw JSONs are re-rooted under
+        # `mocks/<group>/<file>` by `:rerooted_mocks` so the manifest generator
+        # derives the correct classpath path (it keys off the last 3 segments).
+        "//plugins/a2ui/mocks:rerooted_mocks",
     ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Adds android implementation for a2ui assets

WIP
- [ ] Finalize mobile INTL implementation details
- [ ] Test and verify all assets are working in the demo app

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->