### PR TITLE
Fix release failing when bench_js pushes baseline first

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,9 @@ commands:
           echo -e $GPG_KEY | gpg --import --batch
           echo -e "pinentry-mode loopback\npassphrase $DEPLOY_MAVEN_GPG_PASSPHRASE" > ~/.gnupg/gpg.conf
       - run:
+          name: Sync to latest tip of current branch # Catch up to any baseline commits that were pushed before release
+          command: git pull --ff-only origin "${CIRCLE_BRANCH}"
+      - run:
           command: |
             source ~/.bashrc
             bundle install
@@ -651,6 +654,7 @@ workflows:
             - bundle-analyze
             - build_and_test_ios
             - build_docs
+            - bench_js
 
   full_release:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -397,7 +397,7 @@ jobs:
       - run:
           name: Post benchmark comparison (PR only)
           command: |
-            PR_NUM=$(echo "${CIRCLE_PULL_REQUEST:-}" | grep -oE '[0-9]+$')
+            PR_NUM="${CIRCLE_PULL_REQUEST##*/}"
             if [ -n "${PR_NUM}" ]; then
               node scripts/compare-benchmarks.js > bench-comparison.md
               if [ -s bench-comparison.md ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ parameters:
 orbs:
   macos: circleci/macos@2.5.4
   android: circleci/android@3.2.0
-  codecov: codecov/codecov@5.4.3
+  codecov: codecov/codecov@6.0.0
 
 executors:
   base:


### PR DESCRIPTION
## Summary

The release on `main` failed because `bench_js` and `release` run concurrently
(both gated only on `test`) and both push to `main`. `bench_js` won the race with
its `[skip ci] Update benchmark baseline` commit, leaving the release branched
behind it. `auto shipit` then aborted:

> Current commit is behind, skipping the release to avoid collisions.

(`git merge-base --is-ancestor <baseline> HEAD` failed — the release's local HEAD
didn't contain the baseline commit.)

## Changes

- Sync before shipit (`auto_shipit`): `git pull --ff-only origin "$CIRCLE_BRANCH"`
  before `auto shipit`, so the release job's HEAD includes any baseline commit
  `bench_js` pushed and the `--is-ancestor` check passes. Covers all release paths
  (`build_and_test_main`, `maybe_release`, `full_release`).
- Serialize (`build_and_test_main`): `release` now `requires: bench_js`, so the
  baseline lands before release pulls.
- Benchmark-comparison step on `main`: `PR_NUM` was extracted with `grep -oE`, which
  exits 1 (and fails the step under `set -e`) when there's no PR. Switched to
  `${CIRCLE_PULL_REQUEST##*/}` so the no-PR case yields an empty string and skips.
- Bump codecov orb `5.4.3` → `6.0.0`: 5.4.3 fails CLI signature verification
  (`gpg: no valid OpenPGP data found`) after Codecov rotated their signing key.

## Notes

The collision check is fine — the bug was stale local state in the release job, not
the guard. These changes make the state current so it passes.

The `--ff-only` sync assumes `$CIRCLE_BRANCH` is set. It is for all current release
paths; a tag-triggered release would need a guard, left for later.
