### PR TITLE
Run release before bench_js to keep auto graduation working

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,8 +75,8 @@ commands:
           command: |
             source ~/.bashrc
             bundle install
-            pnpm install --frozen-lockfile
-            pnpm exec auto shipit -vv --only-graduate-with-release-label
+            npx pnpm@10.18.1 install --frozen-lockfile
+            npx pnpm@10.18.1 exec auto shipit -vv --only-graduate-with-release-label
           no_output_timeout: 40m
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,9 +72,6 @@ commands:
           echo -e $GPG_KEY | gpg --import --batch
           echo -e "pinentry-mode loopback\npassphrase $DEPLOY_MAVEN_GPG_PASSPHRASE" > ~/.gnupg/gpg.conf
       - run:
-          name: Sync to latest tip of current branch # Catch up to any baseline commits that were pushed before release
-          command: git pull --ff-only origin "${CIRCLE_BRANCH}"
-      - run:
           command: |
             source ~/.bashrc
             bundle install
@@ -391,7 +388,7 @@ jobs:
                 cp "$f" "$(dirname $f)/baseline.json"
               done
               git add '*/benchmarks/baseline.json'
-              git diff --staged --quiet || (git commit -m "[skip ci] Update benchmark baseline" && git push origin main)
+              git diff --staged --quiet || (git commit -m "[skip ci] Update benchmark baseline" && git pull --rebase origin main && git push origin main)
             fi
 
       - run:
@@ -631,8 +628,9 @@ workflows:
       - bench_js:
           context:
             - Publish
+          # Run after release to avoid messing up Auto
           requires:
-            - test
+            - release
 
       - bundle_analyze:
           name: bundle-analyze
@@ -654,7 +652,6 @@ workflows:
             - bundle-analyze
             - build_and_test_ios
             - build_docs
-            - bench_js
 
   full_release:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,8 @@ commands:
           command: |
             source ~/.bashrc
             bundle install
-            npx auto shipit -vv --only-graduate-with-release-label
+            pnpm install --frozen-lockfile
+            pnpm exec auto shipit -vv --only-graduate-with-release-label
           no_output_timeout: 40m
 
 jobs:

--- a/package.json
+++ b/package.json
@@ -191,7 +191,10 @@
     "ignoredBuiltDependencies": [
       "core-js-pure",
       "yarn"
-    ]
+    ],
+    "patchedDependencies": {
+      "@auto-it/core@11.3.6": "patches/@auto-it__core@11.3.6.patch"
+    }
   },
   "resolutions": {
     "esbuild": "0.19.8",

--- a/patches/@auto-it__core@11.3.6.patch
+++ b/patches/@auto-it__core@11.3.6.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/auto.js b/dist/auto.js
+index 98aa739a9245219920c378d00bcec76d283b46fe..8809f06667207b5ffbe9241d2bc583ee3c63eec1 100644
+--- a/dist/auto.js
++++ b/dist/auto.js
+@@ -1004,7 +1004,7 @@ class Auto {
+         const isBaseBranch = !isPR && currentBranch === this.baseBranch;
+         const shouldGraduate = !options.onlyGraduateWithReleaseLabel ||
+             (options.onlyGraduateWithReleaseLabel &&
+-                head[0].labels.some((l) => { var _a, _b; return (_b = (_a = this.semVerLabels) === null || _a === void 0 ? void 0 : _a.get("release")) === null || _b === void 0 ? void 0 : _b.includes(l); }));
++                head.length > 0 && head[0].labels.some((l) => { var _a, _b; return (_b = (_a = this.semVerLabels) === null || _a === void 0 ? void 0 : _a.get("release")) === null || _b === void 0 ? void 0 : _b.includes(l); }));
+         const isPrereleaseBranch = (_b = (_a = this.config) === null || _a === void 0 ? void 0 : _a.prereleaseBranches) === null || _b === void 0 ? void 0 : _b.some((branch) => currentBranch === branch);
+         const publishPrerelease = isPrereleaseBranch ||
+             (currentBranch === this.baseBranch &&

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,11 @@ overrides:
   esbuild: 0.19.8
   jackspeak: 2.1.1
 
+patchedDependencies:
+  '@auto-it/core@11.3.6':
+    hash: 7348abdff98f4b4f40c0ae8225b3979f5ea6f44ddd650c8d6aabba63786c7571
+    path: patches/@auto-it__core@11.3.6.patch
+
 importers:
 
   .:
@@ -9904,7 +9909,7 @@ snapshots:
   '@auto-it/all-contributors@11.3.6(@swc/core@1.15.24)(@types/node@20.19.39)(typescript@5.5.3)':
     dependencies:
       '@auto-it/bot-list': 11.3.6
-      '@auto-it/core': 11.3.6(@swc/core@1.15.24)(@types/node@20.19.39)(typescript@5.5.3)
+      '@auto-it/core': 11.3.6(patch_hash=7348abdff98f4b4f40c0ae8225b3979f5ea6f44ddd650c8d6aabba63786c7571)(@swc/core@1.15.24)(@types/node@20.19.39)(typescript@5.5.3)
       '@octokit/rest': 18.12.0
       all-contributors-cli: 6.19.0
       anymatch: 3.1.3
@@ -9925,7 +9930,7 @@ snapshots:
 
   '@auto-it/bot-list@11.3.6': {}
 
-  '@auto-it/core@11.3.6(@swc/core@1.15.24)(@types/node@20.19.39)(typescript@5.5.3)':
+  '@auto-it/core@11.3.6(patch_hash=7348abdff98f4b4f40c0ae8225b3979f5ea6f44ddd650c8d6aabba63786c7571)(@swc/core@1.15.24)(@types/node@20.19.39)(typescript@5.5.3)':
     dependencies:
       '@auto-it/bot-list': 11.3.6
       '@endemolshinegroup/cosmiconfig-typescript-loader': 3.0.2(cosmiconfig@7.0.0)(typescript@5.5.3)
@@ -9978,7 +9983,7 @@ snapshots:
 
   '@auto-it/npm@11.3.6(@swc/core@1.15.24)(@types/node@20.19.39)(typescript@5.5.3)':
     dependencies:
-      '@auto-it/core': 11.3.6(@swc/core@1.15.24)(@types/node@20.19.39)(typescript@5.5.3)
+      '@auto-it/core': 11.3.6(patch_hash=7348abdff98f4b4f40c0ae8225b3979f5ea6f44ddd650c8d6aabba63786c7571)(@swc/core@1.15.24)(@types/node@20.19.39)(typescript@5.5.3)
       '@auto-it/package-json-utils': 11.3.6
       await-to-js: 3.0.0
       endent: 2.1.0
@@ -10002,7 +10007,7 @@ snapshots:
 
   '@auto-it/omit-release-notes@11.3.6(@swc/core@1.15.24)(@types/node@20.19.39)(typescript@5.5.3)':
     dependencies:
-      '@auto-it/core': 11.3.6(@swc/core@1.15.24)(@types/node@20.19.39)(typescript@5.5.3)
+      '@auto-it/core': 11.3.6(patch_hash=7348abdff98f4b4f40c0ae8225b3979f5ea6f44ddd650c8d6aabba63786c7571)(@swc/core@1.15.24)(@types/node@20.19.39)(typescript@5.5.3)
       fp-ts: 2.16.11
       io-ts: 2.2.22(fp-ts@2.16.11)
       tslib: 2.1.0
@@ -10022,7 +10027,7 @@ snapshots:
   '@auto-it/released@11.3.6(@swc/core@1.15.24)(@types/node@20.19.39)(typescript@5.5.3)':
     dependencies:
       '@auto-it/bot-list': 11.3.6
-      '@auto-it/core': 11.3.6(@swc/core@1.15.24)(@types/node@20.19.39)(typescript@5.5.3)
+      '@auto-it/core': 11.3.6(patch_hash=7348abdff98f4b4f40c0ae8225b3979f5ea6f44ddd650c8d6aabba63786c7571)(@swc/core@1.15.24)(@types/node@20.19.39)(typescript@5.5.3)
       deepmerge: 4.3.1
       fp-ts: 2.16.11
       io-ts: 2.2.22(fp-ts@2.16.11)
@@ -10037,7 +10042,7 @@ snapshots:
 
   '@auto-it/upload-assets@11.3.6(@swc/core@1.15.24)(@types/node@20.19.39)(typescript@5.5.3)':
     dependencies:
-      '@auto-it/core': 11.3.6(@swc/core@1.15.24)(@types/node@20.19.39)(typescript@5.5.3)
+      '@auto-it/core': 11.3.6(patch_hash=7348abdff98f4b4f40c0ae8225b3979f5ea6f44ddd650c8d6aabba63786c7571)(@swc/core@1.15.24)(@types/node@20.19.39)(typescript@5.5.3)
       endent: 2.1.0
       fast-glob: 3.3.3
       file-type: 16.5.4
@@ -10055,7 +10060,7 @@ snapshots:
 
   '@auto-it/version-file@11.3.6(@swc/core@1.15.24)(@types/node@20.19.39)(typescript@5.5.3)':
     dependencies:
-      '@auto-it/core': 11.3.6(@swc/core@1.15.24)(@types/node@20.19.39)(typescript@5.5.3)
+      '@auto-it/core': 11.3.6(patch_hash=7348abdff98f4b4f40c0ae8225b3979f5ea6f44ddd650c8d6aabba63786c7571)(@swc/core@1.15.24)(@types/node@20.19.39)(typescript@5.5.3)
       fp-ts: 2.16.11
       io-ts: 2.2.22(fp-ts@2.16.11)
       semver: 7.7.4
@@ -13348,7 +13353,7 @@ snapshots:
 
   auto@11.3.6(@swc/core@1.15.24)(@types/node@20.19.39)(typescript@5.5.3):
     dependencies:
-      '@auto-it/core': 11.3.6(@swc/core@1.15.24)(@types/node@20.19.39)(typescript@5.5.3)
+      '@auto-it/core': 11.3.6(patch_hash=7348abdff98f4b4f40c0ae8225b3979f5ea6f44ddd650c8d6aabba63786c7571)(@swc/core@1.15.24)(@types/node@20.19.39)(typescript@5.5.3)
       '@auto-it/npm': 11.3.6(@swc/core@1.15.24)(@types/node@20.19.39)(typescript@5.5.3)
       '@auto-it/released': 11.3.6(@swc/core@1.15.24)(@types/node@20.19.39)(typescript@5.5.3)
       '@auto-it/version-file': 11.3.6(@swc/core@1.15.24)(@types/node@20.19.39)(typescript@5.5.3)


### PR DESCRIPTION
## Summary

Release only graduates when HEAD is the release-labeled commit. `bench_js`
pushing its `[skip ci]` baseline commit before release (plus `auto_shipit`'s
`git pull`) moved release's HEAD onto that label-less commit, crashing `auto`
(`head[0].labels`).

## Changes

- `auto_shipit`: drop the `git pull` so release's HEAD stays the labeled commit.
- `bench_js` requires `release` (was `test`); its push now `pull --rebase`s
  first since release has advanced `origin/main`.
- `release` no longer requires `bench_js`.
- Patch `@auto-it/core` (via `pnpm patch`) to guard the gate with
  `head.length > 0 &&`, so `auto` no longer crashes when `main`'s tip is an
  unlabeled commit (baseline commits, `should_release` off a branch) — it routes
  to prerelease/no-op instead.

Tradeoff: baseline lands above the tag, not under it. Folding it under the tag
needs an `auto` version-hook plugin; deferred.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.15.4--canary.885.37636</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.15.4--canary.885.37636
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
