### PR TITLE
move storybook icons dependency to correct BUILD file

### DIFF
--- a/docs/storybook/BUILD
+++ b/docs/storybook/BUILD
@@ -25,7 +25,6 @@ deps = [
     "//:node_modules/@babel/preset-react",
     "//:node_modules/@storybook/react-webpack5",
     "//:node_modules/@storybook/addon-docs",
-    "//:node_modules/@storybook/icons",
     "//:node_modules/@types/react-redux",
     "//:node_modules/react-redux",
     "//:node_modules/redux-state-sync",

--- a/tools/storybook/BUILD
+++ b/tools/storybook/BUILD
@@ -17,6 +17,7 @@ dependencies = [
     ":node_modules/@player-ui/metrics-plugin-react",
     "//:node_modules/@vueless/storybook-dark-mode",
     "//:node_modules/storybook",
+    "//:node_modules/@storybook/icons",
     "//:node_modules/@player-tools/xlr",
     "//:node_modules/@player-tools/xlr-utils",
     "//:node_modules/@types/react-redux",


### PR DESCRIPTION
- Move `@storybook/icons` dependency from the `docs/storybook/BUILD` file to the `@player-ui/storybook` package BUILD.
  - Importing `@player-ui/storybook` right now causes other storybook builds to fail at runtime due to the missing dependency. This issue was being masked because the storybook docs here included the dependency itself.


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [X] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [X] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.15.5--canary.887.37809</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.15.5--canary.887.37809
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
