### PR TITLE
Log cold start time

### DIFF
--- a/android/player/src/main/kotlin/com/intuit/playerui/android/AndroidPlayer.kt
+++ b/android/player/src/main/kotlin/com/intuit/playerui/android/AndroidPlayer.kt
@@ -182,11 +182,17 @@ public class AndroidPlayer private constructor(
 
     /** Apply [AndroidPlayerPlugin]s last */
     init {
+        val startTime = System.currentTimeMillis()
+
         player.format.registerContextualSerializer(assetSerializer.conform<RenderableAsset<*>>())
 
         plugins
             .filterIsInstance<AndroidPlayerPlugin>()
             .forEach { it.apply(this) }
+
+        // Log the time it took to initialize Player
+        val initTime = System.currentTimeMillis() - startTime
+        logger.info("AndroidPlayer initialized in $initTime ms.")
     }
 
     /**

--- a/android/player/src/test/kotlin/com/intuit/playerui/android/AndroidPlayerTest.kt
+++ b/android/player/src/test/kotlin/com/intuit/playerui/android/AndroidPlayerTest.kt
@@ -1,9 +1,16 @@
 package com.intuit.playerui.android
 
+import android.util.Level
+import android.util.clearLogs
 import com.intuit.playerui.android.utils.CoroutineTestDispatcherExtension
 import com.intuit.playerui.core.player.Player
 import com.intuit.playerui.core.plugins.PlayerPlugin
 import com.intuit.playerui.core.plugins.findPlugin
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -11,6 +18,9 @@ import org.junit.jupiter.api.extension.ExtendWith
 
 @ExtendWith(CoroutineTestDispatcherExtension::class)
 internal class AndroidPlayerTest {
+    @AfterEach
+    fun tearDown() = clearLogs()
+
     @Test
     fun `registerPlugin applies AndroidPlayerPlugin`() {
         var applied = false
@@ -55,5 +65,22 @@ internal class AndroidPlayerTest {
         androidPlayer.registerPlugin(plugin)
 
         assertNotNull(androidPlayer.findPlugin<TrackingPlugin>())
+    }
+
+    @Test
+    fun `logs initialization time on startup`() = runBlocking {
+        AndroidPlayer()
+
+        assertLoggedMatching(Regex("""INFO: AndroidPlayer: AndroidPlayer initialized in \d+ ms\."""))
+    }
+
+    private suspend fun assertLoggedMatching(regex: Regex, timeout: Long = 5000) = try {
+        withTimeout(timeout) {
+            while (Level.Info.getLogs().none { regex.matches(it) }) {
+                delay(50)
+            }
+        }
+    } catch (exception: TimeoutCancellationException) {
+        throw AssertionError("No info log matching $regex\nin ${Level.Info.getLogs()}")
     }
 }

--- a/ios/swiftui/Sources/SwiftUIPlayer.swift
+++ b/ios/swiftui/Sources/SwiftUIPlayer.swift
@@ -215,10 +215,15 @@ public struct SwiftUIPlayer: View, HeadlessPlayer {
         context: Context = .shared,
         unloadOnDisappear: Bool = true
     ) {
+        let startTime = Date()
         self._result = result
         self._context = ObservedObject(initialValue: context)
         self.unloadOnDisappear = unloadOnDisappear
         context.load(flow: flow, plugins: plugins, player: self)
+
+        // Log the time it took to initialize Player
+        let initTime = Int((Date().timeIntervalSince(startTime) * 1000).rounded())
+        context.logger.i("SwiftUIPlayer initialized in \(initTime) ms.")
     }
 
     /// The SwiftUI View that is this Player flow

--- a/ios/swiftui/ViewInspector/SwiftUIPlayerTests.swift
+++ b/ios/swiftui/ViewInspector/SwiftUIPlayerTests.swift
@@ -38,6 +38,22 @@ class SwiftUIPlayerTests: XCTestCase {
         XCTAssertTrue(context.isLoaded)
     }
 
+    func testLogsInitializationTime() throws {
+        let context = SwiftUIPlayer.Context { JSContext() }
+        context.logger.logLevel = .info
+
+        let logged = expectation(description: "Initialization time logged")
+        context.logger.hooks.info.tap(name: "test") { messages in
+            let message = (messages as? [String])?.first ?? ""
+            guard message.range(of: #"SwiftUIPlayer initialized in \d+ ms\."#, options: .regularExpression) != nil else { return }
+            logged.fulfill()
+        }
+
+        _ = SwiftUIPlayer(flow: FlowData.COUNTER, plugins: [ReferenceAssetsPlugin()], context: context)
+
+        wait(for: [logged], timeout: 5)
+    }
+
     func testbadDecodeGoesToErrorState() throws {
         var result: Result<CompletedState, PlayerError>?
 

--- a/react/player/src/__tests__/player.test.tsx
+++ b/react/player/src/__tests__/player.test.tsx
@@ -3,7 +3,7 @@ import { act, render, screen, waitFor } from "@testing-library/react";
 import React, { Suspense, type ComponentType } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { ReactPlayer, type ReactPlayerPlugin } from "../player";
-import { Asset } from "@player-ui/player";
+import { Asset, Player } from "@player-ui/player";
 import { makeFlow } from "@player-ui/make-flow";
 
 type ErrorViewProps = Asset<"throwing"> & {
@@ -190,6 +190,26 @@ describe("ReactPlayer", () => {
 
       expect(rp.options.plugins).toContain(plugin);
     });
+  });
+
+  it("should log the initialization time on startup", () => {
+    const info = vi.fn();
+
+    const player = new Player({ plugins: [] });
+    player.logger.addHandler({
+      trace: () => {},
+      debug: () => {},
+      info,
+      warn: () => {},
+      error: () => {},
+    });
+
+    const rp = new ReactPlayer({ player });
+
+    expect(rp.player).toBe(player);
+    expect(info).toHaveBeenCalledWith(
+      expect.stringMatching(/ReactPlayer initialized in \d+ ms\./),
+    );
   });
 
   describe("Error Handling", () => {

--- a/react/player/src/player.tsx
+++ b/react/player/src/player.tsx
@@ -117,6 +117,7 @@ export class ReactPlayer {
   private reactPlayerInfo: ReactPlayerInfo;
 
   constructor(options?: ReactPlayerOptions) {
+    const startTime = performance.now();
     this.options = options ?? {};
 
     const Devtools = _window?.__PLAYER_DEVTOOLS_PLUGIN;
@@ -149,6 +150,10 @@ export class ReactPlayer {
       version: this.player.getVersion(),
       commit: this.player.getCommit(),
     };
+
+    // Log the time it took to initialize Player
+    const coldStartTime = Math.round(performance.now() - startTime);
+    this.player.logger.info(`ReactPlayer initialized in ${coldStartTime} ms.`);
   }
 
   /** Returns the current version Player */


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->
Log the cold start time for the `ReactPlayer`, `SwiftUIPlayer`, `AndroidPlayer`. This is defined as the time from the start of the init to the end. It includes the time to load the JS cores for all plugins.

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.2--canary.890.38467</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 1.0.2--canary.890.38467
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
