### PR TITLE
Add ContextPlugin: shared Player state for external consumers

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -49,6 +49,7 @@ plugins/check-path/react/node_modules
 plugins/common-expressions/core/node_modules
 plugins/computed-properties/core/node_modules
 plugins/console-logger/core/node_modules
+plugins/context/core/node_modules
 plugins/data-change-listener/core/node_modules
 plugins/data-filter/core/node_modules
 plugins/expression/core/node_modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -505,8 +505,8 @@ workflows:
             - Publish
           requires:
             - test-trunk
-            # - build-ios-trunk
-            # - android-test-trunk
+            - build-ios-trunk
+            - android-test-trunk
 
       - test:
           name: test-trunk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -505,8 +505,8 @@ workflows:
             - Publish
           requires:
             - test-trunk
-            - build-ios-trunk
-            - android-test-trunk
+            # - build-ios-trunk
+            # - android-test-trunk
 
       - test:
           name: test-trunk

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -141,6 +141,10 @@ assemble_ios_release(
         # Console Logger (PrintLoggerPlugin)
         "//plugins/console-logger/ios:PlayerUIPrintLoggerPlugin_Sources": "plugins/console-logger/ios/",
 
+        # Context
+        "//plugins/context/ios:PlayerUIContextPlugin_Sources": "plugins/context/ios/",
+        "//plugins/context/core:core_native_bundle": "plugins/context/ios/Resources/",
+
         # Expression
         "//plugins/expression/ios:PlayerUIExpressionPlugin_Sources": "plugins/expression/ios/",
         "//plugins/expression/core:core_native_bundle": "plugins/expression/ios/Resources/",

--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,7 @@ let ios_plugins: [SwiftPlugin] = [
     (name: "AsyncNodePlugin", path: "async-node", resources: true),
     (name: "BaseBeaconPlugin", path: "beacon", resources: true),
     (name: "CheckPathPlugin", path: "check-path", resources: true),
+    (name: "ContextPlugin", path: "context", resources: true),
     (name: "ExpressionPlugin", path: "expression", resources: true),
     (name: "ExternalStatePlugin", path: "external-state", resources: true),
     (name: "PubSubPlugin", path: "pubsub", resources: true),

--- a/ios/BUILD.bazel
+++ b/ios/BUILD.bazel
@@ -31,6 +31,8 @@ xcodeproj(
 
         "//plugins/console-logger/ios:PlayerUIPrintLoggerPluginTests",
 
+        "//plugins/context/ios:PlayerUIContextPluginTests",
+
         "//plugins/expression/ios:PlayerUIExpressionPluginTests",
 
         "//plugins/external-state/ios:PlayerUIExternalStatePluginTests",

--- a/jvm/core/api/core.api
+++ b/jvm/core/api/core.api
@@ -1966,7 +1966,7 @@ synthetic class com/intuit/playerui/core/bridge/serialization/serializers/NodeSe
 
 public final class com/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction {
 	public static final field Companion Lcom/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction$Companion;
-	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Lkotlinx/serialization/DeserializationStrategy;Lcom/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction$CacheStrategy;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lcom/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction$CacheStrategy;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;)Lcom/intuit/playerui/core/bridge/Invokable;
 }
 
@@ -1978,17 +1978,41 @@ public final class com/intuit/playerui/core/bridge/serialization/serializers/Nod
 }
 
 public final class com/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction$Companion {
+	public final fun invoke (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lcom/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction$CacheStrategy;Ljava/lang/String;)Lcom/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction;
 	public final fun invoke (Lkotlin/jvm/functions/Function0;Lkotlinx/serialization/DeserializationStrategy;Lcom/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction$CacheStrategy;Ljava/lang/String;)Lcom/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction;
+	public static synthetic fun invoke$default (Lcom/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction$Companion;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lcom/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction$CacheStrategy;Ljava/lang/String;ILjava/lang/Object;)Lcom/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction;
 	public static synthetic fun invoke$default (Lcom/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction$Companion;Lkotlin/jvm/functions/Function0;Lkotlinx/serialization/DeserializationStrategy;Lcom/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction$CacheStrategy;Ljava/lang/String;ILjava/lang/Object;)Lcom/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction;
 }
 
+final class com/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction$Companion$invoke$1 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
 public final class com/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunctionKt {
+	public static final fun NodeSerializableFunction (Lcom/intuit/playerui/core/bridge/NodeWrapper;Lkotlin/jvm/functions/Function0;Lcom/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction$CacheStrategy;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lcom/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction;
 	public static final fun NodeSerializableFunction (Lcom/intuit/playerui/core/bridge/NodeWrapper;Lkotlinx/serialization/DeserializationStrategy;Lcom/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction$CacheStrategy;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lcom/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction;
+	public static synthetic fun NodeSerializableFunction$default (Lcom/intuit/playerui/core/bridge/NodeWrapper;Lkotlin/jvm/functions/Function0;Lcom/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction$CacheStrategy;Ljava/lang/String;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lcom/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction;
 	public static synthetic fun NodeSerializableFunction$default (Lcom/intuit/playerui/core/bridge/NodeWrapper;Lkotlinx/serialization/DeserializationStrategy;Lcom/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction$CacheStrategy;Ljava/lang/String;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lcom/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction;
 }
 
 synthetic class com/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunctionKt$NodeSerializableFunction$1 : kotlin/jvm/internal/PropertyReference0Impl {
 	public fun get ()Ljava/lang/Object;
+}
+
+final class com/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunctionKt$NodeSerializableFunction$2 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+synthetic class com/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunctionKt$NodeSerializableFunction$3 : kotlin/jvm/internal/PropertyReference0Impl {
+	public fun get ()Ljava/lang/Object;
+}
+
+public final class com/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunctionKt$NodeSerializableFunction$4 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
 }
 
 public final class com/intuit/playerui/core/bridge/serialization/serializers/NodeSerializer : kotlinx/serialization/KSerializer {
@@ -2114,6 +2138,30 @@ synthetic class com/intuit/playerui/core/constants/ConstantsController$Serialize
 	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
+public final class com/intuit/playerui/core/constants/ConstantsController$special$$inlined$NodeSerializableFunction$default$1 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class com/intuit/playerui/core/constants/ConstantsController$special$$inlined$NodeSerializableFunction$default$2 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class com/intuit/playerui/core/constants/ConstantsController$special$$inlined$NodeSerializableFunction$default$3 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class com/intuit/playerui/core/constants/ConstantsController$special$$inlined$NodeSerializableFunction$default$4 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
 public final class com/intuit/playerui/core/data/BindingKt {
 }
 
@@ -2135,6 +2183,12 @@ synthetic class com/intuit/playerui/core/data/DataController$Serializer$1 : kotl
 	public static final field INSTANCE Lcom/intuit/playerui/core/data/DataController$Serializer$1;
 	public final fun invoke (Lcom/intuit/playerui/core/bridge/Node;)Lcom/intuit/playerui/core/data/DataController;
 	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/intuit/playerui/core/data/DataController$special$$inlined$NodeSerializableFunction$default$1 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
 }
 
 public final class com/intuit/playerui/core/data/DataControllerKt {
@@ -2162,6 +2216,18 @@ synthetic class com/intuit/playerui/core/data/DataModelWithParser$Serializer$1 :
 	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
+public final class com/intuit/playerui/core/data/DataModelWithParser$special$$inlined$NodeSerializableFunction$default$1 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class com/intuit/playerui/core/data/DataModelWithParser$special$$inlined$NodeSerializableFunction$default$2 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
 public final class com/intuit/playerui/core/data/DataModelWithParserKt {
 	public static final fun get (Lcom/intuit/playerui/core/data/DataModelWithParser;)Ljava/util/Map;
 	public static final fun set (Lcom/intuit/playerui/core/data/DataModelWithParser;[Lkotlin/Pair;)V
@@ -2185,6 +2251,12 @@ final class com/intuit/playerui/core/data/ReadOnlyDataController$Serializer$1 : 
 	public static final field INSTANCE Lcom/intuit/playerui/core/data/ReadOnlyDataController$Serializer$1;
 	public final fun invoke (Lcom/intuit/playerui/core/bridge/Node;)Lcom/intuit/playerui/core/data/ReadOnlyDataController;
 	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/intuit/playerui/core/data/ReadOnlyDataController$special$$inlined$NodeSerializableFunction$default$1 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
 }
 
 public final class com/intuit/playerui/core/data/ReadOnlyDataControllerKt {
@@ -2234,6 +2306,36 @@ synthetic class com/intuit/playerui/core/error/ErrorController$Serializer$1 : ko
 	public static final field INSTANCE Lcom/intuit/playerui/core/error/ErrorController$Serializer$1;
 	public final fun invoke (Lcom/intuit/playerui/core/bridge/Node;)Lcom/intuit/playerui/core/error/ErrorController;
 	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/intuit/playerui/core/error/ErrorController$special$$inlined$NodeSerializableFunction$default$1 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class com/intuit/playerui/core/error/ErrorController$special$$inlined$NodeSerializableFunction$default$2 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class com/intuit/playerui/core/error/ErrorController$special$$inlined$NodeSerializableFunction$default$3 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class com/intuit/playerui/core/error/ErrorController$special$$inlined$NodeSerializableFunction$default$4 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class com/intuit/playerui/core/error/ErrorController$special$$inlined$NodeSerializableFunction$default$5 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
 }
 
 public final class com/intuit/playerui/core/error/ErrorSeverity : java/lang/Enum {
@@ -2402,6 +2504,12 @@ synthetic class com/intuit/playerui/core/expressions/ExpressionController$Serial
 	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
+public final class com/intuit/playerui/core/expressions/ExpressionController$special$$inlined$NodeSerializableFunction$default$1 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
 public abstract interface class com/intuit/playerui/core/expressions/ExpressionEvaluator {
 	public abstract fun evaluate (Ljava/util/List;)Ljava/lang/Object;
 }
@@ -2512,6 +2620,12 @@ synthetic class com/intuit/playerui/core/flow/FlowController$Serializer$1 : kotl
 	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
+public final class com/intuit/playerui/core/flow/FlowController$special$$inlined$NodeSerializableFunction$default$1 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
 public final class com/intuit/playerui/core/flow/FlowException : com/intuit/playerui/core/player/PlayerException {
 }
 
@@ -2563,6 +2677,12 @@ synthetic class com/intuit/playerui/core/flow/FlowInstance$Serializer$1 : kotlin
 	public static final field INSTANCE Lcom/intuit/playerui/core/flow/FlowInstance$Serializer$1;
 	public final fun invoke (Lcom/intuit/playerui/core/bridge/Node;)Lcom/intuit/playerui/core/flow/FlowInstance;
 	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/intuit/playerui/core/flow/FlowInstance$special$$inlined$NodeSerializableFunction$default$1 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
 }
 
 public final class com/intuit/playerui/core/flow/FlowResult : com/intuit/playerui/core/bridge/NodeWrapper {
@@ -3036,6 +3156,36 @@ final class com/intuit/playerui/core/logger/TapableLogger$info$3 : kotlin/corout
 	public final fun invokeSuspend (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
+public final class com/intuit/playerui/core/logger/TapableLogger$special$$inlined$NodeSerializableFunction$default$1 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class com/intuit/playerui/core/logger/TapableLogger$special$$inlined$NodeSerializableFunction$default$2 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class com/intuit/playerui/core/logger/TapableLogger$special$$inlined$NodeSerializableFunction$default$3 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class com/intuit/playerui/core/logger/TapableLogger$special$$inlined$NodeSerializableFunction$default$4 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class com/intuit/playerui/core/logger/TapableLogger$special$$inlined$NodeSerializableFunction$default$5 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
 final class com/intuit/playerui/core/logger/TapableLogger$trace$3 : kotlin/coroutines/jvm/internal/SuspendLambda, kotlin/jvm/functions/Function2 {
 	public final fun create (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Lkotlin/coroutines/Continuation;
 	public synthetic fun invoke (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
@@ -3204,6 +3354,12 @@ final class com/intuit/playerui/core/player/HeadlessPlayer$runtime$1$1$1 : kotli
 public final class com/intuit/playerui/core/player/HeadlessPlayer$runtime$1$invoke$$inlined$CoroutineExceptionHandler$1 : kotlin/coroutines/AbstractCoroutineContextElement, kotlinx/coroutines/CoroutineExceptionHandler {
 	public fun <init> (Lkotlinx/coroutines/CoroutineExceptionHandler$Key;Lcom/intuit/playerui/core/player/HeadlessPlayer;)V
 	public fun handleException (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Throwable;)V
+}
+
+public final class com/intuit/playerui/core/player/HeadlessPlayer$special$$inlined$NodeSerializableFunction$default$1 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
 }
 
 public final class com/intuit/playerui/core/player/JSPlayerConfig {
@@ -3553,6 +3709,12 @@ synthetic class com/intuit/playerui/core/player/state/InProgressState$Serializer
 	public static final field INSTANCE Lcom/intuit/playerui/core/player/state/InProgressState$Serializer$1;
 	public final fun invoke (Lcom/intuit/playerui/core/bridge/Node;)Lcom/intuit/playerui/core/player/state/InProgressState;
 	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/intuit/playerui/core/player/state/InProgressState$special$$inlined$NodeSerializableFunction$default$1 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
 }
 
 public final class com/intuit/playerui/core/player/state/NamedState : com/intuit/playerui/core/bridge/NodeWrapper {
@@ -3908,6 +4070,18 @@ synthetic class com/intuit/playerui/core/validation/BindingInstance$Serializer$1
 	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
+public final class com/intuit/playerui/core/validation/BindingInstance$special$$inlined$NodeSerializableFunction$default$1 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class com/intuit/playerui/core/validation/BindingInstance$special$$inlined$NodeSerializableFunction$default$2 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
 public final class com/intuit/playerui/core/validation/ErrorValidationResponse : com/intuit/playerui/core/validation/ValidationResponse {
 	public static final field Companion Lcom/intuit/playerui/core/validation/ErrorValidationResponse$Companion;
 	public fun <init> (Lcom/intuit/playerui/core/bridge/Node;)V
@@ -3948,6 +4122,12 @@ synthetic class com/intuit/playerui/core/validation/Validation$Serializer$1 : ko
 	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
+public final class com/intuit/playerui/core/validation/Validation$special$$inlined$NodeSerializableFunction$default$1 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
 public final class com/intuit/playerui/core/validation/ValidationController : com/intuit/playerui/core/bridge/NodeWrapper {
 	public static final field Companion Lcom/intuit/playerui/core/validation/ValidationController$Companion;
 	public fun getNode ()Lcom/intuit/playerui/core/bridge/Node;
@@ -3966,6 +4146,12 @@ synthetic class com/intuit/playerui/core/validation/ValidationController$Seriali
 	public static final field INSTANCE Lcom/intuit/playerui/core/validation/ValidationController$Serializer$1;
 	public final fun invoke (Lcom/intuit/playerui/core/bridge/Node;)Lcom/intuit/playerui/core/validation/ValidationController;
 	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/intuit/playerui/core/validation/ValidationController$special$$inlined$NodeSerializableFunction$default$1 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
 }
 
 public final class com/intuit/playerui/core/validation/ValidationInfo {
@@ -4057,6 +4243,12 @@ synthetic class com/intuit/playerui/core/validation/WarningValidationResponse$Se
 	public static final field INSTANCE Lcom/intuit/playerui/core/validation/WarningValidationResponse$Serializer$1;
 	public final fun invoke (Lcom/intuit/playerui/core/bridge/Node;)Lcom/intuit/playerui/core/validation/WarningValidationResponse;
 	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/intuit/playerui/core/validation/WarningValidationResponse$special$$inlined$NodeSerializableFunction$default$1 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
 }
 
 public final class com/intuit/playerui/core/view/View : com/intuit/playerui/core/bridge/NodeWrapper {

--- a/jvm/core/api/core.api
+++ b/jvm/core/api/core.api
@@ -1983,6 +1983,8 @@ public final class com/intuit/playerui/core/bridge/serialization/serializers/Nod
 }
 
 public final class com/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunctionKt {
+	public static final fun NodeSerializableFunction (Lcom/intuit/playerui/core/bridge/NodeWrapper;Lkotlinx/serialization/DeserializationStrategy;Lcom/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction$CacheStrategy;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lcom/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction;
+	public static synthetic fun NodeSerializableFunction$default (Lcom/intuit/playerui/core/bridge/NodeWrapper;Lkotlinx/serialization/DeserializationStrategy;Lcom/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction$CacheStrategy;Ljava/lang/String;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lcom/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction;
 }
 
 synthetic class com/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunctionKt$NodeSerializableFunction$1 : kotlin/jvm/internal/PropertyReference0Impl {

--- a/jvm/core/src/main/kotlin/com/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction.kt
+++ b/jvm/core/src/main/kotlin/com/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction.kt
@@ -10,48 +10,56 @@ import kotlinx.serialization.DeserializationStrategy
 import kotlin.reflect.KProperty
 
 /** Delegate for automatic deserialization of [Node] values */
-internal class NodeSerializableFunction<R> private constructor(
+public class NodeSerializableFunction<R> private constructor(
     private val provider: () -> Node,
-    private val serializer: DeserializationStrategy<R>,
+    private val serializerProvider: () -> DeserializationStrategy<R>,
     internal val strategy: CacheStrategy,
     private val name: String?,
 ) {
+    /** Memoized result of [serializerProvider] resolved on first access. */
+    private val serializer: DeserializationStrategy<R> by lazy(serializerProvider)
+
     /** Caching strategy for determining how to pull the value from [Node] on subsequent attempts */
     public enum class CacheStrategy {
         None,
         Full,
     }
 
-    /** Cache of container [Node] that will reset the [value] cache if out-of-date with the [provider] */
-    private var cache: Node = provider()
-        get() {
-            val provided = provider()
-            field = provided
-            value = null
-
-            return field
-        }
+    /**
+     * Cache of container [Node] that resets the [value] cache when out-of-date
+     * with the [provider]. Lazily initialized on first [getValue] call so the
+     * delegate can be declared before the underlying node is available
+     * (e.g. when [NodeWrapper.node] is backed by a `lateinit` field).
+     */
+    private var cache: Node? = null
 
     /** Cache of the [T] value, along with the backing [Node] for objects */
     private var value: Invokable<R>? = null
 
     public operator fun getValue(thisRef: Any?, property: KProperty<*>): Invokable<R> {
+        val currentNode = provider()
+        if (cache !== currentNode) {
+            cache = currentNode
+            value = null
+        }
+
         // early exit if we have a value and explicitly using the cache
         value?.takeIf { strategy == CacheStrategy.Full }?.let {
             return it
         }
 
         val key = name ?: property.name
-
-        // will reset cache and value if mismatch
-        val node = cache
-
-        // else get and deserialize the value
-        return node.getInvokable(key, serializer)!!
+        val resolved = currentNode.getInvokable(key, serializer)!!
+        value = resolved
+        return resolved
     }
 
     public companion object {
-        /** Smart constructor responsible for determining the correct [CacheStrategy] and [defaultValue] from the [serializer], if either are not provided */
+        /**
+         * Smart constructor accepting an eager [serializer]. The [provider] is
+         * always lazy. The serializer is wrapped in a `lazy { }` so it is
+         * captured eagerly when supplied this way but never re-evaluated.
+         */
         @ExperimentalPlayerApi
         public operator fun <R> invoke(
             provider: () -> Node,
@@ -60,7 +68,25 @@ internal class NodeSerializableFunction<R> private constructor(
             name: String? = null,
         ): NodeSerializableFunction<R> = NodeSerializableFunction(
             provider,
-            serializer,
+            { serializer },
+            strategy ?: CacheStrategy.Full,
+            name,
+        )
+
+        /**
+         * Smart constructor accepting a lazy [serializerProvider]. Use this
+         * when the serializer can only be resolved after the underlying [Node]
+         * is initialized (e.g. when resolving via `node.format.serializer()`).
+         */
+        @ExperimentalPlayerApi
+        public operator fun <R> invoke(
+            provider: () -> Node,
+            serializerProvider: () -> DeserializationStrategy<R>,
+            strategy: CacheStrategy? = null,
+            name: String? = null,
+        ): NodeSerializableFunction<R> = NodeSerializableFunction(
+            provider,
+            serializerProvider,
             strategy ?: CacheStrategy.Full,
             name,
         )
@@ -68,7 +94,7 @@ internal class NodeSerializableFunction<R> private constructor(
 }
 
 @ExperimentalPlayerApi
-internal fun <R> NodeWrapper.NodeSerializableFunction(
+public fun <R> NodeWrapper.NodeSerializableFunction(
     serializer: DeserializationStrategy<R>,
     strategy: NodeSerializableFunction.CacheStrategy? = null,
     name: String? = null,
@@ -76,8 +102,8 @@ internal fun <R> NodeWrapper.NodeSerializableFunction(
 ): NodeSerializableFunction<R> = NodeSerializableFunction(::node, serializer, strategy, name)
 
 @ExperimentalPlayerApi
-internal inline fun <reified R> NodeWrapper.NodeSerializableFunction(
+public inline fun <reified R> NodeWrapper.NodeSerializableFunction(
     strategy: NodeSerializableFunction.CacheStrategy? = null,
     name: String? = null,
     noinline defaultValue: (Node.(String) -> Invokable<R>)? = null,
-): NodeSerializableFunction<R> = NodeSerializableFunction(node.format.serializer<R>(), strategy, name, defaultValue)
+): NodeSerializableFunction<R> = NodeSerializableFunction(::node, { node.format.serializer<R>() }, strategy, name)

--- a/jvm/core/src/main/kotlin/com/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction.kt
+++ b/jvm/core/src/main/kotlin/com/intuit/playerui/core/bridge/serialization/serializers/NodeSerializableFunction.kt
@@ -4,6 +4,7 @@ import com.intuit.playerui.core.bridge.Invokable
 import com.intuit.playerui.core.bridge.Node
 import com.intuit.playerui.core.bridge.NodeWrapper
 import com.intuit.playerui.core.bridge.getInvokable
+import com.intuit.playerui.core.bridge.serialization.format.RuntimeSerializationException
 import com.intuit.playerui.core.bridge.serialization.format.serializer
 import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
 import kotlinx.serialization.DeserializationStrategy
@@ -11,99 +12,106 @@ import kotlin.reflect.KProperty
 
 /** Delegate for automatic deserialization of [Node] values */
 public class NodeSerializableFunction<R> private constructor(
-    private val provider: () -> Node,
+    private val nodeProvider: () -> Node,
     private val serializerProvider: () -> DeserializationStrategy<R>,
     internal val strategy: CacheStrategy,
     private val name: String?,
 ) {
-    /** Memoized result of [serializerProvider] resolved on first access. */
-    private val serializer: DeserializationStrategy<R> by lazy(serializerProvider)
-
     /** Caching strategy for determining how to pull the value from [Node] on subsequent attempts */
     public enum class CacheStrategy {
         None,
         Full,
     }
 
-    /**
-     * Cache of container [Node] that resets the [value] cache when out-of-date
-     * with the [provider]. Lazily initialized on first [getValue] call so the
-     * delegate can be declared before the underlying node is available
-     * (e.g. when [NodeWrapper.node] is backed by a `lateinit` field).
-     */
-    private var cache: Node? = null
+    /** Cache of container [Node] that resets the [value] cache when out-of-date with the [nodeProvider] */
+    private val cache: Node
+        get() {
+            val provided = nodeProvider()
+            serializer = serializerProvider()
+            value = null
+            return provided
+        }
+
+    private lateinit var serializer: DeserializationStrategy<R>
 
     /** Cache of the [T] value, along with the backing [Node] for objects */
     private var value: Invokable<R>? = null
 
     public operator fun getValue(thisRef: Any?, property: KProperty<*>): Invokable<R> {
-        val currentNode = provider()
-        if (cache !== currentNode) {
-            cache = currentNode
-            value = null
-        }
-
         // early exit if we have a value and explicitly using the cache
         value?.takeIf { strategy == CacheStrategy.Full }?.let {
             return it
         }
 
         val key = name ?: property.name
-        val resolved = currentNode.getInvokable(key, serializer)!!
-        value = resolved
-        return resolved
+
+        // will reset cache and value
+        val node = cache
+        val function = node.getInvokable(key, serializer)
+            ?: throw RuntimeSerializationException("No function named '$key' on $this")
+
+        return function.also { value = it }
     }
 
     public companion object {
-        /**
-         * Smart constructor accepting an eager [serializer]. The [provider] is
-         * always lazy. The serializer is wrapped in a `lazy { }` so it is
-         * captured eagerly when supplied this way but never re-evaluated.
-         */
+        /** Smart constructor responsible for determining the correct [CacheStrategy] and [defaultValue] from the [serializer], if either are not provided */
         @ExperimentalPlayerApi
         public operator fun <R> invoke(
-            provider: () -> Node,
-            serializer: DeserializationStrategy<R>,
-            strategy: CacheStrategy? = null,
-            name: String? = null,
-        ): NodeSerializableFunction<R> = NodeSerializableFunction(
-            provider,
-            { serializer },
-            strategy ?: CacheStrategy.Full,
-            name,
-        )
-
-        /**
-         * Smart constructor accepting a lazy [serializerProvider]. Use this
-         * when the serializer can only be resolved after the underlying [Node]
-         * is initialized (e.g. when resolving via `node.format.serializer()`).
-         */
-        @ExperimentalPlayerApi
-        public operator fun <R> invoke(
-            provider: () -> Node,
+            nodeProvider: () -> Node,
             serializerProvider: () -> DeserializationStrategy<R>,
             strategy: CacheStrategy? = null,
             name: String? = null,
         ): NodeSerializableFunction<R> = NodeSerializableFunction(
-            provider,
+            nodeProvider,
             serializerProvider,
+            strategy ?: CacheStrategy.Full,
+            name,
+        )
+
+        /** Smart constructor responsible for determining the correct [CacheStrategy] and [defaultValue] from the [serializer], if either are not provided */
+        @ExperimentalPlayerApi
+        public operator fun <R> invoke(
+            nodeProvider: () -> Node,
+            serializer: DeserializationStrategy<R>,
+            strategy: CacheStrategy? = null,
+            name: String? = null,
+        ): NodeSerializableFunction<R> = NodeSerializableFunction(
+            nodeProvider,
+            { serializer },
             strategy ?: CacheStrategy.Full,
             name,
         )
     }
 }
 
+/**
+ * Delegate a member function of this [NodeWrapper]'s node, deserializing its
+ * return value with the given [serializer].
+ */
 @ExperimentalPlayerApi
 public fun <R> NodeWrapper.NodeSerializableFunction(
     serializer: DeserializationStrategy<R>,
     strategy: NodeSerializableFunction.CacheStrategy? = null,
     name: String? = null,
     defaultValue: (Node.(String) -> Invokable<R>)? = null,
-): NodeSerializableFunction<R> = NodeSerializableFunction(::node, serializer, strategy, name)
+): NodeSerializableFunction<R> = NodeSerializableFunction(::node, { serializer }, strategy, name)
 
+/**
+ * Delegate a member function of this [NodeWrapper]'s node, deserializing its
+ * return value with the given [serializer].
+ */
+@ExperimentalPlayerApi
+public fun <R> NodeWrapper.NodeSerializableFunction(
+    serializerProvider: () -> DeserializationStrategy<R>,
+    strategy: NodeSerializableFunction.CacheStrategy? = null,
+    name: String? = null,
+    defaultValue: (Node.(String) -> Invokable<R>)? = null,
+): NodeSerializableFunction<R> = NodeSerializableFunction(::node, serializerProvider, strategy, name)
+
+/** Reified convenience that infers the return-type serializer from [R] */
 @ExperimentalPlayerApi
 public inline fun <reified R> NodeWrapper.NodeSerializableFunction(
     strategy: NodeSerializableFunction.CacheStrategy? = null,
     name: String? = null,
     noinline defaultValue: (Node.(String) -> Invokable<R>)? = null,
-): NodeSerializableFunction<R> = NodeSerializableFunction(::node, { node.format.serializer<R>() }, strategy, name)
+): NodeSerializableFunction<R> = NodeSerializableFunction({ node.format.serializer<R>() }, strategy, name, defaultValue)

--- a/plugins/context/README.md
+++ b/plugins/context/README.md
@@ -1,0 +1,245 @@
+# Context Plugin
+
+A per-flow store of context entries, keyed by name, that lets external consumers
+(automation, devtools, native hosts) read, derive, and observe Player state
+without tapping every controller hook themselves.
+
+The package ships two plugins:
+
+- **`ContextPlugin`** — the store. Holds named entries, supports derived
+  (transform) entries, a subscribe API, and a per-flow history of snapshots.
+- **`StateContextPlugin`** — a consumer of `ContextPlugin` that mirrors Player
+  runtime state (flow, view, data, status) into the store and publishes an
+  aggregated `player.state` entry with scoped, callable actions.
+
+## Concepts
+
+- **Entry** — a value stored under a `ContextKey` (a `description` + a globally
+  unique symbol derived from a name via `Symbol.for`).
+- **Transform** — a derived entry computed from other entries. It declares its
+  `sources` and recomputes (and notifies subscribers) whenever any source
+  changes.
+- **History** — on flow end the active store is frozen into a snapshot and
+  pushed onto a history stack, then a fresh store is created for the next flow.
+  Transforms and subscribers persist across rotations; literal values do not.
+
+## Installation
+
+| Platform | Dependency |
+| --- | --- |
+| Core / JS | `@player-ui/context-plugin` |
+| JVM / Android | `com.intuit.playerui.plugins:context:$VERSION` |
+| iOS | the `PlayerUIContextPlugin` target |
+
+---
+
+## `ContextPlugin` (core)
+
+```ts
+import { Player } from "@player-ui/player";
+import { ContextPlugin, defineContextKey } from "@player-ui/context-plugin";
+
+const ctx = new ContextPlugin();
+new Player({ plugins: [ctx] });
+
+// Define a typed, globally-identifiable key.
+const formStateKey = defineContextKey<{ name: string }>(
+  "form.state",
+  "Current form state",
+);
+
+ctx.set(formStateKey, { name: "Ada" });
+ctx.has(formStateKey); // true
+ctx.get(formStateKey); // { name: "Ada" }
+```
+
+### Derived entries (transforms)
+
+A transform recomputes from its `sources` on read, and its subscribers fire when
+any source updates.
+
+```ts
+const firstKey = defineContextKey<string>("first", "First name");
+const lastKey = defineContextKey<string>("last", "Last name");
+const fullNameKey = defineContextKey<string>("full", "Full name");
+
+ctx.registerTransform(fullNameKey, {
+  sources: [firstKey, lastKey],
+  compute: (read) => `${read(firstKey)} ${read(lastKey)}`,
+});
+
+ctx.set(firstKey, "Ada");
+ctx.set(lastKey, "Lovelace");
+ctx.get(fullNameKey); // "Ada Lovelace"
+```
+
+### Function-valued entries
+
+An entry's value may be a function. It is stored and read back as a directly
+callable value — this is how `StateContextPlugin` exposes its actions.
+
+```ts
+const greetKey = defineContextKey<(name: string) => string>("greet", "Greeter");
+ctx.set(greetKey, (name) => `hello ${name}`);
+ctx.get(greetKey)?.("Ada"); // "hello Ada"
+```
+
+### Subscribing
+
+```ts
+// Per-key: fires whenever this entry (or, for a transform, one of its sources)
+// changes. Returns a token for unsubscribe.
+const token = ctx.subscribe(fullNameKey, (value) => console.log(value));
+
+// Global: fires on every update with the changed key.
+ctx.subscribeAll((value, key) => console.log(key.description, value));
+
+ctx.unsubscribe(token);
+```
+
+### Introspection & history
+
+```ts
+ctx.list(); // [{ symbol, description, hasValue, hasTransform }, ...]
+
+const [snapshot] = ctx.history(); // one frozen snapshot per ended flow
+// Read a frozen entry by key — the same typed access as the live store:
+snapshot.get(formStateKey); // { name: "Ada" } as it was when the flow ended
+```
+
+---
+
+## `StateContextPlugin` (core)
+
+Registering `StateContextPlugin` mirrors Player runtime state into the store. It
+auto-registers a `ContextPlugin` if one isn't already present.
+
+```ts
+import { Player } from "@player-ui/player";
+import {
+  ContextPlugin,
+  StateContextPlugin,
+  playerStateContextKey,
+} from "@player-ui/context-plugin";
+
+const ctx = new ContextPlugin();
+new Player({ plugins: [ctx, new StateContextPlugin()] });
+```
+
+It publishes these standard keys (each also importable):
+
+| Key | Description |
+| --- | --- |
+| `flowIdContextKey` | `player.flow.id` — running flow id |
+| `flowStateContextKey` | `player.flow.state` — current FSM state |
+| `viewIdContextKey` | `player.view.id` — resolved view id |
+| `viewContextKey` | `player.view` — resolved view object |
+| `dataContextKey` | `player.data` — data model tree |
+| `playerStatusContextKey` | `player.status` — not-started / in-progress / completed / error |
+| `validationContextKey` | `player.validation` — active validations per binding + `canTransition` |
+| `setDataActionKey` | `player.data.set` — callable that sets a binding |
+| `transitionActionKey` | `player.flow.transition` — callable that transitions the flow |
+
+### Aggregated `player.state`
+
+`playerStateContextKey` is a transform that rolls everything up into one
+`PlayerStateContext`. Actions are scoped to the construct they operate on:
+`transition` under `flow`, `set` under `data`. Actions are bound to the live
+controllers, so they are absent until a flow is in-progress.
+
+```ts
+const state = ctx.get(playerStateContextKey)!;
+
+state.status; // "in-progress"
+state.flow.state; // current FSM state name
+state.data.model; // serialized data model
+
+// Validation state for the running view, keyed by binding:
+state.validation.canTransition; // false if a blocking validation is active
+state.validation.byBinding["data.name"]; // [{ severity, message, displayTarget?, blocking? }]
+
+// Drive the running Player through the scoped actions:
+state.data.set?.("name", "Grace");
+state.flow.transition?.("Next");
+```
+
+> **Validation requires binding tracking.** `player.validation` mirrors the
+> validation controller, which only has state for bindings that the rendering
+> layer tracks (e.g. via the reference-assets plugin). Without a renderer
+> tracking bindings, validation is empty and `canTransition` is `true`. The
+> mirror is a passive, side-effect-free read — it never triggers validation.
+
+---
+
+## Native consumers (JVM & iOS)
+
+Native wrappers read entries by name and deserialize them into typed objects.
+Function-valued members cross the bridge as callables, so the scoped actions are
+invoked directly off the typed result.
+
+### JVM / Kotlin
+
+```kotlin
+import com.intuit.playerui.plugins.context.ContextPlugin
+import com.intuit.playerui.plugins.context.StateContextPlugin
+import com.intuit.playerui.plugins.context.PlayerStateContext
+import com.intuit.playerui.plugins.context.contextPlugin
+
+val context = ContextPlugin()
+val player = HeadlessPlayer(context, StateContextPlugin())
+player.start(flow)
+
+// Typed read; `get<T>` deserializes objects (incl. function members) and
+// passes primitives through.
+val state = player.contextPlugin?.get<PlayerStateContext>("player.state")
+state?.data?.set?.invoke("name", "Grace")
+state?.flow?.transition?.invoke("Next")
+
+// Introspection / history — read a frozen entry by name, typed
+val snapshot = player.contextPlugin?.history()?.last()
+snapshot?.get<PlayerStateContext>("player.state")
+```
+
+### iOS / Swift
+
+```swift
+import PlayerUIContextPlugin
+
+let context = ContextPlugin()
+let player = HeadlessPlayerImpl(plugins: [context, StateContextPlugin()])
+player.start(flow: flow) { _ in }
+
+// `get<T>` decodes into a Decodable type; WrappedFunction members are callable.
+let state = context.get(name: "player.state", as: PlayerStateContext.self)
+state?.data.set?("name", "Grace")
+state?.flow.transition?("Next")
+
+// Introspection / history — read a frozen entry by name, typed
+context.list() // [ContextEntryDescriptor]
+let snapshot = context.history().last
+snapshot?.get(name: "player.state", as: PlayerStateContext.self)
+```
+
+---
+
+## Flow-end semantics
+
+On flow end the active store is **frozen into a history snapshot and then
+rotated** (a fresh store is created, with transforms re-applied and literals
+dropped). Two consequences:
+
+- **Functions become tombstones in snapshots.** A frozen entry keeps its key and
+  description, but a captured function is replaced by a stub that throws if
+  invoked — preserving the distinction between "context that never held this
+  action" and "an action that is no longer valid".
+- **Live reads right after a terminating transition are racy.** Flow end runs
+  asynchronously, so reading `player.state` immediately after a transition that
+  ends the flow may observe either the pre-rotation or post-rotation store. For
+  end-of-flow state, read the **history snapshot** instead — `snapshot.get(key)`
+  (or `get(name)` natively) gives the same typed access as the live store.
+
+> **Reading snapshot entry values.** Across all platforms, read a frozen
+> entry's value with the typed `snapshot.get(key)` / `get(name)` — `entries`
+> exposes only the per-entry descriptor (`name`, `description`). The typed read
+> is the one path that correctly surfaces function-valued entries (tombstones)
+> on every platform.

--- a/plugins/context/README.md
+++ b/plugins/context/README.md
@@ -25,11 +25,11 @@ The package ships two plugins:
 
 ## Installation
 
-| Platform | Dependency |
-| --- | --- |
-| Core / JS | `@player-ui/context-plugin` |
+| Platform      | Dependency                                     |
+| ------------- | ---------------------------------------------- |
+| Core / JS     | `@player-ui/context-plugin`                    |
 | JVM / Android | `com.intuit.playerui.plugins:context:$VERSION` |
-| iOS | the `PlayerUIContextPlugin` target |
+| iOS           | the `PlayerUIContextPlugin` target             |
 
 ---
 
@@ -128,17 +128,17 @@ new Player({ plugins: [ctx, new StateContextPlugin()] });
 
 It publishes these standard keys (each also importable):
 
-| Key | Description |
-| --- | --- |
-| `flowIdContextKey` | `player.flow.id` — running flow id |
-| `flowStateContextKey` | `player.flow.state` — current FSM state |
-| `viewIdContextKey` | `player.view.id` — resolved view id |
-| `viewContextKey` | `player.view` — resolved view object |
-| `dataContextKey` | `player.data` — data model tree |
-| `playerStatusContextKey` | `player.status` — not-started / in-progress / completed / error |
-| `validationContextKey` | `player.validation` — active validations per binding + `canTransition` |
-| `setDataActionKey` | `player.data.set` — callable that sets a binding |
-| `transitionActionKey` | `player.flow.transition` — callable that transitions the flow |
+| Key                      | Description                                                            |
+| ------------------------ | ---------------------------------------------------------------------- |
+| `flowIdContextKey`       | `player.flow.id` — running flow id                                     |
+| `flowStateContextKey`    | `player.flow.state` — current FSM state                                |
+| `viewIdContextKey`       | `player.view.id` — resolved view id                                    |
+| `viewContextKey`         | `player.view` — resolved view object                                   |
+| `dataContextKey`         | `player.data` — data model tree                                        |
+| `playerStatusContextKey` | `player.status` — not-started / in-progress / completed / error        |
+| `validationContextKey`   | `player.validation` — active validations per binding + `canTransition` |
+| `setDataActionKey`       | `player.data.set` — callable that sets a binding                       |
+| `transitionActionKey`    | `player.flow.transition` — callable that transitions the flow          |
 
 ### Aggregated `player.state`
 
@@ -151,16 +151,16 @@ controllers, so they are absent until a flow is in-progress.
 const state = ctx.get(playerStateContextKey)!;
 
 state.status; // "in-progress"
-state.flow.state; // current FSM state name
-state.data.model; // serialized data model
+state.flow?.state; // current FSM state name
+state.data?.model; // serialized data model
 
 // Validation state for the running view, keyed by binding:
-state.validation.canTransition; // false if a blocking validation is active
-state.validation.byBinding["data.name"]; // [{ severity, message, displayTarget?, blocking? }]
+state.validation?.canTransition; // false if a blocking validation is active
+state.validation?.byBinding["data.name"]; // [{ severity, message, displayTarget?, blocking? }]
 
 // Drive the running Player through the scoped actions:
-state.data.set?.("name", "Grace");
-state.flow.transition?.("Next");
+state.data?.set?.("name", "Grace");
+state.flow?.transition?.("Next");
 ```
 
 > **Validation requires binding tracking.** `player.validation` mirrors the
@@ -211,8 +211,8 @@ player.start(flow: flow) { _ in }
 
 // `get<T>` decodes into a Decodable type; WrappedFunction members are callable.
 let state = context.get(name: "player.state", as: PlayerStateContext.self)
-state?.data.set?("name", "Grace")
-state?.flow.transition?("Next")
+state?.data?.set?("name", "Grace")
+state?.flow?.transition?("Next")
 
 // Introspection / history — read a frozen entry by name, typed
 context.list() // [ContextEntryDescriptor]

--- a/plugins/context/README.md
+++ b/plugins/context/README.md
@@ -116,11 +116,7 @@ auto-registers a `ContextPlugin` if one isn't already present.
 
 ```ts
 import { Player } from "@player-ui/player";
-import {
-  ContextPlugin,
-  StateContextPlugin,
-  playerStateContextKey,
-} from "@player-ui/context-plugin";
+import { ContextPlugin, StateContextPlugin } from "@player-ui/context-plugin";
 
 const ctx = new ContextPlugin();
 new Player({ plugins: [ctx, new StateContextPlugin()] });
@@ -131,7 +127,7 @@ It publishes these standard keys (each also importable):
 | Key                      | Description                                                            |
 | ------------------------ | ---------------------------------------------------------------------- |
 | `flowIdContextKey`       | `player.flow.id` — running flow id                                     |
-| `flowStateContextKey`    | `player.flow.state` — current FSM state                                |
+| `flowStateContextKey`    | `player.flow.state` — current FSM (finite state machine) state         |
 | `viewIdContextKey`       | `player.view.id` — resolved view id                                    |
 | `viewContextKey`         | `player.view` — resolved view object                                   |
 | `dataContextKey`         | `player.data` — data model tree                                        |
@@ -142,16 +138,20 @@ It publishes these standard keys (each also importable):
 
 ### Aggregated `player.state`
 
-`playerStateContextKey` is a transform that rolls everything up into one
-`PlayerStateContext`. Actions are scoped to the construct they operate on:
-`transition` under `flow`, `set` under `data`. Actions are bound to the live
-controllers, so they are absent until a flow is in-progress.
+`playerStateContextKey` is a separate, importable key — not one of the
+standard keys in the table above — backed by a transform that rolls
+everything up into one `PlayerStateContext`. Actions are scoped to the
+construct they operate on: `transition` under `flow`, `set` under `data`.
+Actions are bound to the live controllers, so they are absent until a flow is
+in-progress.
 
 ```ts
+import { playerStateContextKey } from "@player-ui/context-plugin";
+
 const state = ctx.get(playerStateContextKey)!;
 
-state.status; // "in-progress"
-state.flow?.state; // current FSM state name
+state.status; // "not-started" | "in-progress" | "completed" | "error"
+state.flow?.state; // current FSM (finite state machine) state name
 state.data?.model; // serialized data model
 
 // Validation state for the running view, keyed by binding:

--- a/plugins/context/core/BUILD
+++ b/plugins/context/core/BUILD
@@ -1,0 +1,21 @@
+load("@rules_player//javascript:defs.bzl", "js_pipeline")
+load("@npm//:defs.bzl", "npm_link_all_packages")
+load("//tools:defs.bzl", "NATIVE_BUILD_DEPS", "tsup_config", "vitest_config")
+
+npm_link_all_packages(name = "node_modules")
+
+tsup_config(name = "tsup_config")
+
+vitest_config(name = "vitest_config")
+
+js_pipeline(
+    package_name = "@player-ui/context-plugin",
+    build_deps = NATIVE_BUILD_DEPS,
+    native_bundle = "ContextPlugin",
+    peer_deps = [
+        ":node_modules/@player-ui/player",
+    ],
+    deps = [
+        "//:node_modules/tapable-ts",
+    ],
+)

--- a/plugins/context/core/BUILD
+++ b/plugins/context/core/BUILD
@@ -18,4 +18,8 @@ js_pipeline(
     deps = [
         "//:node_modules/tapable-ts",
     ],
+    test_deps = [
+        ":node_modules/@player-ui/common-types-plugin",
+        ":node_modules/@player-ui/reference-assets-plugin",
+    ],
 )

--- a/plugins/context/core/package.json
+++ b/plugins/context/core/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@player-ui/context-plugin",
+  "version": "0.0.0-PLACEHOLDER",
+  "main": "src/index.ts",
+  "peerDependencies": {
+    "@player-ui/player": "workspace:^"
+  }
+}

--- a/plugins/context/core/package.json
+++ b/plugins/context/core/package.json
@@ -4,5 +4,9 @@
   "main": "src/index.ts",
   "peerDependencies": {
     "@player-ui/player": "workspace:^"
+  },
+  "devDependencies": {
+    "@player-ui/common-types-plugin": "workspace:^",
+    "@player-ui/reference-assets-plugin": "workspace:^"
   }
 }

--- a/plugins/context/core/src/__tests__/history.test.ts
+++ b/plugins/context/core/src/__tests__/history.test.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "vitest";
+import { ContextHistory } from "../history";
+import type { FrozenContextSnapshot } from "../types";
+
+const snap = (endedAt: number): FrozenContextSnapshot =>
+  Object.freeze({
+    endedAt,
+    entries: Object.freeze([]),
+  });
+
+test("push appends in order", () => {
+  const h = new ContextHistory();
+  h.push(snap(1));
+  h.push(snap(2));
+  h.push(snap(3));
+
+  expect(h.size()).toBe(3);
+  expect(h.entries().map((s) => s.endedAt)).toEqual([1, 2, 3]);
+});
+
+test("clear empties the stack", () => {
+  const h = new ContextHistory();
+  h.push(snap(1));
+  h.clear();
+  expect(h.size()).toBe(0);
+  expect(h.entries()).toEqual([]);
+});

--- a/plugins/context/core/src/__tests__/key.test.ts
+++ b/plugins/context/core/src/__tests__/key.test.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "vitest";
+import { defineContextKey, resolveContextKeySymbol } from "../key";
+
+test("two keys with the same name share Symbol.for identity", () => {
+  const a = defineContextKey<string>("form-state", "Current form state");
+  const b = defineContextKey<string>("form-state", "Different description");
+
+  expect(a.symbol).toBe(b.symbol);
+  expect(a.description).toBe("Current form state");
+  expect(b.description).toBe("Different description");
+});
+
+test("resolveContextKeySymbol matches defineContextKey identity", () => {
+  const key = defineContextKey("simulation", "Simulator context");
+  expect(resolveContextKeySymbol("simulation")).toBe(key.symbol);
+});
+
+test("distinct names produce distinct symbols", () => {
+  const a = defineContextKey("alpha", "A");
+  const b = defineContextKey("beta", "B");
+  expect(a.symbol).not.toBe(b.symbol);
+});

--- a/plugins/context/core/src/__tests__/plugin.test.ts
+++ b/plugins/context/core/src/__tests__/plugin.test.ts
@@ -267,6 +267,104 @@ test("subscribeAllByName surfaces the resolved key name and description", () => 
   expect(handler).toHaveBeenCalledWith(true, "flag", "A flag");
 });
 
+test("a function-valued context entry round-trips through get and is callable", () => {
+  const plugin = new ContextPlugin();
+  new Player({ plugins: [plugin] });
+
+  const addKey = defineContextKey<(a: number, b: number) => number>(
+    "math.add",
+    "Add two numbers",
+  );
+
+  expect(plugin.has(addKey)).toBe(false);
+  plugin.set(addKey, (a, b) => a + b);
+  expect(plugin.has(addKey)).toBe(true);
+  expect(plugin.get(addKey)!(2, 3)).toBe(5);
+});
+
+test("setting a function entry twice replaces the prior implementation", () => {
+  const plugin = new ContextPlugin();
+  new Player({ plugins: [plugin] });
+  const key = defineContextKey<() => string>("greet", "Greet");
+
+  plugin.set(key, () => "v1");
+  plugin.set(key, () => "v2");
+  expect(plugin.get(key)!()).toBe("v2");
+});
+
+test("function entries appear in list() like any other entry", () => {
+  const plugin = new ContextPlugin();
+  new Player({ plugins: [plugin] });
+  const a = defineContextKey<() => void>("a", "Action A");
+  const b = defineContextKey<() => void>("b", "Action B");
+
+  plugin.set(a, () => undefined);
+  plugin.set(b, () => undefined);
+
+  const descriptions = plugin.list().map((d) => d.description);
+  expect(descriptions).toEqual(
+    expect.arrayContaining(["Action A", "Action B"]),
+  );
+});
+
+test("getByName resolves a function entry so native consumers can invoke it", () => {
+  const plugin = new ContextPlugin();
+  new Player({ plugins: [plugin] });
+  const key = defineContextKey<(msg: string) => string>(
+    "echo",
+    "Echo the input",
+  );
+  plugin.set(key, (msg) => `said: ${msg}`);
+
+  const echo = plugin.getByName("echo") as (msg: string) => string;
+  expect(echo("hello")).toBe("said: hello");
+});
+
+test("singleton aliasing shares function entries across ContextPlugin instances", () => {
+  const a = new ContextPlugin();
+  const b = new ContextPlugin();
+  new Player({ plugins: [a, b] });
+  const key = defineContextKey<() => string>("shared", "Shared");
+
+  a.set(key, () => "from-a");
+  expect(b.get(key)!()).toBe("from-a");
+});
+
+test("flow-end freeze replaces a function entry with a throwing tombstone", () => {
+  const plugin = new ContextPlugin();
+  const player = new Player({ plugins: [plugin] });
+  const actionKey = defineContextKey<() => string>("do.thing", "Do the thing");
+
+  player.start(minimalFlow as any);
+  plugin.set(actionKey, () => "live");
+  expect(plugin.get(actionKey)!()).toBe("live");
+
+  // End the flow so the active store is frozen into a history snapshot.
+  player.hooks.onEnd.call();
+
+  const [snapshot] = plugin.history();
+  // Read the frozen entry by key — the same typed access as live context.
+  const frozen = snapshot.get(actionKey);
+  // The capability is preserved (still callable) but poisoned post-flow.
+  expect(typeof frozen).toBe("function");
+  expect(() => frozen!()).toThrowError(/no longer valid/);
+});
+
+test("snapshot.get returns undefined for a key absent when frozen", () => {
+  const plugin = new ContextPlugin();
+  const player = new Player({ plugins: [plugin] });
+  const present = defineContextKey<string>("present", "Present");
+  const absent = defineContextKey<string>("absent", "Absent");
+
+  player.start(minimalFlow as any);
+  plugin.set(present, "here");
+  player.hooks.onEnd.call();
+
+  const [snapshot] = plugin.history();
+  expect(snapshot.get(present)).toBe("here");
+  expect(snapshot.get(absent)).toBeUndefined();
+});
+
 test("getContextPlugin returns the existing plugin or registers a new one", () => {
   const existing = new ContextPlugin();
   const player = new Player({ plugins: [existing] });

--- a/plugins/context/core/src/__tests__/plugin.test.ts
+++ b/plugins/context/core/src/__tests__/plugin.test.ts
@@ -1,0 +1,278 @@
+import { test, expect, vitest } from "vitest";
+import { Player } from "@player-ui/player";
+import { ContextPlugin } from "../plugin";
+import { ContextPluginSymbol } from "../symbols";
+import { defineContextKey } from "../key";
+import { getContextPlugin } from "../utils";
+
+const minimalFlow = {
+  id: "flow-alpha",
+  views: [{ id: "view-1", type: "info" }],
+  navigation: {
+    BEGIN: "FLOW_1",
+    FLOW_1: {
+      startState: "VIEW_1",
+      VIEW_1: {
+        ref: "view-1",
+        state_type: "VIEW",
+        transitions: { "*": "END_Done" },
+      },
+      END_Done: { state_type: "END", outcome: "done" },
+    },
+  },
+};
+
+test("findPlugin returns the registered ContextPlugin via its symbol", () => {
+  const plugin = new ContextPlugin();
+  const player = new Player({ plugins: [plugin] });
+  expect(player.findPlugin<ContextPlugin>(ContextPluginSymbol)).toBe(plugin);
+});
+
+test("set / get / has round-trip", () => {
+  const plugin = new ContextPlugin();
+  new Player({ plugins: [plugin] });
+  const key = defineContextKey<string>("greeting", "Greeting string");
+
+  expect(plugin.has(key)).toBe(false);
+  plugin.set(key, "hello");
+  expect(plugin.get(key)).toBe("hello");
+  expect(plugin.has(key)).toBe(true);
+});
+
+test("transform aggregates from other context entries on get", () => {
+  const plugin = new ContextPlugin();
+  new Player({ plugins: [plugin] });
+
+  const first = defineContextKey<string>("first", "First name");
+  const last = defineContextKey<string>("last", "Last name");
+  const full = defineContextKey<string>("full", "Full name");
+
+  plugin.set(first, "Ada");
+  plugin.set(last, "Lovelace");
+  plugin.registerTransform(full, {
+    sources: [first, last],
+    compute: (read) => `${read(first) ?? ""} ${read(last) ?? ""}`.trim(),
+  });
+
+  expect(plugin.get(full)).toBe("Ada Lovelace");
+});
+
+test("literal value takes precedence over registered transform", () => {
+  const plugin = new ContextPlugin();
+  new Player({ plugins: [plugin] });
+  const src = defineContextKey<number>("src", "Source");
+  const target = defineContextKey<number>("target", "Target");
+
+  plugin.set(src, 10);
+  const compute = vitest.fn().mockReturnValue(999);
+  plugin.registerTransform(target, { sources: [src], compute });
+  expect(plugin.get(target)).toBe(999);
+
+  plugin.set(target, 5);
+  compute.mockClear();
+  expect(plugin.get(target)).toBe(5);
+  expect(compute).not.toHaveBeenCalled();
+});
+
+test("per-key subscriber fires on direct set", () => {
+  const plugin = new ContextPlugin();
+  new Player({ plugins: [plugin] });
+  const key = defineContextKey<number>("c", "Counter");
+  const handler = vitest.fn();
+
+  plugin.subscribe(key, handler);
+  plugin.set(key, 1);
+  plugin.set(key, 2);
+
+  expect(handler).toHaveBeenCalledTimes(2);
+  expect(handler).toHaveBeenNthCalledWith(1, 1, key);
+  expect(handler).toHaveBeenNthCalledWith(2, 2, key);
+});
+
+test("subscriber on transform target fires when a source updates", () => {
+  const plugin = new ContextPlugin();
+  new Player({ plugins: [plugin] });
+  const src = defineContextKey<number>("src", "Source");
+  const target = defineContextKey<number>("target", "Target");
+
+  plugin.registerTransform(target, {
+    sources: [src],
+    compute: (read) => (read(src) ?? 0) + 1,
+  });
+  const handler = vitest.fn();
+  plugin.subscribe(target, handler);
+
+  plugin.set(src, 41);
+  expect(handler).toHaveBeenCalledTimes(1);
+  expect(handler).toHaveBeenCalledWith(42, target);
+});
+
+test("subscribeAll receives every literal set and every dependent invalidation", () => {
+  const plugin = new ContextPlugin();
+  new Player({ plugins: [plugin] });
+  const src = defineContextKey<number>("src", "Source");
+  const target = defineContextKey<number>("target", "Target");
+
+  plugin.registerTransform(target, {
+    sources: [src],
+    compute: (read) => (read(src) ?? 0) * 2,
+  });
+  const handler = vitest.fn();
+  plugin.subscribeAll(handler);
+
+  plugin.set(src, 3);
+  expect(handler).toHaveBeenCalledTimes(2);
+  expect(handler).toHaveBeenNthCalledWith(1, 3, src);
+  expect(handler).toHaveBeenNthCalledWith(2, 6, target);
+});
+
+test("unsubscribe stops a per-key handler", () => {
+  const plugin = new ContextPlugin();
+  new Player({ plugins: [plugin] });
+  const key = defineContextKey<number>("k", "K");
+  const handler = vitest.fn();
+
+  const token = plugin.subscribe(key, handler);
+  plugin.set(key, 1);
+  plugin.unsubscribe(token);
+  plugin.set(key, 2);
+
+  expect(handler).toHaveBeenCalledTimes(1);
+});
+
+test("unsubscribe stops a global handler", () => {
+  const plugin = new ContextPlugin();
+  new Player({ plugins: [plugin] });
+  const key = defineContextKey<number>("k", "K");
+  const handler = vitest.fn();
+
+  const token = plugin.subscribeAll(handler);
+  plugin.set(key, 1);
+  plugin.unsubscribe(token);
+  plugin.set(key, 2);
+
+  expect(handler).toHaveBeenCalledTimes(1);
+});
+
+test("two ContextPlugin instances share state via singleton aliasing", () => {
+  const a = new ContextPlugin();
+  const b = new ContextPlugin();
+  new Player({ plugins: [a, b] });
+  const key = defineContextKey<string>("shared", "Shared");
+
+  a.set(key, "from-a");
+  expect(b.get(key)).toBe("from-a");
+});
+
+test("flow end freezes the store, pushes to history, then rotates", () => {
+  const plugin = new ContextPlugin();
+  const player = new Player({ plugins: [plugin] });
+  const key = defineContextKey<string>("phase", "Phase");
+
+  player.start(minimalFlow as any);
+  plugin.set(key, "active");
+  expect(plugin.get(key)).toBe("active");
+
+  player.hooks.onEnd.call();
+
+  expect(plugin.history()).toHaveLength(1);
+  const snapshot = plugin.history()[0];
+  expect(snapshot.flowId).toBe("flow-alpha");
+  expect(snapshot.entries.map((e) => e.value)).toEqual(["active"]);
+  expect(Object.isFrozen(snapshot)).toBe(true);
+
+  expect(plugin.has(key)).toBe(false);
+  expect(plugin.get(key)).toBeUndefined();
+});
+
+test("transforms and subscribers persist across flow rotation", () => {
+  const plugin = new ContextPlugin();
+  const player = new Player({ plugins: [plugin] });
+  const src = defineContextKey<number>("src", "Source");
+  const target = defineContextKey<number>("target", "Target");
+
+  plugin.registerTransform(target, {
+    sources: [src],
+    compute: (read) => (read(src) ?? 0) + 100,
+  });
+  const handler = vitest.fn();
+  plugin.subscribe(target, handler);
+
+  player.start(minimalFlow as any);
+  plugin.set(src, 1);
+  player.hooks.onEnd.call();
+
+  player.start(minimalFlow as any);
+  plugin.set(src, 2);
+
+  expect(handler).toHaveBeenCalledTimes(2);
+  expect(handler).toHaveBeenNthCalledWith(1, 101, target);
+  expect(handler).toHaveBeenNthCalledWith(2, 102, target);
+});
+
+test("re-registering a transform for the same key silently replaces", () => {
+  const plugin = new ContextPlugin();
+  new Player({ plugins: [plugin] });
+  const target = defineContextKey<string>("t", "T");
+
+  plugin.registerTransform(target, { sources: [], compute: () => "v1" });
+  plugin.registerTransform(target, { sources: [], compute: () => "v2" });
+
+  expect(plugin.get(target)).toBe("v2");
+});
+
+test("list exposes registered descriptors with hasValue / hasTransform flags", () => {
+  const plugin = new ContextPlugin();
+  new Player({ plugins: [plugin] });
+  const literal = defineContextKey<number>("lit", "Literal");
+  const derived = defineContextKey<number>("der", "Derived");
+
+  plugin.set(literal, 1);
+  plugin.registerTransform(derived, { sources: [], compute: () => 2 });
+
+  const items = plugin.list();
+  const byDesc = Object.fromEntries(items.map((d) => [d.description, d]));
+  expect(byDesc.Literal).toMatchObject({ hasValue: true, hasTransform: false });
+  expect(byDesc.Derived).toMatchObject({
+    hasValue: false,
+    hasTransform: true,
+  });
+});
+
+test("name-based bridge API round-trips set/get/has/subscribe", () => {
+  const plugin = new ContextPlugin();
+  new Player({ plugins: [plugin] });
+
+  expect(plugin.hasByName("formState")).toBe(false);
+  plugin.setByName("formState", "Current form state", { name: "Ada" });
+  expect(plugin.getByName("formState")).toEqual({ name: "Ada" });
+  expect(plugin.hasByName("formState")).toBe(true);
+
+  const handler = vitest.fn();
+  plugin.subscribeByName("counter", "A counter", handler);
+  plugin.setByName("counter", "A counter", 7);
+
+  expect(handler).toHaveBeenCalledWith(7, "counter");
+});
+
+test("subscribeAllByName surfaces the resolved key name and description", () => {
+  const plugin = new ContextPlugin();
+  new Player({ plugins: [plugin] });
+
+  const handler = vitest.fn();
+  plugin.subscribeAllByName(handler);
+
+  plugin.setByName("flag", "A flag", true);
+
+  expect(handler).toHaveBeenCalledWith(true, "flag", "A flag");
+});
+
+test("getContextPlugin returns the existing plugin or registers a new one", () => {
+  const existing = new ContextPlugin();
+  const player = new Player({ plugins: [existing] });
+  expect(getContextPlugin(player)).toBe(existing);
+
+  const fresh = new Player();
+  const created = getContextPlugin(fresh);
+  expect(fresh.findPlugin<ContextPlugin>(ContextPluginSymbol)).toBe(created);
+});

--- a/plugins/context/core/src/__tests__/plugin.test.ts
+++ b/plugins/context/core/src/__tests__/plugin.test.ts
@@ -89,6 +89,56 @@ test("per-key subscriber fires on direct set", () => {
   expect(handler).toHaveBeenNthCalledWith(2, 2, key);
 });
 
+test("setting a literal to the same value again does not re-notify subscribers", () => {
+  const plugin = new ContextPlugin();
+  new Player({ plugins: [plugin] });
+  const key = defineContextKey<number>("c", "Counter");
+  const handler = vitest.fn();
+
+  plugin.subscribe(key, handler);
+  plugin.set(key, 1);
+  plugin.set(key, 1);
+  plugin.set(key, 2);
+
+  expect(handler).toHaveBeenCalledTimes(2);
+  expect(handler).toHaveBeenNthCalledWith(1, 1, key);
+  expect(handler).toHaveBeenNthCalledWith(2, 2, key);
+});
+
+test("setting a literal to a new but deep-equal object still notifies (Object.is, not dequal)", () => {
+  const plugin = new ContextPlugin();
+  new Player({ plugins: [plugin] });
+  const key = defineContextKey<{ n: number }>("obj", "Object");
+  const handler = vitest.fn();
+
+  plugin.subscribe(key, handler);
+  plugin.set(key, { n: 1 });
+  plugin.set(key, { n: 1 });
+
+  expect(handler).toHaveBeenCalledTimes(2);
+});
+
+test("a transform recompute that yields an unchanged value does not re-notify dependents", () => {
+  const plugin = new ContextPlugin();
+  new Player({ plugins: [plugin] });
+  const src = defineContextKey<number>("src", "Source");
+  const target = defineContextKey<number>("target", "Target");
+
+  plugin.registerTransform(target, {
+    sources: [src],
+    // Clamped: any src >= 10 computes to the same value.
+    compute: (read) => Math.min(read(src) ?? 0, 10),
+  });
+  const handler = vitest.fn();
+  plugin.subscribe(target, handler);
+
+  plugin.set(src, 10);
+  plugin.set(src, 20);
+
+  expect(handler).toHaveBeenCalledTimes(1);
+  expect(handler).toHaveBeenCalledWith(10, target);
+});
+
 test("subscriber on transform target fires when a source updates", () => {
   const plugin = new ContextPlugin();
   new Player({ plugins: [plugin] });
@@ -270,6 +320,23 @@ test("flow end freezes the store, pushes to history, then rotates", () => {
 
   expect(plugin.has(key)).toBe(false);
   expect(plugin.get(key)).toBeUndefined();
+});
+
+test("flow rotation resets notify-dedup state, so a repeated value re-notifies in the new flow", () => {
+  const plugin = new ContextPlugin();
+  const player = new Player({ plugins: [plugin] });
+  const key = defineContextKey<string>("phase", "Phase");
+  const handler = vitest.fn();
+  plugin.subscribe(key, handler);
+
+  player.start(minimalFlow as any);
+  plugin.set(key, "active");
+  player.hooks.onEnd.call();
+
+  player.start(minimalFlow as any);
+  plugin.set(key, "active");
+
+  expect(handler).toHaveBeenCalledTimes(2);
 });
 
 test("transforms and subscribers persist across flow rotation", () => {

--- a/plugins/context/core/src/__tests__/plugin.test.ts
+++ b/plugins/context/core/src/__tests__/plugin.test.ts
@@ -107,6 +107,93 @@ test("subscriber on transform target fires when a source updates", () => {
   expect(handler).toHaveBeenCalledWith(42, target);
 });
 
+test("subscriber on a chained transform fires when a root source updates", () => {
+  const plugin = new ContextPlugin();
+  new Player({ plugins: [plugin] });
+  const root = defineContextKey<number>("root", "Root");
+  const mid = defineContextKey<number>("mid", "Mid");
+  const top = defineContextKey<number>("top", "Top");
+
+  // root -> mid -> top
+  plugin.registerTransform(mid, {
+    sources: [root],
+    compute: (read) => (read(root) ?? 0) + 1,
+  });
+  plugin.registerTransform(top, {
+    sources: [mid],
+    compute: (read) => (read(mid) ?? 0) * 10,
+  });
+
+  const midHandler = vitest.fn();
+  const topHandler = vitest.fn();
+  plugin.subscribe(mid, midHandler);
+  plugin.subscribe(top, topHandler);
+
+  plugin.set(root, 4);
+
+  expect(midHandler).toHaveBeenCalledTimes(1);
+  expect(midHandler).toHaveBeenCalledWith(5, mid);
+  expect(topHandler).toHaveBeenCalledTimes(1);
+  expect(topHandler).toHaveBeenCalledWith(50, top);
+});
+
+test("transitive invalidation notifies each dependent exactly once in a diamond", () => {
+  const plugin = new ContextPlugin();
+  new Player({ plugins: [plugin] });
+  const root = defineContextKey<number>("root", "Root");
+  const left = defineContextKey<number>("left", "Left");
+  const right = defineContextKey<number>("right", "Right");
+  const top = defineContextKey<number>("top", "Top");
+
+  // root -> {left, right} -> top
+  plugin.registerTransform(left, {
+    sources: [root],
+    compute: (read) => (read(root) ?? 0) + 1,
+  });
+  plugin.registerTransform(right, {
+    sources: [root],
+    compute: (read) => (read(root) ?? 0) + 2,
+  });
+  plugin.registerTransform(top, {
+    sources: [left, right],
+    compute: (read) => (read(left) ?? 0) + (read(right) ?? 0),
+  });
+
+  const topHandler = vitest.fn();
+  plugin.subscribe(top, topHandler);
+
+  plugin.set(root, 10);
+
+  expect(topHandler).toHaveBeenCalledTimes(1);
+  expect(topHandler).toHaveBeenCalledWith(23, top);
+});
+
+test("transitive invalidation terminates on a cyclic dependency graph", () => {
+  const plugin = new ContextPlugin();
+  new Player({ plugins: [plugin] });
+  const root = defineContextKey<number>("root", "Root");
+  const a = defineContextKey<number>("a", "A");
+  const b = defineContextKey<number>("b", "B");
+
+  // root -> a -> b -> a (cycle in the dependency graph)
+  plugin.registerTransform(a, {
+    sources: [root, b],
+    compute: (read) => (read(root) ?? 0) + 1,
+  });
+  plugin.registerTransform(b, {
+    sources: [a],
+    compute: () => 0,
+  });
+
+  const aHandler = vitest.fn();
+  plugin.subscribe(a, aHandler);
+
+  plugin.set(root, 1);
+
+  expect(aHandler).toHaveBeenCalledTimes(1);
+  expect(aHandler).toHaveBeenCalledWith(2, a);
+});
+
 test("subscribeAll receives every literal set and every dependent invalidation", () => {
   const plugin = new ContextPlugin();
   new Player({ plugins: [plugin] });

--- a/plugins/context/core/src/__tests__/state-plugin.test.ts
+++ b/plugins/context/core/src/__tests__/state-plugin.test.ts
@@ -1,0 +1,154 @@
+import { test, expect, vitest } from "vitest";
+import { Player } from "@player-ui/player";
+import type { DataController } from "@player-ui/player";
+import { ContextPlugin } from "../plugin";
+import { ContextPluginSymbol } from "../symbols";
+import {
+  StateContextPlugin,
+  dataContextKey,
+  flowIdContextKey,
+  flowStateContextKey,
+  playerStateContextKey,
+  playerStatusContextKey,
+  viewContextKey,
+  viewIdContextKey,
+} from "../state-plugin";
+
+const minimalFlow = {
+  id: "flow-state-test",
+  views: [{ id: "view-1", type: "info" }],
+  data: { name: "Ada" },
+  navigation: {
+    BEGIN: "FLOW_1",
+    FLOW_1: {
+      startState: "VIEW_1",
+      VIEW_1: {
+        ref: "view-1",
+        state_type: "VIEW",
+        transitions: { "*": "END_Done" },
+      },
+      END_Done: { state_type: "END", outcome: "done" },
+    },
+  },
+};
+
+test("StateContextPlugin auto-registers a ContextPlugin if absent", () => {
+  const state = new StateContextPlugin();
+  const player = new Player({ plugins: [state] });
+  const ctx = player.findPlugin<ContextPlugin>(ContextPluginSymbol);
+  expect(ctx).toBeInstanceOf(ContextPlugin);
+});
+
+test("StateContextPlugin reuses an existing ContextPlugin", () => {
+  const ctx = new ContextPlugin();
+  const state = new StateContextPlugin();
+  const player = new Player({ plugins: [ctx, state] });
+  expect(player.findPlugin<ContextPlugin>(ContextPluginSymbol)).toBe(ctx);
+});
+
+test("publishes flow id, view id, view, data, status on flow start", () => {
+  const ctx = new ContextPlugin();
+  const state = new StateContextPlugin();
+  const player = new Player({ plugins: [ctx, state] });
+
+  player.start(minimalFlow as any);
+
+  expect(ctx.get(flowIdContextKey)).toBe("flow-state-test");
+  expect(ctx.get(playerStatusContextKey)).toBe("in-progress");
+  expect(ctx.get(flowStateContextKey)).toBe("VIEW_1");
+  expect(ctx.get(viewIdContextKey)).toBe("view-1");
+  expect(ctx.get(viewContextKey)).toMatchObject({
+    id: "view-1",
+    type: "info",
+  });
+  expect(ctx.get(dataContextKey)).toEqual({ name: "Ada" });
+});
+
+test("data context entry updates when the data controller updates", () => {
+  const ctx = new ContextPlugin();
+  const state = new StateContextPlugin();
+  const player = new Player({ plugins: [ctx, state] });
+
+  let dataController: DataController | undefined;
+  player.hooks.dataController.tap("test", (dc) => {
+    dataController = dc;
+  });
+
+  player.start(minimalFlow as any);
+  dataController!.set([["name", "Grace"]]);
+
+  expect(ctx.get(dataContextKey)).toEqual({ name: "Grace" });
+});
+
+test("list() reports all six state-context descriptors after StateContextPlugin applies", () => {
+  const ctx = new ContextPlugin();
+  const state = new StateContextPlugin();
+  new Player({ plugins: [ctx, state] });
+
+  const descriptions = ctx.list().map((d) => d.description);
+  expect(descriptions).toEqual(
+    expect.arrayContaining([
+      flowIdContextKey.description,
+      flowStateContextKey.description,
+      viewIdContextKey.description,
+      viewContextKey.description,
+      dataContextKey.description,
+      playerStatusContextKey.description,
+    ]),
+  );
+});
+
+test("aggregate playerStateContextKey composes every published source", () => {
+  const ctx = new ContextPlugin();
+  const state = new StateContextPlugin();
+  const player = new Player({ plugins: [ctx, state] });
+
+  player.start(minimalFlow as any);
+
+  const snapshot = ctx.get(playerStateContextKey);
+  expect(snapshot).toEqual({
+    status: "in-progress",
+    flow: { id: "flow-state-test", state: "VIEW_1" },
+    view: {
+      id: "view-1",
+      resolved: expect.objectContaining({ id: "view-1", type: "info" }),
+    },
+    data: { name: "Ada" },
+  });
+});
+
+test("aggregate subscribers fire when any source updates", () => {
+  const ctx = new ContextPlugin();
+  const state = new StateContextPlugin();
+  const player = new Player({ plugins: [ctx, state] });
+
+  let dataController: DataController | undefined;
+  player.hooks.dataController.tap("test", (dc) => {
+    dataController = dc;
+  });
+
+  const handler = vitest.fn();
+  ctx.subscribe(playerStateContextKey, handler);
+
+  player.start(minimalFlow as any);
+  handler.mockClear();
+  dataController!.set([["name", "Grace"]]);
+
+  expect(handler).toHaveBeenCalled();
+  const lastCall = handler.mock.calls[handler.mock.calls.length - 1];
+  expect(lastCall[0]).toMatchObject({ data: { name: "Grace" } });
+});
+
+test("status flips to completed after the flow ends", () => {
+  const ctx = new ContextPlugin();
+  const state = new StateContextPlugin();
+  const player = new Player({ plugins: [ctx, state] });
+
+  player.start(minimalFlow as any);
+  player.hooks.state.call({
+    status: "completed",
+    flow: minimalFlow as any,
+  } as any);
+
+  expect(ctx.get(playerStatusContextKey)).toBe("completed");
+});

--- a/plugins/context/core/src/__tests__/state-plugin.test.ts
+++ b/plugins/context/core/src/__tests__/state-plugin.test.ts
@@ -1,6 +1,8 @@
 import { test, expect, vitest } from "vitest";
 import { Player } from "@player-ui/player";
 import type { DataController } from "@player-ui/player";
+import { CommonTypesPlugin } from "@player-ui/common-types-plugin";
+import { ReferenceAssetsPlugin } from "@player-ui/reference-assets-plugin";
 import { ContextPlugin } from "../plugin";
 import { ContextPluginSymbol } from "../symbols";
 import {
@@ -10,9 +12,52 @@ import {
   flowStateContextKey,
   playerStateContextKey,
   playerStatusContextKey,
+  setDataActionKey,
+  transitionActionKey,
+  validationContextKey,
   viewContextKey,
   viewIdContextKey,
 } from "../state-plugin";
+
+/**
+ * A flow with a required `data.name` binding rendered by an input asset.
+ * Bindings are tracked by the reference-assets renderer and the `required`
+ * validator comes from the common-types plugin, so validation activates on a
+ * `change` trigger when the value is cleared.
+ */
+const validationFlow = {
+  id: "flow-validation",
+  views: [
+    {
+      id: "view-1",
+      type: "input",
+      binding: "data.name",
+      label: { asset: { id: "label", type: "text", value: "Name" } },
+    },
+  ],
+  data: { name: "Ada" },
+  schema: {
+    ROOT: { data: { type: "DataType" } },
+    DataType: {
+      name: {
+        type: "StringType",
+        validation: [{ type: "required", trigger: "change" }],
+      },
+    },
+  },
+  navigation: {
+    BEGIN: "FLOW_1",
+    FLOW_1: {
+      startState: "VIEW_1",
+      VIEW_1: {
+        ref: "view-1",
+        state_type: "VIEW",
+        transitions: { "*": "END_Done" },
+      },
+      END_Done: { state_type: "END", outcome: "done" },
+    },
+  },
+};
 
 const minimalFlow = {
   id: "flow-state-test",
@@ -24,6 +69,31 @@ const minimalFlow = {
       startState: "VIEW_1",
       VIEW_1: {
         ref: "view-1",
+        state_type: "VIEW",
+        transitions: { "*": "END_Done" },
+      },
+      END_Done: { state_type: "END", outcome: "done" },
+    },
+  },
+};
+
+const multiViewFlow = {
+  id: "flow-multi",
+  views: [
+    { id: "view-1", type: "info" },
+    { id: "view-2", type: "info" },
+  ],
+  navigation: {
+    BEGIN: "FLOW_1",
+    FLOW_1: {
+      startState: "VIEW_1",
+      VIEW_1: {
+        ref: "view-1",
+        state_type: "VIEW",
+        transitions: { Next: "VIEW_2", "*": "END_Done" },
+      },
+      VIEW_2: {
+        ref: "view-2",
         state_type: "VIEW",
         transitions: { "*": "END_Done" },
       },
@@ -106,15 +176,41 @@ test("aggregate playerStateContextKey composes every published source", () => {
   player.start(minimalFlow as any);
 
   const snapshot = ctx.get(playerStateContextKey);
-  expect(snapshot).toEqual({
+  expect(snapshot).toMatchObject({
     status: "in-progress",
     flow: { id: "flow-state-test", state: "VIEW_1" },
     view: {
       id: "view-1",
       resolved: expect.objectContaining({ id: "view-1", type: "info" }),
     },
-    data: { name: "Ada" },
+    data: { model: { name: "Ada" } },
   });
+  // Actions are scoped to the construct they operate on.
+  expect(typeof snapshot!.flow.transition).toBe("function");
+  expect(typeof snapshot!.data.set).toBe("function");
+});
+
+test("aggregate player.state exposes invokable actions scoped to their constructs", () => {
+  const ctx = new ContextPlugin();
+  const state = new StateContextPlugin();
+  const player = new Player({ plugins: [ctx, state] });
+
+  player.start(multiViewFlow as any);
+  const before = ctx.get(playerStateContextKey)!;
+  expect(before.flow.state).toBe("VIEW_1");
+
+  // The scoped flow.transition action advances the running flow.
+  before.flow.transition!("Next");
+  expect(ctx.get(flowStateContextKey)).toBe("VIEW_2");
+
+  // The scoped data.set action drives the data model; reading the aggregate
+  // back reflects the write through data.model.
+  ctx.get(playerStateContextKey)!.data.set!("name", "Grace");
+  expect(ctx.get(playerStateContextKey)!.data.model).toEqual({ name: "Grace" });
+
+  // Transitioning again drives the flow to its terminal END state.
+  ctx.get(playerStateContextKey)!.flow.transition!("Next");
+  expect(ctx.get(flowStateContextKey)).toBe("END_Done");
 });
 
 test("aggregate subscribers fire when any source updates", () => {
@@ -136,7 +232,103 @@ test("aggregate subscribers fire when any source updates", () => {
 
   expect(handler).toHaveBeenCalled();
   const lastCall = handler.mock.calls[handler.mock.calls.length - 1];
-  expect(lastCall[0]).toMatchObject({ data: { name: "Grace" } });
+  expect(lastCall[0]).toMatchObject({ data: { model: { name: "Grace" } } });
+});
+
+test("setData action is a function-valued context entry that writes to the data model", () => {
+  const ctx = new ContextPlugin();
+  const state = new StateContextPlugin();
+  const player = new Player({ plugins: [ctx, state] });
+
+  player.start(minimalFlow as any);
+  const setData = ctx.get(setDataActionKey);
+  expect(typeof setData).toBe("function");
+  setData!("name", "Grace");
+
+  expect(ctx.get(dataContextKey)).toEqual({ name: "Grace" });
+});
+
+test("transition action is a function-valued context entry that advances the flow", () => {
+  const ctx = new ContextPlugin();
+  const state = new StateContextPlugin();
+  const player = new Player({ plugins: [ctx, state] });
+
+  player.start(multiViewFlow as any);
+  expect(ctx.get(flowStateContextKey)).toBe("VIEW_1");
+
+  ctx.get(transitionActionKey)!("Next");
+
+  expect(ctx.get(flowStateContextKey)).toBe("VIEW_2");
+});
+
+test("actions are absent until their controller instances exist", () => {
+  const ctx = new ContextPlugin();
+  const state = new StateContextPlugin();
+  new Player({ plugins: [ctx, state] });
+
+  // Before a flow starts there is no data/flow controller bound, so the
+  // action entries hold no callable.
+  expect(ctx.get(setDataActionKey)).toBeUndefined();
+  expect(ctx.get(transitionActionKey)).toBeUndefined();
+});
+
+test("action entries are re-bound to the live controllers when a flow starts", () => {
+  const ctx = new ContextPlugin();
+  const state = new StateContextPlugin();
+  const player = new Player({ plugins: [ctx, state] });
+
+  player.start(minimalFlow as any);
+  expect(typeof ctx.get(setDataActionKey)).toBe("function");
+  expect(typeof ctx.get(transitionActionKey)).toBe("function");
+});
+
+test("validation context is empty and transitionable with no failing validations", () => {
+  const ctx = new ContextPlugin();
+  const state = new StateContextPlugin();
+  const player = new Player({
+    plugins: [ctx, state, new CommonTypesPlugin(), new ReferenceAssetsPlugin()],
+  });
+
+  player.start(validationFlow as any);
+
+  expect(ctx.get(validationContextKey)).toEqual({
+    canTransition: true,
+    byBinding: {},
+  });
+});
+
+test("validation context reflects a failing binding and blocks transition", async () => {
+  const ctx = new ContextPlugin();
+  const state = new StateContextPlugin();
+  const player = new Player({
+    plugins: [ctx, state, new CommonTypesPlugin(), new ReferenceAssetsPlugin()],
+  });
+
+  player.start(validationFlow as any);
+  const dataController = (player.getState() as any).controllers.data;
+  dataController.set([["data.name", ""]]); // required → fails when empty
+
+  await vitest.waitFor(() => {
+    const validation = ctx.get(validationContextKey)!;
+    expect(validation.canTransition).toBe(false);
+    expect(validation.byBinding["data.name"]?.[0]).toMatchObject({
+      severity: "error",
+      message: expect.any(String),
+      blocking: true,
+    });
+  });
+
+  // The aggregate surfaces it too.
+  expect(ctx.get(playerStateContextKey)!.validation.canTransition).toBe(false);
+
+  // Fixing the value clears the validation and re-enables transition.
+  dataController.set([["data.name", "Ada"]]);
+  await vitest.waitFor(() => {
+    expect(ctx.get(validationContextKey)).toEqual({
+      canTransition: true,
+      byBinding: {},
+    });
+  });
 });
 
 test("status flips to completed after the flow ends", () => {

--- a/plugins/context/core/src/__tests__/state-plugin.test.ts
+++ b/plugins/context/core/src/__tests__/state-plugin.test.ts
@@ -186,8 +186,8 @@ test("aggregate playerStateContextKey composes every published source", () => {
     data: { model: { name: "Ada" } },
   });
   // Actions are scoped to the construct they operate on.
-  expect(typeof snapshot!.flow.transition).toBe("function");
-  expect(typeof snapshot!.data.set).toBe("function");
+  expect(typeof snapshot!.flow!.transition).toBe("function");
+  expect(typeof snapshot!.data!.set).toBe("function");
 });
 
 test("aggregate player.state exposes invokable actions scoped to their constructs", () => {
@@ -197,19 +197,21 @@ test("aggregate player.state exposes invokable actions scoped to their construct
 
   player.start(multiViewFlow as any);
   const before = ctx.get(playerStateContextKey)!;
-  expect(before.flow.state).toBe("VIEW_1");
+  expect(before.flow!.state).toBe("VIEW_1");
 
   // The scoped flow.transition action advances the running flow.
-  before.flow.transition!("Next");
+  before.flow!.transition!("Next");
   expect(ctx.get(flowStateContextKey)).toBe("VIEW_2");
 
   // The scoped data.set action drives the data model; reading the aggregate
   // back reflects the write through data.model.
-  ctx.get(playerStateContextKey)!.data.set!("name", "Grace");
-  expect(ctx.get(playerStateContextKey)!.data.model).toEqual({ name: "Grace" });
+  ctx.get(playerStateContextKey)!.data!.set!("name", "Grace");
+  expect(ctx.get(playerStateContextKey)!.data!.model).toEqual({
+    name: "Grace",
+  });
 
   // Transitioning again drives the flow to its terminal END state.
-  ctx.get(playerStateContextKey)!.flow.transition!("Next");
+  ctx.get(playerStateContextKey)!.flow!.transition!("Next");
   expect(ctx.get(flowStateContextKey)).toBe("END_Done");
 });
 
@@ -319,7 +321,7 @@ test("validation context reflects a failing binding and blocks transition", asyn
   });
 
   // The aggregate surfaces it too.
-  expect(ctx.get(playerStateContextKey)!.validation.canTransition).toBe(false);
+  expect(ctx.get(playerStateContextKey)!.validation!.canTransition).toBe(false);
 
   // Fixing the value clears the validation and re-enables transition.
   dataController.set([["data.name", "Ada"]]);

--- a/plugins/context/core/src/__tests__/state-plugin.test.ts
+++ b/plugins/context/core/src/__tests__/state-plugin.test.ts
@@ -116,6 +116,15 @@ test("StateContextPlugin reuses an existing ContextPlugin", () => {
   expect(player.findPlugin<ContextPlugin>(ContextPluginSymbol)).toBe(ctx);
 });
 
+test("status is not-started immediately, before any flow starts", () => {
+  const ctx = new ContextPlugin();
+  const state = new StateContextPlugin();
+  new Player({ plugins: [ctx, state] });
+
+  expect(ctx.get(playerStatusContextKey)).toBe("not-started");
+  expect(ctx.get(playerStateContextKey)!.status).toBe("not-started");
+});
+
 test("publishes flow id, view id, view, data, status on flow start", () => {
   const ctx = new ContextPlugin();
   const state = new StateContextPlugin();

--- a/plugins/context/core/src/__tests__/store.test.ts
+++ b/plugins/context/core/src/__tests__/store.test.ts
@@ -1,0 +1,107 @@
+import { test, expect } from "vitest";
+import { ContextStore } from "../store";
+import { defineContextKey } from "../key";
+
+test("set / get / has literal", () => {
+  const store = new ContextStore();
+  const key = defineContextKey<number>("count", "A count");
+
+  expect(store.has(key)).toBe(false);
+  store.set(key, 42);
+  expect(store.has(key)).toBe(true);
+  expect(store.get(key)).toBe(42);
+
+  const descriptors = store.list();
+  expect(descriptors).toHaveLength(1);
+  expect(descriptors[0]).toMatchObject({
+    description: "A count",
+    hasValue: true,
+    hasTransform: false,
+  });
+});
+
+test("transform aggregates from sources on get", () => {
+  const store = new ContextStore();
+  const a = defineContextKey<number>("a", "A");
+  const b = defineContextKey<number>("b", "B");
+  const sum = defineContextKey<number>("sum", "A + B");
+
+  store.set(a, 2);
+  store.set(b, 3);
+  store.registerTransform(sum, {
+    sources: [a, b],
+    compute: (read) => (read(a) ?? 0) + (read(b) ?? 0),
+  });
+
+  expect(store.get(sum)).toBe(5);
+  expect(store.has(sum)).toBe(true);
+});
+
+test("literal overrides transform on get", () => {
+  const store = new ContextStore();
+  const a = defineContextKey<number>("a", "A");
+  const target = defineContextKey<number>("t", "T");
+
+  store.set(a, 10);
+  store.registerTransform(target, {
+    sources: [a],
+    compute: (read) => (read(a) ?? 0) * 2,
+  });
+  expect(store.get(target)).toBe(20);
+
+  store.set(target, 99);
+  expect(store.get(target)).toBe(99);
+});
+
+test("dependentsOf tracks reverse index from transform sources", () => {
+  const store = new ContextStore();
+  const src = defineContextKey<number>("src", "src");
+  const t1 = defineContextKey<number>("t1", "t1");
+  const t2 = defineContextKey<number>("t2", "t2");
+
+  store.registerTransform(t1, { sources: [src], compute: () => 1 });
+  store.registerTransform(t2, { sources: [src], compute: () => 2 });
+
+  const deps = store.dependentsOf(src.symbol);
+  const depSymbols = new Set(deps.map((k) => k.symbol));
+  expect(depSymbols.has(t1.symbol)).toBe(true);
+  expect(depSymbols.has(t2.symbol)).toBe(true);
+  expect(deps).toHaveLength(2);
+});
+
+test("re-registering a transform updates the reverse index", () => {
+  const store = new ContextStore();
+  const oldSrc = defineContextKey<number>("old", "old");
+  const newSrc = defineContextKey<number>("new", "new");
+  const target = defineContextKey<number>("target", "target");
+
+  store.registerTransform(target, { sources: [oldSrc], compute: () => 1 });
+  store.registerTransform(target, { sources: [newSrc], compute: () => 2 });
+
+  expect(store.dependentsOf(oldSrc.symbol)).toHaveLength(0);
+  expect(store.dependentsOf(newSrc.symbol)).toHaveLength(1);
+});
+
+test("freeze captures literal and transform-computed values, deep-freezes the snapshot", () => {
+  const store = new ContextStore();
+  const a = defineContextKey<number>("a", "A");
+  const doubled = defineContextKey<number>("doubled", "A doubled");
+
+  store.set(a, 7);
+  store.registerTransform(doubled, {
+    sources: [a],
+    compute: (read) => (read(a) ?? 0) * 2,
+  });
+
+  const snapshot = store.freeze({ endedAt: 1000 });
+  expect(snapshot.endedAt).toBe(1000);
+  expect(snapshot.entries).toHaveLength(2);
+  const byDesc = Object.fromEntries(
+    snapshot.entries.map((e) => [e.description, e.value]),
+  );
+  expect(byDesc).toEqual({ A: 7, "A doubled": 14 });
+
+  expect(Object.isFrozen(snapshot)).toBe(true);
+  expect(Object.isFrozen(snapshot.entries)).toBe(true);
+  expect(Object.isFrozen(snapshot.entries[0])).toBe(true);
+});

--- a/plugins/context/core/src/__tests__/store.test.ts
+++ b/plugins/context/core/src/__tests__/store.test.ts
@@ -69,6 +69,47 @@ test("dependentsOf tracks reverse index from transform sources", () => {
   expect(deps).toHaveLength(2);
 });
 
+test("transitiveDependentsOf walks the full dependency chain breadth-first", () => {
+  const store = new ContextStore();
+  const root = defineContextKey<number>("root", "root");
+  const mid = defineContextKey<number>("mid", "mid");
+  const top = defineContextKey<number>("top", "top");
+
+  store.registerTransform(mid, { sources: [root], compute: () => 1 });
+  store.registerTransform(top, { sources: [mid], compute: () => 2 });
+
+  expect(store.dependentsOf(root.symbol).map((k) => k.symbol)).toEqual([
+    mid.symbol,
+  ]);
+  expect(
+    store.transitiveDependentsOf(root.symbol).map((k) => k.symbol),
+  ).toEqual([mid.symbol, top.symbol]);
+});
+
+test("transitiveDependentsOf dedupes diamonds and terminates on cycles", () => {
+  const store = new ContextStore();
+  const root = defineContextKey<number>("root", "root");
+  const left = defineContextKey<number>("left", "left");
+  const right = defineContextKey<number>("right", "right");
+  const top = defineContextKey<number>("top", "top");
+
+  store.registerTransform(left, { sources: [root], compute: () => 1 });
+  store.registerTransform(right, { sources: [root], compute: () => 2 });
+  store.registerTransform(top, { sources: [left, right], compute: () => 3 });
+
+  const diamond = store.transitiveDependentsOf(root.symbol);
+  expect(diamond).toHaveLength(3);
+  expect(diamond.filter((k) => k.symbol === top.symbol)).toHaveLength(1);
+
+  // introduce a cycle: top feeds back into left
+  store.registerTransform(left, { sources: [root, top], compute: () => 1 });
+  const cyclic = store.transitiveDependentsOf(root.symbol);
+  expect(new Set(cyclic.map((k) => k.symbol))).toEqual(
+    new Set([left.symbol, right.symbol, top.symbol]),
+  );
+  expect(cyclic).toHaveLength(3);
+});
+
 test("re-registering a transform updates the reverse index", () => {
   const store = new ContextStore();
   const oldSrc = defineContextKey<number>("old", "old");

--- a/plugins/context/core/src/history.ts
+++ b/plugins/context/core/src/history.ts
@@ -1,0 +1,25 @@
+import type { FrozenContextSnapshot } from "./types";
+
+/**
+ * Append-only stack of frozen per-flow snapshots. The plugin pushes one
+ * snapshot on each flow end; consumers read via `entries()`.
+ */
+export class ContextHistory {
+  private stack: FrozenContextSnapshot[] = [];
+
+  push(snapshot: FrozenContextSnapshot): void {
+    this.stack.push(snapshot);
+  }
+
+  entries(): ReadonlyArray<FrozenContextSnapshot> {
+    return this.stack;
+  }
+
+  size(): number {
+    return this.stack.length;
+  }
+
+  clear(): void {
+    this.stack = [];
+  }
+}

--- a/plugins/context/core/src/index.ts
+++ b/plugins/context/core/src/index.ts
@@ -1,0 +1,6 @@
+export * from "./plugin";
+export * from "./symbols";
+export * from "./types";
+export * from "./key";
+export * from "./utils";
+export * from "./state-plugin";

--- a/plugins/context/core/src/key.ts
+++ b/plugins/context/core/src/key.ts
@@ -1,0 +1,35 @@
+import type { ContextKey } from "./types";
+
+const KEY_NAMESPACE = "player-ui.context.";
+
+/**
+ * Create a typed, globally-identifiable context key.
+ *
+ * Identity is backed by `Symbol.for`, so two keys created with the same `name`
+ * in different bundles refer to the same store entry. The `description` is the
+ * human-readable label used by introspection consumers.
+ */
+export const defineContextKey = <Value>(
+  name: string,
+  description: string,
+): ContextKey<Value> => ({
+  symbol: Symbol.for(`${KEY_NAMESPACE}${name}`),
+  description,
+});
+
+/**
+ * Resolve the global symbol for a context key name. Used by native wrappers
+ * that cross the JS bridge with string names instead of JS symbols.
+ */
+export const resolveContextKeySymbol = (name: string): symbol =>
+  Symbol.for(`${KEY_NAMESPACE}${name}`);
+
+/**
+ * Reverse-derive the name from a key created via `defineContextKey`. Returns
+ * `undefined` if the key's symbol was not created in the context namespace.
+ */
+export const nameOfContextKey = (key: ContextKey): string | undefined => {
+  const k = Symbol.keyFor(key.symbol);
+  if (!k || !k.startsWith(KEY_NAMESPACE)) return undefined;
+  return k.slice(KEY_NAMESPACE.length);
+};

--- a/plugins/context/core/src/plugin.ts
+++ b/plugins/context/core/src/plugin.ts
@@ -1,0 +1,261 @@
+import type { Player, PlayerPlugin, Flow } from "@player-ui/player";
+import { SyncHook, SyncWaterfallHook } from "tapable-ts";
+import { ContextStore } from "./store";
+import { ContextHistory } from "./history";
+import { ContextPluginSymbol } from "./symbols";
+import { defineContextKey, nameOfContextKey } from "./key";
+import type {
+  ContextEntryDescriptor,
+  ContextGlobalSubscriber,
+  ContextKey,
+  ContextSubscriber,
+  ContextTransform,
+  FrozenContextSnapshot,
+  SubscriptionToken,
+} from "./types";
+
+type TransformRegistration = {
+  key: ContextKey;
+  transform: ContextTransform<unknown>;
+};
+
+let subscriptionCounter = 0;
+
+/**
+ * Maintains a per-flow store of context entries keyed by symbol, with
+ * registered transforms for derived values and a subscription API for
+ * external consumers. On flow end the active store is frozen into a snapshot
+ * and pushed onto a history stack; a fresh store is created for the next flow,
+ * with transforms re-applied. Subscribers persist across flow rotations.
+ */
+export class ContextPlugin implements PlayerPlugin {
+  name = "context";
+
+  static Symbol: symbol = ContextPluginSymbol;
+  public readonly symbol: symbol = ContextPlugin.Symbol;
+
+  public readonly hooks = {
+    onSet: new SyncHook<[ContextKey, unknown]>(),
+    resolveValue: new SyncWaterfallHook<[unknown, ContextKey]>(),
+    onRegister: new SyncHook<[ContextKey]>(),
+    onFlowFrozen: new SyncHook<[FrozenContextSnapshot]>(),
+  };
+
+  protected store: ContextStore;
+  protected historyStack: ContextHistory;
+  private transforms = new Map<symbol, TransformRegistration>();
+  private perKeySubs = new Map<
+    symbol,
+    Map<SubscriptionToken, ContextSubscriber<unknown>>
+  >();
+  private globalSubs = new Map<SubscriptionToken, ContextGlobalSubscriber>();
+  private tokenIndex = new Map<SubscriptionToken, symbol | undefined>();
+  private currentFlowId: string | undefined;
+
+  constructor() {
+    this.store = new ContextStore();
+    this.historyStack = new ContextHistory();
+  }
+
+  apply(player: Player) {
+    const existing = player.findPlugin<ContextPlugin>(ContextPluginSymbol);
+    if (existing !== undefined && existing !== this) {
+      this.store = existing.store;
+      this.historyStack = existing.historyStack;
+      this.transforms = existing.transforms;
+      this.perKeySubs = existing.perKeySubs;
+      this.globalSubs = existing.globalSubs;
+      this.tokenIndex = existing.tokenIndex;
+      return;
+    }
+
+    player.hooks.onStart.tap(this.name, (flow: Flow) => {
+      this.currentFlowId = flow?.id;
+    });
+
+    player.hooks.onEnd.tap(this.name, () => {
+      const snapshot = this.store.freeze({
+        flowId: this.currentFlowId,
+        endedAt: Date.now(),
+      });
+      this.historyStack.push(snapshot);
+      this.hooks.onFlowFrozen.call(snapshot);
+      this.rotateStore();
+      this.currentFlowId = undefined;
+    });
+  }
+
+  register<Value>(key: ContextKey<Value>): void {
+    const added = this.store.register(key);
+    if (added) {
+      this.hooks.onRegister.call(key);
+    }
+  }
+
+  set<Value>(key: ContextKey<Value>, value: Value): void {
+    const isFirstSighting = !this.store.has(key);
+    this.store.set(key, value);
+    if (isFirstSighting) {
+      this.hooks.onRegister.call(key);
+    }
+    this.notify(key, value);
+
+    const dependents = this.store.dependentsOf(key.symbol);
+    for (const dep of dependents) {
+      const computed = this.store.get(dep);
+      this.notify(dep, computed);
+    }
+  }
+
+  get<Value>(key: ContextKey<Value>): Value | undefined {
+    const raw = this.store.get(key);
+    const resolved = this.hooks.resolveValue.call(raw, key);
+    return resolved as Value | undefined;
+  }
+
+  has(key: ContextKey): boolean {
+    return this.store.has(key);
+  }
+
+  registerTransform<Value>(
+    key: ContextKey<Value>,
+    transform: ContextTransform<Value>,
+  ): void {
+    const isFirstSighting = !this.store.has(key);
+    this.store.registerTransform(key, transform);
+    this.transforms.set(key.symbol, {
+      key,
+      transform: {
+        sources: transform.sources,
+        compute: transform.compute as ContextTransform<unknown>["compute"],
+      },
+    });
+    if (isFirstSighting) {
+      this.hooks.onRegister.call(key);
+    }
+  }
+
+  subscribe<Value>(
+    key: ContextKey<Value>,
+    handler: ContextSubscriber<Value>,
+  ): SubscriptionToken {
+    const token = this.nextToken();
+    let bucket = this.perKeySubs.get(key.symbol);
+    if (!bucket) {
+      bucket = new Map();
+      this.perKeySubs.set(key.symbol, bucket);
+    }
+    bucket.set(token, handler as ContextSubscriber<unknown>);
+    this.tokenIndex.set(token, key.symbol);
+    return token;
+  }
+
+  subscribeAll(handler: ContextGlobalSubscriber): SubscriptionToken {
+    const token = this.nextToken();
+    this.globalSubs.set(token, handler);
+    this.tokenIndex.set(token, undefined);
+    return token;
+  }
+
+  unsubscribe(token: SubscriptionToken): void {
+    const owner = this.tokenIndex.get(token);
+    if (owner === undefined) {
+      this.globalSubs.delete(token);
+    } else {
+      this.perKeySubs.get(owner)?.delete(token);
+    }
+    this.tokenIndex.delete(token);
+  }
+
+  list(): ReadonlyArray<ContextEntryDescriptor> {
+    return this.store.list();
+  }
+
+  history(): ReadonlyArray<FrozenContextSnapshot> {
+    return this.historyStack.entries();
+  }
+
+  snapshot(): FrozenContextSnapshot {
+    return this.store.freeze({
+      flowId: this.currentFlowId,
+      endedAt: Date.now(),
+    });
+  }
+
+  /**
+   * Bridge-friendly: set a value by string name. Used by native wrappers that
+   * cannot construct a `ContextKey` object directly.
+   */
+  setByName(name: string, description: string, value: unknown): void {
+    this.set(this.ensureNamedKey(name, description), value);
+  }
+
+  /** Bridge-friendly: get a value by string name. */
+  getByName(name: string): unknown {
+    return this.get(this.ensureNamedKey(name));
+  }
+
+  /** Bridge-friendly: check presence by string name. */
+  hasByName(name: string): boolean {
+    return this.has(this.ensureNamedKey(name));
+  }
+
+  /** Bridge-friendly: subscribe by string name. */
+  subscribeByName(
+    name: string,
+    description: string,
+    handler: (value: unknown, name: string) => void,
+  ): SubscriptionToken {
+    return this.subscribe(this.ensureNamedKey(name, description), (value) =>
+      handler(value, name),
+    );
+  }
+
+  /**
+   * Bridge-friendly: subscribe to all updates. The handler receives the
+   * key's resolved name (or undefined for non-namespaced keys).
+   */
+  subscribeAllByName(
+    handler: (
+      value: unknown,
+      name: string | undefined,
+      description: string,
+    ) => void,
+  ): SubscriptionToken {
+    return this.subscribeAll((value, key) =>
+      handler(value, nameOfContextKey(key), key.description),
+    );
+  }
+
+  private ensureNamedKey(
+    name: string,
+    description?: string,
+  ): ContextKey<unknown> {
+    return defineContextKey<unknown>(name, description ?? name);
+  }
+
+  private notify<Value>(key: ContextKey<Value>, value: Value | undefined) {
+    this.hooks.onSet.call(key, value);
+    const bucket = this.perKeySubs.get(key.symbol);
+    if (bucket) {
+      for (const handler of bucket.values()) {
+        (handler as ContextSubscriber<Value>)(value, key);
+      }
+    }
+    for (const handler of this.globalSubs.values()) {
+      handler(value, key);
+    }
+  }
+
+  private rotateStore() {
+    this.store = new ContextStore();
+    for (const { key, transform } of this.transforms.values()) {
+      this.store.registerTransform(key, transform);
+    }
+  }
+
+  private nextToken(): SubscriptionToken {
+    subscriptionCounter += 1;
+    return `ctx_${subscriptionCounter}`;
+  }
+}

--- a/plugins/context/core/src/plugin.ts
+++ b/plugins/context/core/src/plugin.ts
@@ -100,7 +100,9 @@ export class ContextPlugin implements PlayerPlugin {
     }
     this.notify(key, value);
 
-    const dependents = this.store.dependentsOf(key.symbol);
+    // Transitive: a chained transform (root -> mid -> top) must notify `top`
+    // when `root` changes, not just the directly-dependent `mid`.
+    const dependents = this.store.transitiveDependentsOf(key.symbol);
     for (const dep of dependents) {
       const computed = this.store.get(dep);
       this.notify(dep, computed);

--- a/plugins/context/core/src/plugin.ts
+++ b/plugins/context/core/src/plugin.ts
@@ -50,6 +50,8 @@ export class ContextPlugin implements PlayerPlugin {
   >();
   private globalSubs = new Map<SubscriptionToken, ContextGlobalSubscriber>();
   private tokenIndex = new Map<SubscriptionToken, symbol | undefined>();
+  /** Last value notify() fired with, per key — dedupes redundant publishes. */
+  private lastNotified = new Map<symbol, unknown>();
   private currentFlowId: string | undefined;
 
   constructor() {
@@ -66,6 +68,7 @@ export class ContextPlugin implements PlayerPlugin {
       this.perKeySubs = existing.perKeySubs;
       this.globalSubs = existing.globalSubs;
       this.tokenIndex = existing.tokenIndex;
+      this.lastNotified = existing.lastNotified;
       return;
     }
 
@@ -98,15 +101,7 @@ export class ContextPlugin implements PlayerPlugin {
     if (isFirstSighting) {
       this.hooks.onRegister.call(key);
     }
-    this.notify(key, value);
-
-    // Transitive: a chained transform (root -> mid -> top) must notify `top`
-    // when `root` changes, not just the directly-dependent `mid`.
-    const dependents = this.store.transitiveDependentsOf(key.symbol);
-    for (const dep of dependents) {
-      const computed = this.store.get(dep);
-      this.notify(dep, computed);
-    }
+    this.notifyIfChanged(key, value);
   }
 
   get<Value>(key: ContextKey<Value>): Value | undefined {
@@ -236,6 +231,41 @@ export class ContextPlugin implements PlayerPlugin {
     return defineContextKey<unknown>(name, description ?? name);
   }
 
+  /**
+   * Notify subscribers of `key` with `value`, unless it's `Object.is`-equal
+   * to the value the last notification for this key carried. Then cascade to
+   * every transitive dependent (a chained transform root -> mid -> top must
+   * notify `top` when `root` changes, not just the directly-dependent `mid`),
+   * applying the same unchanged-value guard to each. `transitiveDependentsOf`
+   * already flattens the full downstream closure in one deduped, cycle-safe
+   * pass, so this walks it directly rather than recursing back through this
+   * method (which would re-walk the graph from each dependent and, on a
+   * diamond, notify a shared descendant more than once).
+   */
+  private notifyIfChanged<Value>(
+    key: ContextKey<Value>,
+    value: Value | undefined,
+  ) {
+    this.publishIfChanged(key, value);
+
+    for (const dep of this.store.transitiveDependentsOf(key.symbol)) {
+      this.publishIfChanged(dep, this.store.get(dep));
+    }
+  }
+
+  private publishIfChanged<Value>(
+    key: ContextKey<Value>,
+    value: Value | undefined,
+  ) {
+    const hasNotified = this.lastNotified.has(key.symbol);
+    const unchanged =
+      hasNotified && Object.is(this.lastNotified.get(key.symbol), value);
+    this.lastNotified.set(key.symbol, value);
+    if (!unchanged) {
+      this.notify(key, value);
+    }
+  }
+
   private notify<Value>(key: ContextKey<Value>, value: Value | undefined) {
     this.hooks.onSet.call(key, value);
     const bucket = this.perKeySubs.get(key.symbol);
@@ -251,6 +281,7 @@ export class ContextPlugin implements PlayerPlugin {
 
   private rotateStore() {
     this.store = new ContextStore();
+    this.lastNotified.clear();
     for (const { key, transform } of this.transforms.values()) {
       this.store.registerTransform(key, transform);
     }

--- a/plugins/context/core/src/state-plugin.ts
+++ b/plugins/context/core/src/state-plugin.ts
@@ -1,0 +1,163 @@
+import type { Player, PlayerPlugin } from "@player-ui/player";
+import { ContextPlugin } from "./plugin";
+import { defineContextKey } from "./key";
+import { getContextPlugin } from "./utils";
+import type { ContextKey } from "./types";
+
+/** Identifier of the currently-running flow. */
+export const flowIdContextKey: ContextKey<string> = defineContextKey<string>(
+  "player.flow.id",
+  "Identifier of the running flow",
+);
+
+/** Name of the current FSM state within the running flow. */
+export const flowStateContextKey: ContextKey<string> = defineContextKey<string>(
+  "player.flow.state",
+  "Name of the current FSM state in the running flow",
+);
+
+/** Identifier of the view currently resolved by the ViewController. */
+export const viewIdContextKey: ContextKey<string> = defineContextKey<string>(
+  "player.view.id",
+  "Identifier of the currently-resolved view",
+);
+
+/** Full resolved view object for the current FSM state. */
+export const viewContextKey: ContextKey<unknown> = defineContextKey<unknown>(
+  "player.view",
+  "Full resolved view object for the current FSM state",
+);
+
+/** Full data model tree for the running flow. */
+export const dataContextKey: ContextKey<unknown> = defineContextKey<unknown>(
+  "player.data",
+  "Full data model tree for the running flow",
+);
+
+/** Player flow status: not-started, in-progress, completed, or error. */
+export const playerStatusContextKey: ContextKey<string> =
+  defineContextKey<string>(
+    "player.status",
+    "Player flow status: not-started, in-progress, completed, or error",
+  );
+
+/** Aggregated snapshot composed from every other StateContextPlugin key. */
+export type PlayerStateContext = {
+  status?: string;
+  flow: {
+    id?: string;
+    state?: string;
+  };
+  view: {
+    id?: string;
+    resolved?: unknown;
+  };
+  data?: unknown;
+};
+
+/**
+ * Single roll-up key that aggregates every other [[StateContextPlugin]] entry
+ * into one object. Backed by a transform — reading recomputes from the latest
+ * source values, and subscribers fire whenever any source updates.
+ */
+export const playerStateContextKey: ContextKey<PlayerStateContext> =
+  defineContextKey<PlayerStateContext>(
+    "player.state",
+    "Aggregated snapshot of every Player runtime context entry",
+  );
+
+/**
+ * A consumer plugin that mirrors Player runtime state into the ContextPlugin
+ * store. Registers a small, opinionated set of context entries (flow id,
+ * current FSM state, view id, full view, data model, status) so external
+ * automation/devtools can observe the running Player without tapping every
+ * controller hook themselves.
+ *
+ * Auto-registers a [[ContextPlugin]] if one isn't already on the player.
+ */
+export class StateContextPlugin implements PlayerPlugin {
+  name = "state-context";
+
+  private contextPlugin?: ContextPlugin;
+
+  apply(player: Player) {
+    const ctx = getContextPlugin(player);
+    this.contextPlugin = ctx;
+
+    ctx.register(flowIdContextKey);
+    ctx.register(flowStateContextKey);
+    ctx.register(viewIdContextKey);
+    ctx.register(viewContextKey);
+    ctx.register(dataContextKey);
+    ctx.register(playerStatusContextKey);
+
+    ctx.registerTransform(playerStateContextKey, {
+      sources: [
+        flowIdContextKey,
+        flowStateContextKey,
+        viewIdContextKey,
+        viewContextKey,
+        dataContextKey,
+        playerStatusContextKey,
+      ],
+      compute: (read) => ({
+        status: read(playerStatusContextKey),
+        flow: {
+          id: read(flowIdContextKey),
+          state: read(flowStateContextKey),
+        },
+        view: {
+          id: read(viewIdContextKey),
+          resolved: read(viewContextKey),
+        },
+        data: read(dataContextKey),
+      }),
+    });
+
+    player.hooks.onStart.tap(this.name, (flow) => {
+      if (flow?.id) {
+        ctx.set(flowIdContextKey, flow.id);
+      }
+    });
+
+    player.hooks.state.tap(this.name, (state) => {
+      ctx.set(playerStatusContextKey, state.status);
+    });
+
+    player.hooks.flowController.tap(this.name, (flowController) => {
+      flowController.hooks.flow.tap(this.name, (flowInstance) => {
+        const recordState = () => {
+          const name = flowInstance.currentState?.name;
+          if (name) {
+            ctx.set(flowStateContextKey, name);
+          }
+        };
+        recordState();
+        flowInstance.hooks.afterTransition.tap(this.name, recordState);
+      });
+    });
+
+    player.hooks.viewController.tap(this.name, (viewController) => {
+      viewController.hooks.view.tap(this.name, (view) => {
+        const id = view.initialView?.id;
+        if (id) {
+          ctx.set(viewIdContextKey, id);
+        }
+        view.hooks.onUpdate.tap(this.name, (resolved) => {
+          ctx.set(viewContextKey, resolved);
+          if (resolved?.id) {
+            ctx.set(viewIdContextKey, resolved.id);
+          }
+        });
+      });
+    });
+
+    player.hooks.dataController.tap(this.name, (dataController) => {
+      const publish = () => {
+        ctx.set(dataContextKey, dataController.serialize());
+      };
+      dataController.hooks.onUpdate.tap(this.name, publish);
+      publish();
+    });
+  }
+}

--- a/plugins/context/core/src/state-plugin.ts
+++ b/plugins/context/core/src/state-plugin.ts
@@ -1,8 +1,29 @@
 import type { Player, PlayerPlugin } from "@player-ui/player";
-import { ContextPlugin } from "./plugin";
 import { defineContextKey } from "./key";
 import { getContextPlugin } from "./utils";
 import type { ContextKey } from "./types";
+
+/** Set a single binding in the Player data model. */
+export type SetDataAction = (binding: string, value: unknown) => void;
+
+/** Transition the running flow using the given transition value. */
+export type TransitionAction = (transition: string) => void;
+
+/** A single validation, projected to its serializable fields. */
+export type ContextValidation = {
+  severity: "error" | "warning";
+  message: string;
+  displayTarget?: "page" | "section" | "field";
+  blocking?: boolean | "once";
+};
+
+/** Validation state for the running view, keyed by binding. */
+export type ValidationContext = {
+  /** Whether the view has no blocking validations (derived, no side effects). */
+  canTransition: boolean;
+  /** Active validations per binding string. */
+  byBinding: Record<string, ReadonlyArray<ContextValidation>>;
+};
 
 /** Identifier of the currently-running flow. */
 export const flowIdContextKey: ContextKey<string> = defineContextKey<string>(
@@ -41,18 +62,60 @@ export const playerStatusContextKey: ContextKey<string> =
     "Player flow status: not-started, in-progress, completed, or error",
   );
 
-/** Aggregated snapshot composed from every other StateContextPlugin key. */
+/** Validation state for the running view, keyed by binding. */
+export const validationContextKey: ContextKey<ValidationContext> =
+  defineContextKey<ValidationContext>(
+    "player.validation",
+    "Validation state for the running view, keyed by binding",
+  );
+
+/**
+ * Action entry whose value is a callable that sets a binding in the data
+ * model. Read via `ctx.get(setDataActionKey)`; absent until a flow is running.
+ */
+export const setDataActionKey: ContextKey<SetDataAction> =
+  defineContextKey<SetDataAction>(
+    "player.data.set",
+    "Set a value in the Player data model at the given binding",
+  );
+
+/**
+ * Action entry whose value is a callable that transitions the running flow.
+ * Read via `ctx.get(transitionActionKey)`; absent until a flow is running.
+ */
+export const transitionActionKey: ContextKey<TransitionAction> =
+  defineContextKey<TransitionAction>(
+    "player.flow.transition",
+    "Transition the current flow using the given transition value",
+  );
+
+/**
+ * Aggregated snapshot composed from every other StateContextPlugin key.
+ *
+ * Actions are scoped to the construct they operate on — `transition` lives
+ * under `flow`, `set` under `data` — rather than in a flat actions bag. Each
+ * is bound to the live controller and is absent until a flow is in-progress.
+ */
 export type PlayerStateContext = {
   status?: string;
   flow: {
     id?: string;
     state?: string;
+    /** Transition the running flow (e.g. 'Next'). */
+    transition?: TransitionAction;
   };
   view: {
     id?: string;
     resolved?: unknown;
   };
-  data?: unknown;
+  data: {
+    /** Full data model tree for the running flow. */
+    model?: unknown;
+    /** Set a value in the data model at the given binding. */
+    set?: SetDataAction;
+  };
+  /** Validation state for the running view, keyed by binding. */
+  validation: ValidationContext;
 };
 
 /**
@@ -78,11 +141,37 @@ export const playerStateContextKey: ContextKey<PlayerStateContext> =
 export class StateContextPlugin implements PlayerPlugin {
   name = "state-context";
 
-  private contextPlugin?: ContextPlugin;
-
   apply(player: Player) {
     const ctx = getContextPlugin(player);
-    this.contextPlugin = ctx;
+
+    // The validation controller for the running flow, captured so data/view
+    // updates can re-publish a passive (side-effect-free) validation snapshot.
+    type ValidationControllerLike = Parameters<
+      Parameters<typeof player.hooks.validationController.tap>[1]
+    >[0];
+    let validationController: ValidationControllerLike | undefined;
+
+    const publishValidation = () => {
+      if (!validationController) return;
+      const byBinding: Record<string, ReadonlyArray<ContextValidation>> = {};
+      let canTransition = true;
+      validationController.getBindings().forEach((binding) => {
+        const all = (validationController!
+          .getValidationForBinding(binding)
+          ?.getAll() ?? []) as ReadonlyArray<ContextValidation>;
+        if (all.length === 0) return;
+        byBinding[binding.asString()] = all.map((v) => ({
+          severity: v.severity,
+          message: v.message,
+          displayTarget: v.displayTarget,
+          blocking: v.blocking,
+        }));
+        if (all.some((v) => v.blocking)) {
+          canTransition = false;
+        }
+      });
+      ctx.set(validationContextKey, { canTransition, byBinding });
+    };
 
     ctx.register(flowIdContextKey);
     ctx.register(flowStateContextKey);
@@ -90,6 +179,9 @@ export class StateContextPlugin implements PlayerPlugin {
     ctx.register(viewContextKey);
     ctx.register(dataContextKey);
     ctx.register(playerStatusContextKey);
+    ctx.register(validationContextKey);
+    ctx.register(setDataActionKey);
+    ctx.register(transitionActionKey);
 
     ctx.registerTransform(playerStateContextKey, {
       sources: [
@@ -99,18 +191,29 @@ export class StateContextPlugin implements PlayerPlugin {
         viewContextKey,
         dataContextKey,
         playerStatusContextKey,
+        validationContextKey,
+        setDataActionKey,
+        transitionActionKey,
       ],
       compute: (read) => ({
         status: read(playerStatusContextKey),
         flow: {
           id: read(flowIdContextKey),
           state: read(flowStateContextKey),
+          transition: read(transitionActionKey),
         },
         view: {
           id: read(viewIdContextKey),
           resolved: read(viewContextKey),
         },
-        data: read(dataContextKey),
+        data: {
+          model: read(dataContextKey),
+          set: read(setDataActionKey),
+        },
+        validation: read(validationContextKey) ?? {
+          canTransition: true,
+          byBinding: {},
+        },
       }),
     });
 
@@ -125,6 +228,11 @@ export class StateContextPlugin implements PlayerPlugin {
     });
 
     player.hooks.flowController.tap(this.name, (flowController) => {
+      // Bind to the concrete controller instance for the running flow.
+      const transition: TransitionAction = (value) =>
+        flowController.transition(value);
+      ctx.set(transitionActionKey, transition);
+
       flowController.hooks.flow.tap(this.name, (flowInstance) => {
         const recordState = () => {
           const name = flowInstance.currentState?.name;
@@ -135,6 +243,11 @@ export class StateContextPlugin implements PlayerPlugin {
         recordState();
         flowInstance.hooks.afterTransition.tap(this.name, recordState);
       });
+    });
+
+    player.hooks.validationController.tap(this.name, (vc) => {
+      validationController = vc;
+      publishValidation();
     });
 
     player.hooks.viewController.tap(this.name, (viewController) => {
@@ -148,13 +261,23 @@ export class StateContextPlugin implements PlayerPlugin {
           if (resolved?.id) {
             ctx.set(viewIdContextKey, resolved.id);
           }
+          // Validation resets per view; re-publish for the resolved view.
+          publishValidation();
         });
       });
     });
 
     player.hooks.dataController.tap(this.name, (dataController) => {
+      // Bind the set-data action to this concrete controller instance.
+      const setData: SetDataAction = (binding, value) => {
+        dataController.set([[binding, value]]);
+      };
+      ctx.set(setDataActionKey, setData);
+
       const publish = () => {
         ctx.set(dataContextKey, dataController.serialize());
+        // Validation re-evaluates on data change.
+        publishValidation();
       };
       dataController.hooks.onUpdate.tap(this.name, publish);
       publish();

--- a/plugins/context/core/src/state-plugin.ts
+++ b/plugins/context/core/src/state-plugin.ts
@@ -98,24 +98,28 @@ export const transitionActionKey: ContextKey<TransitionAction> =
  */
 export type PlayerStateContext = {
   status?: string;
-  flow: {
+  /** Absent until a flow has started. */
+  flow?: {
     id?: string;
     state?: string;
     /** Transition the running flow (e.g. 'Next'). */
     transition?: TransitionAction;
   };
-  view: {
+  /** Absent until a view has resolved. */
+  view?: {
     id?: string;
     resolved?: unknown;
   };
-  data: {
+  /** Absent until a data controller is bound. */
+  data?: {
     /** Full data model tree for the running flow. */
     model?: unknown;
     /** Set a value in the data model at the given binding. */
     set?: SetDataAction;
   };
-  /** Validation state for the running view, keyed by binding. */
-  validation: ValidationContext;
+  /** Validation state for the running view, keyed by binding. Absent until a
+   * validation controller is bound. */
+  validation?: ValidationContext;
 };
 
 /**
@@ -195,26 +199,34 @@ export class StateContextPlugin implements PlayerPlugin {
         setDataActionKey,
         transitionActionKey,
       ],
-      compute: (read) => ({
-        status: read(playerStatusContextKey),
-        flow: {
-          id: read(flowIdContextKey),
-          state: read(flowStateContextKey),
-          transition: read(transitionActionKey),
-        },
-        view: {
-          id: read(viewIdContextKey),
-          resolved: read(viewContextKey),
-        },
-        data: {
-          model: read(dataContextKey),
-          set: read(setDataActionKey),
-        },
-        validation: read(validationContextKey) ?? {
-          canTransition: true,
-          byBinding: {},
-        },
-      }),
+      compute: (read) => {
+        const flowId = read(flowIdContextKey);
+        const flowState = read(flowStateContextKey);
+        const transition = read(transitionActionKey);
+        const viewId = read(viewIdContextKey);
+        const viewResolved = read(viewContextKey);
+        const dataModel = read(dataContextKey);
+        const setData = read(setDataActionKey);
+
+        return {
+          status: read(playerStatusContextKey),
+          flow:
+            flowId !== undefined ||
+            flowState !== undefined ||
+            transition !== undefined
+              ? { id: flowId, state: flowState, transition }
+              : undefined,
+          view:
+            viewId !== undefined || viewResolved !== undefined
+              ? { id: viewId, resolved: viewResolved }
+              : undefined,
+          data:
+            dataModel !== undefined || setData !== undefined
+              ? { model: dataModel, set: setData }
+              : undefined,
+          validation: read(validationContextKey),
+        };
+      },
     });
 
     player.hooks.onStart.tap(this.name, (flow) => {

--- a/plugins/context/core/src/state-plugin.ts
+++ b/plugins/context/core/src/state-plugin.ts
@@ -97,7 +97,8 @@ export const transitionActionKey: ContextKey<TransitionAction> =
  * is bound to the live controller and is absent until a flow is in-progress.
  */
 export type PlayerStateContext = {
-  status?: string;
+  /** Always present — "not-started" before a flow has ever started. */
+  status: string;
   /** Absent until a flow has started. */
   flow?: {
     id?: string;
@@ -187,6 +188,11 @@ export class StateContextPlugin implements PlayerPlugin {
     ctx.register(setDataActionKey);
     ctx.register(transitionActionKey);
 
+    // Player's own state is synchronously "not-started" from construction —
+    // seed it eagerly so `status` is always present, unlike the other
+    // sources, which only populate once a flow actually starts.
+    ctx.set(playerStatusContextKey, player.getState().status);
+
     ctx.registerTransform(playerStateContextKey, {
       sources: [
         flowIdContextKey,
@@ -209,7 +215,9 @@ export class StateContextPlugin implements PlayerPlugin {
         const setData = read(setDataActionKey);
 
         return {
-          status: read(playerStatusContextKey),
+          // Always present — seeded eagerly above and kept live by the
+          // `player.hooks.state` tap below.
+          status: read(playerStatusContextKey) ?? "not-started",
           flow:
             flowId !== undefined ||
             flowState !== undefined ||

--- a/plugins/context/core/src/store.ts
+++ b/plugins/context/core/src/store.ts
@@ -1,0 +1,164 @@
+import type {
+  ContextEntryDescriptor,
+  ContextKey,
+  ContextTransform,
+  FrozenContextEntry,
+  FrozenContextSnapshot,
+} from "./types";
+
+type Entry = {
+  key: ContextKey;
+  hasLiteral: boolean;
+  literal?: unknown;
+  transform?: ContextTransform<unknown>;
+};
+
+const deepFreezeEntry = (entry: FrozenContextEntry): FrozenContextEntry => {
+  Object.freeze(entry);
+  return entry;
+};
+
+/**
+ * Mutable per-flow context store. Owned by a single flow lifecycle; the plugin
+ * rotates the store on flow end and freezes the prior one into a snapshot.
+ */
+export class ContextStore {
+  private entries = new Map<symbol, Entry>();
+  /** source symbol -> set of target symbols (reverse index for invalidation). */
+  private dependents = new Map<symbol, Set<symbol>>();
+
+  register(key: ContextKey): boolean {
+    if (this.entries.has(key.symbol)) {
+      return false;
+    }
+    this.entries.set(key.symbol, { key, hasLiteral: false });
+    return true;
+  }
+
+  set<Value>(key: ContextKey<Value>, value: Value): void {
+    const existing = this.entries.get(key.symbol);
+    if (existing) {
+      existing.hasLiteral = true;
+      existing.literal = value;
+      existing.key = key;
+    } else {
+      this.entries.set(key.symbol, {
+        key,
+        hasLiteral: true,
+        literal: value,
+      });
+    }
+  }
+
+  registerTransform<Value>(
+    key: ContextKey<Value>,
+    transform: ContextTransform<Value>,
+  ): { previousSources?: ReadonlyArray<ContextKey> } {
+    const existing = this.entries.get(key.symbol);
+    const previousSources = existing?.transform?.sources;
+
+    if (previousSources) {
+      for (const src of previousSources) {
+        this.dependents.get(src.symbol)?.delete(key.symbol);
+      }
+    }
+
+    const stored: ContextTransform<unknown> = {
+      sources: transform.sources,
+      compute: transform.compute as ContextTransform<unknown>["compute"],
+    };
+
+    if (existing) {
+      existing.transform = stored;
+      existing.key = key;
+    } else {
+      this.entries.set(key.symbol, {
+        key,
+        hasLiteral: false,
+        transform: stored,
+      });
+    }
+
+    for (const src of transform.sources) {
+      let set = this.dependents.get(src.symbol);
+      if (!set) {
+        set = new Set();
+        this.dependents.set(src.symbol, set);
+      }
+      set.add(key.symbol);
+    }
+
+    return { previousSources };
+  }
+
+  get<Value>(key: ContextKey<Value>): Value | undefined {
+    return this.compute(key.symbol) as Value | undefined;
+  }
+
+  has(key: ContextKey): boolean {
+    const entry = this.entries.get(key.symbol);
+    return Boolean(entry && (entry.hasLiteral || entry.transform));
+  }
+
+  /** Return the keys that depend on the given source key (direct dependents only). */
+  dependentsOf(sourceSymbol: symbol): ReadonlyArray<ContextKey> {
+    const set = this.dependents.get(sourceSymbol);
+    if (!set || set.size === 0) {
+      return [];
+    }
+    const out: ContextKey[] = [];
+    for (const targetSymbol of set) {
+      const target = this.entries.get(targetSymbol);
+      if (target) {
+        out.push(target.key);
+      }
+    }
+    return out;
+  }
+
+  list(): ReadonlyArray<ContextEntryDescriptor> {
+    const out: ContextEntryDescriptor[] = [];
+    for (const entry of this.entries.values()) {
+      out.push({
+        symbol: entry.key.symbol,
+        description: entry.key.description,
+        hasValue: entry.hasLiteral,
+        hasTransform: Boolean(entry.transform),
+      });
+    }
+    return out;
+  }
+
+  freeze(meta: { flowId?: string; endedAt: number }): FrozenContextSnapshot {
+    const frozenEntries: FrozenContextEntry[] = [];
+    for (const entry of this.entries.values()) {
+      const value = this.compute(entry.key.symbol);
+      if (!entry.hasLiteral && !entry.transform) {
+        continue;
+      }
+      frozenEntries.push(
+        deepFreezeEntry({
+          symbol: entry.key.symbol,
+          description: entry.key.description,
+          value,
+        }),
+      );
+    }
+    const snapshot: FrozenContextSnapshot = {
+      flowId: meta.flowId,
+      endedAt: meta.endedAt,
+      entries: Object.freeze(frozenEntries),
+    };
+    return Object.freeze(snapshot);
+  }
+
+  private compute(sym: symbol): unknown {
+    const entry = this.entries.get(sym);
+    if (!entry) return undefined;
+    if (entry.hasLiteral) return entry.literal;
+    if (!entry.transform) return undefined;
+    const reader = <V>(otherKey: { symbol: symbol }): V | undefined =>
+      this.compute(otherKey.symbol) as V | undefined;
+    return entry.transform.compute(reader);
+  }
+}

--- a/plugins/context/core/src/store.ts
+++ b/plugins/context/core/src/store.ts
@@ -5,6 +5,7 @@ import type {
   FrozenContextEntry,
   FrozenContextSnapshot,
 } from "./types";
+import { nameOfContextKey } from "./key";
 
 type Entry = {
   key: ContextKey;
@@ -16,6 +17,40 @@ type Entry = {
 const deepFreezeEntry = (entry: FrozenContextEntry): FrozenContextEntry => {
   Object.freeze(entry);
   return entry;
+};
+
+/**
+ * A poisoned stand-in for a function captured into a history snapshot. The
+ * key and description survive in the snapshot — the capability *existed* —
+ * but the callable is dead: invoking it throws because the flow it was bound
+ * to has ended. This preserves the distinction between "context that never
+ * held this action" and "an action that is no longer valid".
+ */
+const tombstone = (description: string) => (): never => {
+  throw new Error(
+    `[ContextPlugin] Action "${description}" is no longer valid — its flow has ended`,
+  );
+};
+
+/**
+ * Recursively replace every function in [value] (top-level or nested) with a
+ * {@link tombstone}, so a frozen history snapshot carries no live callables.
+ */
+const tombstoneFunctions = (value: unknown, description: string): unknown => {
+  if (typeof value === "function") {
+    return tombstone(description);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => tombstoneFunctions(item, description));
+  }
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      out[k] = tombstoneFunctions(v, description);
+    }
+    return out;
+  }
+  return value;
 };
 
 /**
@@ -132,22 +167,28 @@ export class ContextStore {
   freeze(meta: { flowId?: string; endedAt: number }): FrozenContextSnapshot {
     const frozenEntries: FrozenContextEntry[] = [];
     for (const entry of this.entries.values()) {
-      const value = this.compute(entry.key.symbol);
       if (!entry.hasLiteral && !entry.transform) {
         continue;
       }
+      const computed = this.compute(entry.key.symbol);
+      const value = tombstoneFunctions(computed, entry.key.description);
       frozenEntries.push(
         deepFreezeEntry({
           symbol: entry.key.symbol,
+          name: nameOfContextKey(entry.key),
           description: entry.key.description,
           value,
         }),
       );
     }
+    const bySymbol = new Map(frozenEntries.map((e) => [e.symbol, e.value]));
     const snapshot: FrozenContextSnapshot = {
       flowId: meta.flowId,
       endedAt: meta.endedAt,
       entries: Object.freeze(frozenEntries),
+      get<Value>(key: ContextKey<Value>): Value | undefined {
+        return bySymbol.get(key.symbol) as Value | undefined;
+      },
     };
     return Object.freeze(snapshot);
   }

--- a/plugins/context/core/src/store.ts
+++ b/plugins/context/core/src/store.ts
@@ -151,6 +151,38 @@ export class ContextStore {
     return out;
   }
 
+  /**
+   * Return every key transitively downstream of [sourceSymbol] — direct
+   * dependents, their dependents, and so on. Ordered breadth-first so nearer
+   * dependents come first, deduped so a key reachable by several paths (a
+   * diamond) appears once, and cycle-safe.
+   *
+   * The source itself is never included — `set()` notifies it directly, so
+   * re-emitting it here would double-notify subscribers on a cyclic graph.
+   */
+  transitiveDependentsOf(sourceSymbol: symbol): ReadonlyArray<ContextKey> {
+    const visited = new Set<symbol>([sourceSymbol]);
+    const out: ContextKey[] = [];
+    const queue: symbol[] = [sourceSymbol];
+
+    while (queue.length > 0) {
+      const current = queue.shift() as symbol;
+      const set = this.dependents.get(current);
+      if (!set) continue;
+      for (const targetSymbol of set) {
+        if (visited.has(targetSymbol)) continue;
+        visited.add(targetSymbol);
+        const target = this.entries.get(targetSymbol);
+        if (target) {
+          out.push(target.key);
+        }
+        queue.push(targetSymbol);
+      }
+    }
+
+    return out;
+  }
+
   list(): ReadonlyArray<ContextEntryDescriptor> {
     const out: ContextEntryDescriptor[] = [];
     for (const entry of this.entries.values()) {

--- a/plugins/context/core/src/symbols.ts
+++ b/plugins/context/core/src/symbols.ts
@@ -1,0 +1,1 @@
+export const ContextPluginSymbol = Symbol.for("ContextPlugin");

--- a/plugins/context/core/src/types.ts
+++ b/plugins/context/core/src/types.ts
@@ -1,0 +1,45 @@
+export type ContextKey<Value = unknown> = {
+  readonly symbol: symbol;
+  readonly description: string;
+  /** Phantom marker so TS can infer `Value` from a key. Not present at runtime. */
+  readonly __value?: Value;
+};
+
+export type ContextReader = <Value>(
+  key: ContextKey<Value>,
+) => Value | undefined;
+
+export type ContextTransform<Value> = {
+  /** Source keys whose updates should invalidate (and notify subscribers of) this target. */
+  sources: ReadonlyArray<ContextKey>;
+  /** Compute the target value, reading from other context entries. */
+  compute: (read: ContextReader) => Value | undefined;
+};
+
+export type ContextSubscriber<Value> = (
+  value: Value | undefined,
+  key: ContextKey<Value>,
+) => void;
+
+export type ContextGlobalSubscriber = (value: unknown, key: ContextKey) => void;
+
+export type ContextEntryDescriptor = {
+  symbol: symbol;
+  description: string;
+  hasValue: boolean;
+  hasTransform: boolean;
+};
+
+export type SubscriptionToken = `ctx_${number}`;
+
+export type FrozenContextEntry = {
+  readonly symbol: symbol;
+  readonly description: string;
+  readonly value: unknown;
+};
+
+export type FrozenContextSnapshot = {
+  readonly flowId?: string;
+  readonly endedAt: number;
+  readonly entries: ReadonlyArray<FrozenContextEntry>;
+};

--- a/plugins/context/core/src/types.ts
+++ b/plugins/context/core/src/types.ts
@@ -34,6 +34,12 @@ export type SubscriptionToken = `ctx_${number}`;
 
 export type FrozenContextEntry = {
   readonly symbol: symbol;
+  /**
+   * The entry's key name (from `nameOfContextKey`), or `undefined` for
+   * non-namespaced keys. Unlike `symbol`, this is a plain string that survives
+   * the native bridge, so native consumers read snapshot entries by name.
+   */
+  readonly name: string | undefined;
   readonly description: string;
   readonly value: unknown;
 };
@@ -42,4 +48,10 @@ export type FrozenContextSnapshot = {
   readonly flowId?: string;
   readonly endedAt: number;
   readonly entries: ReadonlyArray<FrozenContextEntry>;
+  /**
+   * Read a frozen entry by its key — the same typed access as live context.
+   * Returns `undefined` if the key was not present when the snapshot froze.
+   * Function-valued entries return their tombstone (a throwing callable).
+   */
+  get<Value>(key: ContextKey<Value>): Value | undefined;
 };

--- a/plugins/context/core/src/utils.ts
+++ b/plugins/context/core/src/utils.ts
@@ -1,0 +1,17 @@
+import type { Player } from "@player-ui/player";
+import { ContextPlugin } from "./plugin";
+import { ContextPluginSymbol } from "./symbols";
+
+/**
+ * Returns the existing ContextPlugin or creates and registers a new one.
+ */
+export function getContextPlugin(player: Player): ContextPlugin {
+  const existing = player.findPlugin<ContextPlugin>(ContextPluginSymbol);
+  const plugin = existing ?? new ContextPlugin();
+
+  if (!existing) {
+    player.registerPlugin(plugin);
+  }
+
+  return plugin;
+}

--- a/plugins/context/ios/BUILD.bazel
+++ b/plugins/context/ios/BUILD.bazel
@@ -2,5 +2,6 @@ load("//tools/ios:util.bzl", "ios_plugin")
 
 ios_plugin(
     name = "ContextPlugin",
-    resources = ["//plugins/context/core:core_native_bundle"]
+    resources = ["//plugins/context/core:core_native_bundle"],
+    deps = ["//ios/swiftui:PlayerUISwiftUI"],
 )

--- a/plugins/context/ios/BUILD.bazel
+++ b/plugins/context/ios/BUILD.bazel
@@ -1,0 +1,6 @@
+load("//tools/ios:util.bzl", "ios_plugin")
+
+ios_plugin(
+    name = "ContextPlugin",
+    resources = ["//plugins/context/core:core_native_bundle"]
+)

--- a/plugins/context/ios/Sources/ContextEntryDescriptor.swift
+++ b/plugins/context/ios/Sources/ContextEntryDescriptor.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Descriptor for a registered context entry, as returned by `ContextPlugin.list()`.
+public struct ContextEntryDescriptor: Decodable {
+    public let description: String
+    public let hasValue: Bool
+    public let hasTransform: Bool
+}

--- a/plugins/context/ios/Sources/ContextPlugin.swift
+++ b/plugins/context/ios/Sources/ContextPlugin.swift
@@ -30,21 +30,21 @@ public class ContextPlugin: JSBasePlugin, NativePlugin {
     /// Store `value` under the context entry identified by `name`, registering
     /// a human-readable `description` for introspection consumers.
     public func set(name: String, description: String, value: AnyType?) {
-        guard let pluginRef = pluginRef else { return }
+        guard let pluginRef else { return }
         let jsValue = encode(value, in: pluginRef.context)
         pluginRef.invokeMethod("setByName", withArguments: [name, description, jsValue as Any])
     }
 
     /// Read the current value for the entry identified by `name`, or nil if unset.
     public func get(name: String) -> AnyType? {
-        guard let pluginRef = pluginRef,
+        guard let pluginRef,
               let result = pluginRef.invokeMethod("getByName", withArguments: [name]) else { return nil }
         return decode(result)
     }
 
     /// Returns true if the entry identified by `name` has a value or transform.
     public func has(name: String) -> Bool {
-        guard let pluginRef = pluginRef,
+        guard let pluginRef,
               let result = pluginRef.invokeMethod("hasByName", withArguments: [name]) else { return false }
         return result.toBool()
     }
@@ -58,7 +58,7 @@ public class ContextPlugin: JSBasePlugin, NativePlugin {
         description: String,
         handler: @escaping (AnyType?, String) -> Void
     ) -> String? {
-        guard let pluginRef = pluginRef else { return nil }
+        guard let pluginRef else { return nil }
         let callback: @convention(block) (JSValue?, JSValue?) -> Void = { [weak self] value, _ in
             handler(self?.decode(value), name)
         }
@@ -73,7 +73,7 @@ public class ContextPlugin: JSBasePlugin, NativePlugin {
     public func subscribeAll(
         handler: @escaping (AnyType?, String?, String) -> Void
     ) -> String? {
-        guard let pluginRef = pluginRef else { return nil }
+        guard let pluginRef else { return nil }
         let callback: @convention(block) (JSValue?, JSValue?, JSValue?) -> Void = { [weak self] value, name, description in
             handler(self?.decode(value), name?.toString(), description?.toString() ?? "")
         }
@@ -93,7 +93,7 @@ public class ContextPlugin: JSBasePlugin, NativePlugin {
     /// `get(name:)?.flow.transition?("Next")`. Returns nil if the entry is
     /// unset or fails to decode.
     public func get<T: Decodable>(name: String, as type: T.Type = T.self) -> T? {
-        guard let pluginRef = pluginRef,
+        guard let pluginRef,
               let result = pluginRef.invokeMethod("getByName", withArguments: [name]),
               !result.isUndefined, !result.isNull else { return nil }
         return try? JSONDecoder().decode(T.self, from: result)
@@ -101,7 +101,7 @@ public class ContextPlugin: JSBasePlugin, NativePlugin {
 
     /// Returns the registered entry descriptors (description + value/transform flags).
     public func list() -> [ContextEntryDescriptor] {
-        guard let pluginRef = pluginRef,
+        guard let pluginRef,
               let result = pluginRef.invokeMethod("list", withArguments: []),
               !result.isUndefined, !result.isNull else { return [] }
         return (try? JSONDecoder().decode([ContextEntryDescriptor].self, from: result)) ?? []
@@ -109,7 +109,7 @@ public class ContextPlugin: JSBasePlugin, NativePlugin {
 
     /// Returns the stack of frozen snapshots from prior flows.
     public func history() -> [FrozenContextSnapshot] {
-        guard let pluginRef = pluginRef,
+        guard let pluginRef,
               let result = pluginRef.invokeMethod("history", withArguments: []),
               !result.isUndefined, !result.isNull,
               let count = result.toArray()?.count else { return [] }
@@ -117,16 +117,16 @@ public class ContextPlugin: JSBasePlugin, NativePlugin {
     }
 
     private func encode(_ value: AnyType?, in context: JSContext) -> Any? {
-        guard let value = value,
+        guard let value,
               let data = try? JSONEncoder().encode(value),
               let dataString = String(data: data, encoding: .utf8) else { return nil }
         return context.evaluateScript("(\(dataString))")
     }
 
     private func decode(_ value: JSValue?) -> AnyType? {
-        guard let value = value, !value.isUndefined, !value.isNull else { return nil }
-        if value.isString, let s = value.toString() {
-            return .string(data: s)
+        guard let value, !value.isUndefined, !value.isNull else { return nil }
+        if value.isString, let string = value.toString() {
+            return .string(data: string)
         }
         // Primitives are not valid top-level JSON for JSONSerialization, so
         // handle them directly before falling back to object decoding.

--- a/plugins/context/ios/Sources/ContextPlugin.swift
+++ b/plugins/context/ios/Sources/ContextPlugin.swift
@@ -1,0 +1,109 @@
+import Foundation
+import JavaScriptCore
+
+#if SWIFT_PACKAGE
+import PlayerUI
+#endif
+
+/**
+ A plugin that maintains a per-flow store of context entries keyed by string
+ name and exposes a subscribe/get/set API for native consumers.
+ */
+public class ContextPlugin: JSBasePlugin, NativePlugin {
+    public convenience init() {
+        self.init(fileName: "ContextPlugin.native", pluginName: "ContextPlugin.ContextPlugin")
+    }
+
+    override open func getUrlForFile(fileName: String) -> URL? {
+        #if SWIFT_PACKAGE
+        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
+        #else
+        ResourceUtilities.urlForFile(
+            name: fileName,
+            ext: "js",
+            bundle: Bundle(for: ContextPlugin.self),
+            pathComponent: "PlayerUI_ContextPlugin.bundle"
+        )
+        #endif
+    }
+
+    /// Store `value` under the context entry identified by `name`, registering
+    /// a human-readable `description` for introspection consumers.
+    public func set(name: String, description: String, value: AnyType?) {
+        guard let pluginRef = pluginRef else { return }
+        let jsValue = encode(value, in: pluginRef.context)
+        pluginRef.invokeMethod("setByName", withArguments: [name, description, jsValue as Any])
+    }
+
+    /// Read the current value for the entry identified by `name`, or nil if unset.
+    public func get(name: String) -> AnyType? {
+        guard let pluginRef = pluginRef,
+              let result = pluginRef.invokeMethod("getByName", withArguments: [name]) else { return nil }
+        return decode(result)
+    }
+
+    /// Returns true if the entry identified by `name` has a value or transform.
+    public func has(name: String) -> Bool {
+        guard let pluginRef = pluginRef,
+              let result = pluginRef.invokeMethod("hasByName", withArguments: [name]) else { return false }
+        return result.toBool()
+    }
+
+    /// Subscribe to updates for the entry identified by `name`. The handler is
+    /// invoked with the new value and the `name` whenever the entry changes.
+    /// Returns a token usable with `unsubscribe`.
+    @discardableResult
+    public func subscribe(
+        name: String,
+        description: String,
+        handler: @escaping (AnyType?, String) -> Void
+    ) -> String? {
+        guard let pluginRef = pluginRef else { return nil }
+        let callback: @convention(block) (JSValue?, JSValue?) -> Void = { [weak self] value, _ in
+            handler(self?.decode(value), name)
+        }
+        let jsCallback = JSValue(object: callback, in: pluginRef.context) as Any
+        let token = pluginRef.invokeMethod("subscribeByName", withArguments: [name, description, jsCallback])
+        return token?.toString()
+    }
+
+    /// Subscribe to every context update. The handler receives the new value,
+    /// the resolved key name (or nil for non-namespaced keys), and description.
+    @discardableResult
+    public func subscribeAll(
+        handler: @escaping (AnyType?, String?, String) -> Void
+    ) -> String? {
+        guard let pluginRef = pluginRef else { return nil }
+        let callback: @convention(block) (JSValue?, JSValue?, JSValue?) -> Void = { [weak self] value, name, description in
+            handler(self?.decode(value), name?.toString(), description?.toString() ?? "")
+        }
+        let jsCallback = JSValue(object: callback, in: pluginRef.context) as Any
+        let token = pluginRef.invokeMethod("subscribeAllByName", withArguments: [jsCallback])
+        return token?.toString()
+    }
+
+    /// Cancel the subscription registered with `token`.
+    public func unsubscribe(token: String) {
+        pluginRef?.invokeMethod("unsubscribe", withArguments: [token])
+    }
+
+    private func encode(_ value: AnyType?, in context: JSContext) -> Any? {
+        guard let value = value,
+              let data = try? JSONEncoder().encode(value),
+              let dataString = String(data: data, encoding: .utf8) else { return nil }
+        return context.evaluateScript("(\(dataString))")
+    }
+
+    private func decode(_ value: JSValue?) -> AnyType? {
+        guard let value = value, !value.isUndefined, !value.isNull else { return nil }
+        if value.isString, let s = value.toString() {
+            return .string(data: s)
+        }
+        guard let object = value.toObject(),
+              let data = try? JSONSerialization.data(withJSONObject: object),
+              let decoded = try? AnyTypeDecodingContext(rawData: data)
+                  .inject(to: JSONDecoder())
+                  .decode(AnyType.self, from: data) else { return nil }
+        return decoded
+    }
+}

--- a/plugins/context/ios/Sources/ContextPlugin.swift
+++ b/plugins/context/ios/Sources/ContextPlugin.swift
@@ -87,6 +87,35 @@ public class ContextPlugin: JSBasePlugin, NativePlugin {
         pluginRef?.invokeMethod("unsubscribe", withArguments: [token])
     }
 
+    /// Read the entry identified by `name`, decoded into a `Decodable` type
+    /// `T` — the same typed access as the JVM `get<T>(name)`. `T` may carry
+    /// `WrappedFunction` members for function-valued fields, so a caller does
+    /// `get(name:)?.flow.transition?("Next")`. Returns nil if the entry is
+    /// unset or fails to decode.
+    public func get<T: Decodable>(name: String, as type: T.Type = T.self) -> T? {
+        guard let pluginRef = pluginRef,
+              let result = pluginRef.invokeMethod("getByName", withArguments: [name]),
+              !result.isUndefined, !result.isNull else { return nil }
+        return try? JSONDecoder().decode(T.self, from: result)
+    }
+
+    /// Returns the registered entry descriptors (description + value/transform flags).
+    public func list() -> [ContextEntryDescriptor] {
+        guard let pluginRef = pluginRef,
+              let result = pluginRef.invokeMethod("list", withArguments: []),
+              !result.isUndefined, !result.isNull else { return [] }
+        return (try? JSONDecoder().decode([ContextEntryDescriptor].self, from: result)) ?? []
+    }
+
+    /// Returns the stack of frozen snapshots from prior flows.
+    public func history() -> [FrozenContextSnapshot] {
+        guard let pluginRef = pluginRef,
+              let result = pluginRef.invokeMethod("history", withArguments: []),
+              !result.isUndefined, !result.isNull,
+              let count = result.toArray()?.count else { return [] }
+        return (0..<count).compactMap { FrozenContextSnapshot(result.objectAtIndexedSubscript($0)) }
+    }
+
     private func encode(_ value: AnyType?, in context: JSContext) -> Any? {
         guard let value = value,
               let data = try? JSONEncoder().encode(value),
@@ -98,6 +127,14 @@ public class ContextPlugin: JSBasePlugin, NativePlugin {
         guard let value = value, !value.isUndefined, !value.isNull else { return nil }
         if value.isString, let s = value.toString() {
             return .string(data: s)
+        }
+        // Primitives are not valid top-level JSON for JSONSerialization, so
+        // handle them directly before falling back to object decoding.
+        if value.isBoolean {
+            return .bool(data: value.toBool())
+        }
+        if value.isNumber {
+            return .number(data: value.toDouble())
         }
         guard let object = value.toObject(),
               let data = try? JSONSerialization.data(withJSONObject: object),

--- a/plugins/context/ios/Sources/ContextPlugin.swift
+++ b/plugins/context/ios/Sources/ContextPlugin.swift
@@ -1,9 +1,18 @@
 import Foundation
 import JavaScriptCore
+import PlayerUI
 
-#if SWIFT_PACKAGE
-    import PlayerUI
-#endif
+/// Names of the JS-side `ContextPlugin.native` methods invoked over the bridge.
+private enum JSMethod {
+    static let setByName = "setByName"
+    static let getByName = "getByName"
+    static let hasByName = "hasByName"
+    static let subscribeByName = "subscribeByName"
+    static let subscribeAllByName = "subscribeAllByName"
+    static let unsubscribe = "unsubscribe"
+    static let list = "list"
+    static let history = "history"
+}
 
 /// A plugin that maintains a per-flow store of context entries keyed by string
 /// name and exposes a subscribe/get/set API for native consumers.
@@ -13,16 +22,7 @@ public class ContextPlugin: JSBasePlugin, NativePlugin {
     }
 
     override open func getUrlForFile(fileName: String) -> URL? {
-        #if SWIFT_PACKAGE
-            ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
-        #else
-            ResourceUtilities.urlForFile(
-                name: fileName,
-                ext: "js",
-                bundle: Bundle(for: ContextPlugin.self),
-                pathComponent: "PlayerUI_ContextPlugin.bundle"
-            )
-        #endif
+        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
     }
 
     /// Store `value` under the context entry identified by `name`, registering
@@ -30,13 +30,16 @@ public class ContextPlugin: JSBasePlugin, NativePlugin {
     public func set(name: String, description: String, value: AnyType?) {
         guard let pluginRef else { return }
         let jsValue = encode(value, in: pluginRef.context)
-        pluginRef.invokeMethod("setByName", withArguments: [name, description, jsValue as Any])
+        pluginRef.invokeMethod(
+            JSMethod.setByName,
+            withArguments: [name, description, jsValue as Any]
+        )
     }
 
     /// Read the current value for the entry identified by `name`, or nil if unset.
     public func get(name: String) -> AnyType? {
         guard let pluginRef,
-              let result = pluginRef.invokeMethod("getByName", withArguments: [name])
+              let result = pluginRef.invokeMethod(JSMethod.getByName, withArguments: [name])
         else { return nil }
         return decode(result)
     }
@@ -44,7 +47,7 @@ public class ContextPlugin: JSBasePlugin, NativePlugin {
     /// Returns true if the entry identified by `name` has a value or transform.
     public func has(name: String) -> Bool {
         guard let pluginRef,
-              let result = pluginRef.invokeMethod("hasByName", withArguments: [name])
+              let result = pluginRef.invokeMethod(JSMethod.hasByName, withArguments: [name])
         else { return false }
         return result.toBool()
     }
@@ -64,7 +67,7 @@ public class ContextPlugin: JSBasePlugin, NativePlugin {
         }
         let jsCallback = JSValue(object: callback, in: pluginRef.context) as Any
         let token = pluginRef.invokeMethod(
-            "subscribeByName",
+            JSMethod.subscribeByName,
             withArguments: [name, description, jsCallback]
         )
         return token?.toString()
@@ -82,23 +85,27 @@ public class ContextPlugin: JSBasePlugin, NativePlugin {
                 handler(self?.decode(value), name?.toString(), description?.toString() ?? "")
             }
         let jsCallback = JSValue(object: callback, in: pluginRef.context) as Any
-        let token = pluginRef.invokeMethod("subscribeAllByName", withArguments: [jsCallback])
+        let token = pluginRef.invokeMethod(JSMethod.subscribeAllByName, withArguments: [jsCallback])
         return token?.toString()
     }
 
     /// Cancel the subscription registered with `token`.
     public func unsubscribe(token: String) {
-        pluginRef?.invokeMethod("unsubscribe", withArguments: [token])
+        pluginRef?.invokeMethod(JSMethod.unsubscribe, withArguments: [token])
     }
 
     /// Read the entry identified by `name`, decoded into a `Decodable` type
     /// `T` — the same typed access as the JVM `get<T>(name)`. `T` may carry
     /// `WrappedFunction` members for function-valued fields, so a caller does
-    /// `get(name:)?.flow.transition?("Next")`. Returns nil if the entry is
-    /// unset or fails to decode.
-    public func get<T: Decodable>(name: String, as _: T.Type = T.self) -> T? {
+    /// `get(name: "player.state", as: PlayerStateContext.self)?.flow?.transition?("Next")`.
+    /// Returns nil if the entry is unset or fails to decode.
+    ///
+    /// - Note: `as` has no default — one would make this call ambiguous with
+    ///   the non-generic `get(name:)` above, since both would then be
+    ///   callable with just a `name:` argument.
+    public func get<T: Decodable>(name: String, as _: T.Type) -> T? {
         guard let pluginRef,
-              let result = pluginRef.invokeMethod("getByName", withArguments: [name]),
+              let result = pluginRef.invokeMethod(JSMethod.getByName, withArguments: [name]),
               !result.isUndefined, !result.isNull else { return nil }
         // `T` may carry `AnyType` members (view.resolved, data.model), which
         // require an AnyTypeDecodingContext, and `WrappedFunction` members,
@@ -119,7 +126,7 @@ public class ContextPlugin: JSBasePlugin, NativePlugin {
     /// Returns the registered entry descriptors (description + value/transform flags).
     public func list() -> [ContextEntryDescriptor] {
         guard let pluginRef,
-              let result = pluginRef.invokeMethod("list", withArguments: []),
+              let result = pluginRef.invokeMethod(JSMethod.list, withArguments: []),
               !result.isUndefined, !result.isNull else { return [] }
         return (try? JSONDecoder().decode([ContextEntryDescriptor].self, from: result)) ?? []
     }
@@ -127,7 +134,7 @@ public class ContextPlugin: JSBasePlugin, NativePlugin {
     /// Returns the stack of frozen snapshots from prior flows.
     public func history() -> [FrozenContextSnapshot] {
         guard let pluginRef,
-              let result = pluginRef.invokeMethod("history", withArguments: []),
+              let result = pluginRef.invokeMethod(JSMethod.history, withArguments: []),
               !result.isUndefined, !result.isNull,
               let count = result.toArray()?.count else { return [] }
         return (0 ..< count)
@@ -137,8 +144,13 @@ public class ContextPlugin: JSBasePlugin, NativePlugin {
     private func encode(_ value: AnyType?, in context: JSContext) -> Any? {
         guard let value,
               let data = try? JSONEncoder().encode(value),
-              let dataString = String(data: data, encoding: .utf8) else { return nil }
-        return context.evaluateScript("(\(dataString))")
+              // `fragmentsAllowed` so primitive entries (a bare string or
+              // number) deserialize too — they are not valid top-level JSON.
+              let object = try? JSONSerialization.jsonObject(
+                  with: data,
+                  options: [.fragmentsAllowed]
+              ) else { return nil }
+        return JSValue(object: object, in: context)
     }
 
     private func decode(_ value: JSValue?) -> AnyType? {

--- a/plugins/context/ios/Sources/ContextPlugin.swift
+++ b/plugins/context/ios/Sources/ContextPlugin.swift
@@ -96,7 +96,20 @@ public class ContextPlugin: JSBasePlugin, NativePlugin {
         guard let pluginRef,
               let result = pluginRef.invokeMethod("getByName", withArguments: [name]),
               !result.isUndefined, !result.isNull else { return nil }
-        return try? JSONDecoder().decode(T.self, from: result)
+        // `T` may carry `AnyType` members (view.resolved, data.model), which
+        // require an AnyTypeDecodingContext, and `WrappedFunction` members,
+        // which recover their live JSValue from the decoder's rootJS by coding
+        // path. Decoding from the JSValue satisfies both.
+        guard let object = result.toObject(),
+              // `fragmentsAllowed` so primitive entries (a bare string or
+              // number) serialize too — they are not valid top-level JSON.
+              let data = try? JSONSerialization.data(
+                withJSONObject: object,
+                options: [.fragmentsAllowed]
+              ) else { return nil }
+        return try? AnyTypeDecodingContext(rawData: data)
+            .inject(to: JSONDecoder())
+            .decode(T.self, from: result)
     }
 
     /// Returns the registered entry descriptors (description + value/transform flags).

--- a/plugins/context/ios/Sources/ContextPlugin.swift
+++ b/plugins/context/ios/Sources/ContextPlugin.swift
@@ -2,13 +2,11 @@ import Foundation
 import JavaScriptCore
 
 #if SWIFT_PACKAGE
-import PlayerUI
+    import PlayerUI
 #endif
 
-/**
- A plugin that maintains a per-flow store of context entries keyed by string
- name and exposes a subscribe/get/set API for native consumers.
- */
+/// A plugin that maintains a per-flow store of context entries keyed by string
+/// name and exposes a subscribe/get/set API for native consumers.
 public class ContextPlugin: JSBasePlugin, NativePlugin {
     public convenience init() {
         self.init(fileName: "ContextPlugin.native", pluginName: "ContextPlugin.ContextPlugin")
@@ -16,14 +14,14 @@ public class ContextPlugin: JSBasePlugin, NativePlugin {
 
     override open func getUrlForFile(fileName: String) -> URL? {
         #if SWIFT_PACKAGE
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
+            ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
         #else
-        ResourceUtilities.urlForFile(
-            name: fileName,
-            ext: "js",
-            bundle: Bundle(for: ContextPlugin.self),
-            pathComponent: "PlayerUI_ContextPlugin.bundle"
-        )
+            ResourceUtilities.urlForFile(
+                name: fileName,
+                ext: "js",
+                bundle: Bundle(for: ContextPlugin.self),
+                pathComponent: "PlayerUI_ContextPlugin.bundle"
+            )
         #endif
     }
 
@@ -38,14 +36,16 @@ public class ContextPlugin: JSBasePlugin, NativePlugin {
     /// Read the current value for the entry identified by `name`, or nil if unset.
     public func get(name: String) -> AnyType? {
         guard let pluginRef,
-              let result = pluginRef.invokeMethod("getByName", withArguments: [name]) else { return nil }
+              let result = pluginRef.invokeMethod("getByName", withArguments: [name])
+        else { return nil }
         return decode(result)
     }
 
     /// Returns true if the entry identified by `name` has a value or transform.
     public func has(name: String) -> Bool {
         guard let pluginRef,
-              let result = pluginRef.invokeMethod("hasByName", withArguments: [name]) else { return false }
+              let result = pluginRef.invokeMethod("hasByName", withArguments: [name])
+        else { return false }
         return result.toBool()
     }
 
@@ -63,7 +63,10 @@ public class ContextPlugin: JSBasePlugin, NativePlugin {
             handler(self?.decode(value), name)
         }
         let jsCallback = JSValue(object: callback, in: pluginRef.context) as Any
-        let token = pluginRef.invokeMethod("subscribeByName", withArguments: [name, description, jsCallback])
+        let token = pluginRef.invokeMethod(
+            "subscribeByName",
+            withArguments: [name, description, jsCallback]
+        )
         return token?.toString()
     }
 
@@ -74,9 +77,10 @@ public class ContextPlugin: JSBasePlugin, NativePlugin {
         handler: @escaping (AnyType?, String?, String) -> Void
     ) -> String? {
         guard let pluginRef else { return nil }
-        let callback: @convention(block) (JSValue?, JSValue?, JSValue?) -> Void = { [weak self] value, name, description in
-            handler(self?.decode(value), name?.toString(), description?.toString() ?? "")
-        }
+        let callback: @convention(block) (JSValue?, JSValue?, JSValue?)
+            -> Void = { [weak self] value, name, description in
+                handler(self?.decode(value), name?.toString(), description?.toString() ?? "")
+            }
         let jsCallback = JSValue(object: callback, in: pluginRef.context) as Any
         let token = pluginRef.invokeMethod("subscribeAllByName", withArguments: [jsCallback])
         return token?.toString()
@@ -92,7 +96,7 @@ public class ContextPlugin: JSBasePlugin, NativePlugin {
     /// `WrappedFunction` members for function-valued fields, so a caller does
     /// `get(name:)?.flow.transition?("Next")`. Returns nil if the entry is
     /// unset or fails to decode.
-    public func get<T: Decodable>(name: String, as type: T.Type = T.self) -> T? {
+    public func get<T: Decodable>(name: String, as _: T.Type = T.self) -> T? {
         guard let pluginRef,
               let result = pluginRef.invokeMethod("getByName", withArguments: [name]),
               !result.isUndefined, !result.isNull else { return nil }
@@ -104,8 +108,8 @@ public class ContextPlugin: JSBasePlugin, NativePlugin {
               // `fragmentsAllowed` so primitive entries (a bare string or
               // number) serialize too — they are not valid top-level JSON.
               let data = try? JSONSerialization.data(
-                withJSONObject: object,
-                options: [.fragmentsAllowed]
+                  withJSONObject: object,
+                  options: [.fragmentsAllowed]
               ) else { return nil }
         return try? AnyTypeDecodingContext(rawData: data)
             .inject(to: JSONDecoder())
@@ -126,7 +130,8 @@ public class ContextPlugin: JSBasePlugin, NativePlugin {
               let result = pluginRef.invokeMethod("history", withArguments: []),
               !result.isUndefined, !result.isNull,
               let count = result.toArray()?.count else { return [] }
-        return (0..<count).compactMap { FrozenContextSnapshot(result.objectAtIndexedSubscript($0)) }
+        return (0 ..< count)
+            .compactMap { FrozenContextSnapshot(result.objectAtIndexedSubscript($0)) }
     }
 
     private func encode(_ value: AnyType?, in context: JSContext) -> Any? {
@@ -152,8 +157,8 @@ public class ContextPlugin: JSBasePlugin, NativePlugin {
         guard let object = value.toObject(),
               let data = try? JSONSerialization.data(withJSONObject: object),
               let decoded = try? AnyTypeDecodingContext(rawData: data)
-                  .inject(to: JSONDecoder())
-                  .decode(AnyType.self, from: data) else { return nil }
+              .inject(to: JSONDecoder())
+              .decode(AnyType.self, from: data) else { return nil }
         return decoded
     }
 }

--- a/plugins/context/ios/Sources/FrozenContextSnapshot.swift
+++ b/plugins/context/ios/Sources/FrozenContextSnapshot.swift
@@ -25,7 +25,7 @@ public struct FrozenContextSnapshot {
     }
 
     init?(_ snapshot: JSValue?) {
-        guard let snapshot = snapshot, !snapshot.isUndefined, !snapshot.isNull,
+        guard let snapshot, !snapshot.isUndefined, !snapshot.isNull,
               let entriesValue = snapshot.objectForKeyedSubscript("entries"),
               let entriesArray = entriesValue.toArray() else { return nil }
 
@@ -39,7 +39,7 @@ public struct FrozenContextSnapshot {
             let name = entry.objectForKeyedSubscript("name")?.toString()
             let description = entry.objectForKeyedSubscript("description")?.toString() ?? ""
             entries.append(FrozenContextEntry(name: name, description: description))
-            if let name = name, let value = entry.objectForKeyedSubscript("value") {
+            if let name, let value = entry.objectForKeyedSubscript("value") {
                 values[name] = value
             }
         }

--- a/plugins/context/ios/Sources/FrozenContextSnapshot.swift
+++ b/plugins/context/ios/Sources/FrozenContextSnapshot.swift
@@ -1,0 +1,57 @@
+import Foundation
+import JavaScriptCore
+
+#if SWIFT_PACKAGE
+import PlayerUI
+#endif
+
+/// A frozen snapshot of the context store captured when a flow ends.
+///
+/// Read entries by name with the same typed access as live context:
+/// `snapshot.get(name: "player.state", as: PlayerStateContext.self)`. The raw
+/// entry `JSValue`s are retained so function-valued entries decode into
+/// callable `WrappedFunction`s (a frozen action's tombstone throws when called).
+public struct FrozenContextSnapshot {
+    public let flowId: String?
+    public let endedAt: Double
+    public let entries: [FrozenContextEntry]
+
+    /// Raw per-name entry JSValues, retained for typed `get`.
+    private let entryValues: [String: JSValue]
+
+    public struct FrozenContextEntry: Decodable {
+        public let name: String?
+        public let description: String
+    }
+
+    init?(_ snapshot: JSValue?) {
+        guard let snapshot = snapshot, !snapshot.isUndefined, !snapshot.isNull,
+              let entriesValue = snapshot.objectForKeyedSubscript("entries"),
+              let entriesArray = entriesValue.toArray() else { return nil }
+
+        self.flowId = snapshot.objectForKeyedSubscript("flowId")?.toString()
+        self.endedAt = snapshot.objectForKeyedSubscript("endedAt")?.toDouble() ?? 0
+
+        var entries: [FrozenContextEntry] = []
+        var values: [String: JSValue] = [:]
+        for index in 0..<entriesArray.count {
+            guard let entry = entriesValue.objectAtIndexedSubscript(index) else { continue }
+            let name = entry.objectForKeyedSubscript("name")?.toString()
+            let description = entry.objectForKeyedSubscript("description")?.toString() ?? ""
+            entries.append(FrozenContextEntry(name: name, description: description))
+            if let name = name, let value = entry.objectForKeyedSubscript("value") {
+                values[name] = value
+            }
+        }
+        self.entries = entries
+        self.entryValues = values
+    }
+
+    /// Read a frozen entry by `name`, decoded into a `Decodable` type `T` — the
+    /// same typed access as live context. Returns nil if the entry was absent
+    /// when the snapshot froze or fails to decode.
+    public func get<T: Decodable>(name: String, as type: T.Type = T.self) -> T? {
+        guard let value = entryValues[name] else { return nil }
+        return try? JSONDecoder().decode(T.self, from: value)
+    }
+}

--- a/plugins/context/ios/Sources/FrozenContextSnapshot.swift
+++ b/plugins/context/ios/Sources/FrozenContextSnapshot.swift
@@ -51,7 +51,18 @@ public struct FrozenContextSnapshot {
     /// same typed access as live context. Returns nil if the entry was absent
     /// when the snapshot froze or fails to decode.
     public func get<T: Decodable>(name: String, as type: T.Type = T.self) -> T? {
-        guard let value = entryValues[name] else { return nil }
-        return try? JSONDecoder().decode(T.self, from: value)
+        guard let value = entryValues[name],
+              let object = value.toObject(),
+              // `fragmentsAllowed` so primitive entries (a bare string or
+              // number) serialize too — they are not valid top-level JSON.
+              let data = try? JSONSerialization.data(
+                withJSONObject: object,
+                options: [.fragmentsAllowed]
+              ) else { return nil }
+        // Mirrors `ContextPlugin.get(name:as:)`: `T` may carry `AnyType`
+        // members, which require an AnyTypeDecodingContext to decode.
+        return try? AnyTypeDecodingContext(rawData: data)
+            .inject(to: JSONDecoder())
+            .decode(T.self, from: value)
     }
 }

--- a/plugins/context/ios/Sources/FrozenContextSnapshot.swift
+++ b/plugins/context/ios/Sources/FrozenContextSnapshot.swift
@@ -1,9 +1,16 @@
 import Foundation
 import JavaScriptCore
+import PlayerUI
 
-#if SWIFT_PACKAGE
-    import PlayerUI
-#endif
+/// Keys read off the JS-side frozen snapshot object.
+private enum JSKey {
+    static let entries = "entries"
+    static let flowId = "flowId"
+    static let endedAt = "endedAt"
+    static let name = "name"
+    static let description = "description"
+    static let value = "value"
+}
 
 /// A frozen snapshot of the context store captured when a flow ends.
 ///
@@ -26,20 +33,20 @@ public struct FrozenContextSnapshot {
 
     init?(_ snapshot: JSValue?) {
         guard let snapshot, !snapshot.isUndefined, !snapshot.isNull,
-              let entriesValue = snapshot.objectForKeyedSubscript("entries"),
+              let entriesValue = snapshot.objectForKeyedSubscript(JSKey.entries),
               let entriesArray = entriesValue.toArray() else { return nil }
 
-        flowId = snapshot.objectForKeyedSubscript("flowId")?.toString()
-        endedAt = snapshot.objectForKeyedSubscript("endedAt")?.toDouble() ?? 0
+        flowId = snapshot.objectForKeyedSubscript(JSKey.flowId)?.toString()
+        endedAt = snapshot.objectForKeyedSubscript(JSKey.endedAt)?.toDouble() ?? 0
 
         var entries = [FrozenContextEntry]()
         var values = [String: JSValue]()
         for index in 0 ..< entriesArray.count {
             guard let entry = entriesValue.objectAtIndexedSubscript(index) else { continue }
-            let name = entry.objectForKeyedSubscript("name")?.toString()
-            let description = entry.objectForKeyedSubscript("description")?.toString() ?? ""
+            let name = entry.objectForKeyedSubscript(JSKey.name)?.toString()
+            let description = entry.objectForKeyedSubscript(JSKey.description)?.toString() ?? ""
             entries.append(FrozenContextEntry(name: name, description: description))
-            if let name, let value = entry.objectForKeyedSubscript("value") {
+            if let name, let value = entry.objectForKeyedSubscript(JSKey.value) {
                 values[name] = value
             }
         }

--- a/plugins/context/ios/Sources/FrozenContextSnapshot.swift
+++ b/plugins/context/ios/Sources/FrozenContextSnapshot.swift
@@ -2,7 +2,7 @@ import Foundation
 import JavaScriptCore
 
 #if SWIFT_PACKAGE
-import PlayerUI
+    import PlayerUI
 #endif
 
 /// A frozen snapshot of the context store captured when a flow ends.
@@ -29,12 +29,12 @@ public struct FrozenContextSnapshot {
               let entriesValue = snapshot.objectForKeyedSubscript("entries"),
               let entriesArray = entriesValue.toArray() else { return nil }
 
-        self.flowId = snapshot.objectForKeyedSubscript("flowId")?.toString()
-        self.endedAt = snapshot.objectForKeyedSubscript("endedAt")?.toDouble() ?? 0
+        flowId = snapshot.objectForKeyedSubscript("flowId")?.toString()
+        endedAt = snapshot.objectForKeyedSubscript("endedAt")?.toDouble() ?? 0
 
-        var entries: [FrozenContextEntry] = []
-        var values: [String: JSValue] = [:]
-        for index in 0..<entriesArray.count {
+        var entries = [FrozenContextEntry]()
+        var values = [String: JSValue]()
+        for index in 0 ..< entriesArray.count {
             guard let entry = entriesValue.objectAtIndexedSubscript(index) else { continue }
             let name = entry.objectForKeyedSubscript("name")?.toString()
             let description = entry.objectForKeyedSubscript("description")?.toString() ?? ""
@@ -44,20 +44,20 @@ public struct FrozenContextSnapshot {
             }
         }
         self.entries = entries
-        self.entryValues = values
+        entryValues = values
     }
 
     /// Read a frozen entry by `name`, decoded into a `Decodable` type `T` — the
     /// same typed access as live context. Returns nil if the entry was absent
     /// when the snapshot froze or fails to decode.
-    public func get<T: Decodable>(name: String, as type: T.Type = T.self) -> T? {
+    public func get<T: Decodable>(name: String, as _: T.Type = T.self) -> T? {
         guard let value = entryValues[name],
               let object = value.toObject(),
               // `fragmentsAllowed` so primitive entries (a bare string or
               // number) serialize too — they are not valid top-level JSON.
               let data = try? JSONSerialization.data(
-                withJSONObject: object,
-                options: [.fragmentsAllowed]
+                  withJSONObject: object,
+                  options: [.fragmentsAllowed]
               ) else { return nil }
         // Mirrors `ContextPlugin.get(name:as:)`: `T` may carry `AnyType`
         // members, which require an AnyTypeDecodingContext to decode.

--- a/plugins/context/ios/Sources/PlayerStateContext.swift
+++ b/plugins/context/ios/Sources/PlayerStateContext.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+#if SWIFT_PACKAGE
+import PlayerUI
+import PlayerUISwiftUI
+#endif
+
+/// Typed view of the aggregated `player.state` context entry. Read it with
+/// `contextPlugin.get(name: "player.state", as: PlayerStateContext.self)`.
+///
+/// Actions are scoped to the construct they operate on — `flow.transition` and
+/// `data.set` — and are nil until a flow is in-progress.
+public struct PlayerStateContext: Decodable {
+    public let status: String?
+    public let flow: Flow
+    public let view: View
+    public let data: Data
+    public let validation: Validation
+
+    public struct Flow: Decodable {
+        public let id: String?
+        public let state: String?
+        /// Transition the running flow using the given transition value (e.g. "Next").
+        public let transition: WrappedFunction<Void>?
+    }
+
+    public struct View: Decodable {
+        public let id: String?
+        public let resolved: AnyType?
+    }
+
+    public struct Data: Decodable {
+        /// Full data model tree for the running flow.
+        public let model: AnyType?
+        /// Set a value in the data model at the given binding.
+        public let set: WrappedFunction<Void>?
+    }
+
+    /// Validation state for the running view, keyed by binding.
+    public struct Validation: Decodable {
+        /// Whether the view has no blocking validations.
+        public let canTransition: Bool
+        /// Active validations per binding string.
+        public let byBinding: [String: [ContextValidation]]
+
+        public struct ContextValidation: Decodable {
+            public let severity: String
+            public let message: String
+            public let displayTarget: String?
+            /// `true`/`false` or the string `"once"`.
+            public let blocking: AnyType?
+        }
+    }
+}

--- a/plugins/context/ios/Sources/PlayerStateContext.swift
+++ b/plugins/context/ios/Sources/PlayerStateContext.swift
@@ -42,13 +42,14 @@ public struct PlayerStateContext: Decodable {
         public let canTransition: Bool
         /// Active validations per binding string.
         public let byBinding: [String: [ContextValidation]]
-
-        public struct ContextValidation: Decodable {
-            public let severity: String
-            public let message: String
-            public let displayTarget: String?
-            /// `true`/`false` or the string `"once"`.
-            public let blocking: AnyType?
-        }
     }
+}
+
+/// A single validation, projected to its serializable fields.
+public struct ContextValidation: Decodable {
+    public let severity: String
+    public let message: String
+    public let displayTarget: String?
+    /// `true`/`false` or the string `"once"`.
+    public let blocking: AnyType?
 }

--- a/plugins/context/ios/Sources/PlayerStateContext.swift
+++ b/plugins/context/ios/Sources/PlayerStateContext.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 #if SWIFT_PACKAGE
-import PlayerUI
-import PlayerUISwiftUI
+    import PlayerUI
+    import PlayerUISwiftUI
 #endif
 
 /// Typed view of the aggregated `player.state` context entry. Read it with

--- a/plugins/context/ios/Sources/PlayerStateContext.swift
+++ b/plugins/context/ios/Sources/PlayerStateContext.swift
@@ -8,7 +8,8 @@ import PlayerUISwiftUI
 /// Actions are scoped to the construct they operate on — `flow.transition` and
 /// `data.set` — and are nil until a flow is in-progress.
 public struct PlayerStateContext: Decodable {
-    public let status: String?
+    /// Always present — "not-started" before a flow has ever started.
+    public let status: String
     /// Absent until a flow has started.
     public let flow: Flow?
     /// Absent until a view has resolved.

--- a/plugins/context/ios/Sources/PlayerStateContext.swift
+++ b/plugins/context/ios/Sources/PlayerStateContext.swift
@@ -1,9 +1,6 @@
 import Foundation
-
-#if SWIFT_PACKAGE
-    import PlayerUI
-    import PlayerUISwiftUI
-#endif
+import PlayerUI
+import PlayerUISwiftUI
 
 /// Typed view of the aggregated `player.state` context entry. Read it with
 /// `contextPlugin.get(name: "player.state", as: PlayerStateContext.self)`.
@@ -12,10 +9,14 @@ import Foundation
 /// `data.set` — and are nil until a flow is in-progress.
 public struct PlayerStateContext: Decodable {
     public let status: String?
-    public let flow: Flow
-    public let view: View
-    public let data: Data
-    public let validation: Validation
+    /// Absent until a flow has started.
+    public let flow: Flow?
+    /// Absent until a view has resolved.
+    public let view: View?
+    /// Absent until a data controller is bound.
+    public let data: Data?
+    /// Absent until a validation controller is bound.
+    public let validation: Validation?
 
     public struct Flow: Decodable {
         public let id: String?

--- a/plugins/context/ios/Sources/StateContextPlugin.swift
+++ b/plugins/context/ios/Sources/StateContextPlugin.swift
@@ -1,0 +1,37 @@
+import Foundation
+import JavaScriptCore
+
+#if SWIFT_PACKAGE
+import PlayerUI
+#endif
+
+/**
+ Wrapper around the JS `StateContextPlugin`. Registering it mirrors Player
+ runtime state into the `ContextPlugin` store and publishes the aggregated
+ `player.state` entry, which can be read as a typed `PlayerStateContext`:
+
+ ```swift
+ contextPlugin.get(name: "player.state", as: PlayerStateContext.self)?
+     .flow.transition?()
+ ```
+
+ Auto-registers a `ContextPlugin` on the JS side if one isn't already present.
+ */
+public class StateContextPlugin: JSBasePlugin, NativePlugin {
+    public convenience init() {
+        self.init(fileName: "ContextPlugin.native", pluginName: "ContextPlugin.StateContextPlugin")
+    }
+
+    override open func getUrlForFile(fileName: String) -> URL? {
+        #if SWIFT_PACKAGE
+        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
+        #else
+        ResourceUtilities.urlForFile(
+            name: fileName,
+            ext: "js",
+            bundle: Bundle(for: StateContextPlugin.self),
+            pathComponent: "PlayerUI_ContextPlugin.bundle"
+        )
+        #endif
+    }
+}

--- a/plugins/context/ios/Sources/StateContextPlugin.swift
+++ b/plugins/context/ios/Sources/StateContextPlugin.swift
@@ -1,9 +1,6 @@
 import Foundation
 import JavaScriptCore
-
-#if SWIFT_PACKAGE
-    import PlayerUI
-#endif
+import PlayerUI
 
 /// Wrapper around the JS `StateContextPlugin`. Registering it mirrors Player
 /// runtime state into the `ContextPlugin` store and publishes the aggregated
@@ -11,7 +8,7 @@ import JavaScriptCore
 ///
 /// ```swift
 /// contextPlugin.get(name: "player.state", as: PlayerStateContext.self)?
-///    .flow.transition?()
+///    .flow?.transition?()
 /// ```
 ///
 /// Auto-registers a `ContextPlugin` on the JS side if one isn't already present.
@@ -21,15 +18,6 @@ public class StateContextPlugin: JSBasePlugin, NativePlugin {
     }
 
     override open func getUrlForFile(fileName: String) -> URL? {
-        #if SWIFT_PACKAGE
-            ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
-        #else
-            ResourceUtilities.urlForFile(
-                name: fileName,
-                ext: "js",
-                bundle: Bundle(for: StateContextPlugin.self),
-                pathComponent: "PlayerUI_ContextPlugin.bundle"
-            )
-        #endif
+        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
     }
 }

--- a/plugins/context/ios/Sources/StateContextPlugin.swift
+++ b/plugins/context/ios/Sources/StateContextPlugin.swift
@@ -2,21 +2,19 @@ import Foundation
 import JavaScriptCore
 
 #if SWIFT_PACKAGE
-import PlayerUI
+    import PlayerUI
 #endif
 
-/**
- Wrapper around the JS `StateContextPlugin`. Registering it mirrors Player
- runtime state into the `ContextPlugin` store and publishes the aggregated
- `player.state` entry, which can be read as a typed `PlayerStateContext`:
-
- ```swift
- contextPlugin.get(name: "player.state", as: PlayerStateContext.self)?
-     .flow.transition?()
- ```
-
- Auto-registers a `ContextPlugin` on the JS side if one isn't already present.
- */
+/// Wrapper around the JS `StateContextPlugin`. Registering it mirrors Player
+/// runtime state into the `ContextPlugin` store and publishes the aggregated
+/// `player.state` entry, which can be read as a typed `PlayerStateContext`:
+///
+/// ```swift
+/// contextPlugin.get(name: "player.state", as: PlayerStateContext.self)?
+///    .flow.transition?()
+/// ```
+///
+/// Auto-registers a `ContextPlugin` on the JS side if one isn't already present.
 public class StateContextPlugin: JSBasePlugin, NativePlugin {
     public convenience init() {
         self.init(fileName: "ContextPlugin.native", pluginName: "ContextPlugin.StateContextPlugin")
@@ -24,14 +22,14 @@ public class StateContextPlugin: JSBasePlugin, NativePlugin {
 
     override open func getUrlForFile(fileName: String) -> URL? {
         #if SWIFT_PACKAGE
-        ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
+            ResourceUtilities.urlForFile(name: fileName, ext: "js", bundle: Bundle.module)
         #else
-        ResourceUtilities.urlForFile(
-            name: fileName,
-            ext: "js",
-            bundle: Bundle(for: StateContextPlugin.self),
-            pathComponent: "PlayerUI_ContextPlugin.bundle"
-        )
+            ResourceUtilities.urlForFile(
+                name: fileName,
+                ext: "js",
+                bundle: Bundle(for: StateContextPlugin.self),
+                pathComponent: "PlayerUI_ContextPlugin.bundle"
+            )
         #endif
     }
 }

--- a/plugins/context/ios/Tests/ContextPluginTests.swift
+++ b/plugins/context/ios/Tests/ContextPluginTests.swift
@@ -2,7 +2,9 @@ import Foundation
 import XCTest
 import JavaScriptCore
 @testable import PlayerUI
+@testable import PlayerUISwiftUI
 @testable import PlayerUITestUtilitiesCore
+@testable import PlayerUIInternalTestUtilities
 @testable import PlayerUIContextPlugin
 
 class ContextPluginTests: XCTestCase {
@@ -62,6 +64,35 @@ class ContextPluginTests: XCTestCase {
         wait(for: [expectation], timeout: 3)
     }
 
+    func testGetDecodesAFunctionValuedMemberAsACallable() {
+        let plugin = ContextPlugin()
+        _ = HeadlessPlayerImpl(plugins: [plugin])
+
+        // Register an object entry with a function member directly on the JS
+        // plugin, mirroring how StateContextPlugin publishes scoped actions.
+        plugin.pluginRef?.context.evaluateScript(
+            "globalThis.__ctxForm = { label: 'Greeter', greet: (msg) => 'echoed: ' + msg };"
+        )
+        let obj = plugin.pluginRef?.context.objectForKeyedSubscript("__ctxForm")
+        plugin.pluginRef?.invokeMethod(
+            "setByName",
+            withArguments: ["form", "A form with an action", obj as Any]
+        )
+
+        guard let form = plugin.get(name: "form", as: FormContext.self) else {
+            return XCTFail("expected a decoded FormContext")
+        }
+        XCTAssertEqual(form.label, "Greeter")
+        // The function member is a directly-callable WrappedFunction.
+        XCTAssertNotNil(form.greet)
+    }
+
+    func testGetReturnsNilForAbsentEntries() {
+        let plugin = ContextPlugin()
+        _ = HeadlessPlayerImpl(plugins: [plugin])
+        XCTAssertNil(plugin.get(name: "absent", as: FormContext.self))
+    }
+
     func testUnsubscribeStopsCallbacks() {
         let plugin = ContextPlugin()
         _ = HeadlessPlayerImpl(plugins: [plugin])
@@ -78,4 +109,155 @@ class ContextPluginTests: XCTestCase {
 
         XCTAssertEqual(callCount, 1)
     }
+
+    func testReadsPlayerStateContextWithScopedActions() {
+        let context = ContextPlugin()
+        let player = HeadlessPlayerImpl(plugins: [context, StateContextPlugin()])
+
+        // Wait until the aggregate has populated (data controller bound).
+        let populated = XCTestExpectation(description: "player.state has actions")
+        _ = context.subscribe(name: "player.state", description: "state") { _, _ in
+            if context.get(name: "player.state", as: PlayerStateContext.self)?.data.set != nil {
+                populated.fulfill()
+            }
+        }
+
+        // The flow.transition action drives the flow to completion, which
+        // resolves the start callback with a CompletedState.
+        let completed = XCTestExpectation(description: "flow completed")
+        player.start(flow: FlowData.COUNTER) { result in
+            if case .success = result { completed.fulfill() }
+        }
+        wait(for: [populated], timeout: 5)
+
+        guard let state = context.get(name: "player.state", as: PlayerStateContext.self) else {
+            return XCTFail("expected a decoded PlayerStateContext")
+        }
+        XCTAssertEqual(state.status, "in-progress")
+        XCTAssertEqual(state.flow.id, "counter-flow")
+
+        // Validation state deserializes across the bridge. With no binding
+        // tracking in this headless flow it is empty and transitionable.
+        XCTAssertTrue(state.validation.canTransition)
+        XCTAssertTrue(state.validation.byBinding.isEmpty)
+
+        // Actions are scoped to their constructs and bridged as callables.
+        guard let transition = state.flow.transition else { return XCTFail("expected a flow.transition action") }
+        guard let set = state.data.set else { return XCTFail("expected a data.set action") }
+
+        // The scoped data.set action drives the real data model; reading the
+        // aggregate back reflects the write through data.model.
+        set("count", 5)
+        let model = context.get(name: "player.state", as: PlayerStateContext.self)?.data.model
+        guard case let .numberDictionary(data)? = model else {
+            return XCTFail("expected a numeric data model, got \(String(describing: model))")
+        }
+        XCTAssertEqual(data["count"], 5)
+
+        // The scoped flow.transition action advances the flow to completion.
+        transition("Next")
+        wait(for: [completed], timeout: 5)
+    }
+
+    func testGetReadsAPrimitiveValue() {
+        let plugin = ContextPlugin()
+        _ = HeadlessPlayerImpl(plugins: [plugin])
+
+        plugin.set(name: "answer", description: "The answer", value: .number(data: 42))
+        guard case let .number(value) = plugin.get(name: "answer") else {
+            return XCTFail("expected a number value")
+        }
+        XCTAssertEqual(value, 42)
+    }
+
+    func testListReportsRegisteredDescriptors() {
+        let plugin = ContextPlugin()
+        _ = HeadlessPlayerImpl(plugins: [plugin])
+
+        plugin.set(name: "flag", description: "A flag", value: .bool(data: true))
+
+        let descriptions = plugin.list().map { $0.description }
+        XCTAssertTrue(descriptions.contains("A flag"))
+        guard let flag = plugin.list().first(where: { $0.description == "A flag" }) else {
+            return XCTFail("expected the flag descriptor")
+        }
+        XCTAssertTrue(flag.hasValue)
+    }
+
+    func testFlowEndFreezesAHistorySnapshotCapturingTheTerminalState() {
+        let context = ContextPlugin()
+        let player = HeadlessPlayerImpl(plugins: [context, StateContextPlugin()])
+
+        let populated = XCTestExpectation(description: "player.state has actions")
+        _ = context.subscribe(name: "player.state", description: "state") { _, _ in
+            if context.get(name: "player.state", as: PlayerStateContext.self)?.flow.transition != nil {
+                populated.fulfill()
+            }
+        }
+
+        let completed = XCTestExpectation(description: "flow completed")
+        player.start(flow: FlowData.COUNTER) { result in
+            if case .success = result { completed.fulfill() }
+        }
+        wait(for: [populated], timeout: 5)
+
+        context.get(name: "player.state", as: PlayerStateContext.self)?.flow.transition?("Next")
+        wait(for: [completed], timeout: 5)
+
+        // Flow end freezes the store into a history snapshot capturing the
+        // terminal flow state, read by name like live context.
+        guard let snapshot = context.history().last else {
+            return XCTFail("expected a frozen history snapshot")
+        }
+        XCTAssertEqual(snapshot.flowId, "counter-flow")
+        XCTAssertEqual(snapshot.get(name: "player.flow.state", as: String.self), "END_Done")
+        // Absent keys read back as nil.
+        XCTAssertNil(snapshot.get(name: "never.frozen", as: String.self))
+    }
+
+    func testFrozenSnapshotActionsAreTombstonedAndThrowWhenInvoked() {
+        let context = ContextPlugin()
+        let player = HeadlessPlayerImpl(plugins: [context, StateContextPlugin()])
+
+        let populated = XCTestExpectation(description: "player.state has actions")
+        _ = context.subscribe(name: "player.state", description: "state") { _, _ in
+            if context.get(name: "player.state", as: PlayerStateContext.self)?.flow.transition != nil {
+                populated.fulfill()
+            }
+        }
+        let completed = XCTestExpectation(description: "flow completed")
+        player.start(flow: FlowData.COUNTER) { result in
+            if case .success = result { completed.fulfill() }
+        }
+        wait(for: [populated], timeout: 5)
+        context.get(name: "player.state", as: PlayerStateContext.self)?.flow.transition?("Next")
+        wait(for: [completed], timeout: 5)
+
+        // The frozen player.state retains its scoped actions, but they are
+        // tombstoned — present yet poisoned: invoking one raises a JS error.
+        guard let frozen = context.history().last?
+            .get(name: "player.state", as: PlayerStateContext.self) else {
+            return XCTFail("expected a frozen PlayerStateContext")
+        }
+        guard let transition = frozen.flow.transition, let jsContext = transition.rawValue?.context else {
+            return XCTFail("expected a tombstoned transition action")
+        }
+
+        // The player's exception handler swallows JS throws, so capture the
+        // thrown value with a temporary handler while invoking the tombstone.
+        var thrown: String?
+        let previous = jsContext.exceptionHandler
+        jsContext.exceptionHandler = { _, value in thrown = value?.toString() }
+        defer { jsContext.exceptionHandler = previous }
+
+        transition("Next")
+        XCTAssertTrue(thrown?.contains("no longer valid") == true, "got: \(thrown ?? "nil")")
+    }
+}
+
+/// A small structured context with a bridged function member, used to verify
+/// `get` decodes function-valued fields into callable `WrappedFunction`s.
+private struct FormContext: Decodable {
+    let label: String
+    let greet: WrappedFunction<Void>?
 }

--- a/plugins/context/ios/Tests/ContextPluginTests.swift
+++ b/plugins/context/ios/Tests/ContextPluginTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import XCTest
+import JavaScriptCore
+@testable import PlayerUI
+@testable import PlayerUITestUtilitiesCore
+@testable import PlayerUIContextPlugin
+
+class ContextPluginTests: XCTestCase {
+    func testSetAndGetRoundTrip() {
+        let plugin = ContextPlugin()
+        let player = HeadlessPlayerImpl(plugins: [plugin])
+        XCTAssertNotNil(player)
+
+        plugin.set(name: "greeting", description: "A greeting", value: .string(data: "hello"))
+
+        guard case let .string(value) = plugin.get(name: "greeting") else {
+            return XCTFail("expected a string value")
+        }
+        XCTAssertEqual(value, "hello")
+    }
+
+    func testHasReflectsPresence() {
+        let plugin = ContextPlugin()
+        _ = HeadlessPlayerImpl(plugins: [plugin])
+
+        XCTAssertFalse(plugin.has(name: "absent"))
+        plugin.set(name: "present", description: "A flag", value: .string(data: "yes"))
+        XCTAssertTrue(plugin.has(name: "present"))
+    }
+
+    func testSubscribeReceivesUpdatesForItsKey() {
+        let plugin = ContextPlugin()
+        _ = HeadlessPlayerImpl(plugins: [plugin])
+
+        let expectation = XCTestExpectation(description: "subscriber called")
+        _ = plugin.subscribe(name: "counter", description: "A counter") { value, name in
+            XCTAssertEqual(name, "counter")
+            if case .string(let s) = value {
+                XCTAssertEqual(s, "tick")
+                expectation.fulfill()
+            } else {
+                XCTFail("expected a string value")
+            }
+        }
+
+        plugin.set(name: "counter", description: "A counter", value: .string(data: "tick"))
+        wait(for: [expectation], timeout: 3)
+    }
+
+    func testSubscribeAllSurfacesNameAndDescription() {
+        let plugin = ContextPlugin()
+        _ = HeadlessPlayerImpl(plugins: [plugin])
+
+        let expectation = XCTestExpectation(description: "global subscriber called")
+        _ = plugin.subscribeAll { _, name, description in
+            XCTAssertEqual(name, "flag")
+            XCTAssertEqual(description, "A flag")
+            expectation.fulfill()
+        }
+
+        plugin.set(name: "flag", description: "A flag", value: .string(data: "on"))
+        wait(for: [expectation], timeout: 3)
+    }
+
+    func testUnsubscribeStopsCallbacks() {
+        let plugin = ContextPlugin()
+        _ = HeadlessPlayerImpl(plugins: [plugin])
+
+        var callCount = 0
+        let token = plugin.subscribe(name: "k", description: "K", handler: { _, _ in
+            callCount += 1
+        })
+        guard let token = token else { return XCTFail("expected a subscription token") }
+
+        plugin.set(name: "k", description: "K", value: .string(data: "one"))
+        plugin.unsubscribe(token: token)
+        plugin.set(name: "k", description: "K", value: .string(data: "two"))
+
+        XCTAssertEqual(callCount, 1)
+    }
+}

--- a/plugins/context/ios/Tests/ContextPluginTests.swift
+++ b/plugins/context/ios/Tests/ContextPluginTests.swift
@@ -1,11 +1,11 @@
 import Foundation
-import XCTest
 import JavaScriptCore
 @testable import PlayerUI
+@testable import PlayerUIContextPlugin
+@testable import PlayerUIInternalTestUtilities
 @testable import PlayerUISwiftUI
 @testable import PlayerUITestUtilitiesCore
-@testable import PlayerUIInternalTestUtilities
-@testable import PlayerUIContextPlugin
+import XCTest
 
 class ContextPluginTests: XCTestCase {
     func testSetAndGetRoundTrip() {
@@ -37,7 +37,7 @@ class ContextPluginTests: XCTestCase {
         let expectation = XCTestExpectation(description: "subscriber called")
         _ = plugin.subscribe(name: "counter", description: "A counter") { value, name in
             XCTAssertEqual(name, "counter")
-            if case .string(let s) = value {
+            if case let .string(s) = value {
                 XCTAssertEqual(s, "tick")
                 expectation.fulfill()
             } else {
@@ -101,7 +101,7 @@ class ContextPluginTests: XCTestCase {
         let token = plugin.subscribe(name: "k", description: "K", handler: { _, _ in
             callCount += 1
         })
-        guard let token = token else { return XCTFail("expected a subscription token") }
+        guard let token else { return XCTFail("expected a subscription token") }
 
         plugin.set(name: "k", description: "K", value: .string(data: "one"))
         plugin.unsubscribe(token: token)
@@ -142,7 +142,8 @@ class ContextPluginTests: XCTestCase {
         XCTAssertTrue(state.validation.byBinding.isEmpty)
 
         // Actions are scoped to their constructs and bridged as callables.
-        guard let transition = state.flow.transition else { return XCTFail("expected a flow.transition action") }
+        guard let transition = state.flow.transition
+        else { return XCTFail("expected a flow.transition action") }
         guard let set = state.data.set else { return XCTFail("expected a data.set action") }
 
         // The scoped data.set action drives the real data model; reading the
@@ -176,7 +177,7 @@ class ContextPluginTests: XCTestCase {
 
         plugin.set(name: "flag", description: "A flag", value: .bool(data: true))
 
-        let descriptions = plugin.list().map { $0.description }
+        let descriptions = plugin.list().map(\.description)
         XCTAssertTrue(descriptions.contains("A flag"))
         guard let flag = plugin.list().first(where: { $0.description == "A flag" }) else {
             return XCTFail("expected the flag descriptor")
@@ -190,7 +191,9 @@ class ContextPluginTests: XCTestCase {
 
         let populated = XCTestExpectation(description: "player.state has actions")
         _ = context.subscribe(name: "player.state", description: "state") { _, _ in
-            if context.get(name: "player.state", as: PlayerStateContext.self)?.flow.transition != nil {
+            if context.get(name: "player.state", as: PlayerStateContext.self)?
+                .flow
+                .transition != nil {
                 populated.fulfill()
             }
         }
@@ -221,7 +224,9 @@ class ContextPluginTests: XCTestCase {
 
         let populated = XCTestExpectation(description: "player.state has actions")
         _ = context.subscribe(name: "player.state", description: "state") { _, _ in
-            if context.get(name: "player.state", as: PlayerStateContext.self)?.flow.transition != nil {
+            if context.get(name: "player.state", as: PlayerStateContext.self)?
+                .flow
+                .transition != nil {
                 populated.fulfill()
             }
         }
@@ -235,11 +240,13 @@ class ContextPluginTests: XCTestCase {
 
         // The frozen player.state retains its scoped actions, but they are
         // tombstoned — present yet poisoned: invoking one raises a JS error.
-        guard let frozen = context.history().last?
+        guard let frozen = context.history()
+            .last?
             .get(name: "player.state", as: PlayerStateContext.self) else {
             return XCTFail("expected a frozen PlayerStateContext")
         }
-        guard let transition = frozen.flow.transition, let jsContext = transition.rawValue?.context else {
+        guard let transition = frozen.flow.transition,
+              let jsContext = transition.rawValue?.context else {
             return XCTFail("expected a tombstoned transition action")
         }
 

--- a/plugins/context/ios/Tests/ContextPluginTests.swift
+++ b/plugins/context/ios/Tests/ContextPluginTests.swift
@@ -117,7 +117,7 @@ class ContextPluginTests: XCTestCase {
         // Wait until the aggregate has populated (data controller bound).
         let populated = XCTestExpectation(description: "player.state has actions")
         _ = context.subscribe(name: "player.state", description: "state") { _, _ in
-            if context.get(name: "player.state", as: PlayerStateContext.self)?.data.set != nil {
+            if context.get(name: "player.state", as: PlayerStateContext.self)?.data?.set != nil {
                 populated.fulfill()
             }
         }
@@ -134,22 +134,22 @@ class ContextPluginTests: XCTestCase {
             return XCTFail("expected a decoded PlayerStateContext")
         }
         XCTAssertEqual(state.status, "in-progress")
-        XCTAssertEqual(state.flow.id, "counter-flow")
+        XCTAssertEqual(state.flow?.id, "counter-flow")
 
         // Validation state deserializes across the bridge. With no binding
         // tracking in this headless flow it is empty and transitionable.
-        XCTAssertTrue(state.validation.canTransition)
-        XCTAssertTrue(state.validation.byBinding.isEmpty)
+        XCTAssertTrue(state.validation?.canTransition ?? false)
+        XCTAssertTrue(state.validation?.byBinding.isEmpty ?? false)
 
         // Actions are scoped to their constructs and bridged as callables.
-        guard let transition = state.flow.transition
+        guard let transition = state.flow?.transition
         else { return XCTFail("expected a flow.transition action") }
-        guard let set = state.data.set else { return XCTFail("expected a data.set action") }
+        guard let set = state.data?.set else { return XCTFail("expected a data.set action") }
 
         // The scoped data.set action drives the real data model; reading the
         // aggregate back reflects the write through data.model.
         set("count", 5)
-        let model = context.get(name: "player.state", as: PlayerStateContext.self)?.data.model
+        let model = context.get(name: "player.state", as: PlayerStateContext.self)?.data?.model
         guard case let .numberDictionary(data)? = model else {
             return XCTFail("expected a numeric data model, got \(String(describing: model))")
         }
@@ -192,7 +192,7 @@ class ContextPluginTests: XCTestCase {
         let populated = XCTestExpectation(description: "player.state has actions")
         _ = context.subscribe(name: "player.state", description: "state") { _, _ in
             if context.get(name: "player.state", as: PlayerStateContext.self)?
-                .flow
+                .flow?
                 .transition != nil {
                 populated.fulfill()
             }
@@ -204,7 +204,7 @@ class ContextPluginTests: XCTestCase {
         }
         wait(for: [populated], timeout: 5)
 
-        context.get(name: "player.state", as: PlayerStateContext.self)?.flow.transition?("Next")
+        context.get(name: "player.state", as: PlayerStateContext.self)?.flow?.transition?("Next")
         wait(for: [completed], timeout: 5)
 
         // Flow end freezes the store into a history snapshot capturing the
@@ -225,7 +225,7 @@ class ContextPluginTests: XCTestCase {
         let populated = XCTestExpectation(description: "player.state has actions")
         _ = context.subscribe(name: "player.state", description: "state") { _, _ in
             if context.get(name: "player.state", as: PlayerStateContext.self)?
-                .flow
+                .flow?
                 .transition != nil {
                 populated.fulfill()
             }
@@ -235,7 +235,7 @@ class ContextPluginTests: XCTestCase {
             if case .success = result { completed.fulfill() }
         }
         wait(for: [populated], timeout: 5)
-        context.get(name: "player.state", as: PlayerStateContext.self)?.flow.transition?("Next")
+        context.get(name: "player.state", as: PlayerStateContext.self)?.flow?.transition?("Next")
         wait(for: [completed], timeout: 5)
 
         // The frozen player.state retains its scoped actions, but they are
@@ -245,7 +245,7 @@ class ContextPluginTests: XCTestCase {
             .get(name: "player.state", as: PlayerStateContext.self) else {
             return XCTFail("expected a frozen PlayerStateContext")
         }
-        guard let transition = frozen.flow.transition,
+        guard let transition = frozen.flow?.transition,
               let jsContext = transition.rawValue?.context else {
             return XCTFail("expected a tombstoned transition action")
         }

--- a/plugins/context/ios/Tests/ContextPluginTests.swift
+++ b/plugins/context/ios/Tests/ContextPluginTests.swift
@@ -110,6 +110,16 @@ class ContextPluginTests: XCTestCase {
         XCTAssertEqual(callCount, 1)
     }
 
+    func testStatusIsNotStartedImmediatelyBeforeAnyFlowStarts() {
+        let context = ContextPlugin()
+        _ = HeadlessPlayerImpl(plugins: [context, StateContextPlugin()])
+
+        XCTAssertEqual(
+            context.get(name: "player.state", as: PlayerStateContext.self)?.status,
+            "not-started"
+        )
+    }
+
     func testReadsPlayerStateContextWithScopedActions() {
         let context = ContextPlugin()
         let player = HeadlessPlayerImpl(plugins: [context, StateContextPlugin()])

--- a/plugins/context/jvm/BUILD
+++ b/plugins/context/jvm/BUILD
@@ -1,0 +1,26 @@
+load("@rules_jvm_external//:defs.bzl", "artifact")
+load("//plugins:defs.bzl", "kt_player_plugin")
+
+main_exports = [
+    "//jvm/core",
+]
+
+main_deps = main_exports
+
+main_resources = [
+    "//plugins/context/core:core_native_bundle",
+]
+
+test_deps = [
+    "//jvm/testutils:with-runtimes",
+    artifact("org.amshove.kluent:kluent"),
+]
+
+kt_player_plugin(
+    name = "context",
+    main_deps = main_deps,
+    main_exports = main_exports,
+    main_resources = main_resources,
+    test_deps = test_deps,
+    test_package = "com.intuit.playerui.plugins.context",
+)

--- a/plugins/context/jvm/api/context.api
+++ b/plugins/context/jvm/api/context.api
@@ -1,0 +1,419 @@
+public final class com/intuit/playerui/plugins/context/ContextEntryDescriptor {
+	public static final field Companion Lcom/intuit/playerui/plugins/context/ContextEntryDescriptor$Companion;
+	public fun <init> (Ljava/lang/String;ZZ)V
+	public synthetic fun <init> (Ljava/lang/String;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Z
+	public final fun component3 ()Z
+	public final fun copy (Ljava/lang/String;ZZ)Lcom/intuit/playerui/plugins/context/ContextEntryDescriptor;
+	public static synthetic fun copy$default (Lcom/intuit/playerui/plugins/context/ContextEntryDescriptor;Ljava/lang/String;ZZILjava/lang/Object;)Lcom/intuit/playerui/plugins/context/ContextEntryDescriptor;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getHasTransform ()Z
+	public final fun getHasValue ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/intuit/playerui/plugins/context/ContextEntryDescriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/intuit/playerui/plugins/context/ContextEntryDescriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/intuit/playerui/plugins/context/ContextEntryDescriptor;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/intuit/playerui/plugins/context/ContextEntryDescriptor;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/intuit/playerui/plugins/context/ContextEntryDescriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/intuit/playerui/plugins/context/ContextPlugin : com/intuit/playerui/core/plugins/JSScriptPluginWrapper, com/intuit/playerui/core/bridge/NodeWrapper {
+	public fun <init> ()V
+	public final fun getGetByName ()Lkotlin/jvm/functions/Function1;
+	public fun getNode ()Lcom/intuit/playerui/core/bridge/Node;
+	public final fun has (Ljava/lang/String;)Z
+	public final fun history ()Ljava/util/List;
+	public final fun list ()Ljava/util/List;
+	public final fun set (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)V
+	public final fun subscribe (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Ljava/lang/String;
+	public final fun subscribeAll (Lkotlin/jvm/functions/Function3;)Ljava/lang/String;
+	public final fun unsubscribe (Ljava/lang/String;)V
+}
+
+private final class com/intuit/playerui/plugins/context/ContextPlugin$Companion {
+}
+
+public final class com/intuit/playerui/plugins/context/ContextPlugin$special$$inlined$NodeSerializableFunction$default$1 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class com/intuit/playerui/plugins/context/ContextPlugin$special$$inlined$NodeSerializableFunction$default$2 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class com/intuit/playerui/plugins/context/ContextPlugin$special$$inlined$NodeSerializableFunction$default$3 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class com/intuit/playerui/plugins/context/ContextPlugin$special$$inlined$NodeSerializableFunction$default$4 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class com/intuit/playerui/plugins/context/ContextPlugin$special$$inlined$NodeSerializableFunction$default$5 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class com/intuit/playerui/plugins/context/ContextPlugin$special$$inlined$NodeSerializableFunction$default$6 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class com/intuit/playerui/plugins/context/ContextPlugin$special$$inlined$NodeSerializableFunction$default$7 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class com/intuit/playerui/plugins/context/ContextPlugin$special$$inlined$NodeSerializableFunction$default$8 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public fun <init> (Lcom/intuit/playerui/core/bridge/NodeWrapper;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class com/intuit/playerui/plugins/context/ContextPluginKt {
+	public static final fun getContextPlugin (Lcom/intuit/playerui/core/player/Player;)Lcom/intuit/playerui/plugins/context/ContextPlugin;
+}
+
+public final class com/intuit/playerui/plugins/context/FrozenContextSnapshot {
+	public static final field Companion Lcom/intuit/playerui/plugins/context/FrozenContextSnapshot$Companion;
+	public fun <init> (Ljava/lang/String;DLjava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;DLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()D
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;DLjava/util/List;)Lcom/intuit/playerui/plugins/context/FrozenContextSnapshot;
+	public static synthetic fun copy$default (Lcom/intuit/playerui/plugins/context/FrozenContextSnapshot;Ljava/lang/String;DLjava/util/List;ILjava/lang/Object;)Lcom/intuit/playerui/plugins/context/FrozenContextSnapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEndedAt ()D
+	public final fun getEntries ()Ljava/util/List;
+	public final fun getFlowId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/intuit/playerui/plugins/context/FrozenContextSnapshot$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/intuit/playerui/plugins/context/FrozenContextSnapshot$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/intuit/playerui/plugins/context/FrozenContextSnapshot;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/intuit/playerui/plugins/context/FrozenContextSnapshot;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/intuit/playerui/plugins/context/FrozenContextSnapshot$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+final class com/intuit/playerui/plugins/context/FrozenContextSnapshot$Companion$$childSerializers$1 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public static final field INSTANCE Lcom/intuit/playerui/plugins/context/FrozenContextSnapshot$Companion$$childSerializers$1;
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/intuit/playerui/plugins/context/FrozenContextSnapshot$FrozenContextEntry {
+	public static final field Companion Lcom/intuit/playerui/plugins/context/FrozenContextSnapshot$FrozenContextEntry$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)Lcom/intuit/playerui/plugins/context/FrozenContextSnapshot$FrozenContextEntry;
+	public static synthetic fun copy$default (Lcom/intuit/playerui/plugins/context/FrozenContextSnapshot$FrozenContextEntry;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;ILjava/lang/Object;)Lcom/intuit/playerui/plugins/context/FrozenContextSnapshot$FrozenContextEntry;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/intuit/playerui/plugins/context/FrozenContextSnapshot$FrozenContextEntry$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/intuit/playerui/plugins/context/FrozenContextSnapshot$FrozenContextEntry$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/intuit/playerui/plugins/context/FrozenContextSnapshot$FrozenContextEntry;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/intuit/playerui/plugins/context/FrozenContextSnapshot$FrozenContextEntry;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/intuit/playerui/plugins/context/FrozenContextSnapshot$FrozenContextEntry$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+final class com/intuit/playerui/plugins/context/FrozenContextSnapshot$FrozenContextEntry$Companion$$childSerializers$1 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public static final field INSTANCE Lcom/intuit/playerui/plugins/context/FrozenContextSnapshot$FrozenContextEntry$Companion$$childSerializers$1;
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/intuit/playerui/plugins/context/PlayerStateContext {
+	public static final field Companion Lcom/intuit/playerui/plugins/context/PlayerStateContext$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Lcom/intuit/playerui/plugins/context/PlayerStateContext$Flow;Lcom/intuit/playerui/plugins/context/PlayerStateContext$View;Lcom/intuit/playerui/plugins/context/PlayerStateContext$Data;Lcom/intuit/playerui/plugins/context/PlayerStateContext$Validation;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/intuit/playerui/plugins/context/PlayerStateContext$Flow;Lcom/intuit/playerui/plugins/context/PlayerStateContext$View;Lcom/intuit/playerui/plugins/context/PlayerStateContext$Data;Lcom/intuit/playerui/plugins/context/PlayerStateContext$Validation;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/intuit/playerui/plugins/context/PlayerStateContext$Flow;
+	public final fun component3 ()Lcom/intuit/playerui/plugins/context/PlayerStateContext$View;
+	public final fun component4 ()Lcom/intuit/playerui/plugins/context/PlayerStateContext$Data;
+	public final fun component5 ()Lcom/intuit/playerui/plugins/context/PlayerStateContext$Validation;
+	public final fun copy (Ljava/lang/String;Lcom/intuit/playerui/plugins/context/PlayerStateContext$Flow;Lcom/intuit/playerui/plugins/context/PlayerStateContext$View;Lcom/intuit/playerui/plugins/context/PlayerStateContext$Data;Lcom/intuit/playerui/plugins/context/PlayerStateContext$Validation;)Lcom/intuit/playerui/plugins/context/PlayerStateContext;
+	public static synthetic fun copy$default (Lcom/intuit/playerui/plugins/context/PlayerStateContext;Ljava/lang/String;Lcom/intuit/playerui/plugins/context/PlayerStateContext$Flow;Lcom/intuit/playerui/plugins/context/PlayerStateContext$View;Lcom/intuit/playerui/plugins/context/PlayerStateContext$Data;Lcom/intuit/playerui/plugins/context/PlayerStateContext$Validation;ILjava/lang/Object;)Lcom/intuit/playerui/plugins/context/PlayerStateContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Lcom/intuit/playerui/plugins/context/PlayerStateContext$Data;
+	public final fun getFlow ()Lcom/intuit/playerui/plugins/context/PlayerStateContext$Flow;
+	public final fun getStatus ()Ljava/lang/String;
+	public final fun getValidation ()Lcom/intuit/playerui/plugins/context/PlayerStateContext$Validation;
+	public final fun getView ()Lcom/intuit/playerui/plugins/context/PlayerStateContext$View;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/intuit/playerui/plugins/context/PlayerStateContext$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/intuit/playerui/plugins/context/PlayerStateContext$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/intuit/playerui/plugins/context/PlayerStateContext;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/intuit/playerui/plugins/context/PlayerStateContext;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/intuit/playerui/plugins/context/PlayerStateContext$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/intuit/playerui/plugins/context/PlayerStateContext$Data {
+	public static final field Companion Lcom/intuit/playerui/plugins/context/PlayerStateContext$Data$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Lkotlin/jvm/functions/Function2;
+	public final fun copy (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Lcom/intuit/playerui/plugins/context/PlayerStateContext$Data;
+	public static synthetic fun copy$default (Lcom/intuit/playerui/plugins/context/PlayerStateContext$Data;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lcom/intuit/playerui/plugins/context/PlayerStateContext$Data;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getModel ()Ljava/lang/Object;
+	public final fun getSet ()Lkotlin/jvm/functions/Function2;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/intuit/playerui/plugins/context/PlayerStateContext$Data$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/intuit/playerui/plugins/context/PlayerStateContext$Data$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/intuit/playerui/plugins/context/PlayerStateContext$Data;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/intuit/playerui/plugins/context/PlayerStateContext$Data;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/intuit/playerui/plugins/context/PlayerStateContext$Data$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+final class com/intuit/playerui/plugins/context/PlayerStateContext$Data$Companion$$childSerializers$1 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public static final field INSTANCE Lcom/intuit/playerui/plugins/context/PlayerStateContext$Data$Companion$$childSerializers$1;
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/KSerializer;
+}
+
+final class com/intuit/playerui/plugins/context/PlayerStateContext$Data$Companion$$childSerializers$2 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public static final field INSTANCE Lcom/intuit/playerui/plugins/context/PlayerStateContext$Data$Companion$$childSerializers$2;
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/intuit/playerui/plugins/context/PlayerStateContext$Flow {
+	public static final field Companion Lcom/intuit/playerui/plugins/context/PlayerStateContext$Flow$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/intuit/playerui/plugins/context/PlayerStateContext$Flow;
+	public static synthetic fun copy$default (Lcom/intuit/playerui/plugins/context/PlayerStateContext$Flow;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/intuit/playerui/plugins/context/PlayerStateContext$Flow;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getState ()Ljava/lang/String;
+	public final fun getTransition ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/intuit/playerui/plugins/context/PlayerStateContext$Flow$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/intuit/playerui/plugins/context/PlayerStateContext$Flow$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/intuit/playerui/plugins/context/PlayerStateContext$Flow;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/intuit/playerui/plugins/context/PlayerStateContext$Flow;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/intuit/playerui/plugins/context/PlayerStateContext$Flow$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+final class com/intuit/playerui/plugins/context/PlayerStateContext$Flow$Companion$$childSerializers$1 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public static final field INSTANCE Lcom/intuit/playerui/plugins/context/PlayerStateContext$Flow$Companion$$childSerializers$1;
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/intuit/playerui/plugins/context/PlayerStateContext$Validation {
+	public static final field Companion Lcom/intuit/playerui/plugins/context/PlayerStateContext$Validation$Companion;
+	public fun <init> ()V
+	public fun <init> (ZLjava/util/Map;)V
+	public synthetic fun <init> (ZLjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (ZLjava/util/Map;)Lcom/intuit/playerui/plugins/context/PlayerStateContext$Validation;
+	public static synthetic fun copy$default (Lcom/intuit/playerui/plugins/context/PlayerStateContext$Validation;ZLjava/util/Map;ILjava/lang/Object;)Lcom/intuit/playerui/plugins/context/PlayerStateContext$Validation;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getByBinding ()Ljava/util/Map;
+	public final fun getCanTransition ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/intuit/playerui/plugins/context/PlayerStateContext$Validation$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/intuit/playerui/plugins/context/PlayerStateContext$Validation$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/intuit/playerui/plugins/context/PlayerStateContext$Validation;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/intuit/playerui/plugins/context/PlayerStateContext$Validation;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/intuit/playerui/plugins/context/PlayerStateContext$Validation$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+final class com/intuit/playerui/plugins/context/PlayerStateContext$Validation$Companion$$childSerializers$1 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public static final field INSTANCE Lcom/intuit/playerui/plugins/context/PlayerStateContext$Validation$Companion$$childSerializers$1;
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/intuit/playerui/plugins/context/PlayerStateContext$Validation$ContextValidation {
+	public static final field Companion Lcom/intuit/playerui/plugins/context/PlayerStateContext$Validation$ContextValidation$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)Lcom/intuit/playerui/plugins/context/PlayerStateContext$Validation$ContextValidation;
+	public static synthetic fun copy$default (Lcom/intuit/playerui/plugins/context/PlayerStateContext$Validation$ContextValidation;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;ILjava/lang/Object;)Lcom/intuit/playerui/plugins/context/PlayerStateContext$Validation$ContextValidation;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBlocking ()Ljava/lang/Object;
+	public final fun getDisplayTarget ()Ljava/lang/String;
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getSeverity ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/intuit/playerui/plugins/context/PlayerStateContext$Validation$ContextValidation$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/intuit/playerui/plugins/context/PlayerStateContext$Validation$ContextValidation$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/intuit/playerui/plugins/context/PlayerStateContext$Validation$ContextValidation;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/intuit/playerui/plugins/context/PlayerStateContext$Validation$ContextValidation;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/intuit/playerui/plugins/context/PlayerStateContext$Validation$ContextValidation$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+final class com/intuit/playerui/plugins/context/PlayerStateContext$Validation$ContextValidation$Companion$$childSerializers$1 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public static final field INSTANCE Lcom/intuit/playerui/plugins/context/PlayerStateContext$Validation$ContextValidation$Companion$$childSerializers$1;
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/intuit/playerui/plugins/context/PlayerStateContext$View {
+	public static final field Companion Lcom/intuit/playerui/plugins/context/PlayerStateContext$View$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Object;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Object;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Object;)Lcom/intuit/playerui/plugins/context/PlayerStateContext$View;
+	public static synthetic fun copy$default (Lcom/intuit/playerui/plugins/context/PlayerStateContext$View;Ljava/lang/String;Ljava/lang/Object;ILjava/lang/Object;)Lcom/intuit/playerui/plugins/context/PlayerStateContext$View;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getResolved ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/intuit/playerui/plugins/context/PlayerStateContext$View$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/intuit/playerui/plugins/context/PlayerStateContext$View$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/intuit/playerui/plugins/context/PlayerStateContext$View;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/intuit/playerui/plugins/context/PlayerStateContext$View;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/intuit/playerui/plugins/context/PlayerStateContext$View$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+final class com/intuit/playerui/plugins/context/PlayerStateContext$View$Companion$$childSerializers$1 : kotlin/jvm/internal/Lambda, kotlin/jvm/functions/Function0 {
+	public static final field INSTANCE Lcom/intuit/playerui/plugins/context/PlayerStateContext$View$Companion$$childSerializers$1;
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/intuit/playerui/plugins/context/StateContextPlugin : com/intuit/playerui/core/plugins/JSScriptPluginWrapper {
+	public fun <init> ()V
+}
+
+private final class com/intuit/playerui/plugins/context/StateContextPlugin$Companion {
+}
+
+public final class com/intuit/playerui/plugins/context/StateContextPluginKt {
+	public static final fun getStateContextPlugin (Lcom/intuit/playerui/core/player/Player;)Lcom/intuit/playerui/plugins/context/StateContextPlugin;
+}
+

--- a/plugins/context/jvm/api/context.api
+++ b/plugins/context/jvm/api/context.api
@@ -175,7 +175,6 @@ final class com/intuit/playerui/plugins/context/FrozenContextSnapshot$FrozenCont
 
 public final class com/intuit/playerui/plugins/context/PlayerStateContext {
 	public static final field Companion Lcom/intuit/playerui/plugins/context/PlayerStateContext$Companion;
-	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Lcom/intuit/playerui/plugins/context/PlayerStateContext$Flow;Lcom/intuit/playerui/plugins/context/PlayerStateContext$View;Lcom/intuit/playerui/plugins/context/PlayerStateContext$Data;Lcom/intuit/playerui/plugins/context/PlayerStateContext$Validation;)V
 	public synthetic fun <init> (Ljava/lang/String;Lcom/intuit/playerui/plugins/context/PlayerStateContext$Flow;Lcom/intuit/playerui/plugins/context/PlayerStateContext$View;Lcom/intuit/playerui/plugins/context/PlayerStateContext$Data;Lcom/intuit/playerui/plugins/context/PlayerStateContext$Validation;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;

--- a/plugins/context/jvm/src/main/kotlin/com/intuit/playerui/plugins/context/ContextEntryDescriptor.kt
+++ b/plugins/context/jvm/src/main/kotlin/com/intuit/playerui/plugins/context/ContextEntryDescriptor.kt
@@ -1,0 +1,11 @@
+package com.intuit.playerui.plugins.context
+
+import kotlinx.serialization.Serializable
+
+/** Descriptor for a registered context entry, as returned by [ContextPlugin.list]. */
+@Serializable
+public data class ContextEntryDescriptor(
+    val description: String,
+    val hasValue: Boolean = false,
+    val hasTransform: Boolean = false,
+)

--- a/plugins/context/jvm/src/main/kotlin/com/intuit/playerui/plugins/context/ContextPlugin.kt
+++ b/plugins/context/jvm/src/main/kotlin/com/intuit/playerui/plugins/context/ContextPlugin.kt
@@ -1,0 +1,72 @@
+package com.intuit.playerui.plugins.context
+
+import com.intuit.playerui.core.bridge.getInvokable
+import com.intuit.playerui.core.player.Player
+import com.intuit.playerui.core.plugins.JSScriptPluginWrapper
+import com.intuit.playerui.core.plugins.findPlugin
+
+/**
+ * JVM wrapper around the JS ContextPlugin. Exposes a name-based API so native
+ * consumers can read, write, and observe context entries without constructing
+ * JS symbol-backed keys on the bridge.
+ */
+public class ContextPlugin : JSScriptPluginWrapper(PLUGIN_NAME, sourcePath = BUNDLED_SOURCE_PATH) {
+    /**
+     * Store [value] under the context entry identified by [name], registering
+     * a human-readable [description] for introspection consumers.
+     */
+    public fun set(
+        name: String,
+        description: String,
+        value: Any?,
+    ) {
+        instance.getInvokable<Any?>("setByName")!!(name, description, value)
+    }
+
+    /** Read the current value for the entry identified by [name], or null if unset. */
+    public fun get(name: String): Any? = instance
+        .getInvokable<Any?>("getByName")!!(name)
+
+    /** Returns true if the entry identified by [name] has a value or transform. */
+    public fun has(name: String): Boolean = instance
+        .getInvokable<Boolean>("hasByName")!!(name)
+
+    /**
+     * Subscribe to updates for the entry identified by [name]. The [block] is
+     * invoked with the new value and the [name] whenever the entry changes.
+     * Returns a token usable with [unsubscribe].
+     */
+    public fun subscribe(
+        name: String,
+        description: String,
+        block: (Any?, String) -> Unit,
+    ): String = instance
+        .getInvokable<String>("subscribeByName")!!(name, description, block)
+
+    /**
+     * Subscribe to every context update. The [block] is invoked with the new
+     * value, the resolved key name (or null for non-namespaced keys), and the
+     * key's description.
+     */
+    public fun subscribeAll(block: (Any?, String?, String) -> Unit): String = instance
+        .getInvokable<String>("subscribeAllByName")!!(block)
+
+    /** Cancel the subscription registered with [token]. */
+    public fun unsubscribe(token: String) {
+        instance.getInvokable<Any?>("unsubscribe")!!(token)
+    }
+
+    /** Returns a list of registered entry descriptors (symbol, description, flags). */
+    public fun list(): Any? = instance.getInvokable<Any?>("list")!!()
+
+    /** Returns the stack of frozen snapshots from prior flows. */
+    public fun history(): Any? = instance.getInvokable<Any?>("history")!!()
+
+    private companion object {
+        private const val PLUGIN_NAME = "ContextPlugin.ContextPlugin"
+        private const val BUNDLED_SOURCE_PATH = "plugins/context/core/dist/ContextPlugin.native.js"
+    }
+}
+
+/** Convenience getter to find the first [ContextPlugin] registered to the [Player]. */
+public val Player.contextPlugin: ContextPlugin? get() = findPlugin()

--- a/plugins/context/jvm/src/main/kotlin/com/intuit/playerui/plugins/context/ContextPlugin.kt
+++ b/plugins/context/jvm/src/main/kotlin/com/intuit/playerui/plugins/context/ContextPlugin.kt
@@ -1,16 +1,40 @@
 package com.intuit.playerui.plugins.context
 
-import com.intuit.playerui.core.bridge.getInvokable
+import com.intuit.playerui.core.bridge.Node
+import com.intuit.playerui.core.bridge.NodeWrapper
+import com.intuit.playerui.core.bridge.deserialize
+import com.intuit.playerui.core.bridge.serialization.serializers.NodeSerializableFunction
+import com.intuit.playerui.core.experimental.ExperimentalPlayerApi
 import com.intuit.playerui.core.player.Player
 import com.intuit.playerui.core.plugins.JSScriptPluginWrapper
 import com.intuit.playerui.core.plugins.findPlugin
 
 /**
  * JVM wrapper around the JS ContextPlugin. Exposes a name-based API so native
- * consumers can read, write, and observe context entries without constructing
- * JS symbol-backed keys on the bridge.
+ * consumers can read, write, and observe context entries.
+ *
+ * Reads are typed: `get<SomeContext>("name")` deserializes the entry into a
+ * Kotlin object, including any function-typed members, so a caller does
+ * `get<SomeContext>("name").someFunction(arg1, arg2)` with full type safety.
  */
-public class ContextPlugin : JSScriptPluginWrapper(PLUGIN_NAME, sourcePath = BUNDLED_SOURCE_PATH) {
+@OptIn(ExperimentalPlayerApi::class)
+public class ContextPlugin :
+    JSScriptPluginWrapper(PLUGIN_NAME, sourcePath = BUNDLED_SOURCE_PATH),
+    NodeWrapper {
+    override val node: Node get() = instance
+
+    private val setByName: (String, String, Any?) -> Unit by NodeSerializableFunction()
+
+    /** Exposed for the inline reified [get]; not part of the public surface. */
+    @PublishedApi
+    internal val getByName: (String) -> Any? by NodeSerializableFunction()
+    private val hasByName: (String) -> Boolean by NodeSerializableFunction()
+    private val subscribeByName: (String, String, (Any?, String) -> Unit) -> String by NodeSerializableFunction()
+    private val subscribeAllByName: ((Any?, String?, String) -> Unit) -> String by NodeSerializableFunction()
+    private val unsubscribe: (String) -> Unit by NodeSerializableFunction()
+    private val list: () -> List<Node> by NodeSerializableFunction()
+    private val history: () -> List<Node> by NodeSerializableFunction()
+
     /**
      * Store [value] under the context entry identified by [name], registering
      * a human-readable [description] for introspection consumers.
@@ -20,16 +44,26 @@ public class ContextPlugin : JSScriptPluginWrapper(PLUGIN_NAME, sourcePath = BUN
         description: String,
         value: Any?,
     ) {
-        instance.getInvokable<Any?>("setByName")!!(name, description, value)
+        setByName(name, description, value)
     }
 
-    /** Read the current value for the entry identified by [name], or null if unset. */
-    public fun get(name: String): Any? = instance
-        .getInvokable<Any?>("getByName")!!(name)
+    /**
+     * Read the entry identified by [name], deserialized into [T], or null if
+     * unset. [T] may be a primitive or any `@Serializable` type, including one
+     * with function-typed members that arrive as callable Kotlin functions:
+     *
+     * ```
+     * plugin.get<PlayerStateContext>("player.state")?.flow?.transition?.invoke("Next")
+     * ```
+     */
+    public inline fun <reified T> get(name: String): T? = when (val value = getByName(name)) {
+        null -> null
+        is Node -> value.deserialize<T>()
+        else -> value as T
+    }
 
     /** Returns true if the entry identified by [name] has a value or transform. */
-    public fun has(name: String): Boolean = instance
-        .getInvokable<Boolean>("hasByName")!!(name)
+    public fun has(name: String): Boolean = hasByName(name)
 
     /**
      * Subscribe to updates for the entry identified by [name]. The [block] is
@@ -40,27 +74,25 @@ public class ContextPlugin : JSScriptPluginWrapper(PLUGIN_NAME, sourcePath = BUN
         name: String,
         description: String,
         block: (Any?, String) -> Unit,
-    ): String = instance
-        .getInvokable<String>("subscribeByName")!!(name, description, block)
+    ): String = subscribeByName(name, description, block)
 
     /**
      * Subscribe to every context update. The [block] is invoked with the new
      * value, the resolved key name (or null for non-namespaced keys), and the
      * key's description.
      */
-    public fun subscribeAll(block: (Any?, String?, String) -> Unit): String = instance
-        .getInvokable<String>("subscribeAllByName")!!(block)
+    public fun subscribeAll(block: (Any?, String?, String) -> Unit): String = subscribeAllByName(block)
 
     /** Cancel the subscription registered with [token]. */
     public fun unsubscribe(token: String) {
-        instance.getInvokable<Any?>("unsubscribe")!!(token)
+        unsubscribe.invoke(token)
     }
 
-    /** Returns a list of registered entry descriptors (symbol, description, flags). */
-    public fun list(): Any? = instance.getInvokable<Any?>("list")!!()
+    /** Returns the registered entry descriptors (description + value/transform flags). */
+    public fun list(): List<ContextEntryDescriptor> = list.invoke().map { it.deserialize() }
 
     /** Returns the stack of frozen snapshots from prior flows. */
-    public fun history(): Any? = instance.getInvokable<Any?>("history")!!()
+    public fun history(): List<FrozenContextSnapshot> = history.invoke().map { it.deserialize() }
 
     private companion object {
         private const val PLUGIN_NAME = "ContextPlugin.ContextPlugin"

--- a/plugins/context/jvm/src/main/kotlin/com/intuit/playerui/plugins/context/ContextPlugin.kt
+++ b/plugins/context/jvm/src/main/kotlin/com/intuit/playerui/plugins/context/ContextPlugin.kt
@@ -23,11 +23,10 @@ public class ContextPlugin :
     NodeWrapper {
     override val node: Node get() = instance
 
-    private val setByName: (String, String, Any?) -> Unit by NodeSerializableFunction()
-
     /** Exposed for the inline reified [get]; not part of the public surface. */
     @PublishedApi
     internal val getByName: (String) -> Any? by NodeSerializableFunction()
+    private val setByName: (String, String, Any?) -> Unit by NodeSerializableFunction()
     private val hasByName: (String) -> Boolean by NodeSerializableFunction()
     private val subscribeByName: (String, String, (Any?, String) -> Unit) -> String by NodeSerializableFunction()
     private val subscribeAllByName: ((Any?, String?, String) -> Unit) -> String by NodeSerializableFunction()

--- a/plugins/context/jvm/src/main/kotlin/com/intuit/playerui/plugins/context/FrozenContextSnapshot.kt
+++ b/plugins/context/jvm/src/main/kotlin/com/intuit/playerui/plugins/context/FrozenContextSnapshot.kt
@@ -1,0 +1,37 @@
+package com.intuit.playerui.plugins.context
+
+import com.intuit.playerui.core.bridge.Node
+import com.intuit.playerui.core.bridge.deserialize
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+
+/** A frozen snapshot of the context store captured when a flow ends. */
+@Serializable
+public data class FrozenContextSnapshot(
+    val flowId: String? = null,
+    val endedAt: Double,
+    val entries: List<FrozenContextEntry> = emptyList(),
+) {
+    @Serializable
+    public data class FrozenContextEntry(
+        val name: String? = null,
+        val description: String,
+        /**
+         * The frozen value. Not part of the public surface — read entries with
+         * [get] for typed, cross-platform-consistent access.
+         */
+        @PublishedApi internal val value: @Contextual Any? = null,
+    )
+
+    /**
+     * Read a frozen entry by its key [name], deserialized into [T] — the same
+     * typed access as live context. Returns null if the entry was absent when
+     * the snapshot froze. Function-valued entries return their tombstone (a
+     * callable that throws when invoked).
+     */
+    public inline fun <reified T> get(name: String): T? = when (val value = entries.firstOrNull { it.name == name }?.value) {
+        null -> null
+        is Node -> value.deserialize<T>()
+        else -> value as T
+    }
+}

--- a/plugins/context/jvm/src/main/kotlin/com/intuit/playerui/plugins/context/PlayerStateContext.kt
+++ b/plugins/context/jvm/src/main/kotlin/com/intuit/playerui/plugins/context/PlayerStateContext.kt
@@ -1,0 +1,58 @@
+package com.intuit.playerui.plugins.context
+
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+
+/**
+ * Typed view of the aggregated `player.state` context entry. Read it with
+ * `contextPlugin.get<PlayerStateContext>("player.state")`.
+ *
+ * Actions are scoped to the construct they operate on — [Flow.transition] and
+ * [Data.set] — and are null until a flow is in-progress.
+ */
+@Serializable
+public data class PlayerStateContext(
+    val status: String? = null,
+    val flow: Flow = Flow(),
+    val view: View = View(),
+    val data: Data = Data(),
+    val validation: Validation = Validation(),
+) {
+    @Serializable
+    public data class Flow(
+        val id: String? = null,
+        val state: String? = null,
+        /** Transition the running flow using the given transition value (e.g. "Next"). */
+        val transition: ((String) -> Unit)? = null,
+    )
+
+    @Serializable
+    public data class View(
+        val id: String? = null,
+        val resolved: @Contextual Any? = null,
+    )
+
+    @Serializable
+    public data class Data(
+        val model: @Contextual Any? = null,
+        /** Set a value in the data model at the given binding. */
+        val set: ((String, @Contextual Any?) -> Unit)? = null,
+    )
+
+    /** Validation state for the running view, keyed by binding. */
+    @Serializable
+    public data class Validation(
+        /** Whether the view has no blocking validations. */
+        val canTransition: Boolean = true,
+        /** Active validations per binding string. */
+        val byBinding: Map<String, List<ContextValidation>> = emptyMap(),
+    ) {
+        @Serializable
+        public data class ContextValidation(
+            val severity: String,
+            val message: String,
+            val displayTarget: String? = null,
+            @Contextual val blocking: Any? = null,
+        )
+    }
+}

--- a/plugins/context/jvm/src/main/kotlin/com/intuit/playerui/plugins/context/PlayerStateContext.kt
+++ b/plugins/context/jvm/src/main/kotlin/com/intuit/playerui/plugins/context/PlayerStateContext.kt
@@ -13,10 +13,14 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class PlayerStateContext(
     val status: String? = null,
-    val flow: Flow = Flow(),
-    val view: View = View(),
-    val data: Data = Data(),
-    val validation: Validation = Validation(),
+    /** Absent until a flow has started. */
+    val flow: Flow? = null,
+    /** Absent until a view has resolved. */
+    val view: View? = null,
+    /** Absent until a data controller is bound. */
+    val data: Data? = null,
+    /** Absent until a validation controller is bound. */
+    val validation: Validation? = null,
 ) {
     @Serializable
     public data class Flow(

--- a/plugins/context/jvm/src/main/kotlin/com/intuit/playerui/plugins/context/PlayerStateContext.kt
+++ b/plugins/context/jvm/src/main/kotlin/com/intuit/playerui/plugins/context/PlayerStateContext.kt
@@ -12,7 +12,8 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 public data class PlayerStateContext(
-    val status: String? = null,
+    /** Always present — "not-started" before a flow has ever started. */
+    val status: String,
     /** Absent until a flow has started. */
     val flow: Flow? = null,
     /** Absent until a view has resolved. */

--- a/plugins/context/jvm/src/main/kotlin/com/intuit/playerui/plugins/context/StateContextPlugin.kt
+++ b/plugins/context/jvm/src/main/kotlin/com/intuit/playerui/plugins/context/StateContextPlugin.kt
@@ -1,0 +1,27 @@
+package com.intuit.playerui.plugins.context
+
+import com.intuit.playerui.core.player.Player
+import com.intuit.playerui.core.plugins.JSScriptPluginWrapper
+import com.intuit.playerui.core.plugins.findPlugin
+
+/**
+ * JVM wrapper around the JS `StateContextPlugin`. Registering it mirrors
+ * Player runtime state into the [ContextPlugin] store and publishes the
+ * aggregated `player.state` entry, which can be read as a typed
+ * [PlayerStateContext]:
+ *
+ * ```
+ * player.contextPlugin?.get<PlayerStateContext>("player.state")?.flow?.transition?.invoke("Next")
+ * ```
+ *
+ * Auto-registers a [ContextPlugin] on the JS side if one isn't already present.
+ */
+public class StateContextPlugin : JSScriptPluginWrapper(PLUGIN_NAME, sourcePath = BUNDLED_SOURCE_PATH) {
+    private companion object {
+        private const val PLUGIN_NAME = "ContextPlugin.StateContextPlugin"
+        private const val BUNDLED_SOURCE_PATH = "plugins/context/core/dist/ContextPlugin.native.js"
+    }
+}
+
+/** Convenience getter to find the first [StateContextPlugin] registered to the [Player]. */
+public val Player.stateContextPlugin: StateContextPlugin? get() = findPlugin()

--- a/plugins/context/jvm/src/test/kotlin/com/intuit/playerui/plugins/context/ContextPluginTest.kt
+++ b/plugins/context/jvm/src/test/kotlin/com/intuit/playerui/plugins/context/ContextPluginTest.kt
@@ -1,0 +1,73 @@
+package com.intuit.playerui.plugins.context
+
+import com.intuit.playerui.utils.test.PlayerTest
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.`should be null`
+import org.amshove.kluent.shouldBe
+import org.junit.jupiter.api.TestTemplate
+
+internal class ContextPluginTest : PlayerTest() {
+    override val plugins = listOf(ContextPlugin())
+
+    private val plugin get() = player.contextPlugin!!
+
+    @TestTemplate
+    fun `set and get round-trip a value`() {
+        plugin.set("formState", "Current form state", mapOf("name" to "Ada"))
+        plugin.get("formState") `should be equal to` mapOf("name" to "Ada")
+    }
+
+    @TestTemplate
+    fun `has reflects presence`() {
+        plugin.has("absent") shouldBe false
+        plugin.set("present", "A flag", true)
+        plugin.has("present") shouldBe true
+    }
+
+    @TestTemplate
+    fun `subscribe receives updates for its key only`() {
+        var received: Any? = null
+        var receivedName: String? = null
+        plugin.subscribe("counter", "A counter") { value, name ->
+            received = value
+            receivedName = name
+        }
+
+        plugin.set("counter", "A counter", 7)
+        plugin.set("other", "Other", 99)
+
+        received `should be equal to` 7
+        receivedName `should be equal to` "counter"
+    }
+
+    @TestTemplate
+    fun `subscribeAll receives every update`() {
+        val events = mutableListOf<Triple<Any?, String?, String>>()
+        plugin.subscribeAll { value, name, description ->
+            events.add(Triple(value, name, description))
+        }
+
+        plugin.set("a", "A", 1)
+        plugin.set("b", "B", 2)
+
+        events.size shouldBe 2
+        events[0] `should be equal to` Triple(1, "a", "A")
+        events[1] `should be equal to` Triple(2, "b", "B")
+    }
+
+    @TestTemplate
+    fun `unsubscribe stops further callbacks`() {
+        var received: Any? = null
+        val token = plugin.subscribe("k", "K") { value, _ -> received = value }
+        plugin.set("k", "K", 1)
+        plugin.unsubscribe(token)
+        plugin.set("k", "K", 2)
+
+        received `should be equal to` 1
+    }
+
+    @TestTemplate
+    fun `get returns null when entry is absent`() {
+        plugin.get("never-set").`should be null`()
+    }
+}

--- a/plugins/context/jvm/src/test/kotlin/com/intuit/playerui/plugins/context/ContextPluginTest.kt
+++ b/plugins/context/jvm/src/test/kotlin/com/intuit/playerui/plugins/context/ContextPluginTest.kt
@@ -3,8 +3,12 @@ package com.intuit.playerui.plugins.context
 import com.intuit.playerui.utils.test.PlayerTest
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should be null`
+import org.amshove.kluent.`should not be null`
 import org.amshove.kluent.shouldBe
 import org.junit.jupiter.api.TestTemplate
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertFailsWith
 
 internal class ContextPluginTest : PlayerTest() {
     override val plugins = listOf(ContextPlugin())
@@ -14,7 +18,7 @@ internal class ContextPluginTest : PlayerTest() {
     @TestTemplate
     fun `set and get round-trip a value`() {
         plugin.set("formState", "Current form state", mapOf("name" to "Ada"))
-        plugin.get("formState") `should be equal to` mapOf("name" to "Ada")
+        plugin.get<Map<String, String>>("formState") `should be equal to` mapOf("name" to "Ada")
     }
 
     @TestTemplate
@@ -68,6 +72,150 @@ internal class ContextPluginTest : PlayerTest() {
 
     @TestTemplate
     fun `get returns null when entry is absent`() {
-        plugin.get("never-set").`should be null`()
+        plugin.get<Any?>("never-set").`should be null`()
+    }
+
+    @TestTemplate
+    fun `get reads a primitive entry without wrapping it in a Node`() {
+        plugin.set("answer", "The answer", 42)
+        plugin.get<Int>("answer") `should be equal to` 42
+    }
+
+    @TestTemplate
+    fun `list reports registered entry descriptors`() {
+        plugin.set("flag", "A flag", true)
+
+        val flag = plugin.list().first { it.description == "A flag" }
+        flag.hasValue shouldBe true
+    }
+
+    @TestTemplate
+    fun `a function-valued member crosses the bridge and is called directly off the typed object`() {
+        // Mirrors how a consumer reads a structured context and invokes a
+        // bridged action member: get<T>("name").someFunction(args).
+        plugin.set(
+            "form",
+            "A form with an action",
+            mapOf(
+                "label" to "Greeter",
+                "greet" to { name: Any? -> "hello $name" },
+            ),
+        )
+
+        val form = plugin.get<FormContext>("form")!!
+        form.label `should be equal to` "Greeter"
+        form.greet("Ada") `should be equal to` "hello Ada"
+    }
+}
+
+@kotlinx.serialization.Serializable
+internal data class FormContext(
+    val label: String,
+    val greet: (String) -> String,
+)
+
+/**
+ * Integration: with [StateContextPlugin] applied and a flow running, the
+ * aggregated `player.state` entry is readable as a typed [PlayerStateContext]
+ * and its construct-scoped actions are directly callable across the bridge.
+ */
+internal class StateContextPluginTest : PlayerTest() {
+    override val plugins = listOf(ContextPlugin(), StateContextPlugin())
+
+    private val plugin get() = player.contextPlugin!!
+
+    @TestTemplate
+    fun `player state context is readable and its scoped actions are callable`() {
+        player.start(multiViewFlow)
+
+        val state = plugin.get<PlayerStateContext>("player.state")!!
+        state.status `should be equal to` "in-progress"
+        state.flow.id `should be equal to` "flow-multi"
+        state.flow.state `should be equal to` "VIEW_1"
+
+        // Validation state deserializes across the bridge. With no binding
+        // tracking (no rendering layer in this headless flow) it is empty and
+        // transitionable.
+        state.validation.canTransition `should be equal to` true
+        state.validation.byBinding.isEmpty() `should be equal to` true
+
+        // Actions are scoped to their constructs and bridged as callables.
+        state.flow.transition.`should not be null`()
+        state.data.set.`should not be null`()
+
+        // The scoped data.set action drives the real data model; reading the
+        // context back reflects the write.
+        state.data.set!!("foo.bar", "baz")
+        val model = plugin.get<PlayerStateContext>("player.state")!!.data.model as Map<*, *>
+        (model["foo"] as Map<*, *>)["bar"] `should be equal to` "baz"
+
+        // The scoped flow.transition action advances the flow to the next
+        // (non-terminal) view — observable synchronously through the live
+        // context, before any flow-end store rotation.
+        state.flow.transition!!("Next")
+        plugin.get<PlayerStateContext>("player.state")!!.flow.state `should be equal to` "VIEW_2"
+    }
+
+    @TestTemplate
+    fun `flow end freezes a typed history snapshot capturing the terminal state`() {
+        // Flow end (onEnd -> freeze -> rotate) is async, so await completion
+        // before asserting on the frozen snapshot.
+        val done = CountDownLatch(1)
+        player.start(multiViewFlow) { done.countDown() }
+
+        plugin.get<PlayerStateContext>("player.state")!!.flow.transition!!("Done")
+        done.await(5, TimeUnit.SECONDS) shouldBe true
+
+        val snapshot = plugin.history().last()
+        snapshot.flowId `should be equal to` "flow-multi"
+        // Read the frozen entry by name — the same typed access as live context.
+        snapshot.get<String>("player.flow.state") `should be equal to` "END_Done"
+        // Absent keys read back as null.
+        snapshot.get<String>("never.frozen").`should be null`()
+    }
+
+    @TestTemplate
+    fun `frozen snapshot actions are tombstoned and throw when invoked`() {
+        val done = CountDownLatch(1)
+        player.start(multiViewFlow) { done.countDown() }
+        plugin.get<PlayerStateContext>("player.state")!!.flow.transition!!("Done")
+        done.await(5, TimeUnit.SECONDS) shouldBe true
+
+        // The frozen player.state aggregate retains its scoped actions, but they
+        // are tombstoned — the action is still present (non-null) yet invoking
+        // it throws because the flow it was bound to has ended.
+        val frozenState = plugin.history().last().get<PlayerStateContext>("player.state")!!
+        frozenState.flow.transition.`should not be null`()
+        assertFailsWith<Exception> { frozenState.flow.transition!!("Next") }
+    }
+
+    private companion object {
+        private val multiViewFlow =
+            """
+            {
+              "id": "flow-multi",
+              "views": [
+                { "id": "view-1", "type": "info" },
+                { "id": "view-2", "type": "info" }
+              ],
+              "navigation": {
+                "BEGIN": "FLOW_1",
+                "FLOW_1": {
+                  "startState": "VIEW_1",
+                  "VIEW_1": {
+                    "ref": "view-1",
+                    "state_type": "VIEW",
+                    "transitions": { "Next": "VIEW_2", "*": "END_Done" }
+                  },
+                  "VIEW_2": {
+                    "ref": "view-2",
+                    "state_type": "VIEW",
+                    "transitions": { "*": "END_Done" }
+                  },
+                  "END_Done": { "state_type": "END", "outcome": "done" }
+                }
+              }
+            }
+            """.trimIndent()
     }
 }

--- a/plugins/context/jvm/src/test/kotlin/com/intuit/playerui/plugins/context/ContextPluginTest.kt
+++ b/plugins/context/jvm/src/test/kotlin/com/intuit/playerui/plugins/context/ContextPluginTest.kt
@@ -125,6 +125,11 @@ internal class StateContextPluginTest : PlayerTest() {
     private val plugin get() = player.contextPlugin!!
 
     @TestTemplate
+    fun `status is not-started immediately, before any flow starts`() {
+        plugin.get<PlayerStateContext>("player.state")!!.status `should be equal to` "not-started"
+    }
+
+    @TestTemplate
     fun `player state context is readable and its scoped actions are callable`() {
         player.start(multiViewFlow)
 

--- a/plugins/context/jvm/src/test/kotlin/com/intuit/playerui/plugins/context/ContextPluginTest.kt
+++ b/plugins/context/jvm/src/test/kotlin/com/intuit/playerui/plugins/context/ContextPluginTest.kt
@@ -130,30 +130,30 @@ internal class StateContextPluginTest : PlayerTest() {
 
         val state = plugin.get<PlayerStateContext>("player.state")!!
         state.status `should be equal to` "in-progress"
-        state.flow.id `should be equal to` "flow-multi"
-        state.flow.state `should be equal to` "VIEW_1"
+        state.flow!!.id `should be equal to` "flow-multi"
+        state.flow!!.state `should be equal to` "VIEW_1"
 
         // Validation state deserializes across the bridge. With no binding
         // tracking (no rendering layer in this headless flow) it is empty and
         // transitionable.
-        state.validation.canTransition `should be equal to` true
-        state.validation.byBinding.isEmpty() `should be equal to` true
+        state.validation!!.canTransition `should be equal to` true
+        state.validation!!.byBinding.isEmpty() `should be equal to` true
 
         // Actions are scoped to their constructs and bridged as callables.
-        state.flow.transition.`should not be null`()
-        state.data.set.`should not be null`()
+        state.flow!!.transition.`should not be null`()
+        state.data!!.set.`should not be null`()
 
         // The scoped data.set action drives the real data model; reading the
         // context back reflects the write.
-        state.data.set!!("foo.bar", "baz")
-        val model = plugin.get<PlayerStateContext>("player.state")!!.data.model as Map<*, *>
+        state.data!!.set!!("foo.bar", "baz")
+        val model = plugin.get<PlayerStateContext>("player.state")!!.data!!.model as Map<*, *>
         (model["foo"] as Map<*, *>)["bar"] `should be equal to` "baz"
 
         // The scoped flow.transition action advances the flow to the next
         // (non-terminal) view — observable synchronously through the live
         // context, before any flow-end store rotation.
-        state.flow.transition!!("Next")
-        plugin.get<PlayerStateContext>("player.state")!!.flow.state `should be equal to` "VIEW_2"
+        state.flow!!.transition!!("Next")
+        plugin.get<PlayerStateContext>("player.state")!!.flow!!.state `should be equal to` "VIEW_2"
     }
 
     @TestTemplate
@@ -163,7 +163,7 @@ internal class StateContextPluginTest : PlayerTest() {
         val done = CountDownLatch(1)
         player.start(multiViewFlow) { done.countDown() }
 
-        plugin.get<PlayerStateContext>("player.state")!!.flow.transition!!("Done")
+        plugin.get<PlayerStateContext>("player.state")!!.flow!!.transition!!("Done")
         done.await(5, TimeUnit.SECONDS) shouldBe true
 
         val snapshot = plugin.history().last()
@@ -178,15 +178,15 @@ internal class StateContextPluginTest : PlayerTest() {
     fun `frozen snapshot actions are tombstoned and throw when invoked`() {
         val done = CountDownLatch(1)
         player.start(multiViewFlow) { done.countDown() }
-        plugin.get<PlayerStateContext>("player.state")!!.flow.transition!!("Done")
+        plugin.get<PlayerStateContext>("player.state")!!.flow!!.transition!!("Done")
         done.await(5, TimeUnit.SECONDS) shouldBe true
 
         // The frozen player.state aggregate retains its scoped actions, but they
         // are tombstoned — the action is still present (non-null) yet invoking
         // it throws because the flow it was bound to has ended.
         val frozenState = plugin.history().last().get<PlayerStateContext>("player.state")!!
-        frozenState.flow.transition.`should not be null`()
-        assertFailsWith<Exception> { frozenState.flow.transition!!("Next") }
+        frozenState.flow!!.transition.`should not be null`()
+        assertFailsWith<Exception> { frozenState.flow!!.transition!!("Next") }
     }
 
     private companion object {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -846,6 +846,12 @@ importers:
         specifier: workspace:^
         version: link:../../../core/player
 
+  plugins/context/core:
+    dependencies:
+      '@player-ui/player':
+        specifier: workspace:^
+        version: link:../../../core/player
+
   plugins/data-change-listener/core:
     dependencies:
       '@player-ui/player':
@@ -9090,6 +9096,16 @@ packages:
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==, tarball: https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==, tarball: https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
+  uvu@0.5.6:
+    resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==, tarball: https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz}
+    engines: {node: '>=8'}
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -851,6 +851,13 @@ importers:
       '@player-ui/player':
         specifier: workspace:^
         version: link:../../../core/player
+    devDependencies:
+      '@player-ui/common-types-plugin':
+        specifier: workspace:^
+        version: link:../../common-types/core
+      '@player-ui/reference-assets-plugin':
+        specifier: workspace:^
+        version: link:../../reference-assets/core
 
   plugins/data-change-listener/core:
     dependencies:


### PR DESCRIPTION
## Summary

Introduces the **ContextPlugin** family — a per-flow store that lets external consumers (automation, devtools, native hosts) read, derive, observe, and drive Player state without tapping every controller hook.

- **`ContextPlugin`** — named entries keyed by symbol; transforms for derived values; subscribe API; per-flow history snapshots (with rotation on flow end).
- **`StateContextPlugin`** — mirrors runtime state and publishes an aggregated `player.state` (`PlayerStateContext`) with construct-scoped, callable actions (`flow.transition`, `data.set`) and `validation` state.
- **Native parity (JVM + iOS)** — typed reads (`get<T>(name)` / `get(name:as:)`) deserialize entries, including function members, into typed objects; `list()`, `history()`, and typed `snapshot.get(name)`.

## Notable behaviors

- **Actions are function-valued entries**, bound to live controllers — no separate action registry. Read back as directly-callable functions across the bridge.
- **Validation** is mirrored via a passive, side-effect-free read (never triggers validation). Populated only for bindings the rendering layer tracks.
- **Flow end** freezes the store into a history snapshot then rotates; captured functions become throwing tombstones. Post-terminating-transition live reads are racy by design — read the snapshot for end-of-flow state.
- **Transform invalidation is transitive.** A write to a root source notifies every downstream transform, not just its direct dependents. `ContextStore.transitiveDependentsOf` walks the reverse index breadth-first, dedupes keys reachable by multiple paths, and terminates on cycles.

## Other changes

`jvm/core/.../NodeSerializableFunction.kt` is made `public` so the JVM wrapper can cache its JS member-function delegates, and its node/serializer resolution is deferred past construction — the delegate is declared on a wrapper whose `node` is backed by `JSScriptPluginWrapper.instance`, a `lateinit` field assigned in `apply`. Eagerly resolving either at construction throws `UninitializedPropertyAccessException`.

`ContextPlugin` passes concrete return-type serializers rather than relying on reified inference, which keeps the added public surface to a single overload (2 lines of `core.api`).

# Release Notes

Adds the `ContextPlugin` family for sharing Player state with external consumers.

- **`@player-ui/context-plugin`** (new) — per-flow context store with symbol-keyed entries, derived transforms, subscriptions, and frozen per-flow history snapshots. `StateContextPlugin` publishes an aggregated `player.state` entry exposing flow/data/validation state plus callable `flow.transition` and `data.set` actions.
- **JVM / iOS** — `ContextPlugin` and `StateContextPlugin` wrappers with typed reads: `get<T>(name)` (JVM) and `get(name:as:)` (iOS) deserialize entries, including function-valued members, into typed objects. Typed `list()`, `history()`, and snapshot reads included.
- **Subscriptions on derived values fire on transitive source updates** — updating a root value notifies subscribers of every transform downstream of it, at any depth.
- [JVM]: **`NodeSerializableFunction`** is now `public` and resolves its backing node and serializer lazily, so delegates can be declared on plugin wrappers whose node is assigned during `apply`. Existing eager call sites are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.0--canary.891.41716</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 1.2.0--canary.891.41716
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
