### PR TITLE
Update Android/iOS Managed Players to include `onStartedFlow` callback

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1189,6 +1189,206 @@
         }
       }
     },
+    "@@rules_swift_package_manager+//:extensions.bzl%swift_deps": {
+      "general": {
+        "bzlTransitiveDigest": "WLqoi29c8XUgPo7uYa9ChpMJhaZvAJGvgjQ0kAg4bKs=",
+        "usagesDigest": "qO7yXJ2fkxAWTU2NfvwC9ZB4ovhfvgOcn5jlPeqsybs=",
+        "recordedInputs": [
+          "REPO_MAPPING:rules_swift_package_manager+,bazel_skylib bazel_skylib+",
+          "REPO_MAPPING:rules_swift_package_manager+,bazel_tools bazel_tools",
+          "REPO_MAPPING:rules_swift_package_manager+,cgrindel_bazel_starlib cgrindel_bazel_starlib+",
+          "FILE:@@//xcode/Package.resolved 32cec8db57528c1e30c85cbfa19db1cf4a16a82f2dd60a4842380efc33249112"
+        ],
+        "generatedRepoSpecs": {
+          "swift_package": {
+            "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package_tool_repo.bzl%swift_package_tool_repo",
+            "attributes": {
+              "env": {},
+              "package": "/xcode/Package.swift"
+            }
+          },
+          "swiftpkg_swift_hooks": {
+            "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
+            "attributes": {
+              "bazel_package_name": "swiftpkg_swift_hooks",
+              "commit": "5f3136ac2a3c27aa469e3f9a1222b15080d431d3",
+              "remote": "https://github.com/intuit/swift-hooks.git",
+              "version": "0.1.0",
+              "env": {},
+              "env_inherit": [],
+              "cached_json_directory": "",
+              "replace_scm_with_registry": false,
+              "target_deps": {}
+            }
+          },
+          "swiftpkg_swiftlint": {
+            "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
+            "attributes": {
+              "bazel_package_name": "swiftpkg_swiftlint",
+              "commit": "88952528a590ed366c6f76f6bfb980b5ebdcefc1",
+              "remote": "https://github.com/realm/SwiftLint.git",
+              "version": "0.63.2",
+              "env": {},
+              "env_inherit": [],
+              "cached_json_directory": "",
+              "replace_scm_with_registry": false,
+              "target_deps": {}
+            }
+          },
+          "swiftpkg_viewinspector": {
+            "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
+            "attributes": {
+              "bazel_package_name": "swiftpkg_viewinspector",
+              "commit": "e9a06346499a3a889165647e3f23f8a7b2609a1c",
+              "remote": "https://github.com/nalexn/ViewInspector",
+              "version": "0.10.3",
+              "env": {},
+              "env_inherit": [],
+              "cached_json_directory": "",
+              "replace_scm_with_registry": false,
+              "target_deps": {}
+            }
+          },
+          "swiftpkg_collectionconcurrencykit": {
+            "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
+            "attributes": {
+              "bazel_package_name": "swiftpkg_collectionconcurrencykit",
+              "commit": "b4f23e24b5a1bff301efc5e70871083ca029ff95",
+              "remote": "https://github.com/JohnSundell/CollectionConcurrencyKit.git",
+              "version": "0.2.0",
+              "env": {},
+              "env_inherit": [],
+              "cached_json_directory": "",
+              "replace_scm_with_registry": false,
+              "target_deps": {}
+            }
+          },
+          "swiftpkg_cryptoswift": {
+            "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
+            "attributes": {
+              "bazel_package_name": "swiftpkg_cryptoswift",
+              "commit": "e45a26384239e028ec87fbcc788f513b67e10d8f",
+              "remote": "https://github.com/krzyzanowskim/CryptoSwift.git",
+              "version": "1.9.0",
+              "env": {},
+              "env_inherit": [],
+              "cached_json_directory": "",
+              "replace_scm_with_registry": false,
+              "target_deps": {}
+            }
+          },
+          "swiftpkg_sourcekitten": {
+            "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
+            "attributes": {
+              "bazel_package_name": "swiftpkg_sourcekitten",
+              "commit": "6529c17fe80dd94843a3df7ed3e6a239790d5c91",
+              "remote": "https://github.com/jpsim/SourceKitten.git",
+              "version": "0.37.3",
+              "env": {},
+              "env_inherit": [],
+              "cached_json_directory": "",
+              "replace_scm_with_registry": false,
+              "target_deps": {}
+            }
+          },
+          "swiftpkg_swift_argument_parser": {
+            "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
+            "attributes": {
+              "bazel_package_name": "swiftpkg_swift_argument_parser",
+              "commit": "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+              "remote": "https://github.com/apple/swift-argument-parser.git",
+              "version": "1.7.1",
+              "env": {},
+              "env_inherit": [],
+              "cached_json_directory": "",
+              "replace_scm_with_registry": false,
+              "target_deps": {}
+            }
+          },
+          "swiftpkg_swift_filename_matcher": {
+            "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
+            "attributes": {
+              "bazel_package_name": "swiftpkg_swift_filename_matcher",
+              "commit": "eef5ac0b6b3cdc64b3039b037bed2def8a1edaeb",
+              "remote": "https://github.com/ileitch/swift-filename-matcher",
+              "version": "2.0.1",
+              "env": {},
+              "env_inherit": [],
+              "cached_json_directory": "",
+              "replace_scm_with_registry": false,
+              "target_deps": {}
+            }
+          },
+          "swiftpkg_swift_syntax": {
+            "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
+            "attributes": {
+              "bazel_package_name": "swiftpkg_swift_syntax",
+              "commit": "65b02a90ad2cc213e09309faeb7f6909e0a8577a",
+              "remote": "https://github.com/swiftlang/swift-syntax.git",
+              "version": "604.0.0-prerelease-2026-01-20",
+              "env": {},
+              "env_inherit": [],
+              "cached_json_directory": "",
+              "replace_scm_with_registry": false,
+              "target_deps": {}
+            }
+          },
+          "swiftpkg_swiftytexttable": {
+            "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
+            "attributes": {
+              "bazel_package_name": "swiftpkg_swiftytexttable",
+              "commit": "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
+              "remote": "https://github.com/scottrhoyt/SwiftyTextTable.git",
+              "version": "0.9.0",
+              "env": {},
+              "env_inherit": [],
+              "cached_json_directory": "",
+              "replace_scm_with_registry": false,
+              "target_deps": {}
+            }
+          },
+          "swiftpkg_swxmlhash": {
+            "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
+            "attributes": {
+              "bazel_package_name": "swiftpkg_swxmlhash",
+              "commit": "a853604c9e9a83ad9954c7e3d2a565273982471f",
+              "remote": "https://github.com/drmohundro/SWXMLHash.git",
+              "version": "7.0.2",
+              "env": {},
+              "env_inherit": [],
+              "cached_json_directory": "",
+              "replace_scm_with_registry": false,
+              "target_deps": {}
+            }
+          },
+          "swiftpkg_yams": {
+            "repoRuleId": "@@rules_swift_package_manager+//swiftpkg/internal:swift_package.bzl%swift_package",
+            "attributes": {
+              "bazel_package_name": "swiftpkg_yams",
+              "commit": "deaf82e867fa2cbd3cd865978b079bfcf384ac28",
+              "remote": "https://github.com/jpsim/Yams.git",
+              "version": "6.2.1",
+              "env": {},
+              "env_inherit": [],
+              "cached_json_directory": "",
+              "replace_scm_with_registry": false,
+              "target_deps": {}
+            }
+          }
+        },
+        "moduleExtensionMetadata": {
+          "explicitRootModuleDirectDeps": [
+            "swiftpkg_swift_hooks",
+            "swiftpkg_swiftlint",
+            "swiftpkg_viewinspector",
+            "swift_package"
+          ],
+          "explicitRootModuleDirectDevDeps": [],
+          "useAllRepos": "NO",
+          "reproducible": false
+        }
+      }
+    },
     "@@tar.bzl+//tar:extensions.bzl%toolchains": {
       "general": {
         "bzlTransitiveDigest": "/2afh6fPjq/rcyE/jztQDK3ierehmFFngfvmqyRv72M=",

--- a/android/player/src/main/kotlin/com/intuit/playerui/android/lifecycle/ManagedPlayerState.kt
+++ b/android/player/src/main/kotlin/com/intuit/playerui/android/lifecycle/ManagedPlayerState.kt
@@ -39,6 +39,9 @@ public sealed class ManagedPlayerState {
         /** Handler that is invoked when the [PlayerViewModel] reaches an [Running] state */
         public fun onRunning(inProgressState: Running) {}
 
+        /** Handler that is invoked when the player starts a flow, passing the flow [String] used to start it */
+        public fun onStartedFlow(flow: String) {}
+
         /** Handler that is invoked when the [PlayerViewModel] reaches the [Done] state */
         public fun onDone(doneState: Done) {}
 

--- a/android/player/src/main/kotlin/com/intuit/playerui/android/lifecycle/PlayerViewModel.kt
+++ b/android/player/src/main/kotlin/com/intuit/playerui/android/lifecycle/PlayerViewModel.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -94,8 +95,18 @@ public open class PlayerViewModel(
     private var _state = MutableStateFlow<ManagedPlayerState>(ManagedPlayerState.NotStarted)
     private val _beacons = MutableSharedFlow<String>()
 
+    // Buffer one item so the started flow isn't dropped if a collector hasn't started yet;
+    // flows start sequentially, so at most one is ever buffered.
+    private val _startedFlows = MutableSharedFlow<String>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
     public val state: StateFlow<ManagedPlayerState> get() = _state.asStateFlow()
     public val beacons: SharedFlow<String> get() = _beacons.asSharedFlow()
+
+    /** Emits the flow [String] used to start the player each time a flow is started */
+    public val startedFlows: SharedFlow<String> get() = _startedFlows.asSharedFlow()
 
     init {
         // next() TODO: If we fix the non-final field error, we can prefetch here
@@ -116,16 +127,21 @@ public open class PlayerViewModel(
         }
     }
 
-    private fun start(flow: String) = player.start(flow) {
-        when {
-            it.isSuccess -> player.logger.info(
-                "Flow completed successfully!",
-                it.getOrNull()?.endState,
-            )
-            it.isFailure -> player.logger.error(
-                "Error in Flow!",
-                it.exceptionOrNull(),
-            )
+    private fun start(flow: String) {
+        // Notify that a flow has started, passing back the in-memory flow that was used to start
+        // Player (avoids deserializing the flow back across the JS bridge)
+        _startedFlows.tryEmit(flow)
+        player.start(flow) {
+            when {
+                it.isSuccess -> player.logger.info(
+                    "Flow completed successfully!",
+                    it.getOrNull()?.endState,
+                )
+                it.isFailure -> player.logger.error(
+                    "Error in Flow!",
+                    it.exceptionOrNull(),
+                )
+            }
         }
     }
 

--- a/android/player/src/main/kotlin/com/intuit/playerui/android/ui/PlayerFragment.kt
+++ b/android/player/src/main/kotlin/com/intuit/playerui/android/ui/PlayerFragment.kt
@@ -96,6 +96,11 @@ public abstract class PlayerFragment :
     init {
         lifecycleScope.launch {
             repeatOnLifecycle(State.STARTED) {
+                // forward started flows to the callback
+                playerViewModel.startedFlows
+                    .onEach { onStartedFlow(it) }
+                    .launchIn(this + Dispatchers.Default)
+
                 // forward state events to callbacks
                 playerViewModel.state
                     .onEach {

--- a/android/player/src/test/kotlin/com/intuit/playerui/android/lifecycle/PlayerViewModelTest.kt
+++ b/android/player/src/test/kotlin/com/intuit/playerui/android/lifecycle/PlayerViewModelTest.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.AfterEach
@@ -37,6 +38,9 @@ import org.junit.jupiter.api.extension.ExtendWith
 internal class PlayerViewModelTest {
     private val validFlow =
         "{\"id\": \"id\",\"navigation\": {\"BEGIN\": \"FLOW_1\",\"FLOW_1\": {\"startState\": \"END_Done\",\"END_Done\": {\"state_type\": \"END\",\"outcome\": \"done\"}}}}"
+
+    private val validFlow2 =
+        "{\"id\": \"id2\",\"navigation\": {\"BEGIN\": \"FLOW_1\",\"FLOW_1\": {\"startState\": \"END_Done\",\"END_Done\": {\"state_type\": \"END\",\"outcome\": \"done\"}}}}"
 
     private val invalidFlow =
         "{\"id\": \"id\",\"navigation\": {\"BEGIN\": \"FLOW\",\"FLOW_1\": {\"startState\": \"END_Done\",\"END_Done\": {\"state_type\": \"END\",\"outcome\": \"done\"}}}}"
@@ -136,6 +140,35 @@ internal class PlayerViewModelTest {
         coVerify(exactly = 1) { flowManager.next(null) }
         coVerify(exactly = 1) { flowManager.next(any()) }
         assertEquals("Error: No flow defined for: FLOW", assertPlayerState<ErrorState>().error.message)
+    }
+
+    @Test
+    fun `startedFlows emits the flow used to start the player`() = runBlocking {
+        coEvery { flowManager.next(any()) } returns validFlow andThen null
+        val started = mutableListOf<String>()
+        val job = launch(Dispatchers.Default) { viewModel.startedFlows.collect { started.add(it) } }
+        viewModel.start()
+        suspendUntilCondition(
+            getValue = { started.toList() },
+            condition = { it.contains(validFlow) },
+            messageSupplier = { "startedFlows did not emit the started flow, got $it" },
+        )
+        job.cancel()
+    }
+
+    @Test
+    fun `startedFlows emits once per flow for multiple flows`() = runBlocking {
+        coEvery { flowManager.next(any()) } returns validFlow andThen validFlow2 andThen null
+        val started = mutableListOf<String>()
+        val job = launch(Dispatchers.Default) { viewModel.startedFlows.collect { started.add(it) } }
+        viewModel.start()
+        suspendUntilCondition(
+            getValue = { started.toList() },
+            condition = { it.containsAll(listOf(validFlow, validFlow2)) },
+            messageSupplier = { "startedFlows did not emit both flows, got $it" },
+        )
+        assertEquals(listOf(validFlow, validFlow2), started)
+        job.cancel()
     }
 
     @Test

--- a/android/player/src/test/kotlin/com/intuit/playerui/android/lifecycle/PlayerViewModelTest.kt
+++ b/android/player/src/test/kotlin/com/intuit/playerui/android/lifecycle/PlayerViewModelTest.kt
@@ -17,10 +17,12 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
@@ -146,7 +148,15 @@ internal class PlayerViewModelTest {
     fun `startedFlows emits the flow used to start the player`() = runBlocking {
         coEvery { flowManager.next(any()) } returns validFlow andThen null
         val started = mutableListOf<String>()
-        val job = launch(Dispatchers.Default) { viewModel.startedFlows.collect { started.add(it) } }
+        // startedFlows is a hot SharedFlow (replay = 0), so gate start() on the collector actually
+        // being subscribed - otherwise the emission can race ahead of the subscription and be missed
+        val subscribed = CompletableDeferred<Unit>()
+        val job = launch(Dispatchers.Default) {
+            viewModel.startedFlows
+                .onSubscription { subscribed.complete(Unit) }
+                .collect { started.add(it) }
+        }
+        subscribed.await()
         viewModel.start()
         suspendUntilCondition(
             getValue = { started.toList() },
@@ -160,7 +170,13 @@ internal class PlayerViewModelTest {
     fun `startedFlows emits once per flow for multiple flows`() = runBlocking {
         coEvery { flowManager.next(any()) } returns validFlow andThen validFlow2 andThen null
         val started = mutableListOf<String>()
-        val job = launch(Dispatchers.Default) { viewModel.startedFlows.collect { started.add(it) } }
+        val subscribed = CompletableDeferred<Unit>()
+        val job = launch(Dispatchers.Default) {
+            viewModel.startedFlows
+                .onSubscription { subscribed.complete(Unit) }
+                .collect { started.add(it) }
+        }
+        subscribed.await()
         viewModel.start()
         suspendUntilCondition(
             getValue = { started.toList() },

--- a/android/player/src/test/kotlin/com/intuit/playerui/android/lifecycle/PlayerViewModelTest.kt
+++ b/android/player/src/test/kotlin/com/intuit/playerui/android/lifecycle/PlayerViewModelTest.kt
@@ -156,7 +156,8 @@ internal class PlayerViewModelTest {
                 .onSubscription { subscribed.complete(Unit) }
                 .collect { started.add(it) }
         }
-        subscribed.await()
+        // bound every wait so a missed emission fails in seconds rather than at the bazel test timeout
+        withTimeout(5_000) { subscribed.await() }
         viewModel.start()
         suspendUntilCondition(
             getValue = { started.toList() },
@@ -164,6 +165,7 @@ internal class PlayerViewModelTest {
             messageSupplier = { "startedFlows did not emit the started flow, got $it" },
         )
         job.cancel()
+        assertEquals(listOf(validFlow), started)
     }
 
     @Test
@@ -176,7 +178,7 @@ internal class PlayerViewModelTest {
                 .onSubscription { subscribed.complete(Unit) }
                 .collect { started.add(it) }
         }
-        subscribed.await()
+        withTimeout(5_000) { subscribed.await() }
         viewModel.start()
         suspendUntilCondition(
             getValue = { started.toList() },

--- a/ios/swiftui/Sources/ManagedPlayer/ManagedPlayer.swift
+++ b/ios/swiftui/Sources/ManagedPlayer/ManagedPlayer.swift
@@ -63,6 +63,7 @@ public struct ManagedPlayer<Loading: View, Fallback: View>: View {
     ///    - flowManager: The `FlowManager` to use for fetching flows
     ///    - handleScroll: Whether or not the `ManagedPlayer` should wrap content in a `ScrollView`
     ///    - onComplete: A handler for when the `FlowManager` signals that it has no more flows to fetch
+    ///    - onStartedFlow: A handler for when a flow is started, passed the flow `String` that was used to start it
     ///    - onError: A handler for when the `SwiftUIPlayer` encounters an error
     ///    - loading: A closure providing a `View` to display while the `FlowManager` fetches flows
     public init(
@@ -71,13 +72,14 @@ public struct ManagedPlayer<Loading: View, Fallback: View>: View {
         context: SwiftUIPlayer.Context = .sharedManaged,
         handleScroll: Bool = true,
         onComplete: @escaping (CompletedState) -> Void,
+        onStartedFlow: @escaping (String) -> Void = { _ in },
         @ViewBuilder fallback: @escaping (ManagedPlayerErrorContext) -> Fallback,
         @ViewBuilder loading: @escaping () -> Loading
     ) {
         self.init(
             plugins: plugins,
             context: context,
-            viewModel: ManagedPlayerViewModel(manager: flowManager, onComplete: onComplete),
+            viewModel: ManagedPlayerViewModel(manager: flowManager, onComplete: onComplete, onStartedFlow: onStartedFlow),
             handleScroll: handleScroll,
             fallback: fallback,
             loading: loading

--- a/ios/swiftui/Sources/ManagedPlayer/ManagedPlayerViewModel.swift
+++ b/ios/swiftui/Sources/ManagedPlayer/ManagedPlayerViewModel.swift
@@ -84,6 +84,8 @@ public class ManagedPlayerViewModel: ObservableObject, NativePlugin {
 
     private var onComplete: (CompletedState) -> Void
 
+    private var onStartedFlow: (String) -> Void
+
     /// The `FlowManager` that is used for this instance
     private var manager: FlowManager
 
@@ -94,14 +96,17 @@ public class ManagedPlayerViewModel: ObservableObject, NativePlugin {
      - parameters:
         - manager: The `FlowManager` to use for fetching flows
         - onComplete: A handler for when the `FlowManager` signals that it has no more flows to fetch
+        - onStartedFlow: A handler for when a flow is started, passed the flow `String` that was used to start it
         - onError: A handler for when the `SwiftUIPlayer` encounters an error
      */
     public init(
         manager: FlowManager,
-        onComplete: @escaping (CompletedState) -> Void
+        onComplete: @escaping (CompletedState) -> Void,
+        onStartedFlow: @escaping (String) -> Void = { _ in }
     ) {
         self.manager = manager
         self.onComplete = onComplete
+        self.onStartedFlow = onStartedFlow
 
         $result.sink { [weak self] result in
             guard let result = result else { return }
@@ -148,6 +153,9 @@ public class ManagedPlayerViewModel: ObservableObject, NativePlugin {
             if !flow.isEmpty {
                 self.flow = flow
                 loadingState = .loaded(flow)
+                // Notify that a flow has started, passing back the in-memory flow that was used to
+                // start Player (avoids deserializing the flow back across the JS bridge)
+                onStartedFlow(flow)
             } else {
                 loadingState = .failed(ManagedPlayerError.emptyFlow)
             }

--- a/ios/swiftui/Tests/ManagedPlayer/ManagedPlayerViewModelTests.swift
+++ b/ios/swiftui/Tests/ManagedPlayer/ManagedPlayerViewModelTests.swift
@@ -48,6 +48,69 @@ class ManagedPlayerViewModelTests: XCTestCase {
         await fulfillment(of: [completed], timeout: 2)
     }
 
+    func testViewModelOnStartedFlow() async throws {
+        let flowManager = ConstantFlowManager([flow1], delay: 0)
+
+        let started = expectation(description: "onStartedFlow called")
+        var startedFlows: [String] = []
+        let viewModel = ManagedPlayerViewModel(manager: flowManager, onComplete: {_ in}, onStartedFlow: { flow in
+            startedFlows.append(flow)
+            started.fulfill()
+        })
+
+        await viewModel.next()
+        await fulfillment(of: [started], timeout: 2)
+        XCTAssertEqual(startedFlows, [self.flow1])
+    }
+
+    func testViewModelOnStartedFlowMultiFlow() async throws {
+        let flowManager = ConstantFlowManager([flow1, flow2], delay: 0)
+
+        let started = expectation(description: "onStartedFlow called for each flow")
+        started.expectedFulfillmentCount = 2
+        var startedFlows: [String] = []
+        let viewModel = ManagedPlayerViewModel(manager: flowManager, onComplete: {_ in}, onStartedFlow: { flow in
+            startedFlows.append(flow)
+            started.fulfill()
+        })
+
+        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow1 } action: { await viewModel.next() }
+
+        let result = """
+        {
+            "status": "completed",
+            "flow": "",
+            "endState": {
+                "outcome":"done"
+            }
+        }
+        """
+
+        let stateObj = JSContext()?.evaluateScript("(\(result))")
+
+        let state = CompletedState.createInstance(from: stateObj)!
+
+        await assertPublished(AnyPublisher(viewModel.$flow)) { $0 == self.flow2 } action: { viewModel.result = .success(state) }
+
+        await fulfillment(of: [started], timeout: 2)
+        XCTAssertEqual(startedFlows, [self.flow1, self.flow2])
+    }
+
+    func testViewModelOnStartedFlowNotCalledForEmptyFlow() {
+        var startedFlows: [String] = []
+        let model = ManagedPlayerViewModel(manager: ConstantFlowManager([FlowData.COUNTER]), onComplete: {_ in}, onStartedFlow: { startedFlows.append($0) })
+
+        model.handleNextFlow("")
+
+        XCTAssertTrue(startedFlows.isEmpty)
+        switch model.loadingState {
+        case .failed(let error):
+            XCTAssertEqual(error as? ManagedPlayerError, ManagedPlayerError.emptyFlow)
+        default:
+            XCTFail("Should Have entered failed state")
+        }
+    }
+
     func testViewModelSuccessMultiFlow() async throws {
         let flowManager = ConstantFlowManager([flow1, flow2], delay: 0)
 


### PR DESCRIPTION
### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [x] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

## Release Notes
Brings the React Managed Player's onStartedFlow callback (added in #881) to iOS and Android. Consumers can now be notified when the managed player starts a flow, and receive the flow that was used to start it — without having to track it themselves. For performance, the callback hands back the in-memory flow String that was passed in, rather than reading it back out of Player (which would force a deserialization across the JS bridge).