### PR TITLE
Shorten `AsyncIterationFlow` `Item` generic param to `I` to avoid shadowing

### DIFF
--- a/jvm/core/src/main/kotlin/com/intuit/playerui/core/managed/AsyncIterationFlow.kt
+++ b/jvm/core/src/main/kotlin/com/intuit/playerui/core/managed/AsyncIterationFlow.kt
@@ -9,9 +9,11 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 /** Wrapper of an [AsyncIterator] that captures iterations within a [StateFlow] */
-public class AsyncIterationFlow<Item : Any, Result : Any, Data : Any>(
-    public val iterator: AsyncIterator<Item, Result, Data>,
+public class AsyncIterationFlow<I : Any, Result : Any, Data : Any>(
+    public val iterator: AsyncIterator<I, Result, Data>,
 ) {
+    // Above I is short for Item -- the outer type parameter must not share a name with the nested
+    // State.Item subclass below, or the @Metadata gets corrupted.
     public sealed class State {
         public object NotStarted : State()
 


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->
> [!CAUTION]
> Moved back to draft. This is not fixing the issue so continuing to debug.

`AsyncInterationFlow` has a generic parameter named `Item` and a subclass called `Item` (`State.Item`). Apparently, this shadowing causes the metadata of the released module to be corrupted with Kotlin compiler 2.0.20 (not sure about other versions).

To fix this, change the generic parameter `Item` to `I`. Because this is the parameter name, I believe this is not a breaking change because it doesn't affect anything for users.

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.2--canary.897.38579</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 1.0.2--canary.897.38579
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
