### PR TITLE
Use `rules_player` 2.6.2 to get ios release notes

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -179,6 +179,7 @@ spm_publish(
     zip = ":PlayerUI_SPM",
     # SPM Release Repo
     repository = "git@github.com:player-ui/playerui-swift-package.git",
+    source_repo = "github.com/player-ui/player"
 )
 
 # SwiftLint

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,9 +7,9 @@ bazel_dep(name = "rules_player")
 
 archive_override(
   module_name = "rules_player",
-  strip_prefix = "rules_player-2.6.1",
-  urls = ["https://github.com/player-ui/rules_player/archive/refs/tags/v2.6.1.tar.gz"],
-  integrity = "sha256-vRBZpHnljz6wBuTUsXT0kHj06B9Av79i6+5EMrie7uc="
+  strip_prefix = "rules_player-2.6.2",
+  urls = ["https://github.com/player-ui/rules_player/archive/refs/tags/v2.6.2.tar.gz"],
+  integrity = "sha256-N5uXRPckX8U1qqEXRAfm5iRQS8EUV6rDCabSWBXLRO8="
 )
 
 bazel_dep(name = "platforms", version = "1.1.0")


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->
Upgrade to `rules_player` [2.6.2](https://github.com/player-ui/rules_player/releases/tag/v2.6.2) which automatically starts adding release notes to our ios releases.

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch` (This is only labeled as `patch` so a release will run as soon as this is merged to confirm it's working)
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->