### PR TITLE
Stop Leaking Invalid Data After Forced Transition

### DIFF
--- a/core/player/src/__tests__/player.test.ts
+++ b/core/player/src/__tests__/player.test.ts
@@ -888,9 +888,10 @@ test("prevents invalid data from being committed during action-driven backward n
   // The invalid data should NOT be committed to the main model because of the transition
   const finalValue = state.controllers.data.get("someValue");
   expect(finalValue).toBeUndefined();
-  // But it should still be in the shadow/invalid model
+  // The transition should have dropped the invalid data entirely, not just
+  // hidden it from the main model
   const shadowValue = state.controllers.data.get("someValue", {
     includeInvalid: true,
   });
-  expect(shadowValue).toBe(-1);
+  expect(shadowValue).toBeUndefined();
 });

--- a/core/player/src/__tests__/player.test.ts
+++ b/core/player/src/__tests__/player.test.ts
@@ -8,6 +8,7 @@ import type { ViewController } from "..";
 import actionsFlow from "./helpers/actions.flow";
 import type { InProgressState } from "../types";
 import { ActionExpPlugin } from "./helpers/action-exp.plugin";
+import TrackBindingPlugin from "./helpers/binding.plugin";
 
 const minimal = {
   id: "minimal-player-content-response-format",
@@ -721,4 +722,175 @@ test("view trigger once when moving between views", async () => {
   await vitest.waitFor(() => {
     expect(viewTap).toHaveBeenCalledOnce();
   });
+});
+
+test("prevents invalid data from being committed during action-driven backward navigation", async () => {
+  const player = new Player({
+    plugins: [new TrackBindingPlugin()],
+  });
+
+  player.hooks.validationController.tap("test", (validationProvider) => {
+    validationProvider.hooks.createValidatorRegistry.tap("test", (registry) => {
+      registry.register("minValue", (_context, value) => {
+        if (typeof value === "number" && value < 0) {
+          return {
+            message: "Amount must be non-negative",
+            severity: "error",
+          };
+        }
+      });
+    });
+  });
+
+  const flow = {
+    id: "schema-invalid-force-navigation",
+    schema: {
+      ROOT: {
+        someValue: {
+          type: "SomeType",
+          validation: [
+            {
+              type: "minValue",
+              severity: "error",
+              trigger: "change",
+            },
+          ],
+        },
+      },
+    },
+    views: [
+      {
+        id: "input-view",
+        type: "info",
+        fields: {
+          asset: {
+            id: "input-fields",
+            type: "collection",
+            values: [
+              {
+                asset: {
+                  id: "some-input",
+                  type: "input",
+                  binding: "someValue",
+                },
+              },
+            ],
+          },
+        },
+        actions: [
+          {
+            asset: {
+              id: "back-action",
+              type: "action",
+              value: "previous",
+              label: {
+                asset: {
+                  id: "back-label",
+                  type: "text",
+                  value: "Back",
+                },
+              },
+            },
+          },
+        ],
+      },
+      {
+        id: "result-view",
+        type: "info",
+        title: {
+          asset: {
+            id: "result-title",
+            type: "text",
+            value: "Result",
+          },
+        },
+        primaryInfo: {
+          asset: {
+            id: "result-text",
+            type: "text",
+            value: "Leaked value: {{someValue}}",
+          },
+        },
+      },
+    ],
+    navigation: {
+      BEGIN: "FLOW_1",
+      FLOW_1: {
+        startState: "VIEW_INPUT",
+        VIEW_INPUT: {
+          state_type: "VIEW",
+          ref: "input-view",
+          transitions: {
+            previous: "ACTION_BACK",
+          },
+        },
+        ACTION_BACK: {
+          state_type: "ACTION",
+          exp: "{{unrelated}} = 'touched'",
+          transitions: {
+            "*": "VIEW_RESULT",
+          },
+        },
+        VIEW_RESULT: {
+          state_type: "VIEW",
+          ref: "result-view",
+          transitions: {
+            "*": "END_done",
+          },
+        },
+        END_done: {
+          state_type: "END",
+          outcome: "done",
+        },
+      },
+    },
+  };
+
+  player.start(flow as any);
+
+  await vitest.waitFor(() => {
+    const state = player.getState() as InProgressState;
+    return (
+      state?.controllers?.flow?.current?.currentState?.name === "VIEW_INPUT"
+    );
+  });
+
+  let state = player.getState() as InProgressState;
+  expect(state.controllers.flow.current?.currentState?.name).toBe("VIEW_INPUT");
+
+  // Simulate entering invalid data
+  state.controllers.data.set([["someValue", -1]]);
+
+  // The invalid data should be rejected and only available in the shadow model
+  expect(state.controllers.data.get("someValue")).toBeUndefined();
+  expect(
+    state.controllers.data.get("someValue", { includeInvalid: true }),
+  ).toBe(-1);
+
+  // Ensure normal navigation is blocked
+  state.controllers.flow.current?.transition("previous");
+
+  let currentState = player.getState() as InProgressState;
+  expect(currentState?.controllers?.flow?.current?.currentState?.name).toBe(
+    "VIEW_INPUT",
+  );
+
+  // Simulate forcing back navigation (bypassing validation)
+  state.controllers.flow.current?.transition("previous", { force: true });
+
+  currentState = player.getState() as InProgressState;
+  expect(currentState?.controllers?.flow?.current?.currentState?.name).toBe(
+    "VIEW_RESULT",
+  );
+
+  state = player.getState() as InProgressState;
+
+  // The invalid data should NOT be committed to the main model because of the transition
+  const finalValue = state.controllers.data.get("someValue");
+  expect(finalValue).toBeUndefined();
+  // But it should still be in the shadow/invalid model
+  const shadowValue = state.controllers.data.get("someValue", {
+    includeInvalid: true,
+  });
+  expect(shadowValue).toBe(-1);
 });

--- a/core/player/src/controllers/validation/controller.ts
+++ b/core/player/src/controllers/validation/controller.ts
@@ -420,6 +420,7 @@ export class ValidationController implements BindingTracker {
   private viewValidationProvider?: ValidationProvider;
   private options?: SimpleValidatorContext;
   private weakBindingTracker = new Set<BindingInstance>();
+  private validationMiddleware?: ValidationMiddleware;
 
   constructor(schema: SchemaController, options?: SimpleValidatorContext) {
     this.schema = schema;
@@ -433,6 +434,55 @@ export class ValidationController implements BindingTracker {
 
   /** Return the middleware for the data-model to stop propagation of invalid data */
   public getDataMiddleware(): Array<DataModelMiddleware> {
+    const validationMiddleware = new ValidationMiddleware(
+      (binding) => {
+        if (!this.options) {
+          return;
+        }
+
+        this.updateValidationsForBinding(binding, "change", this.options);
+        const strongValidation = this.getValidationForBinding(binding);
+
+        // return validation issues directly on bindings first
+        if (strongValidation?.get()?.severity === "error") {
+          return strongValidation.get();
+        }
+
+        // if none, check to see any validations this binding may be a weak ref of and return
+        const newInvalidBindings: Set<StrongOrWeakBinding> = new Set();
+        this.validations.forEach((weakValidation, strongBinding) => {
+          if (
+            caresAboutDataChanges(
+              new Set([binding]),
+              weakValidation.weakBindings,
+            ) &&
+            weakValidation?.get()?.severity === "error"
+          ) {
+            weakValidation?.weakBindings.forEach((weakBinding) => {
+              if (weakBinding === strongBinding) {
+                newInvalidBindings.add({
+                  binding: weakBinding,
+                  isStrong: true,
+                });
+              } else {
+                newInvalidBindings.add({
+                  binding: weakBinding,
+                  isStrong: false,
+                });
+              }
+            });
+          }
+        });
+
+        if (newInvalidBindings.size > 0) {
+          return newInvalidBindings;
+        }
+      },
+      { logger: new ProxyLogger(() => this.options?.logger) },
+    );
+
+    this.validationMiddleware = validationMiddleware;
+
     return [
       {
         set: (transaction, options, next) => {
@@ -450,52 +500,7 @@ export class ValidationController implements BindingTracker {
           return next?.delete(binding, options);
         },
       },
-      new ValidationMiddleware(
-        (binding) => {
-          if (!this.options) {
-            return;
-          }
-
-          this.updateValidationsForBinding(binding, "change", this.options);
-          const strongValidation = this.getValidationForBinding(binding);
-
-          // return validation issues directly on bindings first
-          if (strongValidation?.get()?.severity === "error") {
-            return strongValidation.get();
-          }
-
-          // if none, check to see any validations this binding may be a weak ref of and return
-          const newInvalidBindings: Set<StrongOrWeakBinding> = new Set();
-          this.validations.forEach((weakValidation, strongBinding) => {
-            if (
-              caresAboutDataChanges(
-                new Set([binding]),
-                weakValidation.weakBindings,
-              ) &&
-              weakValidation?.get()?.severity === "error"
-            ) {
-              weakValidation?.weakBindings.forEach((weakBinding) => {
-                if (weakBinding === strongBinding) {
-                  newInvalidBindings.add({
-                    binding: weakBinding,
-                    isStrong: true,
-                  });
-                } else {
-                  newInvalidBindings.add({
-                    binding: weakBinding,
-                    isStrong: false,
-                  });
-                }
-              });
-            }
-          });
-
-          if (newInvalidBindings.size > 0) {
-            return newInvalidBindings;
-          }
-        },
-        { logger: new ProxyLogger(() => this.options?.logger) },
-      ),
+      validationMiddleware,
     ];
   }
 
@@ -533,10 +538,11 @@ export class ValidationController implements BindingTracker {
   public reset() {
     this.validations.clear();
     this.tracker = undefined;
+    this.validationMiddleware?.reset();
   }
 
   public onView(view: ViewInstance): void {
-    this.validations.clear();
+    this.reset();
     if (!this.options) {
       return;
     }

--- a/core/player/src/validator/validation-middleware.ts
+++ b/core/player/src/validator/validation-middleware.ts
@@ -163,4 +163,9 @@ export class ValidationMiddleware implements DataModelMiddleware {
 
     return next?.delete(binding, options);
   }
+
+  /** Clears any invalid values staged in the shadow model */
+  public reset(): void {
+    this.shadowModelPaths.clear();
+  }
 }


### PR DESCRIPTION
Invalid data could be committed to the data model during forced transitions. When an invalid value was set, it was correctly held in the shadow model and kept out of the real data model. However, if the flow transitioned through a non `VIEW` state (like an `ACTION` node evaluating an expression) or moved directly to another view, the `ValidationController` cleared its binding-validation tracking but left the shadow-staged invalid values untouched. Since the validator's "is this binding still invalid?" check depended entirely on that now-cleared tracking state, the previously-invalid value looked "valid" again, and it would get silently flushed into the real model on the next unrelated data.set() call. 

The fix makes `ValidationController` hold a reference to its `ValidationMiddleware` instance and clears its shadow model whenever validation tracking is reset, so invalid data is discarded consistently instead of leaking through on the next incidental data change.


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

## Release Notes
Stop invalid data from leaking into model with unrelated data sets after a forced navigation. 