### PR TITLE
Use `rules_player`  2.6.6

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,10 +6,10 @@ module(
 bazel_dep(name = "rules_player")
 
 archive_override(
-    module_name = "rules_player",
-    strip_prefix = "rules_player-2.6.4",
-    urls = ["https://github.com/player-ui/rules_player/archive/refs/tags/v2.6.4.tar.gz"],
-    integrity = "sha256-wJBbNBVzoZ35sOmmM+AM+blOAWYm16f421BiI/uGN0M=",
+  module_name = "rules_player",
+  strip_prefix = "rules_player-2.6.6",
+  urls = ["https://github.com/player-ui/rules_player/archive/refs/tags/v2.6.6.tar.gz"],
+  integrity = "sha256-cq7zADROKkgDXuFzAezCova+0FiL3meIyx30iZEd/pc="
 )
 
 bazel_dep(name = "platforms", version = "1.1.0")


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->
To support ios hot fixes, upgrade to `rules_player` 2.6.6, https://github.com/player-ui/rules_player/pull/118, which ensures that releases, including hot fixes, get the exact contents of the zip file generated for publishing. (i.e. Will not unexpectedly gain files from `main`.)

You can see the difference by comparing [the canary's zip from this PR](https://github.com/player-ui/playerui-swift-package/releases/tag/1.0.2--canary.906.39719) with [this other 1.0 canary from prior to this PR](https://github.com/player-ui/playerui-swift-package/releases/tag/1.0.2--canary.909.39732). The one from this PR doesn't have a `Podspec` file, while the other does. We got rid of the `Podspec` file a long time ago when we dropped Cocoapods support, but the file was still coming in from `main` in the ios release repo.

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
- [x] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.2--canary.906.39849</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 1.0.2--canary.906.39849
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
