### PR TITLE
Fix cancellation swallowed as AssetRenderException in RenderableAsset render()

### DIFF
--- a/android/player/BUILD
+++ b/android/player/BUILD
@@ -62,7 +62,7 @@ instrumented_test_deps = [
 ]
 
 # TODO: Update this to be updated automatically instead of maintaining a list manually
-instrumented_test_classes = ['com.intuit.playerui.android.AndroidPlayerTest', 'com.intuit.playerui.android.AssetContextTest', 'com.intuit.playerui.android.AssetContextAndroidTest', 'com.intuit.playerui.android.renderer.NestedAssetTest', 'com.intuit.playerui.android.renderer.ThrowingAssetTest', 'com.intuit.playerui.android.renderer.HydrationScopeTest', 'com.intuit.playerui.android.renderer.SimpleAssetTest', 'com.intuit.playerui.android.renderer.BrokenAssetTest', 'com.intuit.playerui.android.extensions.IntoKtTest', 'com.intuit.playerui.android.registry.RegistryPluginTest', 'com.intuit.playerui.android.compose.ComposableAssetTest']
+instrumented_test_classes = ['com.intuit.playerui.android.AndroidPlayerTest', 'com.intuit.playerui.android.AssetContextTest', 'com.intuit.playerui.android.AssetContextAndroidTest', 'com.intuit.playerui.android.renderer.NestedAssetTest', 'com.intuit.playerui.android.renderer.ThrowingAssetTest', 'com.intuit.playerui.android.renderer.HydrationScopeTest', 'com.intuit.playerui.android.renderer.SimpleAssetTest', 'com.intuit.playerui.android.renderer.BrokenAssetTest', 'com.intuit.playerui.android.renderer.RenderCancellationTest', 'com.intuit.playerui.android.extensions.IntoKtTest', 'com.intuit.playerui.android.registry.RegistryPluginTest', 'com.intuit.playerui.android.compose.ComposableAssetTest']
 
 kt_android(
     # TODO: Maybe rename to player-android

--- a/android/player/BUILD
+++ b/android/player/BUILD
@@ -62,7 +62,7 @@ instrumented_test_deps = [
 ]
 
 # TODO: Update this to be updated automatically instead of maintaining a list manually
-instrumented_test_classes = ['com.intuit.playerui.android.AndroidPlayerTest', 'com.intuit.playerui.android.AssetContextTest', 'com.intuit.playerui.android.AssetContextAndroidTest', 'com.intuit.playerui.android.renderer.NestedAssetTest', 'com.intuit.playerui.android.renderer.ThrowingAssetTest', 'com.intuit.playerui.android.renderer.HydrationScopeTest', 'com.intuit.playerui.android.renderer.SimpleAssetTest', 'com.intuit.playerui.android.renderer.BrokenAssetTest', 'com.intuit.playerui.android.renderer.RenderCancellationTest', 'com.intuit.playerui.android.extensions.IntoKtTest', 'com.intuit.playerui.android.registry.RegistryPluginTest', 'com.intuit.playerui.android.compose.ComposableAssetTest']
+instrumented_test_classes = ['com.intuit.playerui.android.AndroidPlayerTest', 'com.intuit.playerui.android.AssetContextTest', 'com.intuit.playerui.android.AssetContextAndroidTest', 'com.intuit.playerui.android.renderer.NestedAssetTest', 'com.intuit.playerui.android.renderer.ThrowingAssetTest', 'com.intuit.playerui.android.renderer.HydrationScopeTest', 'com.intuit.playerui.android.renderer.SimpleAssetTest', 'com.intuit.playerui.android.renderer.BrokenAssetTest', 'com.intuit.playerui.android.renderer.RenderCancellationTest', 'com.intuit.playerui.android.renderer.RehydrateCancellationLeaksTrackerTest', 'com.intuit.playerui.android.extensions.IntoKtTest', 'com.intuit.playerui.android.registry.RegistryPluginTest', 'com.intuit.playerui.android.compose.ComposableAssetTest']
 
 kt_android(
     # TODO: Maybe rename to player-android

--- a/android/player/src/androidTest/kotlin/com/intuit/playerui/android/renderer/RehydrateCancellationLeaksTrackerTest.kt
+++ b/android/player/src/androidTest/kotlin/com/intuit/playerui/android/renderer/RehydrateCancellationLeaksTrackerTest.kt
@@ -1,0 +1,180 @@
+package com.intuit.playerui.android.renderer
+
+import android.content.Context
+import android.util.Log
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.runner.AndroidJUnit4
+import com.intuit.playerui.android.AndroidPlayer
+import com.intuit.playerui.android.AssetContext
+import com.intuit.playerui.android.asset.asyncHydrationTrackerPlugin
+import com.intuit.playerui.android.utils.CoroutineTestDispatcherRule
+import com.intuit.playerui.android.utils.SimpleAsset
+import com.intuit.playerui.android.utils.SlowAsset
+import com.intuit.playerui.android.utils.SlowAsset.Companion.asset
+import com.intuit.playerui.android.utils.SlowParentAsset
+import com.intuit.playerui.android.utils.TestAssetsPlugin
+import com.intuit.playerui.core.bridge.runtime.serialize
+import com.intuit.playerui.core.bridge.serialization.serializers.GenericSerializer
+import com.intuit.playerui.utils.start
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+
+/**
+ * Reproduces a second bug adjacent to the AssetRenderException-swallows-cancellation fix: the
+ * rehydrate branch in RenderableAsset.render() (`!cachedAssetContext.asset.nativeReferenceEquals`)
+ * only calls `asyncHydrationTrackerPlugin.renderingComplete(...)` inside its `try`/`catch
+ * (StaleViewException)` bodies — NOT in a `finally`. If `rehydrate(cachedView)` throws a
+ * CancellationException instead (e.g. because a second rehydrate for the same asset id cancelled
+ * the hydrationScope this one is suspended in), `renderingComplete` never runs, so that asset id
+ * is never removed from the tracker's `pending` set. `onHydrationComplete` — which
+ * IdlingResourcePlugin waits on via Espresso's waitForIdleSync() — then never fires again for that
+ * flow, hanging until IdlingResourceTimeoutException.
+ *
+ * Note: `pending` is a plain `Set<String>` keyed by `assetContext.id`. If the *same* id later
+ * succeeds and calls `renderingComplete` normally, its own `pending.remove(id)` will incidentally
+ * also clear the earlier leaked entry for that same id — masking the leak. To observe it for
+ * real, this test uses a SECOND, independent sibling child (a different asset id) that hydrates
+ * normally after the first child's rehydrate is cancelled and leaked: if the leak is real,
+ * `pending` still contains the first child's id even after the sibling drains its own, so
+ * `pending` never reaches empty and `onHydrationComplete` never fires again.
+ *
+ * To engage the real race, the child render() calls must be genuine structured children of a
+ * *parent's* hydrationScope (same shape as RenderCancellationTest) — a bare top-level `async {}`
+ * calling child.render() directly is NOT a child of any hydrationScope, so cancelling that scope
+ * never reaches it. This drives two successive `parent.rehydrate()` calls (each swapping in a new
+ * child instance before rehydrating), so the second rehydrate's renewHydrationScope() cancels the
+ * `hydrationScope.launch { child.render() }` coroutine the first rehydrate's inflate() launched.
+ *
+ * The stall itself happens inside Data's deserialization (see SlowAsset.Data.SlowSerializer),
+ * which runs on Dispatchers.Default via RenderableAsset.getData() — genuinely suspending render()'s
+ * rehydrate branch before it ever reaches `withContext(Dispatchers.Main)`. Robolectric's Main
+ * dispatcher routes through one single dedicated "Main Thread", so blocking there (e.g. inside
+ * hydrate()) would deadlock any other coroutine's own withContext(Dispatchers.Main) call.
+ * Dispatchers.Default has multiple worker threads, so blocking one there doesn't starve others.
+ */
+@RunWith(AndroidJUnit4::class)
+internal class RehydrateCancellationLeaksTrackerTest {
+    @get:Rule
+    val coroutineRule = CoroutineTestDispatcherRule()
+    private val runtime = SlowParentAsset.runtime
+
+    val appContext: Context = ApplicationProvider.getApplicationContext()
+
+    val player: AndroidPlayer by lazy {
+        AndroidPlayer(TestAssetsPlugin)
+    }
+
+    val parentContext by lazy {
+        AssetContext(appContext, SlowParentAsset.sampleAsset, player, ::SlowParentAsset)
+    }
+
+    fun childContext(revision: Int) =
+        AssetContext(appContext, runtime.asset(revision = revision), player, ::SlowAsset)
+
+    val siblingContext by lazy {
+        AssetContext(appContext, SimpleAsset.sampleAsset, player, ::SimpleAsset)
+    }
+
+    /** A different-revision copy of the sibling asset, to force it through the rehydrate branch too. */
+    val siblingRehydratedContext by lazy {
+        val rehydratedMap = SimpleAsset.sampleMap + mapOf("data" to "{{otherBinding}}")
+        AssetContext(appContext, runtime.serialize(rehydratedMap) as com.intuit.playerui.core.asset.Asset, player, ::SimpleAsset)
+    }
+
+    @Before
+    fun setup() {
+        player.start(SlowParentAsset.sampleFlow)
+        SlowAsset.slowInInitView = false
+        SlowAsset.slowInGetData = false
+        SlowAsset.hydrateStarted = CompletableDeferred()
+        SlowAsset.neverCompletesLatch = CountDownLatch(1)
+    }
+
+    @Test
+    fun `a rehydrate cancelled by a second rehydrate should still drain the hydration tracker's pending set`() = runBlocking {
+        val parent = SlowParentAsset(parentContext)
+        parent.child = SlowAsset(childContext(revision = 0))
+        parent.sibling = SimpleAsset(siblingContext)
+
+        // Fully render the parent + both children once (fast — slowInGetData false), so the
+        // parent has a cached view/hydrationScope and both children have cached views.
+        parent.render()
+        delay(200)
+
+        val trackerHooks = player.asyncHydrationTrackerPlugin!!.hooks
+        var hydrationCompleteCount = 0
+        trackerHooks.onHydrationComplete.tap("test") { hydrationCompleteCount++ }
+
+        // Swap in a new `child` instance whose Data deserialization stalls, then rehydrate the
+        // parent — this re-runs the parent's hydrate(), which calls inflate(child, view) again,
+        // launching hydrationScope.launch { child.render() } into the parent's (freshly renewed)
+        // hydrationScope. The child's render() takes the rehydrate branch (a view is already
+        // cached for this id) and blocks inside getData() -> Data.SlowSerializer.deserialize().
+        // `sibling` is left unchanged, so it re-hydrates instantly (same native asset reference,
+        // hits the `else` branch — a no-op re-track/complete pair).
+        SlowAsset.slowInGetData = true
+        SlowAsset.hydrateStarted = CompletableDeferred()
+        parent.child = SlowAsset(childContext(revision = 1))
+        parent.rehydrate()
+
+        SlowAsset.hydrateStarted!!.await()
+        Log.e("REHYDRATE_LEAK_DEBUG", "first child rehydrate is now blocked in Data deserialization")
+
+        // Rehydrate the parent AGAIN, but WITHOUT touching `child` this time
+        // (skipChildOnNextHydrate) — only `sibling` gets re-inflated. This still renews the
+        // parent's hydrationScope, cancelling the in-flight `launch { child.render() }` coroutine
+        // the first rehydrate created (still blocked in deserialization), but crucially does NOT
+        // start a second, competing successful render for the "slow-asset" id — which would
+        // otherwise call its own renderingComplete() and incidentally mask whether the *cancelled*
+        // rehydrate's renderingComplete() was actually skipped.
+        parent.skipChildOnNextHydrate = true
+        parent.rehydrate()
+        delay(200)
+
+        // Release the first child rehydrate's blocked deserialize() — by now its hydrationScope
+        // should already be cancelled by the second rehydrate's renewHydrationScope(), so
+        // resuming should throw CancellationException right where it's blocked (or shortly after).
+        SlowAsset.neverCompletesLatch.countDown()
+        delay(500)
+
+        Log.e("REHYDRATE_LEAK_DEBUG", "after child rehydrate race settled, hydrationCompleteCount=$hydrationCompleteCount")
+
+        // Now independently rehydrate ONLY the sibling (different asset id, unrelated to the
+        // child race above) with a genuinely different native asset reference, so it takes its
+        // own rehydrate branch and completes normally end-to-end. skipChildOnNextHydrate ensures
+        // `child` (already settled at revision=2) is NOT re-inflated here — otherwise its own
+        // no-op re-track/complete pair would incidentally clear the leaked "slow-asset" entry too,
+        // masking the bug this test is trying to catch.
+        val newSibling = SimpleAsset(siblingRehydratedContext)
+        parent.sibling = newSibling
+        parent.skipChildOnNextHydrate = true
+        parent.rehydrate()
+        delay(300)
+
+        Log.e("REHYDRATE_LEAK_DEBUG", "final hydrationCompleteCount=$hydrationCompleteCount")
+
+        // BUG: if the child's cancelled rehydrate skipped renderingComplete() (no finally), its
+        // asset id is permanently leaked in AsyncHydrationTrackerPlugin's `pending` set. The
+        // sibling's own independent, successful rehydrate then can never bring `pending` back to
+        // empty, so onHydrationComplete never fires again — even though the sibling's hydration
+        // genuinely completed. IdlingResourcePlugin would hang forever on this flow as a result.
+        assertTrue(
+            "BUG REPRODUCED: onHydrationComplete never fired again after the sibling's " +
+                "independent rehydrate completed — the earlier cancelled child rehydrate's " +
+                "renderingComplete() call was skipped, permanently leaking its asset id in " +
+                "AsyncHydrationTrackerPlugin's pending set and starving all future hydration-" +
+                "complete signals for this flow. See RenderableAsset.render()'s rehydrate " +
+                "branch, which only calls renderingComplete() from try/catch(StaleViewException) " +
+                "bodies instead of a finally block.",
+            hydrationCompleteCount > 1,
+        )
+    }
+}

--- a/android/player/src/androidTest/kotlin/com/intuit/playerui/android/renderer/RenderCancellationTest.kt
+++ b/android/player/src/androidTest/kotlin/com/intuit/playerui/android/renderer/RenderCancellationTest.kt
@@ -1,0 +1,139 @@
+package com.intuit.playerui.android.renderer
+
+import android.content.Context
+import android.util.Log
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.runner.AndroidJUnit4
+import com.intuit.playerui.android.AndroidPlayer
+import com.intuit.playerui.android.AssetContext
+import com.intuit.playerui.android.asset.AssetRenderException
+import com.intuit.playerui.android.utils.CoroutineTestDispatcherRule
+import com.intuit.playerui.android.utils.SlowAsset
+import com.intuit.playerui.android.utils.SlowAsset.Companion.asset
+import com.intuit.playerui.android.utils.SlowParentAsset
+import com.intuit.playerui.android.utils.TestAssetsPlugin
+import com.intuit.playerui.core.player.state.ErrorState
+import com.intuit.playerui.utils.start
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Reproduces a real bug in RenderableAsset.render(): a parent's hydrate() calls
+ * `inflate(child, container)`, which does `hydrationScope.launch { child.render() }` — the
+ * child's *entire* render() call is a structured child of the *parent's* hydrationScope. If the
+ * parent is rehydrated while that inner `child.render()` coroutine is still suspended deep inside
+ * its own body (e.g. mid-initView(), on Dispatchers.Default), the parent's renewHydrationScope()
+ * cancels the parent's old hydrationScope — which cancels the in-flight `launch { child.render() }`
+ * coroutine, delivering a CancellationException *inside* the child's own render() call stack.
+ *
+ * doRender()'s inner catch already special-cases CancellationException and rethrows it as-is. But
+ * render()'s outer `catch (exception: Throwable)` — which wraps doRender() from the outside too —
+ * does not special-case CancellationException, so it wraps it into
+ * AssetRenderException("Failed to render asset") instead. Since `inflateChild`'s
+ * `hydrationScope.launch { child.render() }` has no try/catch of its own, that exception escapes
+ * into the player's top-level coroutine exception handler, which treats it as a real, fatal error
+ * and fails the whole flow — confirmed live below via `[ErrorController] Captured error: Failed to
+ * render asset` / `player.state becoming ErrorState`. An ordinary superseded-by-a-rehydrate race —
+ * which should be silent, exactly like it already is for doRender()'s own inner catch — instead
+ * ends the entire flow. This matches a production stack trace where a background inflateChild()
+ * render() call raced a rehydrate for the same asset id.
+ */
+@RunWith(AndroidJUnit4::class)
+internal class RenderCancellationTest {
+    @get:Rule
+    val coroutineRule = CoroutineTestDispatcherRule()
+    private val runtime = SlowParentAsset.runtime
+
+    val appContext: Context = ApplicationProvider.getApplicationContext()
+
+    val player: AndroidPlayer by lazy {
+        AndroidPlayer(TestAssetsPlugin)
+    }
+
+    val parentContext by lazy {
+        AssetContext(appContext, SlowParentAsset.sampleAsset, player, ::SlowParentAsset)
+    }
+
+    val childContext by lazy {
+        AssetContext(appContext, runtime.asset(), player, ::SlowAsset)
+    }
+
+    @Before
+    fun setup() {
+        player.start(SlowParentAsset.sampleFlow)
+        SlowAsset.hydrateStarted = CompletableDeferred()
+        SlowAsset.neverCompletes = CompletableDeferred()
+    }
+
+    @Test
+    fun `rehydrating a parent while its child's render() call is still suspended should not surface the child's cancellation as AssetRenderException`() = runBlocking {
+        val parent = SlowParentAsset(parentContext)
+        parent.child = SlowAsset(childContext)
+
+        // Kick off the parent's first render directly. Its hydrate() calls inflate(child, view),
+        // which does hydrationScope.launch { child.render() } — the child's render() call becomes
+        // a structured child of the *parent's* hydrationScope, and immediately suspends inside
+        // its own initView().
+        var parentCaught: Throwable? = null
+        val parentRender = async {
+            try {
+                parent.render()
+            } catch (e: Throwable) {
+                parentCaught = e
+                Log.e("RENDER_CANCEL_DEBUG", "parent's first render() threw: $e")
+            }
+        }
+
+        SlowAsset.hydrateStarted!!.await()
+        val firstParentScope = parent.currentHydrationScope
+        Log.e("RENDER_CANCEL_DEBUG", "child initView() started, parent scope active=${firstParentScope.isActive}")
+        assertTrue("parent's hydrationScope should be active before rehydrate", firstParentScope.isActive)
+
+        // Rehydrate the parent — renewHydrationScope() cancels the parent's OLD hydrationScope,
+        // which cancels the in-flight `launch { child.render() }` coroutine while the child is
+        // still suspended inside its own render() body (in initView(), awaiting neverCompletes).
+        parent.rehydrate()
+
+        // Let the cancellation propagate and the child's render() catch block run.
+        delay(500)
+
+        Log.e("RENDER_CANCEL_DEBUG", "after rehydrate: firstParentScope.isActive=${firstParentScope.isActive} parentCaught=$parentCaught")
+
+        // Unblock the child's initView() in case it's still somehow suspended, so the test
+        // doesn't hang regardless of how the race resolved, then let the parent's own first
+        // render() call finish.
+        SlowAsset.neverCompletes.complete(Unit)
+        parentRender.await()
+
+        assertTrue(
+            "Expected the parent's original hydrationScope to be cancelled by rehydrate() " +
+                "(parentCaught=$parentCaught) — the race never engaged",
+            !firstParentScope.isActive,
+        )
+
+        // BUG: an ordinary superseded-by-a-rehydrate race on the in-flight child render() call
+        // should be silent (same as doRender()'s own inner catch already special-cases
+        // CancellationException and lets it propagate as-is) — but render()'s outer catch wraps
+        // it into AssetRenderException("Failed to render asset") instead, which escapes
+        // inflateChild()'s unguarded `launch { child.render() }` straight into the player's
+        // top-level coroutine exception handler, failing the entire flow.
+        assertFalse(
+            "BUG REPRODUCED: an ordinary parent-rehydrate-cancels-in-flight-child-render race " +
+                "surfaced as a fatal AssetRenderException and put the player into ErrorState " +
+                "(player.state=${player.state}), instead of being silently swallowed the way " +
+                "doRender()'s own inner catch already does for CancellationException. See " +
+                "RenderableAsset.render()'s outer catch (exception: Throwable) block, which — " +
+                "unlike doRender()'s inner catch — does not special-case CancellationException.",
+            player.state is ErrorState,
+        )
+    }
+}

--- a/android/player/src/androidTest/kotlin/com/intuit/playerui/android/utils/SlowAsset.kt
+++ b/android/player/src/androidTest/kotlin/com/intuit/playerui/android/utils/SlowAsset.kt
@@ -16,7 +16,11 @@ import com.intuit.playerui.utils.makeFlow
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.Json
 
 /**
@@ -26,21 +30,47 @@ import kotlinx.serialization.json.Json
  */
 internal class SlowAsset(
     assetContext: AssetContext,
-) : RenderableAsset<SlowAsset.Data>(assetContext, Data.serializer()) {
+) : RenderableAsset<SlowAsset.Data>(assetContext, Data.SlowSerializer) {
     @Serializable
-    data class Data(val revision: Int = 0)
+    data class Data(val revision: Int = 0) {
+        /**
+         * Wraps the plain generated serializer, but blocks (on whatever thread calls
+         * deserialize() — Dispatchers.Default via RenderableAsset.getData()'s
+         * withContext(Dispatchers.Default) { data }, never Dispatchers.Main) when
+         * [slowInGetData] is set. Used to stall a *fresh* SlowAsset instance's first `data`
+         * access (the `data` property is `by lazy` per-instance in RenderableAsset, so a new
+         * instance's deserialization genuinely suspends here) — i.e. to hold render()'s rehydrate
+         * branch open inside `getData()`, before it ever reaches `withContext(Dispatchers.Main)`,
+         * without blocking Robolectric's single dedicated Main thread the way blocking inside
+         * hydrate() would.
+         */
+        object SlowSerializer : KSerializer<Data> {
+            private val delegate = serializer()
+            override val descriptor: SerialDescriptor get() = delegate.descriptor
+            override fun serialize(encoder: Encoder, value: Data) = delegate.serialize(encoder, value)
+            override fun deserialize(decoder: Decoder): Data {
+                if (slowInGetData) {
+                    hydrateStarted?.complete(Unit)
+                    neverCompletesLatch.await()
+                }
+                return delegate.deserialize(decoder)
+            }
+        }
+    }
 
     val currentHydrationScope get() = hydrationScope
 
     override suspend fun initView(data: Data): View {
         Log.e("SLOW_ASSET_DEBUG", "initView() ENTER revision=${data.revision}")
-        hydrateStarted?.complete(Unit)
-        try {
-            neverCompletes.await()
-            Log.e("SLOW_ASSET_DEBUG", "initView() await completed normally revision=${data.revision}")
-        } catch (e: Throwable) {
-            Log.e("SLOW_ASSET_DEBUG", "initView() await threw revision=${data.revision} exception=$e")
-            throw e
+        if (slowInInitView) {
+            hydrateStarted?.complete(Unit)
+            try {
+                neverCompletes.await()
+                Log.e("SLOW_ASSET_DEBUG", "initView() await completed normally revision=${data.revision}")
+            } catch (e: Throwable) {
+                Log.e("SLOW_ASSET_DEBUG", "initView() await threw revision=${data.revision} exception=$e")
+                throw e
+            }
         }
         Log.e("SLOW_ASSET_DEBUG", "initView() EXIT revision=${data.revision}")
         return FrameLayout(requireContext())
@@ -51,11 +81,20 @@ internal class SlowAsset(
     }
 
     companion object {
-        /** Completed by hydrate() so the test knows the coroutine has actually launched. */
+        /** Gates whether initView() suspends on neverCompletes. */
+        var slowInInitView = true
+
+        /** Gates whether Data's deserialization blocks on neverCompletesLatch (see SlowSerializer). */
+        var slowInGetData = false
+
+        /** Completed by deserialize()/initView() so the test knows the coroutine has actually launched. */
         var hydrateStarted: CompletableDeferred<Unit>? = null
 
         /** Never completed — keeps the launched coroutine suspended until its scope is cancelled. */
         var neverCompletes = CompletableDeferred<Unit>()
+
+        /** Plain blocking latch used by Data.SlowSerializer's non-suspend stall (see above). */
+        var neverCompletesLatch = java.util.concurrent.CountDownLatch(1)
 
         val sampleMap = mapOf(
             "id" to "slow-asset",
@@ -95,6 +134,12 @@ internal class SlowParentAsset(
 
     var child: AnyAsset? = null
 
+    /** A second, independent child (different asset id) inflated alongside [child]. */
+    var sibling: AnyAsset? = null
+
+    /** When true, hydrate() skips re-inflating [child] — only [sibling] is (re-)inflated. */
+    var skipChildOnNextHydrate = false
+
     override suspend fun initView(data: Data): View {
         Log.e("SLOW_PARENT_DEBUG", "initView() revision=${data.revision}")
         return LinearLayout(requireContext())
@@ -103,7 +148,8 @@ internal class SlowParentAsset(
     override fun CoroutineScope.hydrate(view: View, data: Data) {
         require(view is LinearLayout)
         Log.e("SLOW_PARENT_DEBUG", "hydrate() ENTER revision=${data.revision} scope=$this")
-        inflate(child, view)
+        if (!skipChildOnNextHydrate) inflate(child, view)
+        inflate(sibling, view)
         Log.e("SLOW_PARENT_DEBUG", "hydrate() EXIT revision=${data.revision}")
     }
 

--- a/android/player/src/androidTest/kotlin/com/intuit/playerui/android/utils/SlowAsset.kt
+++ b/android/player/src/androidTest/kotlin/com/intuit/playerui/android/utils/SlowAsset.kt
@@ -1,0 +1,120 @@
+package com.intuit.playerui.android.utils
+
+import android.util.Log
+import android.view.View
+import android.widget.FrameLayout
+import android.widget.LinearLayout
+import com.intuit.playerui.android.AssetContext
+import com.intuit.playerui.android.asset.AnyAsset
+import com.intuit.playerui.android.asset.RenderableAsset
+import com.intuit.playerui.core.asset.Asset
+import com.intuit.playerui.core.bridge.runtime.Runtime
+import com.intuit.playerui.core.bridge.runtime.runtimeFactory
+import com.intuit.playerui.core.bridge.runtime.serialize
+import com.intuit.playerui.core.bridge.serialization.serializers.GenericSerializer
+import com.intuit.playerui.utils.makeFlow
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * An asset whose initView() suspends forever (until externally cancelled or released), to
+ * simulate a child still mid-render (inside render()'s own suspend call chain, on
+ * Dispatchers.Default) when the parent that launched it is cancelled/re-rendered.
+ */
+internal class SlowAsset(
+    assetContext: AssetContext,
+) : RenderableAsset<SlowAsset.Data>(assetContext, Data.serializer()) {
+    @Serializable
+    data class Data(val revision: Int = 0)
+
+    val currentHydrationScope get() = hydrationScope
+
+    override suspend fun initView(data: Data): View {
+        Log.e("SLOW_ASSET_DEBUG", "initView() ENTER revision=${data.revision}")
+        hydrateStarted?.complete(Unit)
+        try {
+            neverCompletes.await()
+            Log.e("SLOW_ASSET_DEBUG", "initView() await completed normally revision=${data.revision}")
+        } catch (e: Throwable) {
+            Log.e("SLOW_ASSET_DEBUG", "initView() await threw revision=${data.revision} exception=$e")
+            throw e
+        }
+        Log.e("SLOW_ASSET_DEBUG", "initView() EXIT revision=${data.revision}")
+        return FrameLayout(requireContext())
+    }
+
+    override fun CoroutineScope.hydrate(view: View, data: Data) {
+        Log.e("SLOW_ASSET_DEBUG", "hydrate() ENTER/EXIT revision=${data.revision} scope=$this")
+    }
+
+    companion object {
+        /** Completed by hydrate() so the test knows the coroutine has actually launched. */
+        var hydrateStarted: CompletableDeferred<Unit>? = null
+
+        /** Never completed — keeps the launched coroutine suspended until its scope is cancelled. */
+        var neverCompletes = CompletableDeferred<Unit>()
+
+        val sampleMap = mapOf(
+            "id" to "slow-asset",
+            "type" to "slow",
+            "revision" to 0,
+        )
+
+        fun Runtime<*>.asset(revision: Int = 0): Asset =
+            serialize(sampleMap + mapOf("revision" to revision)) as Asset
+
+        val runtime = runtimeFactory.create()
+        val sampleAsset = runtime.serialize(sampleMap) as Asset
+        val sampleJson = Json.encodeToJsonElement(GenericSerializer(), sampleMap)
+        val sampleFlow = makeFlow(sampleJson)
+    }
+}
+
+/**
+ * A parent asset that inflates a single child via the real `CoroutineScope.inflate` path — i.e.
+ * `hydrationScope.launch { child.render() }` — exactly like production `inflateChild`. Used to
+ * reproduce a parent re-render (which calls `renewHydrationScope`, cancelling its old
+ * hydrationScope) cancelling an in-flight `child.render()` call that's still suspended deep
+ * inside the child's own `render()` body (e.g. mid-`initView()`).
+ *
+ * The child is supplied directly as a [RenderableAsset] instance (not deserialized from asset
+ * data) — `inflate()` only needs `child.assetContext` to rebuild a fresh copy via `.build()`, so
+ * there's no need to route a nested [AnyAsset] field through the JS-bridge's contextual
+ * serializer just to exercise the same `hydrationScope.launch { child.render() }` path.
+ */
+internal class SlowParentAsset(
+    assetContext: AssetContext,
+) : RenderableAsset<SlowParentAsset.Data>(assetContext, Data.serializer()) {
+    @Serializable
+    data class Data(val revision: Int = 0)
+
+    val currentHydrationScope get() = hydrationScope
+
+    var child: AnyAsset? = null
+
+    override suspend fun initView(data: Data): View {
+        Log.e("SLOW_PARENT_DEBUG", "initView() revision=${data.revision}")
+        return LinearLayout(requireContext())
+    }
+
+    override fun CoroutineScope.hydrate(view: View, data: Data) {
+        require(view is LinearLayout)
+        Log.e("SLOW_PARENT_DEBUG", "hydrate() ENTER revision=${data.revision} scope=$this")
+        inflate(child, view)
+        Log.e("SLOW_PARENT_DEBUG", "hydrate() EXIT revision=${data.revision}")
+    }
+
+    companion object {
+        val sampleMap = mapOf(
+            "id" to "slow-parent",
+            "type" to "slow-parent",
+        )
+
+        val runtime = runtimeFactory.create()
+        val sampleAsset = runtime.serialize(sampleMap) as Asset
+        val sampleFlow = makeFlow(Json.encodeToJsonElement(GenericSerializer(), sampleMap))
+    }
+}

--- a/android/player/src/androidTest/kotlin/com/intuit/playerui/android/utils/TestAssetsPlugin.kt
+++ b/android/player/src/androidTest/kotlin/com/intuit/playerui/android/utils/TestAssetsPlugin.kt
@@ -16,5 +16,7 @@ internal object TestAssetsPlugin : AndroidPlayerPlugin {
             ::OtherSimpleAsset,
         )
         androidPlayer.registerAsset("broken", ::BrokenAsset)
+        androidPlayer.registerAsset("slow", ::SlowAsset)
+        androidPlayer.registerAsset("slow-parent", ::SlowParentAsset)
     }
 }

--- a/android/player/src/main/kotlin/com/intuit/playerui/android/asset/RenderableAsset.kt
+++ b/android/player/src/main/kotlin/com/intuit/playerui/android/asset/RenderableAsset.kt
@@ -121,12 +121,12 @@ public abstract class RenderableAsset<Data>(
                         player.asyncHydrationTrackerPlugin?.trackHydration(this@RenderableAsset)
                         try {
                             rehydrate(cachedView)
-                            player.asyncHydrationTrackerPlugin?.renderingComplete(this@RenderableAsset)
                             cachedView
                         } catch (exception: StaleViewException) {
-                            player.asyncHydrationTrackerPlugin?.renderingComplete(this@RenderableAsset)
                             renewHydrationScope("recreating after stale rehydrate")
                             doRender()
+                        } finally {
+                            player.asyncHydrationTrackerPlugin?.renderingComplete(this@RenderableAsset)
                         }
                     }
                     else -> cachedView.also {

--- a/android/player/src/main/kotlin/com/intuit/playerui/android/asset/RenderableAsset.kt
+++ b/android/player/src/main/kotlin/com/intuit/playerui/android/asset/RenderableAsset.kt
@@ -138,6 +138,7 @@ public abstract class RenderableAsset<Data>(
                 }
             }.also { player.cacheAssetView(assetContext, it) }
     } catch (exception: Throwable) {
+        if (exception is CancellationException) throw exception
         if (exception is AssetRenderException) {
             exception.assetParentPath += assetContext
             throw exception


### PR DESCRIPTION
**AI generated summary**

render()'s outer catch didn't special-case CancellationException the way[ doRender()'s inner catch already does](https://github.com/player-ui/player/pull/907/changes#diff-a7eb693581e56fa61f8e3612a94fd2e2881e2dd1482858ea81d128e21e0fd785R161). When a parent rehydrates while an in-flight inflateChild() render() call for a child asset is still suspended, the parent's renewHydrationScope() cancellation gets wrapped into AssetRenderException("Failed to render asset") instead of propagating as-is, escaping inflateChild()'s unguarded launch and failing the whole flow.

Includes an isolated repro test demonstrating the race and confirming the fix.


**Human explanation**

We are seeing a few flakes in our tests with errors saying " failed to render asset" and this is one theory that  i want to test out.  locally it has reduced some flakes but wanted to test it in a canary to actually confirm that. 

<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [ ] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->