### PR TITLE
No ios lint on main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -696,10 +696,6 @@ workflows:
           requires:
             - bazelrc
 
-      - lint_ios:
-          requires:
-            - bazelrc
-
       - android_test:
           context:
             - Build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -633,10 +633,6 @@ workflows:
             - build
             - test
 
-      - lint_ios:
-          requires:
-            - bazelrc
-
       - android_test:
           context:
             - Build


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->
Wraps the CircleCI Lint step in a conditional block to run only when the pipeline is running on a non-main branch.


### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
- [x] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->

# Release Notes
Wraps the CircleCI Lint step in a conditional block to run only when the pipeline is running on a non-main branch.