### PR TITLE
Remove js-benchmarking from forked PR jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -588,15 +588,6 @@ workflows:
           requires:
             - build-trunk
 
-      - bench_js:
-          name: js-benchmark-tests-fork
-          filters:
-            branches:
-              only:
-                - /pull\/.*/
-          requires:
-            - build-fork
-
       - build_and_deploy_docs_preview:
           name: preview-docs-trunk
           context:


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

Removes js-benchmarking from forked PR jobs by getting rid of the `bench-js` job that runs the benchmark tests on forked PRs. JS Benchmark tests will never pass on a PR from a forked repo because forks don't have the secrets/contexts needed.

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
- [x] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->

# Release Notes
Removes `js-benchmarking` job from forked PRs (they will never pass because forks don't have the require secrets).