### PR TITLE
fix(async-node): preserve streamed async updates over stale hook results

### DIFF
--- a/plugins/async-node/core/src/__tests__/index.test.ts
+++ b/plugins/async-node/core/src/__tests__/index.test.ts
@@ -707,17 +707,7 @@ describe("view", () => {
       },
     );
 
-    let updateNumber = 0;
-
     const player = new Player({ plugins: [plugin] });
-
-    player.hooks.viewController.tap("async-node-test", (vc) => {
-      vc.hooks.view.tap("async-node-test", (view) => {
-        view.hooks.onUpdate.tap("async-node-test", () => {
-          updateNumber++;
-        });
-      });
-    });
 
     player.start(basicFRFWithActions as any);
 

--- a/plugins/async-node/core/src/__tests__/index.test.ts
+++ b/plugins/async-node/core/src/__tests__/index.test.ts
@@ -684,6 +684,153 @@ describe("view", () => {
     expect(view?.actions[1]).toBeUndefined();
   });
 
+  test("preserves callback-streamed content when the hook resolves with undefined", async () => {
+    // Regression: a streaming consumer pushes content through the callback while
+    // the hook is still pending, then resolves the hook with nothing. Previously
+    // the bail path re-parsed the undefined return (last-writer-wins) and
+    // reverted the streamed content back to the async placeholder.
+    let deferredResolve: ((value: any) => void) | undefined;
+    let updateContent: ((content: any) => void) | undefined;
+
+    const plugin = new AsyncNodePlugin({
+      plugins: [new AsyncNodePluginPlugin()],
+    });
+
+    plugin.hooks.onAsyncNode.tap(
+      "test",
+      async (_node: Node.Async, update: (content: any) => void) => {
+        updateContent = update;
+        // Resolve the hook with nothing; content is delivered via the callback.
+        return new Promise((resolve) => {
+          deferredResolve = resolve;
+        });
+      },
+    );
+
+    let updateNumber = 0;
+
+    const player = new Player({ plugins: [plugin] });
+
+    player.hooks.viewController.tap("async-node-test", (vc) => {
+      vc.hooks.view.tap("async-node-test", (view) => {
+        view.hooks.onUpdate.tap("async-node-test", () => {
+          updateNumber++;
+        });
+      });
+    });
+
+    player.start(basicFRFWithActions as any);
+
+    let view = (player.getState() as InProgressState).controllers.view
+      .currentView?.lastUpdate;
+
+    expect(view).toBeDefined();
+    expect(view?.actions[1]).toBeUndefined();
+
+    // Wait until the hook has run and handed us the streaming callback.
+    await waitFor(() => {
+      expect(updateContent).toBeDefined();
+      expect(deferredResolve).toBeDefined();
+    });
+
+    // Stream content through the callback while the hook promise is still pending.
+    updateContent?.({
+      asset: {
+        id: "next-label-action",
+        type: "action",
+        value: "streamed value",
+      },
+    });
+
+    await waitFor(() => {
+      view = (player.getState() as InProgressState).controllers.view.currentView
+        ?.lastUpdate;
+      expect(view?.actions[1]?.asset.type).toBe("action");
+    });
+
+    // Now resolve the hook with nothing. The streamed content must survive.
+    deferredResolve?.(undefined);
+
+    await waitFor(() => {
+      view = (player.getState() as InProgressState).controllers.view.currentView
+        ?.lastUpdate;
+      expect(view?.actions[1]?.asset.type).toBe("action");
+    });
+
+    view = (player.getState() as InProgressState).controllers.view.currentView
+      ?.lastUpdate;
+    expect(view?.actions[0].asset.type).toBe("action");
+    expect(view?.actions[1]?.asset.type).toBe("action");
+  });
+
+  test("callback-streamed content is not overwritten by a stale hook return value", async () => {
+    // Regression: a streaming consumer pushes content through the callback while
+    // the hook is still pending, then resolves the hook with a different (stale)
+    // value. The callback is the source of truth once used, so the bail return
+    // must not overwrite it — otherwise the streamed row is intermittently
+    // replaced by the stale content.
+    let deferredResolve: ((value: any) => void) | undefined;
+    let updateContent: ((content: any) => void) | undefined;
+
+    const plugin = new AsyncNodePlugin({
+      plugins: [new AsyncNodePluginPlugin()],
+    });
+
+    plugin.hooks.onAsyncNode.tap(
+      "test",
+      async (_node: Node.Async, update: (content: any) => void) => {
+        updateContent = update;
+        return new Promise((resolve) => {
+          deferredResolve = resolve;
+        });
+      },
+    );
+
+    const player = new Player({ plugins: [plugin] });
+
+    player.start(basicFRFWithActions as any);
+
+    await waitFor(() => {
+      expect(updateContent).toBeDefined();
+      expect(deferredResolve).toBeDefined();
+    });
+
+    // Stream the authoritative content through the callback.
+    updateContent?.({
+      asset: {
+        id: "streamed-action",
+        type: "action",
+        value: "streamed value",
+      },
+    });
+
+    let view: any;
+    await waitFor(() => {
+      view = (player.getState() as InProgressState).controllers.view.currentView
+        ?.lastUpdate;
+      expect(view?.actions[1]?.asset.id).toBe("streamed-action");
+    });
+
+    // Resolve the hook with a stale, non-null value. It must not win.
+    deferredResolve?.({
+      asset: {
+        id: "stale-action",
+        type: "action",
+        value: "stale value",
+      },
+    });
+
+    await waitFor(() => {
+      view = (player.getState() as InProgressState).controllers.view.currentView
+        ?.lastUpdate;
+      expect(view?.actions[1]?.asset.id).toBe("streamed-action");
+    });
+
+    view = (player.getState() as InProgressState).controllers.view.currentView
+      ?.lastUpdate;
+    expect(view?.actions[1]?.asset.id).toBe("streamed-action");
+  });
+
   test("replaces async nodes with provided node", async () => {
     const plugin = new AsyncNodePlugin({
       plugins: [new AsyncNodePluginPlugin()],

--- a/plugins/async-node/core/src/index.ts
+++ b/plugins/async-node/core/src/index.ts
@@ -315,16 +315,33 @@ export class AsyncNodePluginPlugin implements AsyncNodeViewPlugin {
     options: Resolve.NodeResolveOptions,
   ) {
     try {
+      // Track whether the callback pushed content while the hook was pending;
+      // if so it wins over the bail return (avoids the last-writer-wins race
+      // that intermittently dropped streamed rows).
+      let deliveredViaCallback = false;
+
       const result = await this.basePlugin?.hooks.onAsyncNode.call(
         node,
-        (result) => {
-          this.parseNodeAndUpdate(node, context, result, options.parseNode);
+        (streamedResult) => {
+          deliveredViaCallback = true;
+          this.parseNodeAndUpdate(
+            node,
+            context,
+            streamedResult,
+            options.parseNode,
+          );
         },
       );
 
       // Stop tracking before the next update is triggered
       context.inProgressNodes.delete(node.id);
-      this.parseNodeAndUpdate(node, context, result, options.parseNode);
+
+      // Once the callback has delivered content it is the source of truth, so a
+      // stale/empty bail return must not clobber it. Skip unless no callback ran
+      // (!deliveredViaCallback) and the return carries content (result != null).
+      if (!deliveredViaCallback && result != null) {
+        this.parseNodeAndUpdate(node, context, result, options.parseNode);
+      }
     } catch (e: unknown) {
       const cause = e instanceof Error ? e : new Error(String(e));
       const playerState = this.basePlugin?.getPlayerInstance()?.getState();


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->
Summary
A support request surfaced a race condition in the async-node plugin's node resolution. The onAsyncNode hook exposes two independent delivery channels for resolved content — the bail return (Bail(x)) and the push callback (callback(x)) — and both write the same node's resolved content with no coordination. Last writer wins.

Problem
The bail return was always re-parsed after the hook resolved. Because it resolves after any callback invoked while the hook was pending, it is always the last write — so it clobbers whatever the callback already delivered. Two variants:

Empty return: a consumer streams content through the callback, then resolves the hook with null/undefined, reverting the streamed content back to the async placeholder.
Stale return: a consumer streams content through the callback, then resolves the hook with a stale non-null value, which overwrites the freshest callback content.
Either way, content streamed via the callback is dropped — intermittently, depending on whether the promise resolution lands before or after the callback push (e.g. a later REPLACE_AT_COMPLETE that adds the action row).

Fix
Guard the bail write with if (!deliveredViaCallback && result != null):

!deliveredViaCallback — once the callback delivers content it becomes the source of truth, so a stale bail return can no longer overwrite it.
result != null — a null/undefined return can never trigger the revert-to-placeholder path.
One-shot consumers (return a value, no callback) are unchanged; clearing a node is done through the callback, not a null bail return.

Testing
Added regression tests covering both the empty-return and stale-return cases. 
### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->