### PR TITLE
Do not discard `undefined` matches when dedupeing

### DIFF
--- a/core/partial-match-registry/src/__tests__/registry.test.ts
+++ b/core/partial-match-registry/src/__tests__/registry.test.ts
@@ -132,3 +132,16 @@ test("logs debug message when initialSet has duplicate keys", () => {
   expect(registryWithDuplicates.get({ type: "action" })).toBe("third-value");
   expect(registryWithDuplicates.get({ type: "other" })).toBe("other-value");
 });
+
+test("regonizes keys with undefined value as different from missing keys ", () => {
+  const registry = new Registry<string>([
+    [{ type: "action", other: undefined }, "first-value"],
+    [{ type: "action" }, "second-value"], // Not a duplicate of above
+  ]);
+
+  // Verify the final value is the last one set
+  expect(registry.get({ type: "action" })).toBe("first-value");
+  expect(registry.get({ type: "action", other: "something" })).toBe(
+    "second-value",
+  );
+});

--- a/core/partial-match-registry/src/index.ts
+++ b/core/partial-match-registry/src/index.ts
@@ -68,7 +68,10 @@ export class Registry<V> {
     // Find and remove any existing entry that matches this key
     // Use matcher to check for matching keys (handles deep equality)
     const existingIndex = this.store.findIndex(
-      (entry) => entry.matcher(match) && matcher(entry.key),
+      (entry) =>
+        entry.matcher.count === matcher.count &&
+        entry.matcher(match) &&
+        matcher(entry.key),
     );
     if (existingIndex !== -1) {
       this.store.splice(existingIndex, 1);


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->
Prior to player 1.0, we supported Registry matches with `undefined` fields, like this:

```tsx
{ type: 'action', other: undefined }
```

These matches are looking specifically for when a field is missing. This can be useful when a user wants to have one transform just in case a field is missing.

Our 1.0 deduplication logic would consider these 2 matches to be the same and throw one out:
```tsx
{ type: 'action', other: undefined}
{ type: 'action'}
```

This PR changes the dedupe logic to not do that, so we continue to support this use case.

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.2--canary.926.40597</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 1.0.2--canary.926.40597
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
