### PR TITLE
Re-run flaky tests up to 3 times on CI (iOS only)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -65,9 +65,6 @@ common:ci-base --remote_build_event_upload=minimal
 common:ci-base --nolegacy_important_outputs
 # Bazel 9 drops the executor's path by default. Add path so we have all the Android CI paths for testing.
 test:ci-base --test_env=PATH
-# Re-run failing tests up to 3 times on CI before marking them failed, to absorb flaky tests.
-test:ci-base --flaky_test_attempts=3
-coverage:ci-base --flaky_test_attempts=3
 # Only show progress every 60 seconds on CI.
 # We want to find a compromise between printing often enough to show that the build isn't stuck,
 # but not so often that we produce a long log file that requires a lot of scrolling.
@@ -79,6 +76,9 @@ common:ci --config=ci-base --local_resources=cpu=8 --local_resources=memory=1500
 
 # Circle m4pro.medium 6 cores 28gb ram (?)
 common:ci-mac --config=ci-base --local_resources=cpu=4 --local_resources=memory=26000
+# Re-run failing iOS tests up to 3 times on CI before marking them failed, to absorb flaky tests.
+test:ci-mac --flaky_test_attempts=3
+coverage:ci-mac --flaky_test_attempts=3
 
 # For bench tests we are using a large resource_class which has 4 cpu cores and 8GB RAM
 common:ci-benchmark --config=ci-base --local_resources=cpu=4 --local_resources=memory=8000

--- a/.bazelrc
+++ b/.bazelrc
@@ -65,6 +65,9 @@ common:ci-base --remote_build_event_upload=minimal
 common:ci-base --nolegacy_important_outputs
 # Bazel 9 drops the executor's path by default. Add path so we have all the Android CI paths for testing.
 test:ci-base --test_env=PATH
+# Re-run failing tests up to 3 times on CI before marking them failed, to absorb flaky tests.
+test:ci-base --flaky_test_attempts=3
+coverage:ci-base --flaky_test_attempts=3
 # Only show progress every 60 seconds on CI.
 # We want to find a compromise between printing often enough to show that the build isn't stuck,
 # but not so often that we produce a long log file that requires a lot of scrolling.


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->
### Summary

Adds --flaky_test_attempts=3 to the ci-mac Bazel config so flaky iOS tests are automatically retried up to 3 times before failing the build, instead of failing the whole CI job on the first flake.

### Why

iOS UI/unit tests currently run as a single bazel coverage invocation covering all targets under //ios/... and //plugins/... in one CircleCI job. When any single test flakes, the only recovery today is a developer manually re-running the entire build_and_test_ios job — which reboots the simulator, rebuilds PlayerUIDemo, and rebuilds/reruns every iOS and plugins test target from scratch.

This flag lets Bazel retry just the failing test target in-process, without a rebuild or simulator reboot, and without requiring a human to notice the failure and manually trigger a rerun.

### Scope / limitations
Scoped to ci-mac only (iOS). 
Retry granularity is the Bazel test target, which in this repo's ios_pipeline macro is the whole XCTest bundle for a module (e.g. all tests in PlayerUISwiftUI) — not the individual failing test method. Bazel has no finer-grained retry mechanism for XCTest bundles.
This is a stopgap to reduce CI noise and save developer time on manual reruns.
P.S. This is not a replacement for fixing flaky tests directly. Will continue to fix flakes as they're identified.

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->