### PR TITLE
Extract JS bridging keys into CoreJSKeys enum

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "SwiftHooks",
+        "repositoryURL": "https://github.com/intuit/swift-hooks.git",
+        "state": {
+          "branch": null,
+          "revision": "5f3136ac2a3c27aa469e3f9a1222b15080d431d3",
+          "version": "0.1.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/ios/core/Sources/Types/Core/CompletedState.swift
+++ b/ios/core/Sources/Types/Core/CompletedState.swift
@@ -30,12 +30,16 @@ public class PlayerControllers {
     public init?(from value: JSValue?) {
         guard let controllers = value else { return nil }
         rawValue = controllers
-        data = DataController.createInstance(value: rawValue.objectForKeyedSubscript("data"))
-        flow = FlowController.createInstance(value: rawValue.objectForKeyedSubscript("flow"))
-        view = ViewController.createInstance(value: rawValue.objectForKeyedSubscript("view"))
+        data = DataController
+            .createInstance(value: rawValue.objectForKeyedSubscript(CoreJSKeys.data))
+        flow = FlowController
+            .createInstance(value: rawValue.objectForKeyedSubscript(CoreJSKeys.flow))
+        view = ViewController
+            .createInstance(value: rawValue.objectForKeyedSubscript(CoreJSKeys.view))
         expression = ExpressionEvaluator
-            .createInstance(value: rawValue.objectForKeyedSubscript("expression"))
-        error = ErrorController.createInstance(value: rawValue.objectForKeyedSubscript("error"))
+            .createInstance(value: rawValue.objectForKeyedSubscript(CoreJSKeys.expression))
+        error = ErrorController
+            .createInstance(value: rawValue.objectForKeyedSubscript(CoreJSKeys.error))
     }
 }
 
@@ -76,7 +80,7 @@ extension BaseFlowState: CreatedFromJSValue {
     ///   - value: The JSValue to construct the state from
     public static func createInstance(value: JSValue) -> BaseFlowState {
         guard
-            let rawStatus = value.objectForKeyedSubscript("status")?.toString(),
+            let rawStatus = value.objectForKeyedSubscript(CoreJSKeys.status)?.toString(),
             let status = PlayerFlowStatus(rawValue: rawStatus),
             let state = { () -> BaseFlowState? in
                 switch status {
@@ -136,15 +140,17 @@ public class CompletedState: BaseFlowState, PlayerFlowExecutionData {
     /// - returns: A CompletedState object if the JSValue was one
     public static func createInstance(from value: JSValue?) -> CompletedState? {
         guard
-            let flow = value?.objectForKeyedSubscript("flow"),
-            let controllersJSValue = value?.objectForKeyedSubscript("controllers"),
-            let dataControllerJSValue = controllersJSValue.objectForKeyedSubscript("data")
+            let flow = value?.objectForKeyedSubscript(CoreJSKeys.flow),
+            let controllersJSValue = value?.objectForKeyedSubscript(CoreJSKeys.controllers),
+            let dataControllerJSValue = controllersJSValue.objectForKeyedSubscript(CoreJSKeys.data)
         else { return nil }
 
         return CompletedState(
             flow: Flow.createInstance(value: flow),
-            endState: value.map { NavigationFlowEndState($0.objectForKeyedSubscript("endState")) },
-            data: value?.objectForKeyedSubscript("data")?.toObject() as? [String: Any] ?? [:],
+            endState: value
+                .map { NavigationFlowEndState($0.objectForKeyedSubscript(CoreJSKeys.endState)) },
+            data: value?.objectForKeyedSubscript(CoreJSKeys.data)?
+                .toObject() as? [String: Any] ?? [:],
             controllers: Controllers(data: .createInstance(value: dataControllerJSValue))
         )
     }
@@ -208,16 +214,18 @@ public class InProgressState: BaseFlowState, PlayerFlowExecutionData {
     /// - returns: A InProgressState object if the JSValue was one
     public static func createInstance(from value: JSValue?) -> InProgressState? {
         guard
-            let flow = value?.objectForKeyedSubscript("flow")
+            let flow = value?.objectForKeyedSubscript(CoreJSKeys.flow)
         else { return nil }
         return InProgressState(
             flow: Flow.createInstance(value: flow),
             flowResult: value
-                .map { NavigationFlowEndState($0.objectForKeyedSubscript("flowResult")) },
-            controllers: PlayerControllers(from: value?.objectForKeyedSubscript("controllers")),
-            logger: JSLogger(from: value?.objectForKeyedSubscript("logger")),
+                .map { NavigationFlowEndState($0.objectForKeyedSubscript(CoreJSKeys.flowResult)) },
+            controllers: PlayerControllers(
+                from: value?.objectForKeyedSubscript(CoreJSKeys.controllers)
+            ),
+            logger: JSLogger(from: value?.objectForKeyedSubscript(CoreJSKeys.logger)),
             fail: {
-                value?.objectForKeyedSubscript("fail")?
+                value?.objectForKeyedSubscript(CoreJSKeys.fail)?
                     .call(withArguments: [value?.context.error(for: $0) as Any])
             }
         )
@@ -244,8 +252,8 @@ public class ErrorState: BaseFlowState, PlayerFlowExecutionData {
     /// - returns: A ErrorState object if the JSValue was one
     public static func createInstance(from value: JSValue?) -> ErrorState? {
         guard
-            let flow = value?.objectForKeyedSubscript("flow"),
-            let err = value?.objectForKeyedSubscript("error")
+            let flow = value?.objectForKeyedSubscript(CoreJSKeys.flow),
+            let err = value?.objectForKeyedSubscript(CoreJSKeys.error)
         else { return nil }
 
         return ErrorState(

--- a/ios/core/Sources/Types/Core/CoreJSKeys.swift
+++ b/ios/core/Sources/Types/Core/CoreJSKeys.swift
@@ -26,7 +26,7 @@ enum CoreJSKeys {
     static let attributes = "attributes"
     static let outcome = "outcome"
     static let param = "param"
-    static let await_ = "await"
+    static let isAwait = "await"
     static let status = "status"
     static let flowResult = "flowResult"
     static let logger = "logger"

--- a/ios/core/Sources/Types/Core/CoreJSKeys.swift
+++ b/ios/core/Sources/Types/Core/CoreJSKeys.swift
@@ -1,0 +1,40 @@
+//
+//  CoreJSKeys.swift
+//  PlayerUI
+//
+
+import Foundation
+
+/// Shared `objectForKeyedSubscript`/`setObject(_:forKeyedSubscript:)` key names used across the
+/// Core flow/state/view JSValue wrappers (CompletedState, NavigationStates, Flow, FlowType,
+/// PlayerView, ViewController, FlowController). Keys that are decoded in more than one of those
+/// files share a single case here rather than being redeclared per file.
+enum CoreJSKeys {
+    static let flow = "flow"
+    static let data = "data"
+    static let view = "view"
+    static let error = "error"
+    static let id = "id"
+    static let ref = "ref"
+    static let exp = "exp"
+    static let stateType = "state_type"
+    static let currentState = "currentState"
+    static let endState = "endState"
+    static let controllers = "controllers"
+    static let expression = "expression"
+    static let transitions = "transitions"
+    static let attributes = "attributes"
+    static let outcome = "outcome"
+    static let param = "param"
+    static let await_ = "await"
+    static let status = "status"
+    static let flowResult = "flowResult"
+    static let logger = "logger"
+    static let fail = "fail"
+    static let name = "name"
+    static let value = "value"
+    static let initialView = "initialView"
+    static let currentView = "currentView"
+    static let current = "current"
+    static let transition = "transition"
+}

--- a/ios/core/Sources/Types/Core/Flow.swift
+++ b/ios/core/Sources/Types/Core/Flow.swift
@@ -18,17 +18,17 @@ public class Flow: CreatedFromJSValue {
 
     /// The ID of this flow
     public var id: String? {
-        value.objectForKeyedSubscript("id")?.toString()
+        value.objectForKeyedSubscript(CoreJSKeys.id)?.toString()
     }
 
     /// The original data associated with this flow
     public var data: [String: Any]? {
-        value.objectForKeyedSubscript("data")?.toObject() as? [String: Any]
+        value.objectForKeyedSubscript(CoreJSKeys.data)?.toObject() as? [String: Any]
     }
 
     /// The name of this flow
     public var currentState: NamedState? {
-        value.objectForKeyedSubscript("currentState").map { NamedState($0) }
+        value.objectForKeyedSubscript(CoreJSKeys.currentState).map { NamedState($0) }
     }
 
     /// Construct a Flow from a JSValue
@@ -82,9 +82,9 @@ public struct NamedState: CreatedFromJSValue {
     public let value: NavigationBaseState?
 
     init(_ value: JSValue) {
-        name = value.objectForKeyedSubscript("name").toString()
+        name = value.objectForKeyedSubscript(CoreJSKeys.name).toString()
         self.value = NavigationBaseState
-            .createInstance(value: value.objectForKeyedSubscript("value"))
+            .createInstance(value: value.objectForKeyedSubscript(CoreJSKeys.value))
     }
 
     public static func createInstance(value: JSValue) -> NamedState {

--- a/ios/core/Sources/Types/Core/FlowController.swift
+++ b/ios/core/Sources/Types/Core/FlowController.swift
@@ -18,7 +18,7 @@ public class FlowController: CreatedFromJSValue {
 
     /// The current flow for this controller
     public var current: Flow? {
-        value.objectForKeyedSubscript("current").map { Flow($0) }
+        value.objectForKeyedSubscript(CoreJSKeys.current).map { Flow($0) }
     }
 
     /// Construct a FlowController from a JSValue
@@ -33,7 +33,8 @@ public class FlowController: CreatedFromJSValue {
     /// - parameters:
     ///   - action: The action to use for transitioning
     public func transition(with action: String) throws {
-        try value.objectForKeyedSubscript("transition").callWithErrorHandling(args: [action])
+        try value.objectForKeyedSubscript(CoreJSKeys.transition)
+            .callWithErrorHandling(args: [action])
     }
 
     /// Creates an instance from a JSValue, used for generic construction

--- a/ios/core/Sources/Types/Core/FlowType.swift
+++ b/ios/core/Sources/Types/Core/FlowType.swift
@@ -17,12 +17,12 @@ public class FlowType: CreatedFromJSValue {
 
     /// The ID of this flow
     public var id: String? {
-        value.objectForKeyedSubscript("id")?.toString()
+        value.objectForKeyedSubscript(CoreJSKeys.id)?.toString()
     }
 
     /// The original data associated with this flow
     public var data: [String: Any]? {
-        value.objectForKeyedSubscript("data")?.toObject() as? [String: Any]
+        value.objectForKeyedSubscript(CoreJSKeys.data)?.toObject() as? [String: Any]
     }
 
     /// Construct a Flow from a JSValue

--- a/ios/core/Sources/Types/Core/NavigationStates.swift
+++ b/ios/core/Sources/Types/Core/NavigationStates.swift
@@ -139,7 +139,7 @@ public class NavigationFlowAsyncActionState: NavigationFlowTransitionableState {
     }
 
     public var await: Bool {
-        rawValue.objectForKeyedSubscript(CoreJSKeys.await_).toBool()
+        rawValue.objectForKeyedSubscript(CoreJSKeys.isAwait).toBool()
     }
 
     public enum Expression {

--- a/ios/core/Sources/Types/Core/NavigationStates.swift
+++ b/ios/core/Sources/Types/Core/NavigationStates.swift
@@ -16,7 +16,9 @@ open class NavigationBaseState: CreatedFromJSValue, JSValueProviding {
 
     public init(_ value: JSValue) {
         rawValue = value
-        stateType = NavigationFlowStateType(value.objectForKeyedSubscript("state_type").toString())
+        stateType = NavigationFlowStateType(
+            value.objectForKeyedSubscript(CoreJSKeys.stateType).toString()
+        )
     }
 
     public static func createInstance(value: JSValue) -> NavigationBaseState {
@@ -39,7 +41,7 @@ open class NavigationBaseState: CreatedFromJSValue, JSValueProviding {
 open class NavigationFlowTransitionableState: NavigationBaseState {
     /// A mapping of transition-name to FlowState name
     public var transitions: [String: String]? {
-        rawValue.objectForKeyedSubscript("transitions").toObject() as? [String: String]
+        rawValue.objectForKeyedSubscript(CoreJSKeys.transitions).toObject() as? [String: String]
     }
 }
 
@@ -48,12 +50,12 @@ open class NavigationFlowTransitionableState: NavigationBaseState {
 public class NavigationFlowViewState: NavigationFlowTransitionableState {
     /// An id corresponding to a view from the 'views' array
     public var ref: String {
-        rawValue.objectForKeyedSubscript("ref").toString()
+        rawValue.objectForKeyedSubscript(CoreJSKeys.ref).toString()
     }
 
     /// View meta-properties
     public var attributes: [String: Any]? {
-        rawValue.objectForKeyedSubscript("attributes").toObject() as? [String: Any]
+        rawValue.objectForKeyedSubscript(CoreJSKeys.attributes).toObject() as? [String: Any]
     }
 
     public subscript<T>(dynamicMember member: String) -> T? {
@@ -69,7 +71,7 @@ public class NavigationFlowViewState: NavigationFlowTransitionableState {
 public class NavigationFlowExternalState: NavigationFlowTransitionableState {
     /// A reference for this external state
     public var ref: String? {
-        rawValue.objectForKeyedSubscript("ref").toString()
+        rawValue.objectForKeyedSubscript(CoreJSKeys.ref).toString()
     }
 
     public subscript<T>(dynamicMember member: String) -> T? {
@@ -82,7 +84,7 @@ public class NavigationFlowExternalState: NavigationFlowTransitionableState {
 public class NavigationFlowEndState: NavigationBaseState {
     /// A description of _how_ the flow ended.
     public var outcome: String {
-        rawValue.objectForKeyedSubscript("outcome").toString()
+        rawValue.objectForKeyedSubscript(CoreJSKeys.outcome).toString()
     }
 
     public convenience init?(from value: JSValue?) {
@@ -97,14 +99,14 @@ public class NavigationFlowEndState: NavigationBaseState {
 
 public extension NavigationFlowEndState {
     var param: [String: Any]? {
-        rawValue.objectForKeyedSubscript("param").toObject() as? [String: Any]
+        rawValue.objectForKeyedSubscript(CoreJSKeys.param).toObject() as? [String: Any]
     }
 }
 
 public class NavigationFlowFlowState: NavigationFlowTransitionableState {
     /// A reference to a FLOW id state to run
     public var ref: String {
-        rawValue.objectForKeyedSubscript("ref").toString()
+        rawValue.objectForKeyedSubscript(CoreJSKeys.ref).toString()
     }
 }
 
@@ -112,10 +114,10 @@ public class NavigationFlowFlowState: NavigationFlowTransitionableState {
 public class NavigationFlowActionState: NavigationFlowTransitionableState {
     /// An expression to execute. The return value determines the transition to take
     public var exp: Expression {
-        if let multi = rawValue.objectForKeyedSubscript("exp").toObject() as? [String] {
+        if let multi = rawValue.objectForKeyedSubscript(CoreJSKeys.exp).toObject() as? [String] {
             .multi(exp: multi)
         } else {
-            .single(exp: rawValue.objectForKeyedSubscript("exp").toString())
+            .single(exp: rawValue.objectForKeyedSubscript(CoreJSKeys.exp).toString())
         }
     }
 
@@ -129,15 +131,15 @@ public class NavigationFlowActionState: NavigationFlowTransitionableState {
 public class NavigationFlowAsyncActionState: NavigationFlowTransitionableState {
     /// An expression to execute. The return value determines the transition to take
     public var exp: Expression {
-        if let multi = rawValue.objectForKeyedSubscript("exp").toObject() as? [String] {
+        if let multi = rawValue.objectForKeyedSubscript(CoreJSKeys.exp).toObject() as? [String] {
             .multi(exp: multi)
         } else {
-            .single(exp: rawValue.objectForKeyedSubscript("exp").toString())
+            .single(exp: rawValue.objectForKeyedSubscript(CoreJSKeys.exp).toString())
         }
     }
 
     public var await: Bool {
-        rawValue.objectForKeyedSubscript("await").toBool()
+        rawValue.objectForKeyedSubscript(CoreJSKeys.await_).toBool()
     }
 
     public enum Expression {

--- a/ios/core/Sources/Types/Core/PlayerView.swift
+++ b/ios/core/Sources/Types/Core/PlayerView.swift
@@ -19,8 +19,8 @@ public class PlayerView: CreatedFromJSValue {
     /// Gets the ID for this view
     public var id: String {
         value
-            .objectForKeyedSubscript("initialView")?
-            .objectForKeyedSubscript("id")?
+            .objectForKeyedSubscript(CoreJSKeys.initialView)?
+            .objectForKeyedSubscript(CoreJSKeys.id)?
             .toString() ?? "something went really wrong and this view has no id"
     }
 

--- a/ios/core/Sources/Types/Core/ViewController.swift
+++ b/ios/core/Sources/Types/Core/ViewController.swift
@@ -18,7 +18,7 @@ public class ViewController: CreatedFromJSValue {
 
     /// The current view being managed by the View Controller
     public var currentView: PlayerView? {
-        guard let view = value.objectForKeyedSubscript("currentView") else { return nil }
+        guard let view = value.objectForKeyedSubscript(CoreJSKeys.currentView) else { return nil }
         return PlayerView(view)
     }
 


### PR DESCRIPTION

Extracts raw string literals used with `objectForKeyedSubscript`/`setObject(_:forKeyedSubscript:)` in `CompletedState`, `NavigationStates`, `Flow`, `FlowType`, `PlayerView`, `ViewController`, and `FlowController` into a new `CoreJSKeys` enum, matching the existing `JSKeys`/`TryCatchResultKeys` pattern in `JSValue+Extensions.swift`.

Keys used in multiple files (flow, data, id, error, controllers) now share a single case instead of being redeclared per file.

Existing test suites pass; no new tests needed since this is a no-behavior-change refactor.

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->