### PR TITLE
Consolidate duplicated pluginName string literals into shared constants

### DIFF
--- a/plugins/beacon/ios/Sources/BaseBeaconPlugin.swift
+++ b/plugins/beacon/ios/Sources/BaseBeaconPlugin.swift
@@ -48,16 +48,12 @@ public struct DefaultBeacon: Codable, Hashable {
 open class BaseBeaconPlugin<BeaconStruct: Decodable>: JSBasePlugin {
     /// The name used to identify this plugin to Player's JS runtime, shared by both
     /// `BaseBeaconPlugin` (ios) and `BeaconPlugin` (swiftui)
-    /// - Note: computed rather than a stored property because static stored properties
-    ///   aren't supported on generic types
     public static var beaconPluginName: String {
         "BeaconPlugin.BeaconPlugin"
     }
 
     /// The bundled JS file name for this plugin, shared by both
     /// `BaseBeaconPlugin` (ios) and `BeaconPlugin` (swiftui)
-    /// - Note: computed rather than a stored property because static stored properties
-    ///   aren't supported on generic types
     public static var beaconFileName: String {
         "BeaconPlugin.native"
     }

--- a/plugins/beacon/ios/Sources/BaseBeaconPlugin.swift
+++ b/plugins/beacon/ios/Sources/BaseBeaconPlugin.swift
@@ -46,6 +46,14 @@ public struct DefaultBeacon: Codable, Hashable {
 /// A Base implementation wrapping @player-ui/beacon-plugin
 /// Used as a base for framework specific integrations
 open class BaseBeaconPlugin<BeaconStruct: Decodable>: JSBasePlugin {
+    /// The name used to identify this plugin to Player's JS runtime, shared by both
+    /// `BaseBeaconPlugin` (ios) and `BeaconPlugin` (swiftui)
+    /// - Note: computed rather than a stored property because static stored properties
+    ///   aren't supported on generic types
+    public static var beaconPluginName: String {
+        "BeaconPlugin.BeaconPlugin"
+    }
+
     public var hooks: BeaconPluginHooks?
     /// The callback to call when a beacon is fired from the plugin
     public var callback: ((BeaconStruct) -> Void)?
@@ -58,7 +66,10 @@ open class BaseBeaconPlugin<BeaconStruct: Decodable>: JSBasePlugin {
     /// - context: The context to load the plugin into
     /// - onBeacon: A callback to receive beacon events
     public convenience init(plugins: [JSBasePlugin] = [], onBeacon: ((BeaconStruct) -> Void)?) {
-        self.init(fileName: "BeaconPlugin.native", pluginName: "BeaconPlugin.BeaconPlugin")
+        self.init(
+            fileName: "BeaconPlugin.native",
+            pluginName: BaseBeaconPlugin.beaconPluginName
+        )
         callback = onBeacon
         self.plugins = plugins
     }

--- a/plugins/beacon/ios/Sources/BaseBeaconPlugin.swift
+++ b/plugins/beacon/ios/Sources/BaseBeaconPlugin.swift
@@ -54,6 +54,14 @@ open class BaseBeaconPlugin<BeaconStruct: Decodable>: JSBasePlugin {
         "BeaconPlugin.BeaconPlugin"
     }
 
+    /// The bundled JS file name for this plugin, shared by both
+    /// `BaseBeaconPlugin` (ios) and `BeaconPlugin` (swiftui)
+    /// - Note: computed rather than a stored property because static stored properties
+    ///   aren't supported on generic types
+    public static var beaconFileName: String {
+        "BeaconPlugin.native"
+    }
+
     public var hooks: BeaconPluginHooks?
     /// The callback to call when a beacon is fired from the plugin
     public var callback: ((BeaconStruct) -> Void)?
@@ -67,7 +75,7 @@ open class BaseBeaconPlugin<BeaconStruct: Decodable>: JSBasePlugin {
     /// - onBeacon: A callback to receive beacon events
     public convenience init(plugins: [JSBasePlugin] = [], onBeacon: ((BeaconStruct) -> Void)?) {
         self.init(
-            fileName: "BeaconPlugin.native",
+            fileName: BaseBeaconPlugin.beaconFileName,
             pluginName: BaseBeaconPlugin.beaconPluginName
         )
         callback = onBeacon

--- a/plugins/beacon/swiftui/Sources/SwiftUIBeaconPlugin.swift
+++ b/plugins/beacon/swiftui/Sources/SwiftUIBeaconPlugin.swift
@@ -20,9 +20,9 @@ open class BeaconPlugin<BeaconStruct: Decodable>: BaseBeaconPlugin<BeaconStruct>
     /// - onBeacon: A callback to receive beacon events
     public convenience init(plugins: [JSBasePlugin] = [], onBeacon: ((BeaconStruct) -> Void)?) {
         self.init(
-            fileName: "BeaconPlugin.native",
             // `BeaconStruct` must be specified explicitly here since it can't be inferred
             // from `Self` the way it can inside `BaseBeaconPlugin`'s own initializer
+            fileName: BaseBeaconPlugin<BeaconStruct>.beaconFileName,
             pluginName: BaseBeaconPlugin<BeaconStruct>.beaconPluginName
         )
         callback = onBeacon

--- a/plugins/beacon/swiftui/Sources/SwiftUIBeaconPlugin.swift
+++ b/plugins/beacon/swiftui/Sources/SwiftUIBeaconPlugin.swift
@@ -19,7 +19,12 @@ open class BeaconPlugin<BeaconStruct: Decodable>: BaseBeaconPlugin<BeaconStruct>
     /// - context: The context to load the plugin into
     /// - onBeacon: A callback to receive beacon events
     public convenience init(plugins: [JSBasePlugin] = [], onBeacon: ((BeaconStruct) -> Void)?) {
-        self.init(fileName: "BeaconPlugin.native", pluginName: "BeaconPlugin.BeaconPlugin")
+        self.init(
+            fileName: "BeaconPlugin.native",
+            // `BeaconStruct` must be specified explicitly here since it can't be inferred
+            // from `Self` the way it can inside `BaseBeaconPlugin`'s own initializer
+            pluginName: BaseBeaconPlugin<BeaconStruct>.beaconPluginName
+        )
         callback = onBeacon
         self.plugins = plugins
     }

--- a/plugins/check-path/ios/Sources/CheckPathPlugin.swift
+++ b/plugins/check-path/ios/Sources/CheckPathPlugin.swift
@@ -10,6 +10,10 @@ import PlayerUI
 
 /// Base functionality for CheckPath
 open class BaseCheckPathPlugin: JSBasePlugin {
+    /// The name used to identify this plugin to Player's JS runtime, shared by both
+    /// `CheckPathPlugin` (ios) and `SwiftUICheckPathPlugin` (swiftui)
+    public static let checkPathPluginName = "CheckPathPlugin.CheckPathPlugin"
+
     /// The getParent method allows you to query up the tree and return the first parent that
     /// matches the given query if such exists.
     /// In case when query is not provided, the closest parent returned.
@@ -61,6 +65,9 @@ open class BaseCheckPathPlugin: JSBasePlugin {
 open class CheckPathPlugin: BaseCheckPathPlugin, NativePlugin {
     /// Constructs the CheckPathPlugin
     public convenience init() {
-        self.init(fileName: "CheckPathPlugin.native", pluginName: "CheckPathPlugin.CheckPathPlugin")
+        self.init(
+            fileName: "CheckPathPlugin.native",
+            pluginName: BaseCheckPathPlugin.checkPathPluginName
+        )
     }
 }

--- a/plugins/check-path/ios/Sources/CheckPathPlugin.swift
+++ b/plugins/check-path/ios/Sources/CheckPathPlugin.swift
@@ -14,6 +14,10 @@ open class BaseCheckPathPlugin: JSBasePlugin {
     /// `CheckPathPlugin` (ios) and `SwiftUICheckPathPlugin` (swiftui)
     public static let checkPathPluginName = "CheckPathPlugin.CheckPathPlugin"
 
+    /// The bundled JS file name for this plugin, shared by both
+    /// `CheckPathPlugin` (ios) and `SwiftUICheckPathPlugin` (swiftui)
+    public static let checkPathFileName = "CheckPathPlugin.native"
+
     /// The getParent method allows you to query up the tree and return the first parent that
     /// matches the given query if such exists.
     /// In case when query is not provided, the closest parent returned.
@@ -66,7 +70,7 @@ open class CheckPathPlugin: BaseCheckPathPlugin, NativePlugin {
     /// Constructs the CheckPathPlugin
     public convenience init() {
         self.init(
-            fileName: "CheckPathPlugin.native",
+            fileName: BaseCheckPathPlugin.checkPathFileName,
             pluginName: BaseCheckPathPlugin.checkPathPluginName
         )
     }

--- a/plugins/check-path/swiftui/Sources/SwiftUICheckPathPlugin.swift
+++ b/plugins/check-path/swiftui/Sources/SwiftUICheckPathPlugin.swift
@@ -9,7 +9,7 @@ public class SwiftUICheckPathPlugin: BaseCheckPathPlugin, NativePlugin {
     /// Constructs the SwiftUICheckPathPlugin
     public convenience init() {
         self.init(
-            fileName: "CheckPathPlugin.native",
+            fileName: BaseCheckPathPlugin.checkPathFileName,
             pluginName: BaseCheckPathPlugin.checkPathPluginName
         )
     }

--- a/plugins/check-path/swiftui/Sources/SwiftUICheckPathPlugin.swift
+++ b/plugins/check-path/swiftui/Sources/SwiftUICheckPathPlugin.swift
@@ -8,7 +8,10 @@ import SwiftUI
 public class SwiftUICheckPathPlugin: BaseCheckPathPlugin, NativePlugin {
     /// Constructs the SwiftUICheckPathPlugin
     public convenience init() {
-        self.init(fileName: "CheckPathPlugin.native", pluginName: "CheckPathPlugin.CheckPathPlugin")
+        self.init(
+            fileName: "CheckPathPlugin.native",
+            pluginName: BaseCheckPathPlugin.checkPathPluginName
+        )
     }
 
     public func apply(player: some HeadlessPlayer) {

--- a/plugins/external-state/ios/Sources/ExternalStatePlugin.swift
+++ b/plugins/external-state/ios/Sources/ExternalStatePlugin.swift
@@ -45,6 +45,10 @@ public class ExternalStatePlugin: JSBasePlugin, NativePlugin {
     /// `ExternalStatePlugin` (ios) and `ExternalStateViewModifierPlugin` (swiftui)
     public static let externalStatePluginName = "ExternalStatePlugin.ExternalStatePlugin"
 
+    /// The bundled JS file name for this plugin, shared by both
+    /// `ExternalStatePlugin` (ios) and `ExternalStateViewModifierPlugin` (swiftui)
+    public static let externalStateFileName = "ExternalStatePlugin.native"
+
     private var handlers: [ExternalStateHandler]
 
     /// Construct a plugin to handle external states. Every match/key must include a `ref`.
@@ -53,7 +57,7 @@ public class ExternalStatePlugin: JSBasePlugin, NativePlugin {
     public init(handlers: [ExternalStateHandler]) {
         self.handlers = handlers
         super.init(
-            fileName: "ExternalStatePlugin.native",
+            fileName: ExternalStatePlugin.externalStateFileName,
             pluginName: ExternalStatePlugin.externalStatePluginName
         )
     }

--- a/plugins/external-state/ios/Sources/ExternalStatePlugin.swift
+++ b/plugins/external-state/ios/Sources/ExternalStatePlugin.swift
@@ -41,6 +41,10 @@ public struct ExternalStateHandler {
 public class ExternalStatePlugin: JSBasePlugin, NativePlugin {
     public static let bundle: Bundle = .module
 
+    /// The name used to identify this plugin to Player's JS runtime, shared by both
+    /// `ExternalStatePlugin` (ios) and `ExternalStateViewModifierPlugin` (swiftui)
+    public static let externalStatePluginName = "ExternalStatePlugin.ExternalStatePlugin"
+
     private var handlers: [ExternalStateHandler]
 
     /// Construct a plugin to handle external states. Every match/key must include a `ref`.
@@ -50,7 +54,7 @@ public class ExternalStatePlugin: JSBasePlugin, NativePlugin {
         self.handlers = handlers
         super.init(
             fileName: "ExternalStatePlugin.native",
-            pluginName: "ExternalStatePlugin.ExternalStatePlugin"
+            pluginName: ExternalStatePlugin.externalStatePluginName
         )
     }
 

--- a/plugins/external-state/swiftui/Sources/ExternalStateViewModifierPlugin.swift
+++ b/plugins/external-state/swiftui/Sources/ExternalStateViewModifierPlugin.swift
@@ -52,7 +52,7 @@ open class ExternalStateViewModifierPlugin<ModifierType: ExternalStateViewModifi
         self.handlers = handlers
         super.init(
             fileName: "ExternalStatePlugin.native",
-            pluginName: "ExternalStatePlugin.ExternalStatePlugin"
+            pluginName: ExternalStatePlugin.externalStatePluginName
         )
     }
 

--- a/plugins/external-state/swiftui/Sources/ExternalStateViewModifierPlugin.swift
+++ b/plugins/external-state/swiftui/Sources/ExternalStateViewModifierPlugin.swift
@@ -51,7 +51,7 @@ open class ExternalStateViewModifierPlugin<ModifierType: ExternalStateViewModifi
     public init(handlers: [ExternalStateViewModifierHandler]) {
         self.handlers = handlers
         super.init(
-            fileName: "ExternalStatePlugin.native",
+            fileName: ExternalStatePlugin.externalStateFileName,
             pluginName: ExternalStatePlugin.externalStatePluginName
         )
     }

--- a/plugins/pending-transaction/swiftui/Sources/SwiftUIPendingTransactionPlugin.swift
+++ b/plugins/pending-transaction/swiftui/Sources/SwiftUIPendingTransactionPlugin.swift
@@ -37,7 +37,7 @@ public class SwiftUIPendingTransactionPlugin<T: Identifiable & Hashable>: Native
         // transactionContext should attach to decoder prior to decoding a view
         player.assetRegistry.decoder.setPendingTransaction(transactionContext)
 
-        player.hooks?.view.tap(name: "SwiftUIPendingTransactionPlugin") { view in
+        player.hooks?.view.tap(name: pluginName) { view in
             let keyPath = self.keyPath
             return AnyView(view.environment(keyPath, self.transactionContext))
         }


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->
Consolidates the duplicated pluginName string literals into shared constants so they're not retyped in both the ios and swiftui targets.

# Changes
- `external-state`, `check-path`, `beacon`: added a single static let/static var for pluginName on the ios-side base class, swiftui target now references it instead of retyping the string
- beacon: `beaconPluginName` is a computed `static var` instead of a stored let since `BaseBeaconPlugin` is generic and Swift doesn't allow static stored properties there. Left a comment on the swiftui call site explaining why it needs the explicit `<BeaconStruct>` param
- `pending-transaction`: bonus one-liner, same-file retype bug (`pluginName` was declared then retyped again a few lines down). Now just references the property

No behaviour change, same strings, just single-sourced.

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->