### PR TITLE
Consolidates repeated string literal hook names into extensio

### DIFF
--- a/ios/core/Sources/Player/CoreHooksNames.swift
+++ b/ios/core/Sources/Player/CoreHooksNames.swift
@@ -1,0 +1,34 @@
+//
+//  CoreHooksNames.swift
+//  PlayerUI
+//
+
+import Foundation
+
+public extension CoreHooks {
+    /// Hook names shared by all `CoreHooks` conformers (`HeadlessHooks`, `TestHooks`,
+    /// `SwiftUIPlayerHooks`)
+    static var flowControllerHookName: String {
+        "flowController"
+    }
+
+    static var viewControllerHookName: String {
+        "viewController"
+    }
+
+    static var dataControllerHookName: String {
+        "dataController"
+    }
+
+    static var errorControllerHookName: String {
+        "errorController"
+    }
+
+    static var stateHookName: String {
+        "state"
+    }
+
+    static var onStartHookName: String {
+        "onStart"
+    }
+}

--- a/ios/core/Sources/Player/HeadlessPlayer.swift
+++ b/ios/core/Sources/Player/HeadlessPlayer.swift
@@ -64,6 +64,34 @@ public protocol CoreHooks {
     init(from: JSValue)
 }
 
+public extension CoreHooks {
+    /// Hook names shared by all `CoreHooks` conformers (`HeadlessHooks`, `TestHooks`,
+    /// `SwiftUIPlayerHooks`)
+    static var flowControllerHookName: String {
+        "flowController"
+    }
+
+    static var viewControllerHookName: String {
+        "viewController"
+    }
+
+    static var dataControllerHookName: String {
+        "dataController"
+    }
+
+    static var errorControllerHookName: String {
+        "errorController"
+    }
+
+    static var stateHookName: String {
+        "state"
+    }
+
+    static var onStartHookName: String {
+        "onStart"
+    }
+}
+
 // MARK: PlayerRegistry
 
 /// Defines the minimum required functionality for a registry

--- a/ios/core/Sources/Player/HeadlessPlayer.swift
+++ b/ios/core/Sources/Player/HeadlessPlayer.swift
@@ -64,34 +64,6 @@ public protocol CoreHooks {
     init(from: JSValue)
 }
 
-public extension CoreHooks {
-    /// Hook names shared by all `CoreHooks` conformers (`HeadlessHooks`, `TestHooks`,
-    /// `SwiftUIPlayerHooks`)
-    static var flowControllerHookName: String {
-        "flowController"
-    }
-
-    static var viewControllerHookName: String {
-        "viewController"
-    }
-
-    static var dataControllerHookName: String {
-        "dataController"
-    }
-
-    static var errorControllerHookName: String {
-        "errorController"
-    }
-
-    static var stateHookName: String {
-        "state"
-    }
-
-    static var onStartHookName: String {
-        "onStart"
-    }
-}
-
 // MARK: PlayerRegistry
 
 /// Defines the minimum required functionality for a registry

--- a/ios/swiftui/Sources/SwiftUIPlayer.swift
+++ b/ios/swiftui/Sources/SwiftUIPlayer.swift
@@ -360,14 +360,17 @@ public struct SwiftUIPlayerHooks: CoreHooks {
 
     /// Initialize hooks from reference to javascript core player
     public init(from player: JSValue) {
-        flowController = Hook<FlowController>(baseValue: player, name: "flowController")
-        viewController = Hook<ViewController>(baseValue: player, name: "viewController")
-        dataController = Hook<DataController>(baseValue: player, name: "dataController")
-        errorController = Hook<ErrorController>(baseValue: player, name: "errorController")
-        state = Hook<BaseFlowState>(baseValue: player, name: "state")
+        flowController = Hook<FlowController>(baseValue: player, name: Self.flowControllerHookName)
+        viewController = Hook<ViewController>(baseValue: player, name: Self.viewControllerHookName)
+        dataController = Hook<DataController>(baseValue: player, name: Self.dataControllerHookName)
+        errorController = Hook<ErrorController>(
+            baseValue: player,
+            name: Self.errorControllerHookName
+        )
+        state = Hook<BaseFlowState>(baseValue: player, name: Self.stateHookName)
         view = SyncWaterfallHook<AnyView>()
         transition = SyncBailHook<Void, PlayerViewTransition>()
-        onStart = Hook<FlowType>(baseValue: player, name: "onStart")
+        onStart = Hook<FlowType>(baseValue: player, name: Self.onStartHookName)
     }
 }
 

--- a/ios/test-utils-core/Sources/utilities/HeadlessPlayerImpl.swift
+++ b/ios/test-utils-core/Sources/utilities/HeadlessPlayerImpl.swift
@@ -37,12 +37,12 @@ public class HeadlessHooks: CoreHooks {
     public var onStart: Hook<FlowType>
 
     public required init(from value: JSValue) {
-        flowController = Hook(baseValue: value, name: "flowController")
-        viewController = Hook(baseValue: value, name: "viewController")
-        dataController = Hook(baseValue: value, name: "dataController")
-        errorController = Hook(baseValue: value, name: "errorController")
-        state = Hook(baseValue: value, name: "state")
-        onStart = Hook<FlowType>(baseValue: value, name: "onStart")
+        flowController = Hook(baseValue: value, name: Self.flowControllerHookName)
+        viewController = Hook(baseValue: value, name: Self.viewControllerHookName)
+        dataController = Hook(baseValue: value, name: Self.dataControllerHookName)
+        errorController = Hook(baseValue: value, name: Self.errorControllerHookName)
+        state = Hook(baseValue: value, name: Self.stateHookName)
+        onStart = Hook<FlowType>(baseValue: value, name: Self.onStartHookName)
     }
 }
 

--- a/ios/test-utils-core/Sources/utilities/TestPlayer.swift
+++ b/ios/test-utils-core/Sources/utilities/TestPlayer.swift
@@ -54,11 +54,14 @@ public class TestHooks: CoreHooks {
     public var onStart: Hook<FlowType>
 
     public required init(from player: JSValue) {
-        flowController = Hook<FlowController>(baseValue: player, name: "flowController")
-        viewController = Hook<ViewController>(baseValue: player, name: "viewController")
-        dataController = Hook<DataController>(baseValue: player, name: "dataController")
-        errorController = Hook<ErrorController>(baseValue: player, name: "errorController")
-        state = Hook<BaseFlowState>(baseValue: player, name: "state")
-        onStart = Hook<FlowType>(baseValue: player, name: "onStart")
+        flowController = Hook<FlowController>(baseValue: player, name: Self.flowControllerHookName)
+        viewController = Hook<ViewController>(baseValue: player, name: Self.viewControllerHookName)
+        dataController = Hook<DataController>(baseValue: player, name: Self.dataControllerHookName)
+        errorController = Hook<ErrorController>(
+            baseValue: player,
+            name: Self.errorControllerHookName
+        )
+        state = Hook<BaseFlowState>(baseValue: player, name: Self.stateHookName)
+        onStart = Hook<FlowType>(baseValue: player, name: Self.onStartHookName)
     }
 }


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->
Dedupes the six `Hook(name:)` string literals (`flowController`, `viewController`, `dataController`, `errorController`, `state`, `onStart`) that `HeadlessHooks`, `TestHooks`, and `SwiftUIPlayerHooks` were each retyping independently. Added a public extension `CoreHooks` in `HeadlessPlayer.swift` with static name constants, and pointed all three `init(from:)` implementations at `Self.<x>HookName` instead of raw strings.

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->