### PR TITLE
Isolate setTimeout bridge key as a shared constant

### DIFF
--- a/ios/core/Sources/utilities/JSUtilities.swift
+++ b/ios/core/Sources/utilities/JSUtilities.swift
@@ -10,6 +10,10 @@ import JavaScriptCore
 
 /// Class to hold context-agnostic JS utility functions
 public class JSUtilities {
+    /// The `forKeyedSubscript` key used to inject/remove the native `setTimeout` polyfill on a
+    /// `JSContext`
+    public static let setTimeoutKey: NSString = "setTimeout"
+
     /// Polyfills functions needed for plugins with native versions
     /// - parameters:
     ///   - context: The context to polyfill
@@ -25,7 +29,7 @@ public class JSUtilities {
                 }
         }
         guard let val = JSValue(object: setTimeout, in: context) else { return }
-        context.setObject(val, forKeyedSubscript: "setTimeout" as NSString)
+        context.setObject(val, forKeyedSubscript: setTimeoutKey)
     }
 
     /// Creates a javascript promise in the given context, to execute native code

--- a/ios/core/Tests/utilities/JSUtilitiesTests.swift
+++ b/ios/core/Tests/utilities/JSUtilitiesTests.swift
@@ -21,7 +21,7 @@ class JSUtilitiesTests: XCTestCase {
         let function: @convention(block) () -> Void = {
             expection.fulfill()
         }
-        context.objectForKeyedSubscript("setTimeout")?.call(withArguments: [
+        context.objectForKeyedSubscript(JSUtilities.setTimeoutKey)?.call(withArguments: [
             JSValue(object: function, in: context) as Any,
             1,
         ])

--- a/ios/swiftui/Sources/SwiftUIPlayer.swift
+++ b/ios/swiftui/Sources/SwiftUIPlayer.swift
@@ -237,7 +237,7 @@ public struct SwiftUIPlayer: View, HeadlessPlayer {
             autoreleasepool {
                 if let ctx = player?.context {
                     ctx.exceptionHandler = nil
-                    ctx.setObject(nil, forKeyedSubscript: "setTimeout" as NSString)
+                    ctx.setObject(nil, forKeyedSubscript: JSUtilities.setTimeoutKey)
                     JSGarbageCollect(ctx.jsGlobalContextRef)
                 }
                 // Break plugin → JSContext/JSValue references


### PR DESCRIPTION
<!-- 

Describe what's changing, why, and any other background info.

Make sure to add:
  - Tests
  - Documentation Updates

-->

Dedupes the "setTimeout" string literal used as the forKeyedSubscript key for the JSContext polyfill.

Changes:
- JSUtilities.swift: added static let setTimeoutKey: NSString = "setTimeout"
- SwiftUIPlayer.swift teardown + JSUtilitiesTests.swift: reference the new constant instead of the literal

### Change Type (required)
Indicate the type of change your pull request is:

<!-- 
  We use semantic versioning: https://semver.org/. Review that documentation for 
  more detailed guidelines.
-->
- [x] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `N/A`


### Does your PR have any documentation updates?
- [ ] Updated docs
- [x] No Update needed
- [ ] Unable to update docs
<!--
In an effort to standardize our process and code, please make sure you include documentation and/or update any existing documentation.
Please refer to our site https://player-ui.github.io/latest/about, and include any neccesary information that would be helpful to coders, developers, and learners.

If you are unable to update the current documents, please create an issue for us to get back to it.

-->

<!--
  To include release notes in the automatic changelong, just add a level 1 markdown header below
  and include any markdown notes to go into the changelog: https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes

  Example:

  # Release Notes
  Added new plugin, to use it:
  ```typescript
  const plugin = new Plugin(...)
  ```
-->